### PR TITLE
fix(tui): clarify capability error messages

### DIFF
--- a/server/provider-cache-policy.ts
+++ b/server/provider-cache-policy.ts
@@ -239,9 +239,9 @@ export function promptCacheBlockMessage(reason: PromptCacheBlockReason): string 
     case "unsupported":
       return "Prompt caching is unsupported for the selected provider or model.";
     case "unknown-model":
-      return "No exact prompt-cache request contract is declared for the selected model ID.";
+      return "Prompt-cache support is unknown for the selected model.";
     case "compatible-endpoint":
-      return "Prompt-cache controls are disabled for compatible and custom endpoints.";
+      return "Prompt caching is not supported by the selected provider.";
     case "long-unsupported":
       return "Long prompt-cache retention is unavailable for the selected exact model.";
   }

--- a/server/provider-request-body.ts
+++ b/server/provider-request-body.ts
@@ -212,14 +212,14 @@ function applyGenerationEffort(
   const runtime = providerRuntimeFor(settings);
   if (runtime.effort === "default") return;
   if (runtime.capabilities.reasoningEffort !== "supported") {
-    throw new ProviderError("The selected model does not declare generation-effort support.");
+    throw new ProviderError("Generation effort is not supported by the selected model.");
   }
   if (adapter === "openai") {
     body.reasoning_effort = runtime.effort === "off" ? "none" : runtime.effort;
     return;
   }
   if (runtime.effort === "off") {
-    throw new ProviderError("Anthropic does not define a generation-effort mapping for off.");
+    throw new ProviderError("Anthropic does not support generation effort set to off.");
   }
   body.output_config = { effort: runtime.effort };
 }

--- a/server/settings-v2-conversion.ts
+++ b/server/settings-v2-conversion.ts
@@ -117,7 +117,7 @@ export function effectiveGenerationRuntime(
   const provider = providerForProtocol(connection.protocol);
   if (provider === "anthropic" && profile.effort === "off") {
     throw new SettingsFormatError(
-      "Anthropic does not define a generation-effort mapping for off"
+      "Anthropic does not support generation effort set to off."
     );
   }
   const remoteId = effectiveRemoteId(

--- a/shared/prompt-cache-capabilities.ts
+++ b/shared/prompt-cache-capabilities.ts
@@ -294,7 +294,7 @@ export function promptCachePolicyPresentation(
     return {
       policy,
       available: false,
-      behavior: "This model has no distinct extended-retention mapping.",
+      behavior: "This model does not support a separate long-retention mode.",
       ttl: "Unavailable",
       compactTtl: "n/a",
       writeMultiplier: null,
@@ -389,15 +389,15 @@ function unavailablePresentation(
     "legacy-v1": "Cache policy requires editable format-2 settings.",
     "dry-run": "Dry run never calls a model provider.",
     "unsupported": "Prompt caching is explicitly disabled for this model.",
-    "compatible-endpoint": "Only exact official provider presets receive cache fields.",
-    "unknown-model": "No exact prompt-cache contract is declared for this model ID."
+    "compatible-endpoint": "Prompt caching is not supported by this provider.",
+    "unknown-model": "Prompt-cache support is unknown for this model."
   };
   const compactExplanation: Record<PromptCacheCapabilityReason, string> = {
     "legacy-v1": "Use format 2.",
     "dry-run": "No dry-run cache.",
     "unsupported": "Cache disabled.",
-    "compatible-endpoint": "Official API only.",
-    "unknown-model": "Set model ID."
+    "compatible-endpoint": "Not supported.",
+    "unknown-model": "Support unknown."
   };
   return {
     policy,

--- a/shared/sampling-capabilities.ts
+++ b/shared/sampling-capabilities.ts
@@ -340,7 +340,7 @@ export function samplingUnavailableReasonCompact(reason: SamplingUnavailableReas
 }
 
 /** The same fact again, phrased as a clause that follows a knob's name — e.g.
- *  `dry multiplier` + `for a protocol that does not document it`. Used only
+ *  `dry multiplier` + `because this provider does not support it`. Used only
  *  by the server's route-validation error, which names the offending knob
  *  itself before this text. */
 export function samplingUnavailableReasonClause(reason: SamplingUnavailableReason): string {
@@ -580,29 +580,29 @@ const UNAVAILABLE_REASON_TEXT: Readonly<Record<SamplingUnavailableReason, {
     clause: "for a dry-run connection"
   },
   protocol: {
-    reason: "This protocol does not document this parameter.",
-    compact: "not in protocol",
-    clause: "for a protocol that does not document it"
+    reason: "Not supported by this provider.",
+    compact: "not supported by provider",
+    clause: "because this provider does not support it"
   },
   "preset-unsupported": {
-    reason: "This preset does not document this parameter.",
-    compact: "not in preset",
-    clause: "for a preset that does not document it"
+    reason: "Not supported by this provider.",
+    compact: "not supported by provider",
+    clause: "because this provider does not support it"
   },
   "preset-unknown": {
-    reason: "This endpoint does not document extension parameters.",
-    compact: "unknown endpoint",
-    clause: "for an endpoint with undocumented extension fields"
+    reason: "Provider support is unknown.",
+    compact: "support unknown",
+    clause: "because support is unknown for this provider"
   },
   "model-unsupported": {
-    reason: "This model does not declare sampling support.",
-    compact: "model unsupported",
-    clause: "for a model that does not declare sampling support"
+    reason: "Not supported by this model.",
+    compact: "not supported by model",
+    clause: "because this model does not support sampling settings"
   },
   "model-unknown": {
-    reason: "This model has no documented support for this parameter.",
-    compact: "model unknown",
-    clause: "for a model without a documented sampling contract"
+    reason: "Model support is unknown.",
+    compact: "model support unknown",
+    clause: "because support is unknown for this model"
   },
   "no-exact-tokenizer": {
     reason: "1667 has no exact tokenizer for this model, so it cannot resolve text to token IDs.",

--- a/shared/token-probability-capabilities.ts
+++ b/shared/token-probability-capabilities.ts
@@ -112,12 +112,12 @@ const UNAVAILABLE_REASON_TEXT: Readonly<Record<TokenProbabilityUnavailableReason
     compact: "read-only"
   },
   protocol: {
-    reason: "This protocol does not document token probabilities.",
-    compact: "not in protocol"
+    reason: "This provider does not support token probabilities.",
+    compact: "not supported by provider"
   },
   "preset-unknown": {
-    reason: "This endpoint does not document token probabilities.",
-    compact: "unknown endpoint"
+    reason: "Token probability support is unknown for this provider.",
+    compact: "support unknown"
   },
   "model-refused": {
     reason: "This model refused token probabilities.",

--- a/test/provider-cache-policy.test.ts
+++ b/test/provider-cache-policy.test.ts
@@ -15,6 +15,7 @@ import {
   effectiveGenerationSettings,
   effectivePromptCacheContext
 } from "../server/settings-v2-conversion.js";
+import { promptCachePolicyPresentation } from "../shared/prompt-cache-capabilities.js";
 import { INITIAL_SETTINGS_DOCUMENT_V2 } from "../server/settings-v2-default.js";
 import type {
   FeatureSupportV2,
@@ -163,6 +164,28 @@ test("capability lowering is conservative and never silently downgrades opt-in p
   );
 });
 
+test("unavailable cache policies use provider and model language", () => {
+  const provider = promptCachePolicyPresentation(
+    context("compatible", "supported", "auto"),
+    "auto"
+  );
+  assert.equal(provider.available, false);
+  if (!provider.available) {
+    assert.equal(provider.unavailableReason, "Prompt caching is not supported by this provider.");
+    assert.equal(provider.unavailableReasonCompact, "Not supported.");
+  }
+
+  const model = promptCachePolicyPresentation(
+    context("anthropic-official", "unknown", "auto", "unknown-model"),
+    "auto"
+  );
+  assert.equal(model.available, false);
+  if (!model.available) {
+    assert.equal(model.unavailableReason, "Prompt-cache support is unknown for this model.");
+    assert.equal(model.unavailableReasonCompact, "Support unknown.");
+  }
+});
+
 test("runtime plans cache only stable boundaries and commit rolling state after dispatch", () => {
   const prompt = {
     operation: "continue" as const,
@@ -257,7 +280,7 @@ test("runtime admission accepts exact contracts and rejects unsupported policy p
     () => effectiveGenerationSettings(
       cacheDocument("openai-compatible", "custom", "supported", "auto", "gpt-5.4")
     ),
-    /compatible and custom endpoints/
+    /Prompt caching is not supported by the selected provider/
   );
   assert.throws(
     () => new PromptCacheRuntime().prepare(

--- a/test/provider-request-body.test.ts
+++ b/test/provider-request-body.test.ts
@@ -438,7 +438,16 @@ test("explicit supported effort lowers through each protocol adapter", async () 
       PROMPT,
       OMIT_PLANS[0]!
     ),
-    /does not define a generation-effort mapping for off/
+    /Anthropic does not support generation effort set to off\./
+  );
+
+  await assert.rejects(
+    () => buildOpenAiChatRequestBody(
+      withEffort(settings("openai-compatible"), "high", "unknown"),
+      PROMPT,
+      OMIT_PLANS[0]!
+    ),
+    /Generation effort is not supported by the selected model\./
   );
 });
 
@@ -1601,7 +1610,8 @@ function settings(provider: GenerationSettings["provider"]): GenerationSettings 
 
 function withEffort(
   value: GenerationSettings,
-  effort: ProviderRuntime["effort"]
+  effort: ProviderRuntime["effort"],
+  reasoningEffort: ProviderRuntime["capabilities"]["reasoningEffort"] = "supported"
 ): GenerationSettings {
   return attachProviderRuntime(value, {
     preset: "custom",
@@ -1620,7 +1630,7 @@ function withEffort(
     capabilities: {
       temperature: "supported",
       assistantPrefill: "unknown",
-      reasoningEffort: "supported",
+      reasoningEffort,
       promptCaching: "unknown"
     }
   }, true);

--- a/test/provider-sampling.test.ts
+++ b/test/provider-sampling.test.ts
@@ -73,7 +73,7 @@ test("an LM Studio route with DRY configured fails with the ProviderError naming
   });
   await assert.rejects(
     () => applySamplingFields({}, settings, "openai-chat-completions"),
-    /Configured sampling parameter dry multiplier is unavailable: This endpoint does not document extension parameters\./u
+    /Configured sampling parameter dry multiplier is unavailable: Provider support is unknown\./u
   );
 });
 

--- a/test/sampling-capabilities.test.ts
+++ b/test/sampling-capabilities.test.ts
@@ -398,7 +398,7 @@ test("an unsupported route reports its own reason for mirostat tau/eta even with
   );
 });
 
-test("sampling presentation exposes a stable label and a reason for disabled cells", () => {
+test("sampling presentation exposes a stable label and a provider-facing reason", () => {
   const presentation = samplingKnobPresentation(
     samplingContext("openai-chat-completions", "ollama"),
     EMPTY_SAMPLING_V2,
@@ -407,9 +407,60 @@ test("sampling presentation exposes a stable label and a reason for disabled cel
   assert.deepEqual(presentation, {
     label: "logit bias",
     available: false,
-    reason: "This preset does not document this parameter.",
-    reasonCompact: "not in preset"
+    reason: "Not supported by this provider.",
+    reasonCompact: "not supported by provider"
   });
+});
+
+test("sampling presentation keeps internal routing terms out of unavailable reasons", () => {
+  const cases: readonly {
+    context: SamplingContext;
+    knob: SamplingKnobV2;
+    label: string;
+    reason: string;
+    reasonCompact: string;
+  }[] = [
+    {
+      context: samplingContext("anthropic-messages", "anthropic", "claude-opus-4-5"),
+      knob: "seed",
+      label: "seed",
+      reason: "Not supported by this provider.",
+      reasonCompact: "not supported by provider"
+    },
+    {
+      context: samplingContext("openai-chat-completions", "lm-studio"),
+      knob: "dryMultiplier",
+      label: "dry multiplier",
+      reason: "Provider support is unknown.",
+      reasonCompact: "support unknown"
+    },
+    {
+      context: samplingContext("openai-chat-completions", "openai", "fixture-model", "unsupported"),
+      knob: "topP",
+      label: "top p",
+      reason: "Not supported by this model.",
+      reasonCompact: "not supported by model"
+    },
+    {
+      context: samplingContext("anthropic-messages", "anthropic"),
+      knob: "topP",
+      label: "top p",
+      reason: "Model support is unknown.",
+      reasonCompact: "model support unknown"
+    }
+  ];
+
+  for (const fixture of cases) {
+    assert.deepEqual(
+      samplingKnobPresentation(fixture.context, EMPTY_SAMPLING_V2, fixture.knob),
+      {
+        label: fixture.label,
+        available: false,
+        reason: fixture.reason,
+        reasonCompact: fixture.reasonCompact
+      }
+    );
+  }
 });
 
 test("sampling presentation reports mirostat-off for tau/eta when mirostat is unset", () => {

--- a/test/sampling-e2e.test.ts
+++ b/test/sampling-e2e.test.ts
@@ -235,7 +235,7 @@ test("an LM Studio route with DRY configured refuses to save, naming the reason"
   const before = (await store.loadView()).document;
   await assert.rejects(
     () => store.save(saveCommand(`m1.1767225600005.${"5".repeat(32)}`, 1, candidate)),
-    /dry multiplier.*endpoint with undocumented extension fields/u
+    /dry multiplier.*support is unknown for this provider/u
   );
   assert.deepEqual((await store.loadView()).document, before);
 });
@@ -588,7 +588,7 @@ test("Ollama rejects logit bias at save time without changing the active documen
   });
   await assert.rejects(
     () => store.save(saveCommand(MUTATION_C, 1, candidate)),
-    /logit bias.*preset/u
+    /logit bias.*because this provider does not support it/u
   );
   assert.deepEqual((await store.loadView()).document, before);
 });
@@ -628,7 +628,7 @@ test("Anthropic Messages rejects seed at save time without changing the active d
   }, "anthropic");
   await assert.rejects(
     () => store.save(saveCommand(MUTATION_C, 1, candidate)),
-    /seed.*protocol/u
+    /seed.*because this provider does not support it/u
   );
   assert.deepEqual((await store.loadView()).document, before);
 });

--- a/test/settings-v2-codec.test.ts
+++ b/test/settings-v2-codec.test.ts
@@ -447,7 +447,10 @@ test("save-time sampling validation refuses unavailable preset and model cells",
       }
     }
   };
-  assert.throws(() => parseSettingsDocumentV2(ollama), /logit bias.*preset/);
+  assert.throws(
+    () => parseSettingsDocumentV2(ollama),
+    /logit bias.*because this provider does not support it/
+  );
 
   const anthropic = convertGenerationSettingsV1(legacy(
     "anthropic",
@@ -815,7 +818,7 @@ test("Anthropic runtime lowering rejects normalized effort off without a wire ma
 
   assert.throws(
     () => effectiveGenerationSettings(document),
-    /does not define a generation-effort mapping for off/
+    /Anthropic does not support generation effort set to off\./
   );
 });
 

--- a/test/token-probabilities.test.ts
+++ b/test/token-probabilities.test.ts
@@ -94,16 +94,19 @@ test("the exported supported-preset list agrees with every allow-listed fixture"
   assert.deepEqual([...TOKEN_PROBABILITY_SUPPORTED_PRESETS].sort(), allowListed);
 });
 
-test("presentation text matches the documented wording for every unavailable reason", () => {
+test("presentation text uses user-facing wording for every unavailable reason", () => {
   assert.equal(tokenProbabilityUnavailableReason("legacy-v1"), "Format 1 settings are read-only.");
   assert.equal(tokenProbabilityUnavailableReasonCompact("legacy-v1"), "read-only");
-  assert.equal(tokenProbabilityUnavailableReason("protocol"), "This protocol does not document token probabilities.");
-  assert.equal(tokenProbabilityUnavailableReasonCompact("protocol"), "not in protocol");
+  assert.equal(
+    tokenProbabilityUnavailableReason("protocol"),
+    "This provider does not support token probabilities."
+  );
+  assert.equal(tokenProbabilityUnavailableReasonCompact("protocol"), "not supported by provider");
   assert.equal(
     tokenProbabilityUnavailableReason("preset-unknown"),
-    "This endpoint does not document token probabilities."
+    "Token probability support is unknown for this provider."
   );
-  assert.equal(tokenProbabilityUnavailableReasonCompact("preset-unknown"), "unknown endpoint");
+  assert.equal(tokenProbabilityUnavailableReasonCompact("preset-unknown"), "support unknown");
   assert.equal(tokenProbabilityUnavailableReason("model-refused"), "This model refused token probabilities.");
   assert.equal(tokenProbabilityUnavailableReasonCompact("model-refused"), "model refused");
 });

--- a/tui/test/golden-panels.test.ts
+++ b/tui/test/golden-panels.test.ts
@@ -728,13 +728,13 @@ describe("token probability viewer", () => {
 
   test("empty state: Anthropic Messages names the presets that do document it", async () => {
     const frame = await renderOnce(routeSource("anthropic", "anthropic-messages"), 120, 36, "l");
-    expect(frame).toContain("This protocol does not document token probabilities.");
+    expect(frame).toContain("This provider does not support token probabilities.");
     expect(frame).toContain("OpenAI, OpenRouter, llama.cpp, KoboldCpp, LM Studio");
   });
 
   test("empty state: an endpoint outside the allow-list names the presets that do document it", async () => {
     const frame = await renderOnce(routeSource("ollama", "openai-chat-completions"), 120, 36, "l");
-    expect(frame).toContain("This endpoint does not document token probabilities.");
+    expect(frame).toContain("Token probability support is unknown for this provider.");
     expect(frame).toContain("OpenAI, OpenRouter, llama.cpp, KoboldCpp, LM Studio");
   });
 

--- a/tui/test/sampling-settings.test.ts
+++ b/tui/test/sampling-settings.test.ts
@@ -209,7 +209,7 @@ describe("Sampling Settings user flow", () => {
     expect(state.settings?.draft.sampling.seed).toBe(42);
   });
 
-  test("seed is disabled for Anthropic with the same protocol reason as other OpenAI-only scalars", async () => {
+  test("seed is disabled for Anthropic with a provider-facing reason", async () => {
     const { source, state, press } = settingsHarness();
     useAnthropicSettings(source);
     await enterSampling(state, press);
@@ -220,7 +220,7 @@ describe("Sampling Settings user flow", () => {
     expect(seedLine).toContain("‹ — ›");
 
     await press(key("return"));
-    expect(state.settings?.sampling?.result).toBe("seed disabled · not in protocol");
+    expect(state.settings?.sampling?.result).toBe("seed disabled · not supported by provider");
     expect(state.settings?.draft.sampling.seed).toBe(null);
   });
 
@@ -383,7 +383,20 @@ describe("Sampling Settings user flow", () => {
     await moveLayer2Cursor(press, samplingLayerRowIndex("phrase-bias"));
     await press(key("return"));
     expect(state.settings?.sampling?.panel).toBe("sampling");
-    expect(state.settings?.sampling?.result).toContain("not in preset");
+    expect(state.settings?.sampling?.result).toContain("not supported by provider");
+  });
+
+  test("an unavailable frequency penalty names the provider limitation", async () => {
+    const { source, state, press } = settingsHarness();
+    useKoboldcppSettings(source);
+    await enterSampling(state, press);
+    await moveLayer2Cursor(press, samplingLayerRowIndex("frequencyPenalty"));
+
+    expect(render(state, 120, 36)).toContain("Not supported by this provider.");
+
+    await press(key("return"));
+    expect(state.settings?.sampling?.result)
+      .toBe("frequency penalty disabled · not supported by provider");
   });
 
   // Issue #282 stage 1, point 5: llama.cpp is no longer subtracted — it
@@ -921,7 +934,7 @@ describe("Sampling Settings user flow", () => {
     expect(profile.sampling?.mirostatTau).toBe(6);
   });
 
-  test("an LM Studio route hides the extended samplers behind the preset reason", async () => {
+  test("an LM Studio route explains that extended sampler support is unknown", async () => {
     const { source, state, press } = settingsHarness();
     useSupportedSettings(source, "http://127.0.0.1:1234/v1");
     await enterSampling(state, press);
@@ -929,7 +942,7 @@ describe("Sampling Settings user flow", () => {
 
     const dryLine = lines.find((line) => line.includes("dry multiplier"));
     expect(dryLine).toContain("‹ — ›");
-    expect(dryLine).toContain("This endpoint does not document");
+    expect(dryLine).toContain("Provider support is unknown.");
     // A baseline OpenAI field stays available on the same route.
     const topPLine = lines.find((line) => line.includes("top p"));
     expect(topPLine).toContain("‹ default ›");

--- a/tui/test/settings-profiles.test.ts
+++ b/tui/test/settings-profiles.test.ts
@@ -385,7 +385,7 @@ describe("Generation Profile settings", () => {
     await selectRow(press, state, "token-probabilities");
     const frame = frameText(renderStoryScreen(state, { width: 80, height: 24, wrapCache: cache }).lines);
     expect(frame).toContain("‹ — ›");
-    expect(frame).toContain("unknown endpoint");
+    expect(frame).toContain("support unknown");
 
     // Cycling an unavailable row is a no-op: it never writes a count the
     // request was never going to carry.

--- a/tui/test/token-probabilities-model.test.ts
+++ b/tui/test/token-probabilities-model.test.ts
@@ -189,13 +189,13 @@ describe("resolveTokenProbabilityEmptyReason", () => {
 
   test("an Anthropic Messages route resolves protocol, naming the presets that do work", () => {
     const reason = resolveTokenProbabilityEmptyReason(routeView("anthropic", "anthropic-messages"));
-    expect(reason.text).toBe("This protocol does not document token probabilities.");
+    expect(reason.text).toBe("This provider does not support token probabilities.");
     expect(reason.supportedPresets).toEqual(["OpenAI", "OpenRouter", "llama.cpp", "KoboldCpp", "LM Studio"]);
   });
 
   test("an unlisted OpenAI-compatible preset resolves preset-unknown, naming the presets that do work", () => {
     const reason = resolveTokenProbabilityEmptyReason(routeView("ollama", "openai-chat-completions"));
-    expect(reason.text).toBe("This endpoint does not document token probabilities.");
+    expect(reason.text).toBe("Token probability support is unknown for this provider.");
     expect(reason.supportedPresets).toEqual(["OpenAI", "OpenRouter", "llama.cpp", "KoboldCpp", "LM Studio"]);
   });
 


### PR DESCRIPTION
Closes #1

## What changed

- Replace internal terms such as preset, protocol, endpoint, mapping, and contract in capability errors.
- Use provider and model support language for sampling, token probabilities, prompt caching, and generation effort.
- Add regression coverage for full messages, compact messages, and validation errors.

## Why

The old messages exposed implementation terms. They did not tell users why a setting was unavailable.

## User impact

Unavailable settings now identify provider support, model support, or unknown support directly.

## How it was verified

- Root focused tests: 119 passed.
- TUI focused tests: 103 passed.
- Repeated TUI tests after adjacent changes: 49 passed.
- `git diff --check` passed.

The full local CI suite was not run because it is known to be flaky.
