### PR TITLE
fix(tui): support compose clipboard shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ Git manages this installation.
 | Go to the previous or next chapter | `[` and `]` |
 | Continue the story | `Space` |
 | Open the composer | `Enter` or `i` |
+| Copy selected composer text | `Ctrl+C` |
+| Paste text into the composer | `Ctrl+V` |
 | Add a manual take | `w` |
 | Edit the selected story part | `e` |
 | Edit the Author's Note | `a` |

--- a/tui/src/app.ts
+++ b/tui/src/app.ts
@@ -67,6 +67,8 @@ import {
   clearNativeSelectionIfMatches,
   consumesEmptyCopyShortcut,
   handleMainCopyShortcut,
+  isCopyShortcut,
+  isInterruptShortcut,
   mouseComposerSelectionMessage,
   syncMouseComposerSelection
 } from "./copy-actions.js";
@@ -352,15 +354,20 @@ export async function runInteractive(source: AppSource): Promise<void> {
   };
 
   renderer.keyInput.on("keypress", (key) => {
-    const controlCopy = key.ctrl && key.name === "c";
-    if (controlCopy && frames.failed) return requestQuit();
+    const copyShortcut = isCopyShortcut(key);
+    const interruptShortcut = isInterruptShortcut(key);
+    if (copyShortcut && frames.failed) {
+      if (interruptShortcut) requestQuit();
+      return;
+    }
     const queuedSelection = captureQueuedSelection();
     const copySurface = consumesEmptyCopyShortcut(state)
       || (presentedInteraction !== null
         && consumesEmptyCopyShortcut(presentedInteraction.state));
-    if (controlCopy && !hasCopyablePresentedSelection(queuedSelection) && !copySurface
+    if (copyShortcut && !hasCopyablePresentedSelection(queuedSelection) && !copySurface
       && inputs.shouldQuitImmediately(state.mode, false)) {
-      return requestQuit();
+      if (interruptShortcut) requestQuit();
+      return;
     }
     const queuedKey = { ...key } as KeyEvent;
     // Keyboard admission clears pending mouse click gestures at one site.
@@ -373,12 +380,12 @@ export async function runInteractive(source: AppSource): Promise<void> {
       const native = selection.kind === "captured"
         ? selection.native ?? EMPTY_NATIVE_SELECTION
         : EMPTY_NATIVE_SELECTION;
-      if (controlCopy) {
+      if (copyShortcut) {
         const copied = handleMainCopyShortcut(
           native,
           state,
           repaint,
-          requestQuit,
+          interruptShortcut ? requestQuit : () => undefined,
           selection.kind === "captured" ? selection : undefined
         );
         if (copied) {
@@ -436,7 +443,7 @@ export async function runInteractive(source: AppSource): Promise<void> {
       ), (work) => backend.observe(work));
     }, () => {
       retirePresentedSelection(renderer, queuedSelection);
-      if (controlCopy) requestQuit();
+      if (interruptShortcut) requestQuit();
     });
   });
   renderer.keyInput.on("paste", (event) => {
@@ -579,14 +586,15 @@ export async function handleKey(
   previewTheme: ActionContext["previewTheme"] = () => undefined,
   backend: ActionRunner = new ActionRuntime(state, repaint)
 ): Promise<void> {
-  if (key.ctrl && key.name === "c"
+  if (isCopyShortcut(key)
     && state.mode !== "EDITOR"
     && consumesEmptyCopyShortcut(state)) {
     return;
   }
-  if (key.ctrl && key.name === "c"
+  if (isCopyShortcut(key)
     && state.mode !== "EDITOR") {
-    return requestQuit();
+    if (isInterruptShortcut(key)) requestQuit();
+    return;
   }
   const resolved = resolveKey(key, state.mode, {
     confirmingPrune: state.prune !== null,

--- a/tui/src/compose-clipboard.ts
+++ b/tui/src/compose-clipboard.ts
@@ -1,0 +1,44 @@
+import { readFromClipboard } from "./clipboard.js";
+import { insertComposerText, type ComposerState } from "./composer-model.js";
+import { sanitizePastedText } from "./keys.js";
+
+interface ComposeClipboardHost {
+  interactionVersion: number;
+  mode: string;
+  composer: ComposerState;
+  toast: string | null;
+}
+
+/** Read the platform clipboard without applying a result to a changed draft. */
+export async function pasteClipboardIntoComposer(
+  host: ComposeClipboardHost
+): Promise<void> {
+  const claim = {
+    interactionVersion: host.interactionVersion,
+    composer: host.composer,
+    text: host.composer.text,
+    cursor: host.composer.cursor,
+    anchor: host.composer.anchor,
+    fullscreen: host.composer.fullscreen
+  };
+  const text = await readFromClipboard();
+  if (host.mode !== "COMPOSE"
+    || host.interactionVersion !== claim.interactionVersion
+    || host.composer !== claim.composer
+    || host.composer.text !== claim.text
+    || host.composer.cursor !== claim.cursor
+    || host.composer.anchor !== claim.anchor
+    || host.composer.fullscreen !== claim.fullscreen) {
+    return;
+  }
+  if (text === null) {
+    host.toast = "clipboard unreadable · paste with ⌘V or ctrl+shift+v";
+    return;
+  }
+  const clean = sanitizePastedText(text);
+  if (clean.length === 0) {
+    host.toast = "clipboard has no insertable text";
+    return;
+  }
+  insertComposerText(host.composer, clean);
+}

--- a/tui/src/copy-actions.ts
+++ b/tui/src/copy-actions.ts
@@ -1,4 +1,4 @@
-import type { CliRenderer } from "@opentui/core";
+import type { CliRenderer, KeyEvent } from "@opentui/core";
 import { countWords } from "../../shared/story-text.js";
 import { copyToClipboard, type CopyOutcome } from "./clipboard.js";
 import {
@@ -57,6 +57,16 @@ export const EMPTY_NATIVE_SELECTION: NativeSelectionSnapshot = {
   range: null,
   backward: false
 };
+
+/** Terminals can report the platform copy key as Control or Command. */
+export function isCopyShortcut(key: KeyEvent): boolean {
+  return Boolean(key.ctrl || key.super) && key.name.toLowerCase() === "c";
+}
+
+/** Only Control+C has process-interrupt semantics when there is no selection. */
+export function isInterruptShortcut(key: KeyEvent): boolean {
+  return Boolean(key.ctrl) && key.name.toLowerCase() === "c";
+}
 
 /** Native selection objects are renderer-owned and keep changing while an
  * input waits. Copy the fields reducers need at event arrival. */

--- a/tui/src/keys.ts
+++ b/tui/src/keys.ts
@@ -394,9 +394,11 @@ export function resolveKey(key: KeyEvent, mode: AppMode, options: ResolveOptions
   const navChord = resolveReferenceBinding("nav-chord", key, mode, mapView);
   if (navChord !== null) return { action: navChord.action };
   if (mode === "COMPOSE") {
+    const name = key.name.toLowerCase();
     const composeChord = resolveReferenceBinding("compose-chord", key, mode, mapView);
     if (composeChord !== null) return { action: composeChord.action };
-    if (key.ctrl && key.name.toLowerCase() === "f") return { action: "toggle-compose-fullscreen" };
+    if ((key.ctrl || key.super) && name === "v") return { action: "paste-clipboard" };
+    if (key.ctrl && name === "f") return { action: "toggle-compose-fullscreen" };
     // The rewrite composer's second fixed destination (issue #319, and
     // docs/generation-boundaries.md): plain `enter` always replaces in
     // place, `⌃s` always sends the result as a new take instead — the exact
@@ -404,7 +406,7 @@ export function resolveKey(key: KeyEvent, mode: AppMode, options: ResolveOptions
     // EDITOR, above), just with the opposite default here. Outside a
     // rewrite composer it resolves but does nothing (story-actions.ts's
     // composeAction), same as an unbound chord elsewhere.
-    if (key.ctrl && key.name.toLowerCase() === "s") return { action: "send-as-take" };
+    if (key.ctrl && name === "s") return { action: "send-as-take" };
     if (key.name === "return") return { action: key.shift ? "newline" : "send" };
     // LF / Ctrl+J inserts a line; it never sends the draft.
     if (isLinefeedKey(key)) return { action: "newline" };
@@ -436,9 +438,9 @@ export function resolveKey(key: KeyEvent, mode: AppMode, options: ResolveOptions
     if (key.ctrl && name === "o") return { action: "save-edit-inplace" };
     if (key.ctrl && key.shift && name === "s") return { action: "save-edit-inplace" };
     if (key.ctrl && name === "s") return { action: "save-edit" };
-    if (key.ctrl && name === "c") return { action: "copy-selection" };
-    if (key.ctrl && name === "x") return { action: "cut-selection" };
-    if (key.ctrl && name === "v") return { action: "paste-clipboard" };
+    if ((key.ctrl || key.super) && name === "c") return { action: "copy-selection" };
+    if ((key.ctrl || key.super) && name === "x") return { action: "cut-selection" };
+    if ((key.ctrl || key.super) && name === "v") return { action: "paste-clipboard" };
     if ((key.ctrl && name === "z" && !key.shift) || key.ctrl && name === "-"
       || key.super && name === "z" && !key.shift) return { action: "undo-edit" };
     if ((key.ctrl && name === "z" && key.shift) || key.ctrl && (name === "y" || name === ".")

--- a/tui/src/mouse-actions.ts
+++ b/tui/src/mouse-actions.ts
@@ -268,8 +268,9 @@ export function mouseToAction(
   state: MouseActionState,
   resolveReleaseTarget = false
 ): ResolvedKey | null {
-  // Right-click leaves the composer rather than acting on what is under it.
-  if (state.mode === "COMPOSE" && event.type === "down" && event.button === 2) return { action: "cancel" };
+  // Keep terminal clipboard gestures inside the composer. A right-click can
+  // open a terminal menu, and Shift+right-click commonly bypasses mouse mode.
+  if (state.mode === "COMPOSE" && event.type === "down" && event.button === 2) return null;
   // Shift-drag belongs to the terminal's own selection; never steal it.
   if (event.modifiers.shift) return null;
   if (event.type === "scroll") {

--- a/tui/src/story-actions.ts
+++ b/tui/src/story-actions.ts
@@ -4,6 +4,7 @@ import type { AppSource } from "./app.js";
 import { openFactFromSelection, openPartEditor } from "./editor-action.js";
 import { applyTextKey, type ResolvedKey } from "./keys.js";
 import { copyToClipboard } from "./clipboard.js";
+import { pasteClipboardIntoComposer } from "./compose-clipboard.js";
 import { applyComposerEdit } from "./composer-editing.js";
 import { copyStoryText } from "./copy-actions.js";
 import { recordHumanWords, saveConfig } from "./config.js";
@@ -405,6 +406,10 @@ export async function composeAction(
   }
   if (resolved.action === "toggle-compose-fullscreen") {
     state.composer.fullscreen = !state.composer.fullscreen;
+    return;
+  }
+  if (resolved.action === "paste-clipboard") {
+    await pasteClipboardIntoComposer(state);
     return;
   }
   if (resolved.action === "newline") { insertComposerText(state.composer, "\n"); return; }

--- a/tui/test/hit-map-chrome.test.ts
+++ b/tui/test/hit-map-chrome.test.ts
@@ -919,7 +919,7 @@ describe("hit map clickable chrome", () => {
     }
   });
 
-  test("focused prose clicks only focus, and COMPOSE right-click cancels anywhere", async () => {
+  test("focused prose clicks only focus, and right-click keeps COMPOSE ownership", async () => {
     const source = demoAppSource();
     const state = initialState(source, false);
     state.stream = null;
@@ -930,11 +930,26 @@ describe("hit map clickable chrome", () => {
       .toMatchObject({ action: "focus-index", index: state.focusIndex });
     state.mode = "COMPOSE";
     state.composer = createComposer("draft stays");
-    const resolved = mouseToAction(click(999, 999, 2), state)!;
-    expect(resolved).toEqual({ action: "cancel" });
-    await dispatch(resolved, state, source, createWrapCache(), () => {}, async () => {}, () => {});
-    expect(state.mode).toBe("NAV");
-    expect(state.composer.text).toBe("draft stays");
+    for (const fullscreen of [false, true]) {
+      state.composer.fullscreen = fullscreen;
+      render(state);
+      const composerRow = state.hitRows.findIndex((row) => row?.target.kind === "composer");
+      expect(composerRow).toBeGreaterThan(-1);
+      expect(mouseToAction(click(2, composerRow, 2), state)).toBe(null);
+      expect(state.mode).toBe("COMPOSE");
+    }
+
+    await dispatch(
+      resolveKey({ ...key("space"), sequence: " " } as KeyEvent, state.mode),
+      state,
+      source,
+      createWrapCache(),
+      () => {},
+      async () => {},
+      () => {}
+    );
+    expect(state.mode).toBe("COMPOSE");
+    expect(state.composer.text).toBe("draft stays ");
   });
 
   test("every screen footer renders untruncated at wide and compact sizes", () => {

--- a/tui/test/keys.test.ts
+++ b/tui/test/keys.test.ts
@@ -77,9 +77,9 @@ const DECLARED_DIVERGENCES = [
   { label: "ctrl+x", event: key("x", { ctrl: true }),
     actions: ["none", "cut-selection", "none"] },
   { label: "ctrl+v", event: key("v", { ctrl: true }),
-    actions: ["none", "paste-clipboard", "paste-clipboard"] },
+    actions: ["paste-clipboard", "paste-clipboard", "paste-clipboard"] },
   { label: "cmd+v", event: key("v", { super: true }),
-    actions: ["input", "input", "paste-clipboard"] },
+    actions: ["paste-clipboard", "paste-clipboard", "paste-clipboard"] },
   { label: "cmd+a", event: key("a", { super: true }),
     actions: ["input", "select-all", "select-all"] },
   { label: "ctrl+d", event: key("d", { ctrl: true }),
@@ -282,6 +282,8 @@ describe("text surfaces and palette", () => {
     expect(resolveKey(key("f", { ctrl: true }), "COMPOSE").action).toBe("toggle-compose-fullscreen");
     expect(resolveKey(key("up", { ctrl: true }), "COMPOSE").action).toBe("history-previous");
     expect(resolveKey(key("down", { ctrl: true }), "COMPOSE").action).toBe("history-next");
+    expect(resolveKey(key("v", { ctrl: true }), "COMPOSE").action).toBe("paste-clipboard");
+    expect(resolveKey(key("v", { super: true }), "COMPOSE").action).toBe("paste-clipboard");
     expect(resolveKey(key("?"), "COMPOSE")).toEqual({ action: "input", text: "?" });
   });
 

--- a/tui/test/sampling-clipboard.test.ts
+++ b/tui/test/sampling-clipboard.test.ts
@@ -7,6 +7,7 @@ import type { SettingsView } from "../../shared/settings-v2-types.js";
 import { setComposerText } from "../src/composer-model.js";
 
 type ClipboardReader = () => Promise<string | null>;
+type ClipboardWriter = (text: string) => Promise<"internal">;
 
 const bunTest = await import("bun:test") as unknown as {
   mock: {
@@ -14,9 +15,10 @@ const bunTest = await import("bun:test") as unknown as {
   };
 };
 let clipboardReader: ClipboardReader = async () => null;
+let clipboardWriter: ClipboardWriter = async () => "internal";
 bunTest.mock.module("../src/clipboard.js", () => ({
   readFromClipboard: () => clipboardReader(),
-  copyToClipboard: async () => "internal"
+  copyToClipboard: (text: string) => clipboardWriter(text)
 }));
 
 const {
@@ -26,6 +28,86 @@ const {
   selectRow,
   settingsHarness
 } = await import("./settings-test-harness.js");
+const { EMPTY_NATIVE_SELECTION, handleMainCopyShortcut } = await import("../src/copy-actions.js");
+
+describe("Direct clipboard ownership", () => {
+  test("Command+C without a selection does not quit", async () => {
+    let quits = 0;
+    const { state, press } = settingsHarness(() => { quits += 1; });
+
+    await press(key("c", { super: true }));
+
+    expect(state.mode).toBe("NAV");
+    expect(quits).toBe(0);
+  });
+
+  test("pastes into inline and fullscreen drafts with Control or Command", async () => {
+    const cases = [
+      { fullscreen: false, key: key("v", { ctrl: true }) },
+      { fullscreen: true, key: key("v", { super: true }) }
+    ];
+    for (const clipboardCase of cases) {
+      const { state, press } = settingsHarness();
+      state.mode = "COMPOSE";
+      setComposerText(state.composer, "before after");
+      state.composer.cursor = 7;
+      state.composer.fullscreen = clipboardCase.fullscreen;
+      clipboardReader = async () => "pasted\ntext";
+
+      await press(clipboardCase.key);
+
+      expect(state.composer.text).toBe("before pasted\ntextafter");
+      expect(state.composer.fullscreen).toBe(clipboardCase.fullscreen);
+    }
+  });
+
+  test("copies selected text from inline and fullscreen drafts", async () => {
+    for (const fullscreen of [false, true]) {
+      const { state } = settingsHarness();
+      state.mode = "COMPOSE";
+      setComposerText(state.composer, "copy this draft");
+      state.composer.anchor = 5;
+      state.composer.fullscreen = fullscreen;
+      const copied: string[] = [];
+      clipboardWriter = async (text) => {
+        copied.push(text);
+        return "internal";
+      };
+
+      expect(handleMainCopyShortcut(
+        EMPTY_NATIVE_SELECTION,
+        state,
+        () => undefined,
+        () => { throw new Error("copy must not quit"); }
+      )).toBeTrue();
+      await Promise.resolve();
+
+      expect(copied).toEqual(["this draft"]);
+      expect(state.composer.fullscreen).toBe(fullscreen);
+    }
+  });
+
+  test("ignores a clipboard read after the draft changes", async () => {
+    const { state, press } = settingsHarness();
+    state.mode = "COMPOSE";
+    setComposerText(state.composer, "seed");
+    const read = deferred<string | null>();
+    const started = deferred<void>();
+    clipboardReader = async () => {
+      started.resolve();
+      return read.promise;
+    };
+
+    const paste = press(key("v", { ctrl: true }));
+    await started.promise;
+    await press(key("x"));
+    read.resolve("late clipboard text");
+    await paste;
+
+    expect(state.composer.text).toBe("seedx");
+    expect(state.toast).toBe(null);
+  });
+});
 
 describe("nested Sampling clipboard ownership", () => {
   test("ignores a late read after every owner-changing action and applies a current paste", async () => {

--- a/tui/test/settings-test-harness.ts
+++ b/tui/test/settings-test-harness.ts
@@ -15,14 +15,21 @@ import { createWrapCache, type ProseStyle } from "../src/wrap.js";
 
 export function key(
   name: string,
-  options: { sequence?: string; ctrl?: boolean; shift?: boolean; meta?: boolean } = {}
+  options: {
+    sequence?: string;
+    ctrl?: boolean;
+    shift?: boolean;
+    meta?: boolean;
+    super?: boolean;
+  } = {}
 ): KeyEvent {
   return {
     name,
     sequence: options.sequence ?? name,
     shift: options.shift ?? false,
     ctrl: options.ctrl ?? false,
-    meta: options.meta ?? false
+    meta: options.meta ?? false,
+    super: options.super ?? false
   } as KeyEvent;
 }
 
@@ -40,7 +47,7 @@ export function generationFromProbeTarget(target: ProviderProbeTarget) {
     : target;
 }
 
-export function settingsHarness() {
+export function settingsHarness(requestQuit: () => void = () => undefined) {
   const source = demoAppSource();
   const state = initialState(source, false);
   const cache = createWrapCache<ProseStyle>();
@@ -59,7 +66,7 @@ export function settingsHarness() {
     cache,
     repaint,
     async () => undefined,
-    () => undefined,
+    requestQuit,
     null,
     (theme) => {
       state.config = { ...state.config, theme };


### PR DESCRIPTION
Closes #3

## What changed

The composer now owns Ctrl+C, Command+C, Ctrl+V, and Command+V. Clipboard operations work in inline mode and full-screen mode.

A right-click now keeps the composer open. This prevents a later Space key from continuing the story unexpectedly.

Clipboard reads use the composer state that started the operation. A stale read cannot replace a newer draft.

## How it was verified

- `npm run typecheck`
- `npm test`: 1,921 passed; 177 skipped
- `cd tui && bun run typecheck`
- `cd tui && bun test --timeout 30000`: 1,469 passed
- Autoreview: clean after one accepted P2 fix