### PR TITLE
feat(tui): add editor context actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This file records notable changes to 1667. Product terms use the definitions in
 
 ## Unreleased
 
+- **Editors now have standard clipboard actions.** Right-click an editable
+  text field to open Copy, Paste, and Select all. Press `Ctrl+A` or
+  `Command+A` to select all text. Direct supports these actions in its inline
+  and full-screen forms. Thanks @10fra for the request.
 - **A token probability viewer shows the alternative tokens the model
   weighed.** Press `l` on a story part to open it. The viewer shows the
   take's prose with the selected token marked, and below it the alternative

--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ Git manages this installation.
 | Go to the previous or next chapter | `[` and `]` |
 | Continue the story | `Space` |
 | Open the composer | `Enter` or `i` |
+| Copy selected composer text | `Ctrl+C` |
+| Paste text into the composer | `Ctrl+V` |
 | Add a manual take | `w` |
 | Edit the selected story part | `e` |
 | Edit the Author's Note | `a` |

--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ Git manages this installation.
 | Open the composer | `Enter` or `i` |
 | Copy selected composer text | `Ctrl+C` |
 | Paste text into the composer | `Ctrl+V` |
+| Select all text in an editor | `Ctrl+A` or `Command+A` |
+| Open the editor action menu | Right-click an editor |
 | Add a manual take | `w` |
 | Edit the selected story part | `e` |
 | Edit the Author's Note | `a` |

--- a/tui/bench/perf.ts
+++ b/tui/bench/perf.ts
@@ -25,6 +25,7 @@ import {
   type StoryWrapBuildStats
 } from "../src/story-wrap-build.js";
 import { appendStreamText, emptyStreamText } from "../src/stream-text.js";
+import { createNoticeLog } from "../src/notice-log.js";
 
 const SENTENCE_WORDS = "The lantern held its flame while the storm counted windows, and nobody in the inn below said the traveler's name aloud."
   .split(" ");
@@ -143,15 +144,21 @@ function stateFor(payload: StoryPayload): StoryScreenState {
   return {
     payload, focusIndex: payload.path.length - 1, mode: "NAV", showInstructions: true,
     expandedPromptIds: new Set(),
-    composer: createComposer(), toast: null, stream: null, abort: null, backendTask: null,
-    retakePrompt: null,
+    composer: createComposer(), editor: null, retakePrompt: null, request: null, probs: null,
+    toast: null, notices: createNoticeLog(), stream: null, abort: null, backendTask: null,
     freshLandedAt: new Map(), now: 1_667_000_000_000,
     model: "bench", systemPrompt: "Continue the story.", assistantPrefill: true,
-    map: null, contextMeterExpanded: false, prune: null, tag: null, typewriter: false,
+    contextWindow: 32768, maxTokens: 1024,
+    map: null, search: null, contextMeterExpanded: false, prune: null, tag: null, typewriter: false,
     expandedChapterSummaryIds: new Set(), chapterDeleteArmedId: null,
-    demo: true, storyFolder: "", library: null, facts: null, commands: null, chapters: null, settings: null,
-    summary: null, actions: null, hitRows: [], contextWindow: 32768,
+    demo: true, storyFolder: "", readingPositions: {},
+    library: null, facts: null, commands: null, card: null, archive: null,
+    chapters: null, settings: null, summary: null,
+    actions: null, textActions: null, hitRows: [],
     viewScroll: null, viewScrollDelta: 0, lastViewportStart: 0,
+    composerScrollTop: 0, editorScrollTop: 0, keysScrollTop: 0,
+    composerSelectionProjection: null, storySelectionProjection: null,
+    promptTokenCount: null, generationRoute: "bench",
     config: {
       theme: "lantern", factsRail: "auto", composeFocus: "off", composeMaxHeight: null,
       quota: { date: "", words: 0 },

--- a/tui/src/app.ts
+++ b/tui/src/app.ts
@@ -67,6 +67,8 @@ import {
   clearNativeSelectionIfMatches,
   consumesEmptyCopyShortcut,
   handleMainCopyShortcut,
+  isCopyShortcut,
+  isInterruptShortcut,
   mouseComposerSelectionMessage,
   syncMouseComposerSelection
 } from "./copy-actions.js";
@@ -352,15 +354,20 @@ export async function runInteractive(source: AppSource): Promise<void> {
   };
 
   renderer.keyInput.on("keypress", (key) => {
-    const controlCopy = key.ctrl && key.name === "c";
-    if (controlCopy && frames.failed) return requestQuit();
+    const copyShortcut = isCopyShortcut(key);
+    const interruptShortcut = isInterruptShortcut(key);
+    if (copyShortcut && frames.failed) {
+      if (interruptShortcut) requestQuit();
+      return;
+    }
     const queuedSelection = captureQueuedSelection();
     const copySurface = consumesEmptyCopyShortcut(state)
       || (presentedInteraction !== null
         && consumesEmptyCopyShortcut(presentedInteraction.state));
-    if (controlCopy && !hasCopyablePresentedSelection(queuedSelection) && !copySurface
+    if (copyShortcut && !hasCopyablePresentedSelection(queuedSelection) && !copySurface
       && inputs.shouldQuitImmediately(state.mode, false)) {
-      return requestQuit();
+      if (interruptShortcut) requestQuit();
+      return;
     }
     const queuedKey = { ...key } as KeyEvent;
     // Keyboard admission clears pending mouse click gestures at one site.
@@ -373,12 +380,12 @@ export async function runInteractive(source: AppSource): Promise<void> {
       const native = selection.kind === "captured"
         ? selection.native ?? EMPTY_NATIVE_SELECTION
         : EMPTY_NATIVE_SELECTION;
-      if (controlCopy) {
+      if (copyShortcut) {
         const copied = handleMainCopyShortcut(
           native,
           state,
           repaint,
-          requestQuit,
+          interruptShortcut ? requestQuit : () => undefined,
           selection.kind === "captured" ? selection : undefined
         );
         if (copied) {
@@ -436,7 +443,7 @@ export async function runInteractive(source: AppSource): Promise<void> {
       ), (work) => backend.observe(work));
     }, () => {
       retirePresentedSelection(renderer, queuedSelection);
-      if (controlCopy) requestQuit();
+      if (interruptShortcut) requestQuit();
     });
   });
   renderer.keyInput.on("paste", (event) => {
@@ -579,14 +586,15 @@ export async function handleKey(
   previewTheme: ActionContext["previewTheme"] = () => undefined,
   backend: ActionRunner = new ActionRuntime(state, repaint)
 ): Promise<void> {
-  if (key.ctrl && key.name === "c"
+  if (isCopyShortcut(key)
     && state.mode !== "EDITOR"
     && consumesEmptyCopyShortcut(state)) {
     return;
   }
-  if (key.ctrl && key.name === "c"
+  if (isCopyShortcut(key)
     && state.mode !== "EDITOR") {
-    return requestQuit();
+    if (isInterruptShortcut(key)) requestQuit();
+    return;
   }
   const resolved = resolveKey(key, state.mode, {
     confirmingPrune: state.prune !== null,

--- a/tui/src/app.ts
+++ b/tui/src/app.ts
@@ -61,7 +61,10 @@ import { startRecoveryOrchestration } from "./recovery-orchestration.js";
 import { inlineEditorAction } from "./editor-action.js";
 import { requestRewriteStop } from "./rewrite-action.js";
 import { emptyStreamText } from "./stream-text.js";
-import { selectionAwarePartMenuAction } from "./selection-menu.js";
+import {
+  selectionAwarePartMenuAction,
+  selectionAwareTextMenuAction
+} from "./selection-menu.js";
 import {
   EMPTY_NATIVE_SELECTION,
   clearNativeSelectionIfMatches,
@@ -81,6 +84,11 @@ import {
 } from "./presented-selection.js";
 import type { BackgroundUpdateStarter } from "./update-runtime.js";
 import { startPromptTokenCountLane, type PromptTokenCountLane } from "./prompt-token-count.js";
+import {
+  openTextActions,
+  textActionsMenuAction
+} from "./text-actions.js";
+import { composerRangeFromProjection } from "./selection-projection.js";
 
 export { recoveryNotice } from "./recovery-orchestration.js";
 
@@ -520,12 +528,21 @@ export async function runInteractive(source: AppSource): Promise<void> {
       frameFailed: frames.failed,
       requestInputRecovery: () => frames.requestInputRecovery(),
       stillPresented: (captured) => captured === presentedInteraction,
-      decorate: (resolved, gesture, presented) => selectionAwarePartMenuAction(
-        gesture as never,
-        resolved,
-        renderer,
-        (presented as InteractivePresentedInteraction).storySelectionProjection
-      ),
+      decorate: (resolved, gesture, presented) => {
+        const interaction = presented as InteractivePresentedInteraction;
+        const partAction = selectionAwarePartMenuAction(
+          gesture as never,
+          resolved,
+          renderer,
+          interaction.storySelectionProjection
+        );
+        return selectionAwareTextMenuAction(
+          gesture as never,
+          partAction,
+          renderer,
+          interaction.composerSelectionProjection
+        );
+      },
       run: (action, queuedEvent, captured) => {
         const reconciled = reconcilePresentedMouseAction({
           action, event: queuedEvent, captured,
@@ -604,6 +621,7 @@ export async function handleKey(
     settingsSampling: state.settings !== null && state.settings.sampling !== null,
     commandsTags: state.commands?.view === "tags",
     settingsPicker: state.settings?.modelPicker != null,
+    textActionsOpen: state.textActions !== null,
     factEditor: state.editor?.kind === "fact",
     authorsNoteEditor: state.editor?.kind === "document" && state.editor.target.kind === "authors-note",
     mapView: state.map?.view
@@ -633,7 +651,7 @@ export async function dispatch(
   state.quitArmed = false;
   // The part menu carries its own per-action guard (Copy stays legal during a
   // stream), so the blanket one would wrongly refuse it here.
-  if (generationBusy(state) && state.actions === null
+  if (generationBusy(state) && state.actions === null && state.textActions === null
     && actionConflictsWithGeneration(resolved.action, state)) {
     state.toast = "stream running · esc stops it first";
     return repaint();
@@ -645,6 +663,67 @@ export async function dispatch(
   // and confirmations. Those surfaces stay open while retry runs; otherwise
   // their reducers would swallow the banner's advertised keyboard/click action.
   if (resolved.action === "retry") await handleOverlayAction(resolved, state, source, context);
+  else if (resolved.action === "open-text-actions") {
+    if (resolved.nativeSelection === undefined && resolved.composerEditable === false) return;
+    let sync: ReturnType<typeof syncMouseComposerSelection> = "none";
+    const projectedSelection = resolved.nativeSelection?.range === null
+      || resolved.nativeSelection?.range === undefined
+      || resolved.composerSelectionProjection === undefined
+      ? null
+      : composerRangeFromProjection(
+          resolved.composerSelectionProjection,
+          resolved.nativeSelection.range.start,
+          resolved.nativeSelection.range.end
+        );
+    const selectionMatchesClickedSource = resolved.composerSourceId === undefined
+      || projectedSelection !== null && projectedSelection.kind !== "mixed"
+        && projectedSelection.sourceId === resolved.composerSourceId;
+    if (resolved.nativeSelection !== undefined && selectionMatchesClickedSource) {
+      sync = syncMouseComposerSelection(
+        resolved.nativeSelection,
+        state,
+        resolved.composerSelectionProjection ?? null
+      );
+      if (sync === "mixed") {
+        state.toast = mouseComposerSelectionMessage(state, sync);
+        return repaint();
+      }
+      if (sync === "uneditable") {
+        state.toast = mouseComposerSelectionMessage(state, sync);
+      }
+    }
+    openTextActions(
+      state,
+      sync === "none" ? undefined : resolved.nativeSelection,
+      sync === "none" ? null : resolved.composerSelectionProjection ?? null,
+      sync === "none" ? resolved.composerSourceId : undefined,
+      sync === "uneditable"
+    );
+  }
+  else if (state.textActions !== null) {
+    const overlay = state.textActions;
+    const action = textActionsMenuAction(resolved, state);
+    if (action !== null) {
+      const copied = action.action === "copy-selection"
+        && handleMainCopyShortcut(
+          overlay.nativeSelection ?? EMPTY_NATIVE_SELECTION,
+          state,
+          repaint,
+          () => undefined,
+          {
+            composer: overlay.composerSelectionProjection,
+            story: null
+          }
+        );
+      if (!copied && state.mode === "COMPOSE") {
+        await composeAction(action, state, source, context);
+      } else if (!copied && state.mode === "EDITOR") {
+        await inlineEditorAction(action, state, source, context);
+      } else if (!copied && state.mode === "SETTINGS") {
+        await handleOverlayAction(action, state, source, context);
+      }
+    }
+  }
   else if (state.prune !== null) await pruneAction(resolved, state, source, context);
   else if (state.actions !== null) await actionsMenuAction(resolved, state, source, context);
   else if (await handleOverlayAction(resolved, state, source, context)) { /* handled */ }
@@ -712,6 +791,7 @@ export function initialState(source: AppSource, renderMode: boolean): RuntimeSta
     chapterDeleteArmedId: null,
     typewriter: false,
     actions: null,
+    textActions: null,
     hitRows: [],
     viewScroll: null,
     viewScrollDelta: 0,

--- a/tui/src/compose-clipboard.ts
+++ b/tui/src/compose-clipboard.ts
@@ -1,0 +1,44 @@
+import { readFromClipboard } from "./clipboard.js";
+import { insertComposerText, type ComposerState } from "./composer-model.js";
+import { sanitizePastedText } from "./keys.js";
+
+interface ComposeClipboardHost {
+  interactionVersion: number;
+  mode: string;
+  composer: ComposerState;
+  toast: string | null;
+}
+
+/** Read the platform clipboard without applying a result to a changed draft. */
+export async function pasteClipboardIntoComposer(
+  host: ComposeClipboardHost
+): Promise<void> {
+  const claim = {
+    interactionVersion: host.interactionVersion,
+    composer: host.composer,
+    text: host.composer.text,
+    cursor: host.composer.cursor,
+    anchor: host.composer.anchor,
+    fullscreen: host.composer.fullscreen
+  };
+  const text = await readFromClipboard();
+  if (host.mode !== "COMPOSE"
+    || host.interactionVersion !== claim.interactionVersion
+    || host.composer !== claim.composer
+    || host.composer.text !== claim.text
+    || host.composer.cursor !== claim.cursor
+    || host.composer.anchor !== claim.anchor
+    || host.composer.fullscreen !== claim.fullscreen) {
+    return;
+  }
+  if (text === null) {
+    host.toast = "clipboard unreadable · paste with ⌘V or ctrl+shift+v";
+    return;
+  }
+  const clean = sanitizePastedText(text);
+  if (clean.length === 0) {
+    host.toast = "clipboard has no insertable text";
+    return;
+  }
+  insertComposerText(host.composer, clean);
+}

--- a/tui/src/copy-actions.ts
+++ b/tui/src/copy-actions.ts
@@ -1,4 +1,4 @@
-import type { CliRenderer } from "@opentui/core";
+import type { CliRenderer, KeyEvent } from "@opentui/core";
 import { countWords } from "../../shared/story-text.js";
 import { copyToClipboard, type CopyOutcome } from "./clipboard.js";
 import {
@@ -57,6 +57,16 @@ export const EMPTY_NATIVE_SELECTION: NativeSelectionSnapshot = {
   range: null,
   backward: false
 };
+
+/** Terminals can report the platform copy key as Control or Command. */
+export function isCopyShortcut(key: KeyEvent): boolean {
+  return Boolean(key.ctrl || key.super) && key.name.toLowerCase() === "c";
+}
+
+/** Only Control+C has process-interrupt semantics when there is no selection. */
+export function isInterruptShortcut(key: KeyEvent): boolean {
+  return Boolean(key.ctrl) && key.name.toLowerCase() === "c";
+}
 
 /** Native selection objects are renderer-owned and keep changing while an
  * input waits. Copy the fields reducers need at event arrival. */

--- a/tui/src/copy-actions.ts
+++ b/tui/src/copy-actions.ts
@@ -147,7 +147,8 @@ export function consumesEmptyCopyShortcut(
 ): boolean {
   return state.mode === "COMPOSE"
     || state.mode === "EDITOR"
-    || state.mode === "SETTINGS" && state.settings?.edit != null;
+    || state.mode === "SETTINGS"
+      && (state.settings?.edit != null || state.settings?.sampling?.edit != null);
 }
 
 /** Convert OpenTUI's painted-cell range into the same raw document selection
@@ -273,7 +274,11 @@ function activeComposer(
     : state.mode === "COMPOSE"
       ? sourceId === undefined ? state.composer : null
       : state.mode === "SETTINGS"
-        ? sourceId === undefined ? state.settings?.edit?.composer ?? null : null
+        ? sourceId === undefined
+          ? state.settings?.sampling?.edit?.composer
+            ?? state.settings?.edit?.composer
+            ?? null
+          : null
         : null;
 }
 

--- a/tui/src/editor-action.ts
+++ b/tui/src/editor-action.ts
@@ -95,6 +95,7 @@ function closeInlineEditor(
   toast?: string
 ): void {
   if (state.editor !== editor) return;
+  state.textActions = null;
   state.editor = null;
   state.editorScrollTop = 0;
   if (editor.returnMode === "FACTS" && state.facts !== null) {

--- a/tui/src/editor-open.ts
+++ b/tui/src/editor-open.ts
@@ -169,6 +169,7 @@ function openInlineEditor(
   state: RuntimeState,
   editor: Omit<InlineEditorSession, "kind">
 ): void {
+  state.textActions = null;
   state.editor = { kind: "document", ...editor };
   state.editorScrollTop = 0;
   state.mode = "EDITOR";
@@ -178,6 +179,7 @@ function openFactSession(
   state: RuntimeState,
   editor: Omit<FactEditorSession, "kind">
 ): void {
+  state.textActions = null;
   state.editor = { kind: "fact", ...editor };
   state.editorScrollTop = 0;
   state.mode = "EDITOR";

--- a/tui/src/fact-editor-policy.ts
+++ b/tui/src/fact-editor-policy.ts
@@ -265,6 +265,14 @@ export function factEditorComposerForSource(
   return spec.kind === "choice" ? null : spec.composer(editor);
 }
 
+/** Return only a composer that the focused Fact row can edit. */
+export function factEditorActiveTextComposer(
+  editor: FactEditorSession
+): ComposerState | null {
+  const spec = factEditorRowSpec(editor.focus);
+  return spec.kind === "text" ? spec.composer(editor) : null;
+}
+
 function factEditorRowSpec(row: FactEditorRow): FactEditorRowSpec {
   return FACT_EDITOR_ROW_TABLE[row];
 }

--- a/tui/src/hit.ts
+++ b/tui/src/hit.ts
@@ -30,7 +30,12 @@ export type HitTarget =
   | { kind: "inline-action"; action: KeyAction }
   /** A rendered part prompt; left-click toggles its inline expansion. */
   | { kind: "prompt"; index: number; rowId: string }
-  | { kind: "composer" }
+  | {
+      kind: "composer";
+      /** Exact field identity for multi-buffer editors. */
+      composerSourceId?: string;
+      composerEditable?: boolean;
+    }
   /** Page behind an open panel: a click there dismisses the panel. */
   | { kind: "scrim" }
   /** Panel chrome — titles, headers, rules: visible but not actionable. */

--- a/tui/src/interactive-frame-runtime.ts
+++ b/tui/src/interactive-frame-runtime.ts
@@ -219,7 +219,8 @@ export function createInteractiveFrameRuntime(
       options.palette(),
       layout,
       frame.selectable,
-      state.mode === "SETTINGS" && state.settings?.edit !== null
+      state.mode === "SETTINGS"
+        && (state.settings?.edit != null || state.settings?.sampling?.edit != null)
         ? { singleSelectionBuffer: true }
         : undefined
     );

--- a/tui/src/keys-text-surface.ts
+++ b/tui/src/keys-text-surface.ts
@@ -52,8 +52,9 @@ export function textSurfaceKey(key: KeyEvent): ResolvedKey | null {
   if (key.ctrl && name === "k") return { action: "delete-line-end" };
   if (key.ctrl && name === "u") return { action: "delete-line-start" };
 
-  // Emacs line motion, which the full-screen editor has always answered.
-  if (key.ctrl && name === "a") return { action: "cursor-line-start", ...extend };
+  // Ctrl+A and Command+A use the platform-wide Select All convention.
+  if ((key.ctrl || key.super) && name === "a") return { action: "select-all" };
+  // Alt+A keeps a terminal-safe line-start chord for Emacs-style motion.
   if (key.ctrl && name === "e") return { action: "cursor-line-end", ...extend };
   if (alt && name === "a") return { action: "cursor-line-start", ...extend };
   if (alt && name === "e") return { action: "cursor-line-end", ...extend };

--- a/tui/src/keys.ts
+++ b/tui/src/keys.ts
@@ -14,7 +14,10 @@ import { textSurfaceKey } from "./keys-text-surface.js";
 import { openDirectComposer } from "./composer-ownership.js";
 import type { MapView } from "./map-state.js";
 import { resolveReferenceBinding } from "./reference-bindings.js";
-import type { StorySelectionSpan } from "./selection-projection.js";
+import type {
+  ComposerSelectionProjection,
+  StorySelectionSpan
+} from "./selection-projection.js";
 import type {
   DocumentEditorSession,
   PendingGenerationDraft,
@@ -57,7 +60,7 @@ export type KeyAction =
   | "open-chapters" | "create-chapter" | "summarize-chapter" | "chapter-previous" | "chapter-next"
   | "toggle-context-meter" | "open-search" | "toggle-search-case" | "open-request"
   | "complete" | "open-log" | "clear-log" | "row-action"
-  | "open-probs" | "next-part";
+  | "open-probs" | "next-part" | "open-text-actions";
 
 export type AppMode = "NAV" | "COMPOSE" | "EDITOR" | "MAP" | "KEYS" | "TAG"
   | "LIBRARY" | "FACTS" | "COMMANDS" | "SUMMARY" | "SETTINGS" | "ACTIONS" | "CHAPTERS"
@@ -70,6 +73,18 @@ export interface ResolvedKey {
   selectionText?: string;
   /** Story-source selection retained without tinting the menu overlay. */
   selectionSpans?: readonly StorySelectionSpan[];
+  /** Native editor selection captured before a context-menu repaint. */
+  nativeSelection?: {
+    identity: object | null;
+    text: string;
+    range: { start: number; end: number } | null;
+    backward: boolean;
+  };
+  /** Projection paired with nativeSelection at event arrival. */
+  composerSelectionProjection?: ComposerSelectionProjection;
+  /** Exact field under a context-menu click in a multi-buffer editor. */
+  composerSourceId?: string;
+  composerEditable?: boolean;
   /** Extend an editor/composer selection instead of only moving its caret. */
   extendSelection?: boolean;
   /** Absolute cursor placement (mouse clicks). */
@@ -327,6 +342,8 @@ export interface ResolveOptions {
   /** The open document editor targets the Author's Note, so its depth chord
    *  applies. No other editor target binds `⌥-`/`⌥=`. */
   authorsNoteEditor?: boolean;
+  /** The editor context menu owns all keys until it closes. */
+  textActionsOpen?: boolean;
   mapView?: MapView;
 }
 
@@ -365,10 +382,17 @@ export function resolveKey(key: KeyEvent, mode: AppMode, options: ResolveOptions
   const { confirmingPrune = false, tagChoosingStatus = false, connectionDown = false,
     overlayTyping = false, settingsSampling = false, commandsTags = false,
     factEditor = false, authorsNoteEditor = false, settingsPicker = false,
+    textActionsOpen = false,
     mapView = "path" } = options;
   const globalReference = resolveReferenceBinding("global", key, mode, mapView);
   if (globalReference !== null || key.name === "escape") {
     return { action: "cancel" };
+  }
+  if (textActionsOpen) {
+    if (key.name === "down") return { action: "focus-next" };
+    if (key.name === "up") return { action: "focus-previous" };
+    if (key.name === "return") return { action: "apply" };
+    return { action: "none" };
   }
   const ownsText = textOwnsKeyboard(mode, {
     overlayTyping, commandsTags, tagChoosingStatus

--- a/tui/src/keys.ts
+++ b/tui/src/keys.ts
@@ -394,9 +394,11 @@ export function resolveKey(key: KeyEvent, mode: AppMode, options: ResolveOptions
   const navChord = resolveReferenceBinding("nav-chord", key, mode, mapView);
   if (navChord !== null) return { action: navChord.action };
   if (mode === "COMPOSE") {
+    const name = key.name.toLowerCase();
     const composeChord = resolveReferenceBinding("compose-chord", key, mode, mapView);
     if (composeChord !== null) return { action: composeChord.action };
-    if (key.ctrl && key.name.toLowerCase() === "f") return { action: "toggle-compose-fullscreen" };
+    if ((key.ctrl || key.super) && name === "v") return { action: "paste-clipboard" };
+    if (key.ctrl && name === "f") return { action: "toggle-compose-fullscreen" };
     // The rewrite composer's second fixed destination (issue #319, and
     // docs/generation-boundaries.md): plain `enter` always replaces in
     // place, `⌃s` always sends the result as a new take instead — the exact
@@ -404,7 +406,7 @@ export function resolveKey(key: KeyEvent, mode: AppMode, options: ResolveOptions
     // EDITOR, above), just with the opposite default here. Outside a
     // rewrite composer it resolves but does nothing (story-actions.ts's
     // composeAction), same as an unbound chord elsewhere.
-    if (key.ctrl && key.name.toLowerCase() === "s") return { action: "send-as-take" };
+    if (key.ctrl && name === "s") return { action: "send-as-take" };
     if (key.name === "return") return { action: key.shift ? "newline" : "send" };
     // LF / Ctrl+J inserts a line; it never sends the draft.
     if (isLinefeedKey(key)) return { action: "newline" };
@@ -436,9 +438,9 @@ export function resolveKey(key: KeyEvent, mode: AppMode, options: ResolveOptions
     if (key.ctrl && name === "o") return { action: "save-edit-inplace" };
     if (key.ctrl && key.shift && name === "s") return { action: "save-edit-inplace" };
     if (key.ctrl && name === "s") return { action: "save-edit" };
-    if (key.ctrl && name === "c") return { action: "copy-selection" };
-    if (key.ctrl && name === "x") return { action: "cut-selection" };
-    if (key.ctrl && name === "v") return { action: "paste-clipboard" };
+    if ((key.ctrl || key.super) && name === "c") return { action: "copy-selection" };
+    if ((key.ctrl || key.super) && name === "x") return { action: "cut-selection" };
+    if ((key.ctrl || key.super) && name === "v") return { action: "paste-clipboard" };
     if ((key.ctrl && name === "z" && !key.shift) || key.ctrl && name === "-"
       || key.super && name === "z" && !key.shift) return { action: "undo-edit" };
     if ((key.ctrl && name === "z" && key.shift) || key.ctrl && (name === "y" || name === ".")

--- a/tui/src/mouse-actions.ts
+++ b/tui/src/mouse-actions.ts
@@ -268,8 +268,9 @@ export function mouseToAction(
   state: MouseActionState,
   resolveReleaseTarget = false
 ): ResolvedKey | null {
-  // Right-click leaves the composer rather than acting on what is under it.
-  if (state.mode === "COMPOSE" && event.type === "down" && event.button === 2) return { action: "cancel" };
+  // Keep terminal clipboard gestures inside the composer. A right-click can
+  // open a terminal menu, and Shift+right-click commonly bypasses mouse mode.
+  if (state.mode === "COMPOSE" && event.type === "down" && event.button === 2) return null;
   // Shift-drag belongs to the terminal's own selection; never steal it.
   if (event.modifiers.shift) return null;
   if (event.type === "scroll") {

--- a/tui/src/mouse-actions.ts
+++ b/tui/src/mouse-actions.ts
@@ -4,6 +4,7 @@ import { hitAt } from "./hit.js";
 import type { ResolvedKey } from "./keys.js";
 import { generationBusy } from "./story-actions.js";
 import type { RuntimeState } from "./state.js";
+import { activeTextComposer } from "./text-actions.js";
 
 export type MouseGesture = Pick<
   MouseEvent,
@@ -16,8 +17,8 @@ export type MouseGesture = Pick<
  *  has to compare the row, not its index. */
 export type MouseActionState = Pick<RuntimeState,
   | "mode" | "focusIndex" | "hitRows" | "map" | "payload" | "stream" | "demo"
-  | "connection"
-  | "actions" | "library" | "facts" | "commands" | "chapters" | "settings"
+  | "connection" | "composer" | "editor"
+  | "actions" | "textActions" | "library" | "facts" | "commands" | "chapters" | "settings"
   | "search"
   | "request"
 > & {
@@ -185,6 +186,8 @@ export function captureMouseActionState(state: RuntimeState): MouseActionState {
     payload: state.payload,
     stream: state.stream,
     demo: state.demo,
+    composer: state.composer,
+    editor: state.editor,
     // The palette's rows depend on both, so identifying one means seeing what
     // the frame that drew it saw.
     connection: state.connection,
@@ -195,6 +198,7 @@ export function captureMouseActionState(state: RuntimeState): MouseActionState {
       openedColdFolds: new Set(state.map.openedColdFolds)
     },
     actions: state.actions === null ? null : { ...state.actions },
+    textActions: state.textActions === null ? null : { ...state.textActions },
     library: state.library === null ? null : {
       ...state.library,
       prompt: state.library.prompt === null
@@ -256,7 +260,8 @@ function captureSamplingSettings(
 
 /** True while any panel or modal owns the screen. */
 export function overlayOpen(state: MouseActionState): boolean {
-  return state.mode !== "NAV" && state.mode !== "COMPOSE";
+  return state.textActions !== null
+    || state.mode !== "NAV" && state.mode !== "COMPOSE";
 }
 
 /** Translate a mouse gesture into the same action vocabulary the keyboard
@@ -268,9 +273,6 @@ export function mouseToAction(
   state: MouseActionState,
   resolveReleaseTarget = false
 ): ResolvedKey | null {
-  // Keep terminal clipboard gestures inside the composer. A right-click can
-  // open a terminal menu, and Shift+right-click commonly bypasses mouse mode.
-  if (state.mode === "COMPOSE" && event.type === "down" && event.button === 2) return null;
   // Shift-drag belongs to the terminal's own selection; never steal it.
   if (event.modifiers.shift) return null;
   if (event.type === "scroll") {
@@ -290,6 +292,27 @@ export function mouseToAction(
     target = hitAt(state.hitRows, event.x, event.y, false);
   }
   if (target === null) return null;
+
+  const selectedList = target.kind === "list"
+    && (target.selected ?? listCursor(state) === target.index);
+  if (state.textActions === null
+    && event.button === 2
+    && (target.kind === "composer"
+      && (target.composerSourceId !== undefined || activeTextComposer(state) !== null)
+      || state.mode === "SETTINGS" && selectedList && activeTextComposer(state) !== null)) {
+    return {
+      action: "open-text-actions",
+      ...(target.kind === "composer" && target.composerSourceId !== undefined
+        ? { composerSourceId: target.composerSourceId }
+        : {}),
+      ...(target.kind === "composer" && target.composerEditable !== undefined
+        ? { composerEditable: target.composerEditable }
+        : {})
+    };
+  }
+  // A terminal can own right-click clipboard behavior while Direct is open.
+  // Only the composer target above replaces that behavior with this app menu.
+  if (state.mode === "COMPOSE" && event.button === 2) return null;
 
   if (target.kind === "scrim") return { action: "cancel" };
   if (target.kind === "settings-row" && event.button === 0) {
@@ -348,6 +371,7 @@ export function mouseToAction(
 
 /** Where the open overlay's cursor sits, for click-again-to-run. */
 function listCursor(state: MouseActionState): number | null {
+  if (state.textActions !== null) return state.textActions.cursor;
   if (state.request !== null) return state.request.cursor;
   if (state.actions !== null) return state.actions.cursor;
   if (state.library !== null) return state.library.cursor;

--- a/tui/src/presented-mouse-action.ts
+++ b/tui/src/presented-mouse-action.ts
@@ -21,6 +21,7 @@ import {
   type MouseGesture
 } from "./mouse-actions.js";
 import type { RuntimeState } from "./state.js";
+import { availableTextActions } from "./text-actions.js";
 
 export interface PresentedInteraction {
   version: number;
@@ -104,7 +105,11 @@ export function reconcilePresentedMouseAction({
   return {
     ...latest,
     ...(action.selectionText === undefined ? {} : { selectionText: action.selectionText }),
-    ...(action.selectionSpans === undefined ? {} : { selectionSpans: action.selectionSpans })
+    ...(action.selectionSpans === undefined ? {} : { selectionSpans: action.selectionSpans }),
+    ...(action.nativeSelection === undefined ? {} : { nativeSelection: action.nativeSelection }),
+    ...(action.composerSelectionProjection === undefined
+      ? {}
+      : { composerSelectionProjection: action.composerSelectionProjection })
   };
 }
 
@@ -188,7 +193,9 @@ function sameMouseTarget(
     && before.take === after.take
     && before.view === after.view
     && before.settingsRow === after.settingsRow
-    && before.text === after.text;
+    && before.text === after.text
+    && before.composerSourceId === after.composerSourceId
+    && before.composerEditable === after.composerEditable;
 }
 
 function mapRowAt(
@@ -223,6 +230,7 @@ function mapRowId(state: MouseActionState, index: number | undefined): string | 
  *  Null means the row cannot be named, which reconciliation refuses. */
 function listRowIdentity(state: MouseActionState, index: number | undefined): string | null {
   if (index === undefined) return null;
+  if (state.textActions !== null) return availableTextActions(state.textActions)[index]?.id ?? null;
   if (state.request !== null) return requestRowIdentity(state, index);
   if (state.mode === "MAP" && state.map !== null) return mapRowId(state, index);
   if (state.search !== null) {
@@ -295,12 +303,16 @@ const NO_SELECTION = "none";
 
 /** Whether the open surface has rows a click could land on the wrong one of. */
 function selectableRowsOpen(state: MouseActionState): boolean {
-  return state.map !== null || state.actions !== null || state.library !== null
+  return state.map !== null || state.actions !== null || state.textActions !== null || state.library !== null
     || state.facts !== null || state.commands !== null || state.chapters !== null
     || state.settings !== null || state.search !== null || state.request !== null;
 }
 
 function selectedListIdentity(state: MouseActionState): string | null {
+  if (state.textActions !== null) {
+    const entry = availableTextActions(state.textActions)[state.textActions.cursor];
+    return entry === undefined ? null : `text-actions:${entry.id}`;
+  }
   if (state.request !== null) return requestRowIdentity(state, state.request.cursor);
   if (state.search !== null) {
     return searchRowIdentity(state, state.search.cursor);

--- a/tui/src/screens/panels.ts
+++ b/tui/src/screens/panels.ts
@@ -18,6 +18,7 @@ import { canRewriteSelection } from "../selection-projection.js";
 import type { OverlayState, StoryScreenState, StreamView } from "../state.js";
 import { currentPartActions } from "../story-actions.js";
 import { generationBusy } from "../generation-action.js";
+import { availableTextActions, TEXT_ACTIONS } from "../text-actions.js";
 import { deriveSummaryProgress } from "../summary-model.js";
 import { chapterDisplayTitle,
   chapterListModel, chapterWindow } from "../chapter-model.js";
@@ -78,6 +79,10 @@ export const ACTIONS_FOOTER_ACTIONS = [
   { token: "↵ run", action: "apply" },
   { token: "esc close", action: "cancel" }
 ] as const satisfies ReadonlyArray<{ token: string; action: KeyAction }>;
+const TEXT_ACTIONS_FOOTER_ACTIONS = [
+  { token: "↑", action: "focus-previous" }, { token: "↓", action: "focus-next" },
+  { token: "↵", action: "apply" }, { token: "esc", action: "cancel" }
+] as const satisfies ReadonlyArray<{ token: string; action: KeyAction }>;
 export const TAGS_FOOTER_ACTIONS = [
   { token: "↑", action: "focus-previous" }, { token: "↓", action: "focus-next" },
   { token: "d delete", action: "delete-item" }, { token: "esc commands", action: "cancel" }
@@ -137,10 +142,42 @@ export function renderPanels(
   }
   else if (state.settings !== null) composition = renderSettingsPanel(base, local, width, height);
   else if (state.summary !== null) composition = renderSummary(dimPage(base), local, width, height);
+  if (state.textActions !== null) {
+    composition = renderTextActionsPanel(dimPage(composition.lines), local, width, height);
+  }
   if (state.connection.down) {
     composition = { ...composition, lines: renderConnectionBanner(composition.lines, local, width, deadlines) };
   }
   return composition;
+}
+
+export function renderTextActionsPanel(
+  base: FrameLine[],
+  state: Pick<OverlayState, "textActions" | "hitRows">,
+  width: number,
+  height: number
+): FrameComposition {
+  const overlay = state.textActions!;
+  const actions = availableTextActions(overlay);
+  const contentWidth = panelHorizontalGeometry(width, 48).contentWidth;
+  const leadWidth = Math.min(4, contentWidth);
+  const widestName = Math.max(...TEXT_ACTIONS.map((action) => visibleWidth(action.name)));
+  const nameWidth = Math.min(widestName + 2, Math.max(0, contentWidth - leadWidth));
+  const descriptionWidth = Math.max(0, contentWidth - leadWidth - nameWidth);
+  const content: FrameLine[] = actions.map((action, index): FrameLine => [
+    raisedSegment(cellPad(index === overlay.cursor ? "  ▸ " : "", leadWidth),
+      index === overlay.cursor ? "focus / accent" : "chrome"),
+    raisedSegment(cellPad(truncate(action.name, nameWidth), nameWidth),
+      index === overlay.cursor ? "prose" : "prose · dim"),
+    raisedSegment(truncate(action.description, descriptionWidth), "chrome")
+  ]);
+  return placePanel(base, "edit actions", content,
+    "↑ ↓ ↵ esc", width, height, 48,
+    {
+      rows: state.hitRows,
+      targets: actions.map((_, index): HitTarget => ({ kind: "list", index })),
+      footerActions: TEXT_ACTIONS_FOOTER_ACTIONS
+    });
 }
 
 /** OpenCode-style part menu: right-click a part, or press x. */

--- a/tui/src/screens/story.ts
+++ b/tui/src/screens/story.ts
@@ -43,7 +43,7 @@ import { renderRequestViewerScreen } from "./request-viewer.js";
 import { renderTokenProbabilitiesScreen } from "./token-probabilities.js";
 import { renderLogScreen } from "./log.js";
 import { wrapFeedback } from "./feedback-wrap.js";
-import { renderPanels } from "./panels.js";
+import { renderPanels, renderTextActionsPanel } from "./panels.js";
 import { renderConnectionBanner } from "./connection-banner.js";
 import {
   fitLine,
@@ -761,6 +761,23 @@ function renderInlineEditor(
   return renderEditorLayoutFrame(state, view, width, height, estimate, layout, deadlines);
 }
 
+function composerHitTarget(line: FrameLine | undefined): HitTarget {
+  const sources = new Map<string, boolean>();
+  for (const part of line ?? []) {
+    if (part.composerHitSource !== undefined) {
+      sources.set(part.composerHitSource.id, part.composerHitSource.editable);
+    }
+  }
+  if (sources.size !== 1) return { kind: "composer" };
+  const source = sources.entries().next().value;
+  if (source === undefined) return { kind: "composer" };
+  return {
+    kind: "composer",
+    composerSourceId: source[0],
+    composerEditable: source[1]
+  };
+}
+
 function authorNoteStatus(
   host: DocumentEditorSession,
   width: number
@@ -797,14 +814,17 @@ function renderEditorLayoutFrame(
     .slice(0, height)
     .map((line) => fitLine(line, width));
   const hitRows: HitRows = Array.from({ length: height }, (_, row): HitRow | null => row < height - 1
-    ? { target: { kind: "composer" }, left: 0, right: width }
+    ? { target: composerHitTarget(base[row]), left: 0, right: width }
     : null);
+  const composition = state.textActions === null
+    ? { lines: base, selectable: null }
+    : renderTextActionsPanel(dimPage(base), { ...state, hitRows }, width, height);
   const lines = state.connection.down
-    ? renderConnectionBanner(base, { ...state, hitRows }, width, deadlines)
-    : base;
+    ? renderConnectionBanner(composition.lines, { ...state, hitRows }, width, deadlines)
+    : composition.lines;
   return {
     lines,
-    selectable: null,
+    selectable: composition.selectable,
     derived: {
       hitRows,
       viewScroll: state.viewScroll,

--- a/tui/src/screens/story/fact-editor-layout.ts
+++ b/tui/src/screens/story/fact-editor-layout.ts
@@ -55,7 +55,7 @@ export function renderFactEditorLayout(
   const tag = editor.focus === "tag"
     ? renderTextInput(editor.tag, true, "tag", "none", body.fieldWidth,
         FACT_TAG_COMPOSER_SOURCE)
-    : renderComposerChoiceRow({
+    : composerHitSource(renderComposerChoiceRow({
         indent: "",
         fieldWidth: body.fieldWidth,
         label: "tag",
@@ -63,8 +63,8 @@ export function renderFactEditorLayout(
         sourceId: FACT_TAG_COMPOSER_SOURCE,
         sourceStart: tagLabel === editor.tag.text ? 0 : null,
         focused: false
-      });
-  const activation = renderComposerChoiceRow({
+      }), FACT_TAG_COMPOSER_SOURCE, true);
+  const activation = composerHitSource(renderComposerChoiceRow({
     indent: "",
     fieldWidth: body.fieldWidth,
     label: "activation",
@@ -72,7 +72,7 @@ export function renderFactEditorLayout(
     sourceId: FACT_ACTIVATION_COMPOSER_SOURCE,
     sourceStart: null,
     focused: editor.focus === "activation"
-  });
+  }), FACT_ACTIVATION_COMPOSER_SOURCE, false);
   const keys = renderTextInput(
     editor.keys,
     editor.focus === "keys",
@@ -81,7 +81,7 @@ export function renderFactEditorLayout(
     body.fieldWidth,
     FACT_KEYS_COMPOSER_SOURCE
   );
-  const priority = renderComposerChoiceRow({
+  const priority = composerHitSource(renderComposerChoiceRow({
     indent: "",
     fieldWidth: body.fieldWidth,
     label: "priority",
@@ -89,7 +89,7 @@ export function renderFactEditorLayout(
     sourceId: FACT_PRIORITY_COMPOSER_SOURCE,
     sourceStart: null,
     focused: editor.focus === "priority"
-  });
+  }), FACT_PRIORITY_COMPOSER_SOURCE, false);
   const budget = renderTextInput(
     editor.budget,
     editor.focus === "budget",
@@ -107,8 +107,12 @@ export function renderFactEditorLayout(
       keys,
       priority,
       budget,
-      ...body.lines.slice(1).map((line) =>
-        composerSource(line, FACT_BODY_COMPOSER_SOURCE))
+      ...body.lines.slice(1).map((line, index) => {
+        const sourced = composerSource(line, FACT_BODY_COMPOSER_SOURCE);
+        return index < body.bodyRows
+          ? composerHitSource(sourced, FACT_BODY_COMPOSER_SOURCE, true)
+          : sourced;
+      })
     ],
     lineCount: body.lineCount + 5,
     bodyRows: body.bodyRows + 5,
@@ -143,7 +147,7 @@ function renderTextInput(
     fieldWidth - visibleWidth(prefix) - visibleWidth(label) - visibleWidth("[  ]")
   );
   const position = composerPosition(composer);
-  return composerSource(composerFieldLine("", fieldWidth, [
+  return composerHitSource(composerSource(composerFieldLine("", fieldWidth, [
     segment("┃ ", "compose accent"),
     segment(focused ? "▸ " : "  ", "focus / accent"),
     segment(label, focused ? "prose" : "chrome"),
@@ -158,7 +162,18 @@ function renderTextInput(
       placeholder
     ),
     segment(" ]", focused ? "focus / accent" : "chrome")
-  ]), sourceId);
+  ]), sourceId), sourceId, true);
+}
+
+function composerHitSource(
+  line: FrameLine,
+  sourceId: string,
+  editable: boolean
+): FrameLine {
+  return line.map((part) => ({
+    ...part,
+    composerHitSource: { id: sourceId, editable }
+  }));
 }
 
 function composerSource(

--- a/tui/src/screens/story/frame.ts
+++ b/tui/src/screens/story/frame.ts
@@ -32,6 +32,11 @@ export interface FrameSegment {
     id: string;
     editable: boolean;
   };
+  /** Field ownership for context clicks, including empty editor fields. */
+  composerHitSource?: {
+    id: string;
+    editable: boolean;
+  };
   /** Raw story field at the first grapheme of this rendered text. */
   storySource?: {
     key: string;

--- a/tui/src/selection-menu.ts
+++ b/tui/src/selection-menu.ts
@@ -1,7 +1,14 @@
 import type { CliRenderer, MouseEvent } from "@opentui/core";
-import { storySelectionFromRendererSelection } from "./copy-actions.js";
+import {
+  captureNativeSelection,
+  storySelectionFromRendererSelection
+} from "./copy-actions.js";
 import type { ResolvedKey } from "./keys.js";
-import type { StorySelectionProjection } from "./selection-projection.js";
+import type {
+  ComposerSelectionProjection,
+  StorySelectionProjection
+} from "./selection-projection.js";
+import { composerRangeFromProjection } from "./selection-projection.js";
 
 type SelectionReader = Pick<CliRenderer, "clearSelection" | "getSelection">;
 
@@ -28,5 +35,45 @@ export function selectionAwarePartMenuAction(
     ...resolved,
     selectionText,
     ...(selection === null ? {} : { selectionSpans: selection.spans })
+  };
+}
+
+/** Preserve a native editor selection before the context menu replaces it. */
+export function selectionAwareTextMenuAction(
+  event: MouseEvent,
+  resolved: ResolvedKey | null,
+  renderer: SelectionReader,
+  projection: ComposerSelectionProjection | null = null
+): ResolvedKey | null {
+  if (resolved?.action !== "open-text-actions"
+    || event.type !== "down"
+    || event.button !== 2) {
+    return resolved;
+  }
+  const selection = captureNativeSelection(renderer);
+  if (selection === null || selection.text.length === 0) return resolved;
+  if (projection === null || selection.range === null) {
+    event.preventDefault();
+    return resolved;
+  }
+  const projected = composerRangeFromProjection(
+    projection,
+    selection.range.start,
+    selection.range.end
+  );
+  if (projected === null) {
+    event.preventDefault();
+    return resolved;
+  }
+  if (projected.kind === "mixed") {
+    event.preventDefault();
+    return null;
+  }
+  event.preventDefault();
+  renderer.clearSelection();
+  return {
+    ...resolved,
+    nativeSelection: selection,
+    ...(projection === null ? {} : { composerSelectionProjection: projection })
   };
 }

--- a/tui/src/state.ts
+++ b/tui/src/state.ts
@@ -15,7 +15,7 @@ import type { NoticeLog } from "./notice-log.js";
 import type { HitRows } from "./hit.js";
 import type { UserConfig } from "./config.js";
 import type { ReadingPositions } from "./reading-position.js";
-import type { AppMode } from "./keys.js";
+import type { AppMode, ResolvedKey } from "./keys.js";
 import type { UndoEntry } from "./model.js";
 import type { PrunePlan } from "./prune-model.js";
 import type { ComposerState } from "./composer-model.js";
@@ -407,10 +407,21 @@ export interface PartActionsOverlay {
   selectionSpans?: readonly StorySelectionSpan[];
 }
 
+export interface TextActionsOverlay {
+  cursor: number;
+  owner: ComposerState | null;
+  ownerSnapshot: Pick<ComposerState, "text" | "cursor" | "anchor" | "fullscreen"> | null;
+  nativeSelection: ResolvedKey["nativeSelection"];
+  composerSelectionProjection: ComposerSelectionProjection | null;
+  copyOnly: boolean;
+}
+
 /** Everything the overlay panels render from. */
 export interface OverlayState {
   /** Part-actions menu (right-click a part, or press x). */
   actions: PartActionsOverlay | null;
+  /** Copy and paste menu for the active composer-backed field. */
+  textActions: TextActionsOverlay | null;
   /** Row→target map from the last render; mouse handling reads it. */
   hitRows: HitRows;
   config: UserConfig;

--- a/tui/src/story-actions.ts
+++ b/tui/src/story-actions.ts
@@ -4,6 +4,7 @@ import type { AppSource } from "./app.js";
 import { openFactFromSelection, openPartEditor } from "./editor-action.js";
 import { applyTextKey, type ResolvedKey } from "./keys.js";
 import { copyToClipboard } from "./clipboard.js";
+import { pasteClipboardIntoComposer } from "./compose-clipboard.js";
 import { applyComposerEdit } from "./composer-editing.js";
 import { copyStoryText } from "./copy-actions.js";
 import { recordHumanWords, saveConfig } from "./config.js";
@@ -405,6 +406,10 @@ export async function composeAction(
   }
   if (resolved.action === "toggle-compose-fullscreen") {
     state.composer.fullscreen = !state.composer.fullscreen;
+    return;
+  }
+  if (resolved.action === "paste-clipboard") {
+    await pasteClipboardIntoComposer(state);
     return;
   }
   if (resolved.action === "newline") { insertComposerText(state.composer, "\n"); return; }

--- a/tui/src/story-adoption.ts
+++ b/tui/src/story-adoption.ts
@@ -316,6 +316,7 @@ function reconcileStoryBoundIntent(
       || target.kind === "authors-note"
       || target.kind === "story-scalar";
     if (!targetExists) {
+      state.textActions = null;
       state.editor = null;
       state.editorScrollTop = 0;
       if (state.mode === "EDITOR") {
@@ -361,6 +362,7 @@ export function adoptStoryState(state: RuntimeState, payload: StoryPayload): voi
   state.expandedPromptIds = new Set();
   state.chapterDeleteArmedId = null;
   state.actions = null;
+  state.textActions = null;
   state.library = null;
   state.facts = null;
   state.commands = null;

--- a/tui/src/text-actions.ts
+++ b/tui/src/text-actions.ts
@@ -1,0 +1,116 @@
+import { composerSelection, type ComposerState } from "./composer-model.js";
+import {
+  factEditorActiveTextComposer,
+  factEditorComposerForSource
+} from "./fact-editor-policy.js";
+import type { KeyAction, ResolvedKey } from "./keys.js";
+import type { ComposerSelectionProjection } from "./selection-projection.js";
+import type { RuntimeState } from "./state.js";
+
+export interface TextAction {
+  id: "copy" | "paste" | "select-all";
+  name: string;
+  description: string;
+  action: Extract<KeyAction, "copy-selection" | "paste-clipboard" | "select-all">;
+}
+
+export const TEXT_ACTIONS: readonly TextAction[] = [
+  { id: "copy", name: "Copy", description: "copy the selected text", action: "copy-selection" },
+  { id: "paste", name: "Paste", description: "insert text from the clipboard", action: "paste-clipboard" },
+  { id: "select-all", name: "Select all", description: "select the complete text", action: "select-all" }
+];
+
+export function availableTextActions(
+  overlay: Pick<NonNullable<RuntimeState["textActions"]>, "copyOnly">
+): readonly TextAction[] {
+  return overlay.copyOnly ? TEXT_ACTIONS.slice(0, 1) : TEXT_ACTIONS;
+}
+
+type TextOwnerState = Pick<RuntimeState, "mode" | "composer" | "editor" | "settings">;
+
+/** Find the composer-backed field that currently owns text input. */
+export function activeTextComposer(state: TextOwnerState): ComposerState | null {
+  if (state.mode === "COMPOSE") return state.composer;
+  if (state.mode === "EDITOR" && state.editor !== null) {
+    return state.editor.kind === "fact"
+      ? factEditorActiveTextComposer(state.editor)
+      : state.editor.composer;
+  }
+  if (state.mode !== "SETTINGS" || state.settings === null) return null;
+  const sampling = state.settings.sampling?.edit;
+  if (sampling !== null && sampling !== undefined) return sampling.composer;
+  const edit = state.settings.edit;
+  return edit?.kind === "inline" ? edit.composer : null;
+}
+
+export function openTextActions(
+  state: RuntimeState,
+  nativeSelection: ResolvedKey["nativeSelection"] = undefined,
+  composerSelectionProjection: ComposerSelectionProjection | null = null,
+  composerSourceId?: string,
+  copyOnly = false
+): void {
+  const owner = state.mode === "EDITOR"
+    && state.editor?.kind === "fact"
+    && composerSourceId !== undefined
+    ? factEditorComposerForSource(state.editor, composerSourceId)
+    : activeTextComposer(state);
+  if (owner === null && !copyOnly) return;
+  state.textActions = {
+    owner,
+    ownerSnapshot: owner === null ? null : {
+      text: owner.text,
+      cursor: owner.cursor,
+      anchor: owner.anchor,
+      fullscreen: owner.fullscreen
+    },
+    cursor: copyOnly || owner !== null && composerSelection(owner) !== null
+      || (nativeSelection?.text.length ?? 0) > 0 ? 0 : 1,
+    nativeSelection,
+    composerSelectionProjection,
+    copyOnly
+  };
+}
+
+/** Reduce the menu and return the editor action that its chosen row names. */
+export function textActionsMenuAction(
+  resolved: ResolvedKey,
+  state: RuntimeState
+): ResolvedKey | null {
+  const overlay = state.textActions;
+  if (overlay === null) return null;
+  const actions = availableTextActions(overlay);
+  if (resolved.action === "cancel") {
+    state.textActions = null;
+    return null;
+  }
+  if (resolved.action === "focus-next") {
+    overlay.cursor = Math.min(actions.length - 1, overlay.cursor + 1);
+    return null;
+  }
+  if (resolved.action === "focus-previous") {
+    overlay.cursor = Math.max(0, overlay.cursor - 1);
+    return null;
+  }
+  if (resolved.action === "focus-index") {
+    overlay.cursor = Math.max(0, Math.min(
+      actions.length - 1,
+      resolved.index ?? overlay.cursor
+    ));
+    return null;
+  }
+  if (resolved.action !== "apply" && resolved.action !== "open-selected") return null;
+  const selected = actions[overlay.cursor];
+  state.textActions = null;
+  if (selected === undefined) return null;
+  if (overlay.owner !== null && (activeTextComposer(state) !== overlay.owner
+    || overlay.ownerSnapshot === null
+    || overlay.owner.text !== overlay.ownerSnapshot.text
+    || overlay.owner.cursor !== overlay.ownerSnapshot.cursor
+    || overlay.owner.anchor !== overlay.ownerSnapshot.anchor
+    || overlay.owner.fullscreen !== overlay.ownerSnapshot.fullscreen)) {
+    state.toast = "editor changed · open the menu again";
+    return null;
+  }
+  return { action: selected.action };
+}

--- a/tui/test/command-palette.test.ts
+++ b/tui/test/command-palette.test.ts
@@ -212,6 +212,7 @@ function renderCommands(
     stream: null,
     abort: null,
     actions: null,
+    textActions: null,
     config: source.config,
     readingPositions: source.readingPositions,
     demo: false,

--- a/tui/test/editor.test.ts
+++ b/tui/test/editor.test.ts
@@ -6,6 +6,7 @@ import { createStoryViewModel, rowIndexForNode } from "../src/model.js";
 import { renderStoryScreen } from "../src/screens/story.js";
 import { adoptSameStoryPayload } from "../src/story-adoption.js";
 import { frameText } from "../src/screens/story/frame.js";
+import { openTextActions } from "../src/text-actions.js";
 import type { CommandSelectionId } from "../src/command-model.js";
 import type { InlineEditorSession, RuntimeState } from "../src/state.js";
 import { editorHarness, key } from "./editor-harness.js";
@@ -170,6 +171,31 @@ describe("inline editor", () => {
     const forked = state.payload.nodes.filter(({ id, parentId: nodeParentId }) =>
       !beforeIds.has(id) && nodeParentId === parentId);
     expect(forked.length).toBe(2);
+  });
+
+  test("an asynchronous save closes its editor action menu with the editor", async () => {
+    const { source, state, press } = editorHarness();
+    state.focusIndex = rowIndexForNode(createStoryViewModel(state.payload), "p12");
+    await press(key("e"));
+    setComposerText(state.editor!.composer, "saved direction\n---\nsaved prose");
+    const originalCreate = source.api.createNode;
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => { release = resolve; });
+    source.api.createNode = async (...args) => {
+      await gate;
+      return originalCreate(...args);
+    };
+
+    const saving = press(key("s", { sequence: "\u0013", ctrl: true }));
+    await Promise.resolve();
+    openTextActions(state);
+    expect(state.textActions).not.toBe(null);
+    release();
+    await saving;
+
+    expect(state.mode).toBe("NAV");
+    expect(state.editor).toBe(null);
+    expect(state.textActions).toBe(null);
   });
 
   test("demo edited takes preserve earlier human spans and mark only the new edit", async () => {

--- a/tui/test/hit-map-chrome.test.ts
+++ b/tui/test/hit-map-chrome.test.ts
@@ -1,8 +1,15 @@
 import { describe, expect, test } from "bun:test";
 import type { KeyEvent } from "@opentui/core";
 import { dispatch, initialState } from "../src/app.js";
-import { createComposer } from "../src/composer-model.js";
+import { createComposer, setComposerText } from "../src/composer-model.js";
 import { demoAppSource } from "../src/demo.js";
+import { openFactEditor } from "../src/editor-action.js";
+import {
+  FACT_ACTIVATION_COMPOSER_SOURCE,
+  FACT_KEYS_COMPOSER_SOURCE,
+  FACT_TAG_COMPOSER_SOURCE,
+  setFactEditorFocus
+} from "../src/fact-editor-policy.js";
 import { hitAt, type HitTarget } from "../src/hit.js";
 import { GUTTER_VERBS } from "../src/screens/story/row-layout.js";
 import { resolveKey, type AppMode, type KeyAction, type ResolveOptions } from "../src/keys.js";
@@ -22,6 +29,7 @@ import {
 } from "../src/screens/panels.js";
 import { renderStoryScreen } from "../src/screens/story.js";
 import { plainLine, visibleWidth } from "../src/screens/story/frame.js";
+import type { FactEditorSession } from "../src/state.js";
 import { createWrapCache } from "../src/wrap.js";
 
 /** The hit map is rebuilt by rendering, so it has to be tested through a real
@@ -43,6 +51,11 @@ const key = (name: string): KeyEvent => ({
 type State = ReturnType<typeof initialState>;
 type Source = ReturnType<typeof demoAppSource>;
 type FooterActions = ReadonlyArray<{ token: string; action: KeyAction }>;
+
+function currentFactEditor(state: State): FactEditorSession {
+  if (state.editor?.kind !== "fact") throw new Error("Fact editor did not open");
+  return state.editor;
+}
 
 function showMap(state: State, view: "path" | "tree" | "mass" = "path", cursorId = "p12") {
   state.mode = "MAP";
@@ -919,7 +932,7 @@ describe("hit map clickable chrome", () => {
     }
   });
 
-  test("focused prose clicks only focus, and right-click keeps COMPOSE ownership", async () => {
+  test("focused prose clicks only focus, and right-click opens the composer menu", async () => {
     const source = demoAppSource();
     const state = initialState(source, false);
     state.stream = null;
@@ -935,10 +948,158 @@ describe("hit map clickable chrome", () => {
       render(state);
       const composerRow = state.hitRows.findIndex((row) => row?.target.kind === "composer");
       expect(composerRow).toBeGreaterThan(-1);
-      expect(mouseToAction(click(2, composerRow, 2), state)).toBe(null);
+      const action = mouseToAction(click(2, composerRow, 2), state);
+      expect(action).toEqual({ action: "open-text-actions" });
+      await dispatch(
+        action!, state, source, createWrapCache(), () => {}, async () => {}, () => {}
+      );
       expect(state.mode).toBe("COMPOSE");
+      expect(state.textActions).not.toBe(null);
+      for (const width of [120, 40, 24]) {
+        render(state, width, 24);
+      }
+      await dispatch(
+        { action: "cancel" }, state, source, createWrapCache(), () => {}, async () => {}, () => {}
+      );
+      expect(state.textActions).toBe(null);
     }
+    state.composer.fullscreen = false;
+    render(state);
+    const composePartRow = state.hitRows.findIndex((row) => row?.target.kind === "part");
+    expect(composePartRow).toBeGreaterThan(-1);
+    expect(mouseToAction(click(2, composePartRow, 2), state)).toBe(null);
 
+    const node = state.payload.path.at(-1)!;
+    state.mode = "EDITOR";
+    state.editor = {
+      kind: "document",
+      target: {
+        kind: "part",
+        node,
+        pathIndex: state.payload.path.length - 1,
+        savedNode: null
+      },
+      title: "edit part",
+      placeholder: "",
+      composer: createComposer("editor text"),
+      initial: "editor text",
+      returnMode: "NAV",
+      conflict: null,
+      cutConfirmation: null
+    };
+    render(state);
+    const editorRow = state.hitRows.findIndex((row) => row?.target.kind === "composer");
+    expect(editorRow).toBeGreaterThan(-1);
+    const editorAction = mouseToAction(click(2, editorRow, 2), state);
+    expect(editorAction).toEqual({ action: "open-text-actions" });
+    await dispatch(
+      editorAction!, state, source, createWrapCache(), () => {}, async () => {}, () => {}
+    );
+    expect(render(state).some((line) => plainLine(line).includes("edit actions"))).toBeTrue();
+    await dispatch(
+      { action: "cancel" }, state, source, createWrapCache(), () => {}, async () => {}, () => {}
+    );
+
+    openFactEditor(state, null);
+    expect(currentFactEditor(state).tag.text).toBe("");
+    render(state);
+    const emptyTagRow = state.hitRows.findIndex((row) => row?.target.kind === "composer"
+      && row.target.composerSourceId === FACT_TAG_COMPOSER_SOURCE);
+    expect(emptyTagRow).toBeGreaterThan(-1);
+    const emptyTagAction = mouseToAction(click(2, emptyTagRow, 2), state);
+    expect(emptyTagAction).toEqual({
+      action: "open-text-actions",
+      composerSourceId: FACT_TAG_COMPOSER_SOURCE,
+      composerEditable: true
+    });
+    await dispatch(
+      emptyTagAction!, state, source, createWrapCache(), () => {}, async () => {}, () => {}
+    );
+    expect(state.textActions?.owner === currentFactEditor(state).tag).toBeTrue();
+    await dispatch(
+      { action: "cancel" }, state, source, createWrapCache(), () => {}, async () => {}, () => {}
+    );
+    setComposerText(currentFactEditor(state).tag, "weather");
+    render(state);
+    const tagRow = state.hitRows.findIndex((row) => row?.target.kind === "composer"
+      && row.target.composerSourceId === FACT_TAG_COMPOSER_SOURCE);
+    expect(tagRow).toBeGreaterThan(-1);
+    const tagAction = mouseToAction(click(2, tagRow, 2), state);
+    expect(tagAction).toEqual({
+      action: "open-text-actions",
+      composerSourceId: FACT_TAG_COMPOSER_SOURCE,
+      composerEditable: true
+    });
+    await dispatch(
+      tagAction!, state, source, createWrapCache(), () => {}, async () => {}, () => {}
+    );
+    const factEditor = currentFactEditor(state);
+    expect(factEditor.focus).toBe("tag");
+    expect(state.textActions?.owner === factEditor.tag).toBeTrue();
+    await dispatch(
+      { action: "cancel" }, state, source, createWrapCache(), () => {}, async () => {}, () => {}
+    );
+    render(state);
+    const keysRow = state.hitRows.findIndex((row) => row?.target.kind === "composer"
+      && row.target.composerSourceId === FACT_KEYS_COMPOSER_SOURCE);
+    expect(keysRow).toBeGreaterThan(-1);
+    const keysAction = mouseToAction(click(2, keysRow, 2), state);
+    expect(keysAction).toEqual({
+      action: "open-text-actions",
+      composerSourceId: FACT_KEYS_COMPOSER_SOURCE,
+      composerEditable: true
+    });
+    await dispatch(
+      keysAction!, state, source, createWrapCache(), () => {}, async () => {}, () => {}
+    );
+    expect(currentFactEditor(state).focus).toBe("keys");
+    await dispatch(
+      { action: "cancel" }, state, source, createWrapCache(), () => {}, async () => {}, () => {}
+    );
+    render(state);
+    const activationRow = state.hitRows.findIndex((row) => row?.target.kind === "composer"
+      && row.target.composerSourceId === FACT_ACTIVATION_COMPOSER_SOURCE);
+    expect(activationRow).toBeGreaterThan(-1);
+    const activationAction = mouseToAction(click(2, activationRow, 2), state);
+    expect(activationAction).toEqual({
+      action: "open-text-actions",
+      composerSourceId: FACT_ACTIVATION_COMPOSER_SOURCE,
+      composerEditable: false
+    });
+    await dispatch(
+      activationAction!, state, source, createWrapCache(), () => {}, async () => {}, () => {}
+    );
+    expect(state.textActions).toBe(null);
+    setFactEditorFocus(currentFactEditor(state), "activation");
+    render(state);
+    const editorChrome = state.hitRows.findIndex((row) => row?.target.kind === "composer"
+      && row.target.composerSourceId === undefined);
+    expect(editorChrome).toBeGreaterThan(-1);
+    expect(mouseToAction(click(2, editorChrome, 2), state)).toBe(null);
+
+    state.editor = null;
+    state.mode = "SETTINGS";
+    state.settings = initialSettingsOverlay(source.settingsView, state.config);
+    state.settings.cursor = SETTINGS_ROW_IDS.indexOf("model");
+    beginSettingsRowEdit(state.settings, state.config);
+    render(state);
+    const settingsRow = state.hitRows.findIndex((row) => row?.overrides?.some((region) =>
+      region.target.kind === "list" && region.target.index === state.settings!.cursor) === true);
+    expect(settingsRow).toBeGreaterThan(-1);
+    const settingsHit = state.hitRows[settingsRow]!.overrides!.find((region) =>
+      region.target.kind === "list" && region.target.index === state.settings!.cursor)!;
+    const settingsAction = mouseToAction(click(settingsHit.left + 2, settingsRow, 2), state);
+    expect(settingsAction).toEqual({ action: "open-text-actions" });
+    await dispatch(
+      settingsAction!, state, source, createWrapCache(), () => {}, async () => {}, () => {}
+    );
+    expect(render(state).some((line) => plainLine(line).includes("edit actions"))).toBeTrue();
+    await dispatch(
+      { action: "cancel" }, state, source, createWrapCache(), () => {}, async () => {}, () => {}
+    );
+
+    state.settings = null;
+    state.mode = "COMPOSE";
     await dispatch(
       resolveKey({ ...key("space"), sequence: " " } as KeyEvent, state.mode),
       state,

--- a/tui/test/hit-map-chrome.test.ts
+++ b/tui/test/hit-map-chrome.test.ts
@@ -919,7 +919,7 @@ describe("hit map clickable chrome", () => {
     }
   });
 
-  test("focused prose clicks only focus, and COMPOSE right-click cancels anywhere", async () => {
+  test("focused prose clicks only focus, and right-click keeps COMPOSE ownership", async () => {
     const source = demoAppSource();
     const state = initialState(source, false);
     state.stream = null;
@@ -930,11 +930,26 @@ describe("hit map clickable chrome", () => {
       .toMatchObject({ action: "focus-index", index: state.focusIndex });
     state.mode = "COMPOSE";
     state.composer = createComposer("draft stays");
-    const resolved = mouseToAction(click(999, 999, 2), state)!;
-    expect(resolved).toEqual({ action: "cancel" });
-    await dispatch(resolved, state, source, createWrapCache(), () => {}, async () => {}, () => {});
-    expect(state.mode).toBe("NAV");
-    expect(state.composer.text).toBe("draft stays");
+    for (const fullscreen of [false, true]) {
+      state.composer.fullscreen = fullscreen;
+      render(state);
+      const composerRow = state.hitRows.findIndex((row) => row?.target.kind === "composer");
+      expect(composerRow).toBeGreaterThan(-1);
+      expect(mouseToAction(click(2, composerRow, 2), state)).toBe(null);
+      expect(state.mode).toBe("COMPOSE");
+    }
+
+    await dispatch(
+      resolveKey({ ...key("space"), sequence: " " } as KeyEvent, state.mode),
+      state,
+      source,
+      createWrapCache(),
+      () => {},
+      async () => {},
+      () => {}
+    );
+    expect(state.mode).toBe("COMPOSE");
+    expect(state.composer.text).toBe("draft stays ");
   });
 
   test("every screen footer renders untruncated at wide and compact sizes", () => {

--- a/tui/test/hit-map.test.ts
+++ b/tui/test/hit-map.test.ts
@@ -4,6 +4,7 @@ import { dispatch, initialState } from "../src/app.js";
 import { commandContext, commandMatches } from "../src/command-model.js";
 import { setComposerText } from "../src/composer-model.js";
 import { demoAppSource } from "../src/demo.js";
+import { openPartEditor } from "../src/editor-action.js";
 import { hitAt } from "../src/hit.js";
 import { resolveKey, type AppMode, type KeyAction, type ResolveOptions } from "../src/keys.js";
 import {
@@ -23,6 +24,7 @@ import {
 import { renderStoryScreen } from "../src/screens/story.js";
 import { plainLine, visibleWidth } from "../src/screens/story/frame.js";
 import { createWrapCache } from "../src/wrap.js";
+import { openTextActions } from "../src/text-actions.js";
 
 const STREAM_STARTED_AT = "2026-07-22T00:00:00.000Z";
 
@@ -345,10 +347,13 @@ describe("hit map from rendered frames", () => {
     settings.mode = "SETTINGS";
     settings.settings = initialSettingsOverlay(source.settingsView, settings.config);
     beginSettingsRowEdit(settings.settings, settings.config);
+    const editor = initialState(source, false);
+    openPartEditor(editor, false);
 
-    for (const state of [compose, settings]) {
+    for (const state of [compose, settings, editor]) {
       state.stream = null;
       state.connection = { ...state.connection, down: true };
+      openTextActions(state);
       const frame = render(state);
       const banner = plainLine(frame[0]!);
       expect(banner).toContain("retry now");

--- a/tui/test/interactive-frame-runtime.test.ts
+++ b/tui/test/interactive-frame-runtime.test.ts
@@ -150,6 +150,91 @@ describe("interactive frame runtime", () => {
     setup.renderer.destroy();
   });
 
+  test("keeps ordinary Settings in separate native selection buffers", async () => {
+    const setup = await createTestRenderer({ width: 160, height: 36 });
+    const source = demoAppSource(false);
+    const state = initialState(source, false);
+    state.mode = "SETTINGS";
+    state.settings = initialSettingsOverlay(source.settingsView, state.config);
+    const wrapCache = createWrapCache<ProseStyle>();
+    renderStoryScreen(state, { width: 160, height: 36, wrapCache });
+    const paintOptions: Parameters<StorySurface["paint"]>[4][] = [];
+    const surface: StorySurface = {
+      paint(_frame, _palette, _layout, _selectable, options) {
+        paintOptions.push(options);
+      },
+      setPageSelectable() {},
+      setBackground() {},
+      onMouse() {}
+    };
+    const runtime = createInteractiveFrameRuntime({
+      state,
+      renderer: setup.renderer,
+      surface,
+      palette: () => createPalette("lantern", "256"),
+      wrapCache,
+      onBuilt: () => undefined,
+      onError: (error) => { throw error; }
+    });
+
+    runtime.invalidate();
+    runtime.flush();
+
+    expect(paintOptions.at(-1)).toBe(undefined);
+    runtime.dispose();
+    setup.renderer.destroy();
+  });
+
+  test("paints a Sampling edit through one native selection buffer", async () => {
+    const setup = await createTestRenderer({ width: 160, height: 36 });
+    const source = demoAppSource(false);
+    const state = initialState(source, false);
+    state.mode = "SETTINGS";
+    state.settings = initialSettingsOverlay(source.settingsView, state.config);
+    state.settings.sampling = {
+      panel: "sampling",
+      cursor: 0,
+      logitBiasOrder: [],
+      edit: {
+        kind: "scalar",
+        index: 0,
+        knob: "topP",
+        composer: createComposer("0.7"),
+        initial: ""
+      },
+      result: null,
+      biasResolution: { kind: "idle" },
+      resolutionGeneration: 0
+    };
+    const wrapCache = createWrapCache<ProseStyle>();
+    renderStoryScreen(state, { width: 160, height: 36, wrapCache });
+    const paintOptions: Parameters<StorySurface["paint"]>[4][] = [];
+    const surface: StorySurface = {
+      paint(_frame, _palette, _layout, _selectable, options) {
+        paintOptions.push(options);
+      },
+      setPageSelectable() {},
+      setBackground() {},
+      onMouse() {}
+    };
+    const runtime = createInteractiveFrameRuntime({
+      state,
+      renderer: setup.renderer,
+      surface,
+      palette: () => createPalette("lantern", "256"),
+      wrapCache,
+      onBuilt: () => undefined,
+      onError: (error) => { throw error; }
+    });
+
+    runtime.invalidate();
+    runtime.flush();
+
+    expect(paintOptions.at(-1)).toEqual({ singleSelectionBuffer: true });
+    runtime.dispose();
+    setup.renderer.destroy();
+  });
+
   test("an older native frame cannot consume a newer app commit", () => {
     const controlled = createControlledRenderer(120, 36);
     const state = initialState(demoAppSource(false), false);

--- a/tui/test/keys.test.ts
+++ b/tui/test/keys.test.ts
@@ -77,9 +77,9 @@ const DECLARED_DIVERGENCES = [
   { label: "ctrl+x", event: key("x", { ctrl: true }),
     actions: ["none", "cut-selection", "none"] },
   { label: "ctrl+v", event: key("v", { ctrl: true }),
-    actions: ["none", "paste-clipboard", "paste-clipboard"] },
+    actions: ["paste-clipboard", "paste-clipboard", "paste-clipboard"] },
   { label: "cmd+v", event: key("v", { super: true }),
-    actions: ["input", "input", "paste-clipboard"] },
+    actions: ["paste-clipboard", "paste-clipboard", "paste-clipboard"] },
   { label: "cmd+a", event: key("a", { super: true }),
     actions: ["input", "select-all", "select-all"] },
   { label: "ctrl+d", event: key("d", { ctrl: true }),
@@ -282,6 +282,8 @@ describe("text surfaces and palette", () => {
     expect(resolveKey(key("f", { ctrl: true }), "COMPOSE").action).toBe("toggle-compose-fullscreen");
     expect(resolveKey(key("up", { ctrl: true }), "COMPOSE").action).toBe("history-previous");
     expect(resolveKey(key("down", { ctrl: true }), "COMPOSE").action).toBe("history-next");
+    expect(resolveKey(key("v", { ctrl: true }), "COMPOSE").action).toBe("paste-clipboard");
+    expect(resolveKey(key("v", { super: true }), "COMPOSE").action).toBe("paste-clipboard");
     expect(resolveKey(key("?"), "COMPOSE")).toEqual({ action: "input", text: "?" });
   });
 

--- a/tui/test/keys.test.ts
+++ b/tui/test/keys.test.ts
@@ -45,11 +45,6 @@ const DECLARED_DIVERGENCES = [
     actions: ["toggle-compose-fullscreen", "cursor-right", "cursor-word-right"],
     shadowsShared: (event: KeyEvent) => event.name.toLowerCase() === "f"
       && event.ctrl === true && (event.meta === true || event.option === true) },
-  { label: "ctrl+cmd+a", event: key("a", { ctrl: true, super: true }),
-    actions: ["cursor-line-start", "select-all", "select-all"],
-    shadowsShared: (event: KeyEvent) => event.name.toLowerCase() === "a"
-      && event.super === true
-      && (event.ctrl === true || event.meta === true || event.option === true) },
   { label: "ctrl+f", event: key("f", { ctrl: true }),
     actions: ["toggle-compose-fullscreen", "cursor-right", "none"] },
   { label: "ctrl+b", event: key("b", { ctrl: true }),
@@ -80,8 +75,6 @@ const DECLARED_DIVERGENCES = [
     actions: ["paste-clipboard", "paste-clipboard", "paste-clipboard"] },
   { label: "cmd+v", event: key("v", { super: true }),
     actions: ["paste-clipboard", "paste-clipboard", "paste-clipboard"] },
-  { label: "cmd+a", event: key("a", { super: true }),
-    actions: ["input", "select-all", "select-all"] },
   { label: "ctrl+d", event: key("d", { ctrl: true }),
     actions: ["none", "delete-forward", "none"] },
   { label: "ctrl+shift+d", event: key("d", { ctrl: true, shift: true }),
@@ -397,7 +390,10 @@ describe("text surfaces and palette", () => {
     expect(resolveKey(key("backspace", { meta: true }), "EDITOR").action).toBe("delete-word-left");
     expect(resolveKey(key("backspace", { ctrl: true }), "EDITOR").action).toBe("delete-word-left");
     expect(resolveKey(key("k", { ctrl: true }), "EDITOR").action).toBe("delete-line-end");
-    expect(resolveKey(key("a", { ctrl: true }), "EDITOR").action).toBe("cursor-line-start");
+    expect(resolveKey(key("a", { ctrl: true }), "EDITOR").action).toBe("select-all");
+    expect(resolveKey(key("a", { ctrl: true }), "COMPOSE").action).toBe("select-all");
+    expect(resolveKey(key("a", { ctrl: true }), "SETTINGS", { overlayTyping: true }).action)
+      .toBe("select-all");
     expect(resolveKey(key("home", { shift: true }), "EDITOR"))
       .toEqual({ action: "cursor-line-start", extendSelection: true });
     expect(resolveKey(key("home", { ctrl: true, shift: true }), "EDITOR"))

--- a/tui/test/sampling-clipboard.test.ts
+++ b/tui/test/sampling-clipboard.test.ts
@@ -4,7 +4,7 @@ import {
   basicSettingsFromDocument
 } from "../../shared/settings-basic-draft.js";
 import type { SettingsView } from "../../shared/settings-v2-types.js";
-import { setComposerText } from "../src/composer-model.js";
+import { composerSelection, setComposerText } from "../src/composer-model.js";
 
 type ClipboardReader = () => Promise<string | null>;
 type ClipboardWriter = (text: string) => Promise<"internal">;
@@ -29,6 +29,16 @@ const {
   settingsHarness
 } = await import("./settings-test-harness.js");
 const { EMPTY_NATIVE_SELECTION, handleMainCopyShortcut } = await import("../src/copy-actions.js");
+const { openTextActions } = await import("../src/text-actions.js");
+const { dispatch } = await import("../src/app.js");
+const { openFactEditor } = await import("../src/editor-action.js");
+const {
+  FACT_ACTIVATION_COMPOSER_SOURCE,
+  FACT_BODY_COMPOSER_SOURCE,
+  FACT_TAG_COMPOSER_SOURCE
+} = await import("../src/fact-editor-policy.js");
+const { buildComposerSelectionProjection } = await import("../src/selection-projection.js");
+const { fitLine } = await import("../src/screens/story/frame.js");
 
 describe("Direct clipboard ownership", () => {
   test("Command+C without a selection does not quit", async () => {
@@ -59,6 +69,74 @@ describe("Direct clipboard ownership", () => {
       expect(state.composer.text).toBe("before pasted\ntextafter");
       expect(state.composer.fullscreen).toBe(clipboardCase.fullscreen);
     }
+  });
+
+  test("Control+A selects the complete inline and fullscreen draft", async () => {
+    for (const fullscreen of [false, true]) {
+      const { state, press } = settingsHarness();
+      state.mode = "COMPOSE";
+      setComposerText(state.composer, "select the complete draft");
+      state.composer.cursor = 7;
+      state.composer.fullscreen = fullscreen;
+
+      await press(key("a", { ctrl: true }));
+
+      expect(composerSelection(state.composer)).toEqual({
+        start: 0,
+        end: state.composer.text.length
+      });
+    }
+  });
+
+  test("the context menu pastes and selects all without leaving Direct", async () => {
+    const { state, press } = settingsHarness();
+    state.mode = "COMPOSE";
+    setComposerText(state.composer, "draft ");
+    clipboardReader = async () => "from clipboard";
+    state.abort = { kind: "generation" } as never;
+
+    openTextActions(state);
+    expect(state.textActions?.cursor).toBe(1);
+    await press(key("return"));
+
+    expect(state.mode).toBe("COMPOSE");
+    expect(state.composer.text).toBe("draft from clipboard");
+    expect(state.toast).toBe(null);
+    state.abort = null;
+
+    openTextActions(state);
+    await press(key("down"));
+    await press(key("return"));
+    expect(composerSelection(state.composer)).toEqual({
+      start: 0,
+      end: state.composer.text.length
+    });
+
+    const copied: string[] = [];
+    clipboardWriter = async (text) => {
+      copied.push(text);
+      return "internal";
+    };
+    openTextActions(state);
+    expect(state.textActions?.cursor).toBe(0);
+    await press(key("return"));
+    await Promise.resolve();
+    expect(copied).toEqual(["draft from clipboard"]);
+  });
+
+  test("the context menu refuses a composer changed after it opened", async () => {
+    const { state, press } = settingsHarness();
+    state.mode = "COMPOSE";
+    setComposerText(state.composer, "original draft");
+    openTextActions(state);
+    setComposerText(state.composer, "refreshed draft");
+    clipboardReader = async () => "must not paste";
+
+    await press(key("return"));
+
+    expect(state.textActions).toBe(null);
+    expect(state.composer.text).toBe("refreshed draft");
+    expect(state.toast).toBe("editor changed · open the menu again");
   });
 
   test("copies selected text from inline and fullscreen drafts", async () => {
@@ -110,6 +188,37 @@ describe("Direct clipboard ownership", () => {
 });
 
 describe("nested Sampling clipboard ownership", () => {
+  test("Control+C cannot quit with an active Sampling editor", async () => {
+    let quits = 0;
+    const { state, press } = await openSamplingEdit(() => { quits += 1; });
+
+    await press(key("c", { ctrl: true }));
+    openTextActions(state);
+    await press(key("c", { ctrl: true }));
+
+    expect(quits).toBe(0);
+    expect(state.textActions).not.toBe(null);
+  });
+
+  test("the context menu copies from the active Sampling editor", async () => {
+    const { state, press } = await openSamplingEdit();
+    const composer = state.settings!.sampling!.edit!.composer;
+    setComposerText(composer, "0.7");
+    composer.anchor = 0;
+    const copied: string[] = [];
+    clipboardWriter = async (text) => {
+      copied.push(text);
+      return "internal";
+    };
+
+    openTextActions(state);
+    expect(state.textActions?.cursor).toBe(0);
+    await press(key("return"));
+    await Promise.resolve();
+
+    expect(copied).toEqual(["0.7"]);
+  });
+
   test("ignores a late read after every owner-changing action and applies a current paste", async () => {
     const staleCases: readonly {
       name: string;
@@ -204,8 +313,141 @@ describe("nested Sampling clipboard ownership", () => {
   });
 });
 
-async function openSamplingEdit() {
-  const harness = settingsHarness();
+test("the context menu copies a display-only Fact choice", async () => {
+  const { state, source, cache, backend, press } = settingsHarness();
+  openFactEditor(state, null);
+  const text = "always";
+  const projection = buildComposerSelectionProjection([fitLine([{
+    text,
+    composerSource: { id: FACT_ACTIVATION_COMPOSER_SOURCE, editable: false }
+  }], 20)], 20)!;
+  const identity = {};
+  const copied: string[] = [];
+  clipboardWriter = async (value) => {
+    copied.push(value);
+    return "internal";
+  };
+
+  await dispatch(
+    {
+      action: "open-text-actions",
+      nativeSelection: {
+        identity,
+        text,
+        range: { start: 0, end: text.length },
+        backward: false
+      },
+      composerSelectionProjection: projection
+    },
+    state,
+    source,
+    cache,
+    () => undefined,
+    async () => undefined,
+    () => undefined,
+    null,
+    () => undefined,
+    () => undefined,
+    backend
+  );
+  expect(state.textActions?.cursor).toBe(0);
+  expect(state.textActions?.copyOnly).toBeTrue();
+
+  await press(key("return"));
+  await Promise.resolve();
+
+  expect(copied).toEqual([text]);
+});
+
+test("a Fact context menu keeps the clicked field over an old field selection", async () => {
+  const { state, source, cache, backend, press } = settingsHarness();
+  openFactEditor(state, null);
+  const editor = state.editor;
+  if (editor?.kind !== "fact") throw new Error("Fact editor did not open");
+  setComposerText(editor.tag, "weather");
+  setComposerText(editor.composer, "body");
+  const projection = buildComposerSelectionProjection([fitLine([{
+    text: "weather",
+    composerStart: 0,
+    composerSource: { id: FACT_TAG_COMPOSER_SOURCE, editable: true }
+  }], 20)], 20)!;
+
+  await dispatch(
+    {
+      action: "open-text-actions",
+      composerSourceId: FACT_BODY_COMPOSER_SOURCE,
+      nativeSelection: {
+        identity: {},
+        text: "weather",
+        range: { start: 0, end: 7 },
+        backward: false
+      },
+      composerSelectionProjection: projection
+    },
+    state,
+    source,
+    cache,
+    () => undefined,
+    async () => undefined,
+    () => undefined,
+    null,
+    () => undefined,
+    () => undefined,
+    backend
+  );
+  expect(state.textActions?.owner === editor.composer).toBeTrue();
+  clipboardReader = async () => " pasted";
+  await press(key("return"));
+
+  expect(editor.tag.text).toBe("weather");
+  expect(editor.composer.text).toBe("body pasted");
+});
+
+test("a mixed Fact selection does not open an editor menu", async () => {
+  const { state, source, cache, backend } = settingsHarness();
+  openFactEditor(state, null);
+  const projection = buildComposerSelectionProjection([fitLine([
+    {
+      text: "tag",
+      composerStart: 0,
+      composerSource: { id: "fact-tag", editable: true }
+    },
+    {
+      text: "body",
+      composerStart: 0,
+      composerSource: { id: "fact-body", editable: true }
+    }
+  ], 20)], 20)!;
+
+  await dispatch(
+    {
+      action: "open-text-actions",
+      nativeSelection: {
+        identity: {},
+        text: "tagbody",
+        range: { start: 0, end: 7 },
+        backward: false
+      },
+      composerSelectionProjection: projection
+    },
+    state,
+    source,
+    cache,
+    () => undefined,
+    async () => undefined,
+    () => undefined,
+    null,
+    () => undefined,
+    () => undefined,
+    backend
+  );
+
+  expect(state.textActions).toBe(null);
+  expect(state.toast).toBe("select the Fact tag, keys, or text");
+});
+
+async function openSamplingEdit(requestQuit: () => void = () => undefined) {
+  const harness = settingsHarness(requestQuit);
   useSupportedSettings(harness.source);
   await openSettings(harness.press);
   await selectRow(harness.press, harness.state, "sampling");

--- a/tui/test/sampling-clipboard.test.ts
+++ b/tui/test/sampling-clipboard.test.ts
@@ -7,6 +7,7 @@ import type { SettingsView } from "../../shared/settings-v2-types.js";
 import { setComposerText } from "../src/composer-model.js";
 
 type ClipboardReader = () => Promise<string | null>;
+type ClipboardWriter = (text: string) => Promise<"internal">;
 
 const bunTest = await import("bun:test") as unknown as {
   mock: {
@@ -14,9 +15,10 @@ const bunTest = await import("bun:test") as unknown as {
   };
 };
 let clipboardReader: ClipboardReader = async () => null;
+let clipboardWriter: ClipboardWriter = async () => "internal";
 bunTest.mock.module("../src/clipboard.js", () => ({
   readFromClipboard: () => clipboardReader(),
-  copyToClipboard: async () => "internal"
+  copyToClipboard: (text: string) => clipboardWriter(text)
 }));
 
 const {
@@ -26,6 +28,86 @@ const {
   selectRow,
   settingsHarness
 } = await import("./settings-test-harness.js");
+const { EMPTY_NATIVE_SELECTION, handleMainCopyShortcut } = await import("../src/copy-actions.js");
+
+describe("Direct clipboard ownership", () => {
+  test("Command+C without a selection does not quit", async () => {
+    let quits = 0;
+    const { state, press } = settingsHarness(() => { quits += 1; });
+
+    await press(key("c", { super: true }));
+
+    expect(state.mode).toBe("NAV");
+    expect(quits).toBe(0);
+  });
+
+  test("pastes into inline and fullscreen drafts with Control or Command", async () => {
+    const cases = [
+      { fullscreen: false, key: key("v", { ctrl: true }) },
+      { fullscreen: true, key: key("v", { super: true }) }
+    ];
+    for (const clipboardCase of cases) {
+      const { state, press } = settingsHarness();
+      state.mode = "COMPOSE";
+      setComposerText(state.composer, "before after");
+      state.composer.cursor = 7;
+      state.composer.fullscreen = clipboardCase.fullscreen;
+      clipboardReader = async () => "pasted\ntext";
+
+      await press(clipboardCase.key);
+
+      expect(state.composer.text).toBe("before pasted\ntextafter");
+      expect(state.composer.fullscreen).toBe(clipboardCase.fullscreen);
+    }
+  });
+
+  test("copies selected text from inline and fullscreen drafts", async () => {
+    for (const fullscreen of [false, true]) {
+      const { state } = settingsHarness();
+      state.mode = "COMPOSE";
+      setComposerText(state.composer, "copy this draft");
+      state.composer.anchor = 5;
+      state.composer.fullscreen = fullscreen;
+      const copied: string[] = [];
+      clipboardWriter = async (text) => {
+        copied.push(text);
+        return "internal";
+      };
+
+      expect(handleMainCopyShortcut(
+        EMPTY_NATIVE_SELECTION,
+        state,
+        () => undefined,
+        () => { throw new Error("copy must not quit"); }
+      )).toBeTrue();
+      await Promise.resolve();
+
+      expect(copied).toEqual(["this draft"]);
+      expect(state.composer.fullscreen).toBe(fullscreen);
+    }
+  });
+
+  test("ignores a clipboard read after the draft changes", async () => {
+    const { state, press } = settingsHarness();
+    state.mode = "COMPOSE";
+    setComposerText(state.composer, "seed");
+    const read = deferred<string | null>();
+    const started = deferred<void>();
+    clipboardReader = async () => {
+      started.resolve();
+      return read.promise;
+    };
+
+    const paste = press(key("v", { ctrl: true }));
+    await started.promise;
+    await press(key("x"));
+    read.resolve("late clipboard text");
+    await paste;
+
+    expect(state.composer.text).toBe("seedx");
+    expect(state.toast).toBe(null);
+  });
+});
 
 describe("nested Sampling clipboard ownership", () => {
   test("ignores a late read after every owner-changing action and applies a current paste", async () => {

--- a/tui/test/selection-menu.test.ts
+++ b/tui/test/selection-menu.test.ts
@@ -1,6 +1,9 @@
 import { expect, test } from "bun:test";
 import { MouseEvent } from "@opentui/core";
-import { selectionAwarePartMenuAction } from "../src/selection-menu.js";
+import {
+  selectionAwarePartMenuAction,
+  selectionAwareTextMenuAction
+} from "../src/selection-menu.js";
 import type { StorySelectionProjection } from "../src/selection-projection.js";
 
 function rightClick(): MouseEvent {
@@ -52,6 +55,101 @@ test("ordinary part menus keep their whole-part copy fallback", () => {
 
   expect(resolved).toEqual({ action: "open-actions", index: 3 });
   expect(event.defaultPrevented).toBeFalse();
+});
+
+test("an editor menu freezes and clears the native selection before repaint", () => {
+  const event = rightClick();
+  const native = {
+    getSelectedText: () => "selected draft",
+    anchor: { x: 14, y: 2 },
+    focus: { x: 0, y: 2 },
+    selectedRenderables: [{ getSelection: () => ({ start: 0, end: 14 }) }]
+  } as never;
+  let clearCount = 0;
+  const projection = Array.from({ length: 14 }, (_, index) => ({
+    start: index,
+    end: index + 1
+  }));
+
+  const resolved = selectionAwareTextMenuAction(
+    event,
+    { action: "open-text-actions" },
+    {
+      getSelection: () => native,
+      clearSelection: () => { clearCount += 1; }
+    },
+    projection
+  );
+
+  expect(resolved).toEqual({
+    action: "open-text-actions",
+    nativeSelection: {
+      identity: native,
+      text: "selected draft",
+      range: { start: 0, end: 14 },
+      backward: true
+    },
+    composerSelectionProjection: projection
+  });
+  expect(event.defaultPrevented).toBeTrue();
+  expect(clearCount).toBe(1);
+});
+
+test("an editor menu leaves an unrelated native selection untouched", () => {
+  const event = rightClick();
+  let clearCount = 0;
+  const resolved = selectionAwareTextMenuAction(
+    event,
+    { action: "open-text-actions" },
+    {
+      getSelection: () => ({
+        getSelectedText: () => "story chrome",
+        anchor: { x: 0, y: 0 },
+        focus: { x: 12, y: 0 },
+        selectedRenderables: [{ getSelection: () => ({ start: 0, end: 12 }) }]
+      }) as never,
+      clearSelection: () => { clearCount += 1; }
+    },
+    [null]
+  );
+
+  expect(resolved).toEqual({ action: "open-text-actions" });
+  expect(event.defaultPrevented).toBeTrue();
+  expect(clearCount).toBe(0);
+});
+
+test("a mixed editor selection stays selected and does not open a menu", () => {
+  const event = rightClick();
+  let clearCount = 0;
+  const resolved = selectionAwareTextMenuAction(
+    event,
+    { action: "open-text-actions" },
+    {
+      getSelection: () => ({
+        getSelectedText: () => "tagbody",
+        anchor: { x: 0, y: 0 },
+        focus: { x: 7, y: 0 },
+        selectedRenderables: [{ getSelection: () => ({ start: 0, end: 7 }) }]
+      }) as never,
+      clearSelection: () => { clearCount += 1; }
+    },
+    [
+      ...Array.from({ length: 3 }, (_, index) => ({
+        start: index,
+        end: index + 1,
+        sourceId: "fact-tag"
+      })),
+      ...Array.from({ length: 4 }, (_, index) => ({
+        start: index,
+        end: index + 1,
+        sourceId: "fact-body"
+      }))
+    ]
+  );
+
+  expect(resolved).toBe(null);
+  expect(event.defaultPrevented).toBeTrue();
+  expect(clearCount).toBe(0);
 });
 
 test("finishing a prose drag does not refocus and reflow its selection", () => {

--- a/tui/test/settings-test-harness.ts
+++ b/tui/test/settings-test-harness.ts
@@ -15,14 +15,21 @@ import { createWrapCache, type ProseStyle } from "../src/wrap.js";
 
 export function key(
   name: string,
-  options: { sequence?: string; ctrl?: boolean; shift?: boolean; meta?: boolean } = {}
+  options: {
+    sequence?: string;
+    ctrl?: boolean;
+    shift?: boolean;
+    meta?: boolean;
+    super?: boolean;
+  } = {}
 ): KeyEvent {
   return {
     name,
     sequence: options.sequence ?? name,
     shift: options.shift ?? false,
     ctrl: options.ctrl ?? false,
-    meta: options.meta ?? false
+    meta: options.meta ?? false,
+    super: options.super ?? false
   } as KeyEvent;
 }
 
@@ -40,7 +47,7 @@ export function generationFromProbeTarget(target: ProviderProbeTarget) {
     : target;
 }
 
-export function settingsHarness() {
+export function settingsHarness(requestQuit: () => void = () => undefined) {
   const source = demoAppSource();
   const state = initialState(source, false);
   const cache = createWrapCache<ProseStyle>();
@@ -59,7 +66,7 @@ export function settingsHarness() {
     cache,
     repaint,
     async () => undefined,
-    () => undefined,
+    requestQuit,
     null,
     (theme) => {
       state.config = { ...state.config, theme };


### PR DESCRIPTION
Closes #7

## Summary

- add Copy, Paste, and Select all context actions to editor-backed text fields
- make Ctrl+A and Command+A select complete editor text
- preserve exact native-selection and multi-field Fact ownership

## Verification

- npm run build
- npm test
- cd tui && bun run typecheck
- cd tui && bun test --timeout 30000
- cd tui && bun bench/perf.ts
- autoreview clean