### PR TITLE
feat(tui): complete editor shortcuts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,11 @@ This file records notable changes to 1667. Product terms use the definitions in
 - **Editors now have standard clipboard actions.** Right-click an editable
   text field to open Copy, Paste, and Select all. Press `Ctrl+A` or
   `Command+A` to select all text. Direct supports these actions in its inline
-  and full-screen forms. Thanks @10fra for the request.
+  and full-screen forms. Use `Ctrl+X` or `Command+X` to cut selected text. Use
+  `Ctrl+Z` or `Command+Z` to undo an edit. Add `Shift` to redo the edit. Use
+  `Command+Arrow` to move to a line end or a buffer end. Use
+  `Command+Backspace` to delete to the start of a line. Use `Page Up` or
+  `Page Down` to move by one editor page. Thanks @10fra for the request.
 - **A token probability viewer shows the alternative tokens the model
   weighed.** Press `l` on a story part to open it. The viewer shows the
   take's prose with the selected token marked, and below it the alternative

--- a/README.md
+++ b/README.md
@@ -79,9 +79,14 @@ Git manages this installation.
 | Go to the previous or next chapter | `[` and `]` |
 | Continue the story | `Space` |
 | Open the composer | `Enter` or `i` |
-| Copy selected composer text | `Ctrl+C` |
-| Paste text into the composer | `Ctrl+V` |
+| Copy selected editor text | `Ctrl+C` or `Command+C` |
+| Cut selected editor text | `Ctrl+X` or `Command+X` |
+| Paste text into an editor | `Ctrl+V` or `Command+V` |
 | Select all text in an editor | `Ctrl+A` or `Command+A` |
+| Undo or redo an editor change | `Ctrl+Z` and `Ctrl+Shift+Z`, or `Command+Z` and `Command+Shift+Z` |
+| Go to the start or end of an editor line or buffer | `Command+Arrow` |
+| Delete to the start of an editor line | `Command+Backspace` |
+| Move by one editor page | `Page Up` or `Page Down` |
 | Open the editor action menu | Right-click an editor |
 | Add a manual take | `w` |
 | Edit the selected story part | `e` |

--- a/tui/src/app.ts
+++ b/tui/src/app.ts
@@ -85,6 +85,7 @@ import {
 import type { BackgroundUpdateStarter } from "./update-runtime.js";
 import { startPromptTokenCountLane, type PromptTokenCountLane } from "./prompt-token-count.js";
 import {
+  activeTextComposer,
   openTextActions,
   textActionsMenuAction
 } from "./text-actions.js";
@@ -646,6 +647,10 @@ export async function dispatch(
 ): Promise<void> {
   const previousMode = state.mode;
   beginInteraction(state);
+  if (resolved.action !== "cut-selection") {
+    const composer = activeTextComposer(state);
+    if (composer !== null) composer.cutConfirmation = null;
+  }
   if (generationBusy(state) && resolved.action === "cancel" && isPlainNavigation(state)) return await cancelStream();
   if (state.toast !== null) state.toast = null;
   state.quitArmed = false;

--- a/tui/src/composer-clipboard-action.ts
+++ b/tui/src/composer-clipboard-action.ts
@@ -1,0 +1,68 @@
+import { copyToClipboard } from "./clipboard.js";
+import {
+  composerSelection,
+  selectedComposerText,
+  type ComposerState
+} from "./composer-model.js";
+
+export interface ComposerClipboardHost {
+  interactionVersion: number;
+  toast: string | null;
+}
+
+export interface ComposerClipboardOptions {
+  readonly isCurrent: () => boolean;
+  readonly deleteSelection: () => void;
+}
+
+/** Copy or cut one composer selection without applying an asynchronous result
+ * to a changed editor. A destructive OSC 52 cut needs the same second press on
+ * every composer-backed surface because the terminal cannot confirm the host
+ * clipboard write. */
+export async function composerClipboardAction(
+  host: ComposerClipboardHost,
+  composer: ComposerState,
+  cut: boolean,
+  options: ComposerClipboardOptions
+): Promise<void> {
+  const selection = composerSelection(composer);
+  const selectedText = selectedComposerText(composer);
+  if (selection === null || selectedText === null) {
+    composer.cutConfirmation = null;
+    host.toast = "nothing selected";
+    return;
+  }
+  if (!cut) composer.cutConfirmation = null;
+  const claim = {
+    interactionVersion: host.interactionVersion,
+    text: composer.text,
+    cursor: composer.cursor,
+    anchor: composer.anchor
+  };
+  const outcome = await copyToClipboard(selectedText);
+  if (!options.isCurrent()
+    || host.interactionVersion !== claim.interactionVersion
+    || composer.text !== claim.text
+    || composer.cursor !== claim.cursor
+    || composer.anchor !== claim.anchor) {
+    return;
+  }
+  if (outcome === "unavailable") {
+    composer.cutConfirmation = null;
+    host.toast = "no clipboard available · selection kept";
+    return;
+  }
+  if (cut && outcome !== "command") {
+    const confirmation = composer.cutConfirmation;
+    if (confirmation?.start !== selection.start
+      || confirmation.end !== selection.end
+      || confirmation.text !== selectedText) {
+      composer.cutConfirmation = { ...selection, text: selectedText };
+      host.toast = "clipboard write unconfirmed · cut again to confirm";
+      return;
+    }
+  }
+  if (cut) options.deleteSelection();
+  composer.cutConfirmation = null;
+  host.toast = cut ? "selection cut" : "selection copied";
+}

--- a/tui/src/composer-editing.ts
+++ b/tui/src/composer-editing.ts
@@ -8,7 +8,10 @@ import {
   deleteComposerForward,
   moveComposerHorizontal,
   moveComposerTo,
+  moveComposerVertical,
+  redoComposerEdit,
   replaceComposerTextRange,
+  undoComposerEdit,
   type ComposerState
 } from "./composer-model.js";
 import type { KeyAction } from "./keys.js";
@@ -76,6 +79,19 @@ export function deleteComposerToLineBoundary(composer: ComposerState, end: boole
     Math.min(composer.cursor, boundary), Math.max(composer.cursor, boundary), "");
 }
 
+/** Move by logical rows. Direct and one-line Settings editors do not soft-wrap. */
+export function moveComposerPage(
+  composer: ComposerState,
+  direction: -1 | 1,
+  rows: number,
+  selecting = false
+): void {
+  const count = Math.max(1, Math.floor(rows));
+  for (let row = 0; row < count; row += 1) {
+    if (!moveComposerVertical(composer, direction, selecting)) break;
+  }
+}
+
 function wordBoundary(composer: ComposerState, cursor: number, direction: -1 | 1): number {
   const total = composerLength(composer);
   if (direction > 0) {
@@ -138,4 +154,14 @@ export function applyComposerEdit(
     case "delete-line-end": deleteComposerToLineBoundary(composer, true); return "delete";
     default: return null;
   }
+}
+
+/** Apply local text history. Null means that the action is not undo or redo. */
+export function applyComposerHistoryEdit(
+  composer: ComposerState,
+  action: KeyAction
+): boolean | null {
+  if (action === "undo-edit") return undoComposerEdit(composer);
+  if (action === "redo-edit") return redoComposerEdit(composer);
+  return null;
 }

--- a/tui/src/composer-model.ts
+++ b/tui/src/composer-model.ts
@@ -7,9 +7,15 @@ export interface ComposerState {
   /** Fixed end of the active selection; null when movement owns only a caret. */
   anchor: number | null;
   fullscreen: boolean;
+  /** Explicit second-press consent when OSC 52 cannot confirm a cut. */
+  cutConfirmation: ComposerCutConfirmation | null;
 }
 
 export interface ComposerSelection { start: number; end: number }
+
+export interface ComposerCutConfirmation extends ComposerSelection {
+  text: string;
+}
 
 export interface ComposerLineSelection extends ComposerSelection {
   lineBreak: boolean;
@@ -114,7 +120,13 @@ interface EditHistory {
 }
 
 export function createComposer(text = ""): ComposerState {
-  const composer: ComposerState = { text, cursor: 0, anchor: null, fullscreen: false };
+  const composer: ComposerState = {
+    text,
+    cursor: 0,
+    anchor: null,
+    fullscreen: false,
+    cutConfirmation: null
+  };
   const document = buildDocument(text);
   DOCUMENTS.set(composer, document);
   setCursor(composer, document, totalGraphemes(document), false);
@@ -125,6 +137,7 @@ export function setComposerText(composer: ComposerState, text: string): void {
   const previous = documentFor(composer);
   composer.text = text;
   composer.anchor = null;
+  composer.cutConfirmation = null;
   const document = rebuildDocument(text, previous);
   DOCUMENTS.set(composer, document);
   setCursor(composer, document, totalGraphemes(document), false);
@@ -272,6 +285,7 @@ export function resetComposerEditHistory(composer: ComposerState): void {
   history.undo = [];
   history.redo = [];
   history.retainedCodeUnits = 0;
+  composer.cutConfirmation = null;
 }
 
 /** Low-level grapheme document primitives used by the editor command layer. */
@@ -454,6 +468,7 @@ function replaceComposerCodeUnits(
     editStartCodeUnit, Math.min(composer.text.length, endCodeUnit)
   );
   if (editStartCodeUnit === editEndCodeUnit && inserted.length === 0) return;
+  composer.cutConfirmation = null;
   const total = totalGraphemes(document);
   const editStart = knownGraphemeRange?.start
     ?? graphemeBoundaryAtCodeUnit(document, editStartCodeUnit, "before");

--- a/tui/src/composer-surface-action.ts
+++ b/tui/src/composer-surface-action.ts
@@ -1,0 +1,58 @@
+import {
+  composerClipboardAction,
+  type ComposerClipboardHost
+} from "./composer-clipboard-action.js";
+import {
+  applyComposerEdit,
+  applyComposerHistoryEdit,
+  moveComposerPage,
+  type ComposerEditKind
+} from "./composer-editing.js";
+import { insertComposerText, type ComposerState } from "./composer-model.js";
+import type { ResolvedKey } from "./keys.js";
+
+export interface ComposerSurfaceActionOptions {
+  readonly isCurrent: () => boolean;
+  readonly pageRows: number;
+  readonly onEdit?: (kind: ComposerEditKind | "history") => void;
+}
+
+/** Apply commands shared by Direct and single-line composer-backed fields. */
+export async function composerSurfaceAction(
+  resolved: ResolvedKey,
+  host: ComposerClipboardHost,
+  composer: ComposerState,
+  options: ComposerSurfaceActionOptions
+): Promise<boolean> {
+  if (resolved.action === "cut-selection") {
+    await composerClipboardAction(host, composer, true, {
+      isCurrent: options.isCurrent,
+      deleteSelection: () => {
+        options.onEdit?.("delete");
+        insertComposerText(composer, "");
+      }
+    });
+    return true;
+  }
+  if (resolved.action === "cursor-page-up" || resolved.action === "cursor-page-down") {
+    moveComposerPage(
+      composer,
+      resolved.action === "cursor-page-up" ? -1 : 1,
+      options.pageRows,
+      resolved.extendSelection
+    );
+    return true;
+  }
+  const edit = applyComposerEdit(composer, resolved.action, resolved.extendSelection);
+  if (edit !== null) {
+    options.onEdit?.(edit);
+    return true;
+  }
+  const history = applyComposerHistoryEdit(composer, resolved.action);
+  if (history === null) return false;
+  if (history) options.onEdit?.("history");
+  else host.toast = resolved.action === "undo-edit"
+    ? "nothing to undo"
+    : "nothing to redo";
+  return true;
+}

--- a/tui/src/composer-viewport.ts
+++ b/tui/src/composer-viewport.ts
@@ -1,0 +1,23 @@
+/** The default inline editor height from design section 11. */
+export function composerHeightCap(
+  terminalHeight: number,
+  override?: number | null
+): number {
+  if (override !== null && override !== undefined
+    && Number.isFinite(override) && override >= 1) {
+    return Math.floor(override);
+  }
+  return Math.max(6, Math.floor(Math.max(0, terminalHeight) / 3));
+}
+
+/** Number of editable rows in a composer with the standard one-row footer. */
+export function composerPageRows(
+  terminalHeight: number,
+  fullscreen: boolean,
+  override?: number | null
+): number {
+  const height = Math.max(4, Math.floor(terminalHeight));
+  return fullscreen
+    ? Math.max(1, height - 3)
+    : Math.max(1, Math.min(composerHeightCap(height, override), height - 4));
+}

--- a/tui/src/composer-visual-movement.ts
+++ b/tui/src/composer-visual-movement.ts
@@ -19,10 +19,21 @@ export function moveComposerVisualVertical(
   width: number,
   selecting = false
 ): boolean {
+  return moveComposerVisualRows(composer, direction, width, selecting);
+}
+
+/** Move through a page of soft-wrapped rows while retaining the visual column. */
+export function moveComposerVisualRows(
+  composer: ComposerState,
+  rows: number,
+  width: number,
+  selecting = false
+): boolean {
   const layout = wrappedComposerLayout(composer, width);
+  const direction = rows < 0 ? -1 : 1;
   const nextRow = Math.max(
     0,
-    Math.min(layout.rowCount - 1, layout.cursorRow + direction)
+    Math.min(layout.rowCount - 1, layout.cursorRow + Math.trunc(rows))
   );
   const current = layout.rowAt(layout.cursorRow)!;
   if (nextRow === layout.cursorRow) {

--- a/tui/src/copy-actions.ts
+++ b/tui/src/copy-actions.ts
@@ -216,6 +216,7 @@ export function copyActiveSelection(
     ? draft ?? ""
     : story ?? rendered;
   if (text.length === 0) return null;
+  if (composer !== null) composer.cutConfirmation = null;
   return { text, outcome: copy(text) };
 }
 

--- a/tui/src/editor-action.ts
+++ b/tui/src/editor-action.ts
@@ -10,6 +10,7 @@ import { handleAuthorsNoteCommand } from "./authors-note-editor-policy.js";
 import { recordHumanWords } from "./config.js";
 import { parsePartFile, stripGuidance } from "./editor.js";
 import { editorBufferAction } from "./editor-buffer-action.js";
+import { composerPageRows } from "./composer-viewport.js";
 import { editorInsertionPolicy } from "./editor-text-insertion.js";
 import { factEditorChanged, factEditorSavePayload } from "./fact-editor-draft.js";
 import {
@@ -76,7 +77,8 @@ export async function inlineEditorAction(
   const reduceBuffer = () => editorBufferAction(resolved, state, buffer, {
     isCurrent: () => state.mode === "EDITOR" && state.editor === editor,
     ...editorInsertionPolicy(editor),
-    wrapWidth
+    wrapWidth,
+    pageRows: composerPageRows(context.renderer?.height ?? 24, true)
   });
   const outcome = await reduceBuffer();
   if (outcome === "cancel") return closeInlineEditor(state, editor);
@@ -425,11 +427,11 @@ function disarmEditorConfirmations(
   editor: DocumentEditorSession
 ): void {
   if (editor.conflict !== null) editor.conflict.armed = false;
-  editor.cutConfirmation = null;
+  editor.composer.cutConfirmation = null;
   if (editor.kind === "fact") {
-    editor.tagCutConfirmation = null;
-    editor.keysCutConfirmation = null;
-    editor.budgetCutConfirmation = null;
+    editor.tag.cutConfirmation = null;
+    editor.keys.cutConfirmation = null;
+    editor.budget.cutConfirmation = null;
   }
 }
 

--- a/tui/src/editor-buffer-action.ts
+++ b/tui/src/editor-buffer-action.ts
@@ -1,12 +1,10 @@
+import { applyComposerEdit, applyComposerHistoryEdit } from "./composer-editing.js";
 import {
-  composerSelection,
-  redoComposerEdit,
-  selectedComposerText,
-  undoComposerEdit
-} from "./composer-model.js";
-import { applyComposerEdit } from "./composer-editing.js";
-import { moveComposerVisualVertical } from "./composer-visual-movement.js";
-import { copyToClipboard, readFromClipboard } from "./clipboard.js";
+  moveComposerVisualRows,
+  moveComposerVisualVertical
+} from "./composer-visual-movement.js";
+import { readFromClipboard } from "./clipboard.js";
+import { composerClipboardAction } from "./composer-clipboard-action.js";
 import {
   insertEditorText,
   type EditorTextBuffer,
@@ -31,6 +29,7 @@ export type EditorBufferOutcome =
 export interface EditorBufferActionOptions extends EditorTextInsertionPolicy {
   readonly isCurrent: () => boolean;
   readonly wrapWidth: number;
+  readonly pageRows: number;
 }
 
 /** Shared multiline-buffer reducer. Target owners keep save, cancel, conflict,
@@ -45,11 +44,11 @@ export async function editorBufferAction(
   if (resolved.action === "save-edit") return "save";
   if (resolved.action === "save-edit-inplace") return "save-inplace";
   if (resolved.action === "copy-selection") {
-    await copySelection(host, buffer, options, false);
+    await selectionClipboardAction(host, buffer, options, false);
     return "handled";
   }
   if (resolved.action === "cut-selection") {
-    await copySelection(host, buffer, options, true);
+    await selectionClipboardAction(host, buffer, options, true);
     return "handled";
   }
   if (resolved.action === "paste-clipboard") {
@@ -69,6 +68,15 @@ export async function editorBufferAction(
     );
     return "handled";
   }
+  if (resolved.action === "cursor-page-up" || resolved.action === "cursor-page-down") {
+    moveComposerVisualRows(
+      buffer.composer,
+      (resolved.action === "cursor-page-up" ? -1 : 1) * options.pageRows,
+      options.wrapWidth,
+      resolved.extendSelection
+    );
+    return "handled";
+  }
   const kind = applyComposerEdit(
     buffer.composer,
     resolved.action,
@@ -78,11 +86,9 @@ export async function editorBufferAction(
     if (kind === "delete") disarm(buffer, options);
     return "handled";
   }
-  if (resolved.action === "undo-edit" || resolved.action === "redo-edit") {
-    const changed = resolved.action === "undo-edit"
-      ? undoComposerEdit(buffer.composer)
-      : redoComposerEdit(buffer.composer);
-    if (changed) disarm(buffer, options);
+  const history = applyComposerHistoryEdit(buffer.composer, resolved.action);
+  if (history !== null) {
+    if (history) disarm(buffer, options);
     else host.toast = resolved.action === "undo-edit"
       ? "nothing to undo"
       : "nothing to redo";
@@ -115,55 +121,19 @@ async function pasteClipboard(
   insertEditorText(host, buffer, options, clean, "paste");
 }
 
-async function copySelection(
+async function selectionClipboardAction(
   host: EditorBufferHost,
   buffer: EditorBuffer,
   options: EditorBufferActionOptions,
   cut: boolean
 ): Promise<void> {
-  const selection = composerSelection(buffer.composer);
-  const text = selectedComposerText(buffer.composer);
-  if (selection === null || text === null) {
-    buffer.cutConfirmation = null;
-    host.toast = "nothing selected";
-    return;
-  }
-  if (!cut) buffer.cutConfirmation = null;
-  const interactionVersion = host.interactionVersion;
-  const outcome = await copyToClipboard(text);
-  if (!options.isCurrent() || host.interactionVersion !== interactionVersion) {
-    return;
-  }
-  if (outcome === "unavailable") {
-    buffer.cutConfirmation = null;
-    host.toast = "no clipboard available · selection kept";
-    return;
-  }
-  if (cut) {
-    if (outcome !== "command") {
-      const confirmation = buffer.cutConfirmation;
-      if (confirmation?.start !== selection.start
-        || confirmation.end !== selection.end
-        || confirmation.text !== text) {
-        buffer.cutConfirmation = { ...selection, text };
-        host.toast = "clipboard write unconfirmed · ctrl+x again cuts anyway";
-        return;
-      }
-    }
-    const current = composerSelection(buffer.composer);
-    if (current?.start !== selection.start
-      || current.end !== selection.end
-      || selectedComposerText(buffer.composer) !== text) {
-      host.toast = "selection changed · copied without cutting";
-      return;
-    }
-    insertEditorText(host, buffer, {
+  await composerClipboardAction(host, buffer.composer, cut, {
+    isCurrent: options.isCurrent,
+    deleteSelection: () => insertEditorText(host, buffer, {
       ...options,
       insert: () => ({ text: "" })
-    }, "", "input");
-  }
-  buffer.cutConfirmation = null;
-  host.toast = cut ? "selection cut" : "selection copied";
+    }, "", "input")
+  });
 }
 
 function disarm(
@@ -171,7 +141,7 @@ function disarm(
   options: EditorBufferActionOptions
 ): void {
   options.disarmConflict();
-  buffer.cutConfirmation = null;
+  buffer.composer.cutConfirmation = null;
 }
 
 function inputClaim(

--- a/tui/src/editor-open.ts
+++ b/tui/src/editor-open.ts
@@ -35,8 +35,7 @@ export function openPartEditor(state: RuntimeState, humanSibling: boolean): void
       : `edit ¶ ${part.number} · direction above --- · prose below`,
     placeholder: humanSibling ? "write the sibling take…" : "direction\n---\nprose",
     returnMode: "NAV",
-    conflict: null,
-    cutConfirmation: null
+    conflict: null
   });
 }
 
@@ -56,11 +55,7 @@ export function openFactEditor(state: RuntimeState, fact: StoryFact | null): voi
     title: `${fact === null ? "new" : "edit"} fact`,
     placeholder: "fact text…",
     returnMode: "FACTS",
-    conflict: null,
-    cutConfirmation: null,
-    tagCutConfirmation: null,
-    keysCutConfirmation: null,
-    budgetCutConfirmation: null
+    conflict: null
   };
   initializeFactEditorHistory(editor);
   openFactSession(state, editor);
@@ -83,11 +78,7 @@ export function openFactFromSelection(state: RuntimeState, text: string): void {
     title: "new fact from selection",
     placeholder: "fact text…",
     returnMode: "NAV",
-    conflict: null,
-    cutConfirmation: null,
-    tagCutConfirmation: null,
-    keysCutConfirmation: null,
-    budgetCutConfirmation: null
+    conflict: null
   };
   initializeFactEditorHistory(editor);
   openFactSession(state, editor);
@@ -106,8 +97,7 @@ export function openChapterSummaryEditor(
     title: `edit chapter ${chapterNumber} summary`,
     placeholder: "chapter summary…",
     returnMode: "NAV",
-    conflict: null,
-    cutConfirmation: null
+    conflict: null
   });
 }
 
@@ -121,8 +111,7 @@ export function openAuthorsNoteEditor(state: RuntimeState): void {
     title: "author's note",
     placeholder: "Steer the next passage. Style, tone, what is true right now. ⌃s keeps it.",
     returnMode: "NAV",
-    conflict: null,
-    cutConfirmation: null
+    conflict: null
   });
 }
 
@@ -160,8 +149,7 @@ function openStoryScalarEditor(state: RuntimeState, field: StoryScalarField): vo
     title: spec.title,
     placeholder: spec.placeholder,
     returnMode: "NAV",
-    conflict: null,
-    cutConfirmation: null
+    conflict: null
   });
 }
 

--- a/tui/src/editor-text-insertion.ts
+++ b/tui/src/editor-text-insertion.ts
@@ -4,7 +4,6 @@ import type { DocumentEditorSession } from "./state.js";
 
 export interface EditorTextBuffer {
   composer: ComposerState;
-  cutConfirmation: { start: number; end: number; text: string } | null;
 }
 
 export interface EditorTextHost {
@@ -52,7 +51,7 @@ export function insertEditorText(
   source: EditorTextSource
 ): void {
   policy.disarmConflict();
-  buffer.cutConfirmation = null;
+  buffer.composer.cutConfirmation = null;
   const admitted = policy.insert(raw, source);
   if ("blocked" in admitted) {
     host.toast = admitted.blocked;

--- a/tui/src/fact-editor-policy.ts
+++ b/tui/src/fact-editor-policy.ts
@@ -29,75 +29,47 @@ interface FactEditorRowSpec {
   readonly row: FactEditorRow;
   readonly sourceId: string;
   /** A choice row has no text composer of its own — it borrows a neighbor's
-   *  buffer identity only for cut-confirmation and undo grouping, never for
+   *  buffer identity only for undo grouping, never for
    *  actual text input, so a click there gets no composer to type into. Only
    *  a "text" row is that buffer's real owner: focusing a "choice" row always
    *  resets the buffer it borrows (see setFactEditorFocus), because a choice
    *  row never has a selection or cut of its own to preserve there. */
   readonly kind: "text" | "choice";
   readonly composer: (editor: FactEditorSession) => ComposerState;
-  readonly cutConfirmation: {
-    get(editor: FactEditorSession): FactEditorSession["cutConfirmation"];
-    set(editor: FactEditorSession, value: FactEditorSession["cutConfirmation"]): void;
-  };
 }
 
 /** One entry per FACT_EDITOR_ROWS row, typed as a record so every row has one
  *  — an array looked up with `.find(...)!` let a row be added to
  *  FACT_EDITOR_ROWS without a table entry and fail only at runtime, the
  *  first time focus reached it (issue #281 review finding C). Every "which
- *  buffer backs this row", "which row does this click source belong to", and
- *  "which cut-confirmation belongs to this row" lookup derives from here —
+ *  buffer backs this row" and "which row does this click source belong to"
+ *  lookup derives from here —
  *  see setFactEditorFocus and handleFactEditorHistory below, which used to
  *  re-encode this same mapping by hand. */
 const FACT_EDITOR_ROW_TABLE: Record<FactEditorRow, FactEditorRowSpec> = {
   tag: {
     row: "tag", sourceId: FACT_TAG_COMPOSER_SOURCE, kind: "text",
-    composer: (editor) => editor.tag,
-    cutConfirmation: {
-      get: (editor) => editor.tagCutConfirmation,
-      set: (editor, value) => { editor.tagCutConfirmation = value; }
-    }
+    composer: (editor) => editor.tag
   },
   activation: {
     row: "activation", sourceId: FACT_ACTIVATION_COMPOSER_SOURCE, kind: "choice",
-    composer: (editor) => editor.keys,
-    cutConfirmation: {
-      get: (editor) => editor.keysCutConfirmation,
-      set: (editor, value) => { editor.keysCutConfirmation = value; }
-    }
+    composer: (editor) => editor.keys
   },
   keys: {
     row: "keys", sourceId: FACT_KEYS_COMPOSER_SOURCE, kind: "text",
-    composer: (editor) => editor.keys,
-    cutConfirmation: {
-      get: (editor) => editor.keysCutConfirmation,
-      set: (editor, value) => { editor.keysCutConfirmation = value; }
-    }
+    composer: (editor) => editor.keys
   },
   priority: {
     row: "priority", sourceId: FACT_PRIORITY_COMPOSER_SOURCE, kind: "choice",
-    composer: (editor) => editor.budget,
-    cutConfirmation: {
-      get: (editor) => editor.budgetCutConfirmation,
-      set: (editor, value) => { editor.budgetCutConfirmation = value; }
-    }
+    composer: (editor) => editor.budget
   },
   budget: {
     row: "budget", sourceId: FACT_BUDGET_COMPOSER_SOURCE, kind: "text",
-    composer: (editor) => editor.budget,
-    cutConfirmation: {
-      get: (editor) => editor.budgetCutConfirmation,
-      set: (editor, value) => { editor.budgetCutConfirmation = value; }
-    }
+    composer: (editor) => editor.budget
   },
   body: {
     row: "body", sourceId: FACT_BODY_COMPOSER_SOURCE, kind: "text",
-    composer: (editor) => editor.composer,
-    cutConfirmation: {
-      get: (editor) => editor.cutConfirmation,
-      set: (editor, value) => { editor.cutConfirmation = value; }
-    }
+    composer: (editor) => editor.composer
   }
 };
 
@@ -105,7 +77,8 @@ const ACTIVATION_TEXT_ACTIONS = new Set<ResolvedKey["action"]>([
   "input", "backspace", "delete-forward", "delete-word-left", "delete-word-right",
   "delete-line", "delete-line-start", "delete-line-end", "paste-clipboard",
   "cut-selection", "select-all", "cursor-word-left", "cursor-word-right",
-  "cursor-line-start", "cursor-line-end", "cursor-buffer-start", "cursor-buffer-end"
+  "cursor-line-start", "cursor-line-end", "cursor-buffer-start", "cursor-buffer-end",
+  "cursor-page-up", "cursor-page-down"
 ]);
 
 /** Fact-only editor commands. */
@@ -219,7 +192,7 @@ export function setFactEditorFocus(
     if (spec.kind !== "text") continue;
     if (focusSpec.kind === "text" && spec.composer(editor) === focusedComposer) continue;
     spec.composer(editor).anchor = null;
-    spec.cutConfirmation.set(editor, null);
+    spec.composer(editor).cutConfirmation = null;
   }
 }
 
@@ -332,25 +305,10 @@ export function resetFactEditorHistory(editor: FactEditorSession): void {
   resetComposerEditHistory(editor.composer);
 }
 
-/** Share cut-confirmation ownership while the active Fact field changes.
- *  Reads and writes through FACT_EDITOR_ROW_TABLE's cutConfirmation accessors
- *  rather than re-encoding the row-to-buffer mapping as a conditional chain —
- *  a chain like that fell back to the body's cut confirmation for any row a
- *  future edit added without updating it here too (issue #316). */
-export function factEditorBuffer(editor: FactEditorSession): {
-  composer: ComposerState;
-  cutConfirmation: FactEditorSession["cutConfirmation"];
-} {
+/** Return the buffer that owns the focused Fact row. */
+export function factEditorBuffer(editor: FactEditorSession): { composer: ComposerState } {
   const spec = factEditorRowSpec(editor.focus);
-  return {
-    composer: spec.composer(editor),
-    get cutConfirmation() {
-      return spec.cutConfirmation.get(editor);
-    },
-    set cutConfirmation(value) {
-      spec.cutConfirmation.set(editor, value);
-    }
-  };
+  return { composer: spec.composer(editor) };
 }
 
 /** Move through the Fact fields and the first body visual row. Every row but
@@ -415,11 +373,8 @@ function tagLength(text: string): number {
 
 function disarmFactEditor(editor: FactEditorSession): void {
   if (editor.conflict !== null) editor.conflict.armed = false;
-  // Reads FACT_EDITOR_ROW_TABLE rather than the four buffers by name, for the
-  // same reason factEditorBuffer does above: a hand-listed reset would leave
-  // a future row's own cut-confirmation buffer armed after the user believes
-  // a cut was cancelled, since nothing would force this list to grow with it.
+  // Read FACT_EDITOR_ROW_TABLE so a future text row joins this reset by default.
   for (const spec of Object.values(FACT_EDITOR_ROW_TABLE)) {
-    spec.cutConfirmation.set(editor, null);
+    spec.composer(editor).cutConfirmation = null;
   }
 }

--- a/tui/src/keys-text-surface.ts
+++ b/tui/src/keys-text-surface.ts
@@ -4,7 +4,8 @@ import type { ResolvedKey } from "./keys.js";
 /**
  * The three composer-backed surfaces use these editing gestures.
  * They are Direct, the full-screen editor, and the settings fields.
- * They move and delete by character, word, and line.
+ * They move and delete by character, word, line, buffer, and page.
+ * They also share cut, undo, and redo.
  *
  * Four other surfaces hold a plain string, not a composer: the LIBRARY
  * prompt, the FACTS filter, the CHAPTERS rename field, and the TAG name.
@@ -26,6 +27,21 @@ export function textSurfaceKey(key: KeyEvent): ResolvedKey | null {
   const byWord = key.ctrl || alt;
   const extend = key.shift ? { extendSelection: true } : {};
 
+  // Enhanced keyboard reporting exposes Command as `super`. Its arrows use
+  // macOS text conventions: horizontal means line, vertical means buffer.
+  if (key.super && (name === "left" || name === "right")) {
+    return {
+      action: name === "left" ? "cursor-line-start" : "cursor-line-end",
+      ...extend
+    };
+  }
+  if (key.super && (name === "up" || name === "down")) {
+    return {
+      action: name === "up" ? "cursor-buffer-start" : "cursor-buffer-end",
+      ...extend
+    };
+  }
+
   if (key.name === "left") {
     return { action: byWord ? "cursor-word-left" : "cursor-left", ...extend };
   }
@@ -43,6 +59,7 @@ export function textSurfaceKey(key: KeyEvent): ResolvedKey | null {
   // cannot be told from plain backspace. alt does arrive, and ctrl+w is the
   // word delete that lands in every terminal.
   if (key.name === "backspace") {
+    if (key.super) return { action: "delete-line-start" };
     return { action: byWord ? "delete-word-left" : "backspace" };
   }
   if (key.name === "delete") {
@@ -52,8 +69,22 @@ export function textSurfaceKey(key: KeyEvent): ResolvedKey | null {
   if (key.ctrl && name === "k") return { action: "delete-line-end" };
   if (key.ctrl && name === "u") return { action: "delete-line-start" };
 
+  if (name === "pageup" || name === "pagedown") {
+    return {
+      action: name === "pageup" ? "cursor-page-up" : "cursor-page-down",
+      ...extend
+    };
+  }
+
   // Ctrl+A and Command+A use the platform-wide Select All convention.
   if ((key.ctrl || key.super) && name === "a") return { action: "select-all" };
+  if ((key.ctrl || key.super) && name === "x") return { action: "cut-selection" };
+  if ((key.ctrl && name === "z" && !key.shift) || key.ctrl && name === "-"
+    || key.super && name === "z" && !key.shift) return { action: "undo-edit" };
+  if ((key.ctrl && name === "z" && key.shift) || key.ctrl && (name === "y" || name === ".")
+    || key.super && name === "z" && key.shift) {
+    return { action: "redo-edit" };
+  }
   // Alt+A keeps a terminal-safe line-start chord for Emacs-style motion.
   if (key.ctrl && name === "e") return { action: "cursor-line-end", ...extend };
   if (alt && name === "a") return { action: "cursor-line-start", ...extend };

--- a/tui/src/keys.ts
+++ b/tui/src/keys.ts
@@ -45,6 +45,7 @@ export type KeyAction =
   | "cursor-word-left" | "cursor-word-right"
   | "cursor-line-start" | "cursor-line-end"
   | "cursor-buffer-start" | "cursor-buffer-end"
+  | "cursor-page-up" | "cursor-page-down"
   | "delete-forward" | "delete-word-left" | "delete-word-right" | "delete-line"
   | "delete-line-start" | "delete-line-end" | "select-all"
   | "copy-selection" | "cut-selection" | "paste-clipboard" | "undo-edit" | "redo-edit"
@@ -179,7 +180,7 @@ function composerBackedInput(key: KeyEvent): ResolvedKey {
 }
 
 function multilineInput(key: KeyEvent): ResolvedKey {
-  if (key.name === "up" || key.name === "down") {
+  if ((key.name === "up" || key.name === "down") && !key.super) {
     return {
       action: key.name === "up" ? "cursor-up" : "cursor-down",
       ...(key.shift ? { extendSelection: true } : {})
@@ -419,6 +420,13 @@ export function resolveKey(key: KeyEvent, mode: AppMode, options: ResolveOptions
   if (navChord !== null) return { action: navChord.action };
   if (mode === "COMPOSE") {
     const name = key.name.toLowerCase();
+    // Command arrows stay text motion even when a terminal also reports the
+    // Control bit. The compose history chords must not shadow them.
+    if (key.super && (name === "left" || name === "right"
+      || name === "up" || name === "down" || name === "backspace")) {
+      const commandMotion = textSurfaceKey(key);
+      if (commandMotion !== null) return commandMotion;
+    }
     const composeChord = resolveReferenceBinding("compose-chord", key, mode, mapView);
     if (composeChord !== null) return { action: composeChord.action };
     if ((key.ctrl || key.super) && name === "v") return { action: "paste-clipboard" };
@@ -463,14 +471,7 @@ export function resolveKey(key: KeyEvent, mode: AppMode, options: ResolveOptions
     if (key.ctrl && key.shift && name === "s") return { action: "save-edit-inplace" };
     if (key.ctrl && name === "s") return { action: "save-edit" };
     if ((key.ctrl || key.super) && name === "c") return { action: "copy-selection" };
-    if ((key.ctrl || key.super) && name === "x") return { action: "cut-selection" };
     if ((key.ctrl || key.super) && name === "v") return { action: "paste-clipboard" };
-    if ((key.ctrl && name === "z" && !key.shift) || key.ctrl && name === "-"
-      || key.super && name === "z" && !key.shift) return { action: "undo-edit" };
-    if ((key.ctrl && name === "z" && key.shift) || key.ctrl && (name === "y" || name === ".")
-      || key.super && name === "z" && key.shift) {
-      return { action: "redo-edit" };
-    }
     if (key.super && name === "a") return { action: "select-all" };
     if (key.ctrl && key.shift && name === "d") return { action: "delete-line" };
     // The editor's own chords: emacs character motion, and ctrl+d forward
@@ -482,7 +483,7 @@ export function resolveKey(key: KeyEvent, mode: AppMode, options: ResolveOptions
       };
     }
     if (key.name === "return" || isLinefeedKey(key)) return { action: "newline" };
-    if (key.name === "up" || key.name === "down") {
+    if ((key.name === "up" || key.name === "down") && !key.super) {
       return {
         action: key.name === "up" ? "cursor-up" : "cursor-down",
         ...(key.shift ? { extendSelection: true } : {})

--- a/tui/src/sampling-actions.ts
+++ b/tui/src/sampling-actions.ts
@@ -1,4 +1,4 @@
-import { applyComposerEdit } from "./composer-editing.js";
+import { composerSurfaceAction } from "./composer-surface-action.js";
 import { insertComposerText } from "./composer-model.js";
 import { readFromClipboard } from "./clipboard.js";
 import { sanitizePastedText, type ResolvedKey } from "./keys.js";
@@ -50,7 +50,7 @@ export async function samplingOverlayAction(
     return;
   }
   if (nested.edit !== null) {
-    samplingEditAction(resolved, state, source, context);
+    await samplingEditAction(resolved, state, source, context);
     return;
   }
   if (resolved.action === "focus-next" || resolved.action === "focus-previous") {
@@ -161,12 +161,12 @@ function roundSamplingValue(value: number, precision: number): number {
   return Object.is(rounded, -0) ? 0 : rounded;
 }
 
-function samplingEditAction(
+async function samplingEditAction(
   resolved: ResolvedKey,
   state: RuntimeState,
   source: AppSource,
   context: ActionContext
-): void {
+): Promise<void> {
   const settings = state.settings;
   if (settings === null || settings.sampling === null) return;
   const nested = settings.sampling;
@@ -193,9 +193,13 @@ function samplingEditAction(
     insertComposerText(edit.composer, resolved.text ?? "");
     return;
   }
-  if (applyComposerEdit(edit.composer, resolved.action, resolved.extendSelection) !== null) {
-    if (settings.conflict !== null) settings.conflict.armed = false;
-  }
+  await composerSurfaceAction(resolved, state, edit.composer, {
+    isCurrent: () => state.settings === settings
+      && settings.sampling === nested
+      && nested.edit === edit,
+    pageRows: 1,
+    onEdit: () => disarmSettingsConflict(settings)
+  });
 }
 
 /** The phrase text a phrase-bias/banned-strings commit resolves against,

--- a/tui/src/screens/story.ts
+++ b/tui/src/screens/story.ts
@@ -708,16 +708,16 @@ function renderFullscreenComposer(
 function editorFooterHints(editor: DocumentEditorSession): string {
   if (editor.kind === "document"
     && editor.target.kind === "settings-prompt") {
-    return "shift+arrows select · ctrl+c/v · ctrl+s keep draft · esc cancel";
+    return "shift+arrows select · ctrl+c/x/v · ctrl+s keep draft · esc cancel";
   }
   // Part editors offer dual save; other targets and incomplete fixtures keep
   // the single-save footer (tests may stub a minimal session without target).
   if (editor.kind === "document" && editor.target.kind === "part") {
     // ctrl+o is the portable same-take chord; ctrl+shift+s is an alias where
     // the terminal reports modified keys.
-    return "shift+arrows select · ctrl+c/v · ctrl+s new take · ctrl+o same take · esc cancel";
+    return "shift+arrows select · ctrl+c/x/v · ctrl+s new take · ctrl+o same take · esc cancel";
   }
-  return "shift+arrows select · ctrl+c/v · ctrl+s save · esc cancel";
+  return "shift+arrows select · ctrl+c/x/v · ctrl+s save · esc cancel";
 }
 
 function renderInlineEditor(

--- a/tui/src/screens/story/composer.ts
+++ b/tui/src/screens/story/composer.ts
@@ -33,6 +33,12 @@ import {
   type DisplayRole,
   type FrameLine
 } from "./frame.js";
+import {
+  composerHeightCap,
+  composerPageRows
+} from "../../composer-viewport.js";
+
+export { composerHeightCap } from "../../composer-viewport.js";
 
 /** Where the writer's insertion point is, and whether this field has it.
  *
@@ -90,14 +96,6 @@ export interface ComposerLayout {
   dimsStory: boolean;
 }
 
-/** The default cap from design §11. A valid override is taken literally. */
-export function composerHeightCap(terminalHeight: number, override?: number | null): number {
-  if (override !== null && override !== undefined && Number.isFinite(override) && override >= 1) {
-    return Math.floor(override);
-  }
-  return Math.max(6, Math.floor(Math.max(0, terminalHeight) / 3));
-}
-
 /**
  * Pure COMPOSE field renderer. Its lines exclude the app status row: inline
  * callers subtract `lines.length` from the prose viewport; fullscreen callers
@@ -136,9 +134,11 @@ export function renderComposerLayout(options: ComposerLayoutOptions): ComposerLa
     options.promptKind ?? null
   ).slice(0, footerCapacity);
   // Inline always leaves one row of story visible plus the status row.
-  const bodyCapacity = fullscreen
-    ? Math.max(1, terminalHeight - 2 - footer.length)
-    : Math.max(1, Math.min(cap, terminalHeight - 3 - footer.length));
+  const bodyCapacity = footer.length === 1
+    ? composerPageRows(terminalHeight, fullscreen, options.composeMaxHeight)
+    : fullscreen
+      ? Math.max(1, terminalHeight - 2 - footer.length)
+      : Math.max(1, Math.min(cap, terminalHeight - 3 - footer.length));
   const bodyRows = fullscreen ? bodyCapacity : Math.min(rowCount, bodyCapacity);
   const scrollTop = retainedScrollTop(rowCount, bodyRows, cursorRow, options.scrollTop);
   const title = options.title ?? composerTitle(fullscreen, options.directingPart);

--- a/tui/src/settings-field-actions.ts
+++ b/tui/src/settings-field-actions.ts
@@ -1,6 +1,6 @@
 import type { AppSource } from "./app.js";
 import { insertComposerText } from "./composer-model.js";
-import { applyComposerEdit } from "./composer-editing.js";
+import { composerSurfaceAction } from "./composer-surface-action.js";
 import { readFromClipboard } from "./clipboard.js";
 import { applyTextKey, sanitizePastedText, type ResolvedKey } from "./keys.js";
 import {
@@ -154,15 +154,13 @@ export async function settingsInlineEditAction(
     insertComposerText(edit.composer, resolved.text ?? "");
     return;
   }
-  const kind = applyComposerEdit(
-    edit.composer,
-    resolved.action,
-    resolved.extendSelection
-  );
-  if (kind !== null) {
-    if (kind === "delete") disarmSettingsConflict(overlay);
-    return;
-  }
+  await composerSurfaceAction(resolved, state, edit.composer, {
+    isCurrent: () => state.settings === overlay && overlay.edit === edit,
+    pageRows: 1,
+    onEdit: (kind) => {
+      if (kind !== "move") disarmSettingsConflict(overlay);
+    }
+  });
 }
 
 function pasteSettingsInlineEdit(
@@ -177,4 +175,3 @@ function pasteSettingsInlineEdit(
   insertComposerText(edit.composer, clean.replace(/\n+/g, " "));
   return true;
 }
-

--- a/tui/src/settings-prompt-editor.ts
+++ b/tui/src/settings-prompt-editor.ts
@@ -19,7 +19,6 @@ export function openSystemPromptEditor(state: RuntimeState): void {
     initial,
     title: "system prompt",
     placeholder: "Write the default model instructions…",
-    cutConfirmation: null,
     conflict: null,
     returnMode: "SETTINGS",
     target: { kind: "settings-prompt", owner: overlay, scope: "global" }

--- a/tui/src/state.ts
+++ b/tui/src/state.ts
@@ -358,8 +358,6 @@ interface EditorSessionBase {
   composer: ComposerState;
   title: string;
   placeholder: string;
-  /** Explicit second-press consent when OSC 52 cannot confirm a destructive cut. */
-  cutConfirmation: { start: number; end: number; text: string } | null;
 }
 
 export interface InlineEditorSession extends EditorSessionBase {
@@ -390,9 +388,6 @@ export interface FactEditorSession extends EditorSessionBase {
   /** Draft-of-Fact: what the editor would already match if nothing changed —
    *  see shared/fact-draft.ts. Rebased on a clean reconcile, replaced on save. */
   initialFact: FactDraft;
-  tagCutConfirmation: EditorSessionBase["cutConfirmation"];
-  keysCutConfirmation: EditorSessionBase["cutConfirmation"];
-  budgetCutConfirmation: EditorSessionBase["cutConfirmation"];
 }
 
 export type DocumentEditorSession =

--- a/tui/src/story-actions.ts
+++ b/tui/src/story-actions.ts
@@ -5,7 +5,8 @@ import { openFactFromSelection, openPartEditor } from "./editor-action.js";
 import { applyTextKey, type ResolvedKey } from "./keys.js";
 import { copyToClipboard } from "./clipboard.js";
 import { pasteClipboardIntoComposer } from "./compose-clipboard.js";
-import { applyComposerEdit } from "./composer-editing.js";
+import { composerSurfaceAction } from "./composer-surface-action.js";
+import { composerPageRows } from "./composer-viewport.js";
 import { copyStoryText } from "./copy-actions.js";
 import { recordHumanWords, saveConfig } from "./config.js";
 import { rememberFocus } from "./reading-position-persist.js";
@@ -422,11 +423,15 @@ export async function composeAction(
     }
     return;
   }
-  if (applyComposerEdit(
-    state.composer,
-    resolved.action,
-    resolved.extendSelection
-  ) !== null) return;
+  const composer = state.composer;
+  if (await composerSurfaceAction(resolved, state, composer, {
+    isCurrent: () => state.mode === "COMPOSE" && state.composer === composer,
+    pageRows: composerPageRows(
+      context.renderer?.height ?? 24,
+      composer.fullscreen,
+      state.config.composeMaxHeight
+    )
+  })) return;
   if (resolved.action === "history-previous") return historyMove(state, -1);
   if (resolved.action === "history-next") return historyMove(state, 1);
   if (resolved.action === "send" || resolved.action === "send-as-take") {

--- a/tui/test/composer-renderer.test.ts
+++ b/tui/test/composer-renderer.test.ts
@@ -28,9 +28,14 @@ import {
 import {
   deleteComposerLine,
   moveComposerBufferBoundary,
+  moveComposerPage,
   moveComposerWord
 } from "../src/composer-editing.js";
-import { moveComposerVisualVertical } from "../src/composer-visual-movement.js";
+import {
+  moveComposerVisualRows,
+  moveComposerVisualVertical
+} from "../src/composer-visual-movement.js";
+import { composerPageRows } from "../src/composer-viewport.js";
 import { wrappedComposerLayout } from "../src/composer-wrapping.js";
 import {
   applyComposeMode,
@@ -66,6 +71,27 @@ describe("composer renderer", () => {
     expect(composerHeightCap(24)).toBe(8);
     expect(composerHeightCap(10)).toBe(6);
     expect(composerHeightCap(36, 4)).toBe(4);
+  });
+
+  test("moves by the visible page in inline and full-screen editors", () => {
+    const text = Array.from({ length: 30 }, (_, line) => `line ${line}`).join("\n");
+    const inline = createComposer(text);
+    moveComposerTo(inline, 0);
+    const inlineRows = composerPageRows(24, false);
+    expect(inlineRows).toBe(8);
+    moveComposerPage(inline, 1, inlineRows);
+    expect(composerPosition(inline)).toEqual({ line: 8, column: 0 });
+    moveComposerPage(inline, -1, inlineRows);
+    expect(composerPosition(inline)).toEqual({ line: 0, column: 0 });
+
+    const fullscreen = createComposer(text);
+    moveComposerTo(fullscreen, 0);
+    const fullscreenRows = composerPageRows(24, true);
+    expect(fullscreenRows).toBe(21);
+    expect(moveComposerVisualRows(fullscreen, fullscreenRows, 76)).toBeTrue();
+    expect(composerPosition(fullscreen)).toEqual({ line: 21, column: 0 });
+    expect(moveComposerVisualRows(fullscreen, -fullscreenRows, 76)).toBeTrue();
+    expect(composerPosition(fullscreen)).toEqual({ line: 0, column: 0 });
   });
 
   test("frames the composer on entry and places the solid caret at its grapheme offset", () => {

--- a/tui/test/fact-editor.test.ts
+++ b/tui/test/fact-editor.test.ts
@@ -562,39 +562,39 @@ describe("Fact editor", () => {
     await press(key("t", { sequence: "\u0014", ctrl: true }));
     editor.tag.anchor = 0;
     editor.tag.cursor = 3;
-    editor.tagCutConfirmation = { start: 0, end: 3, text: "peo" };
+    editor.tag.cutConfirmation = { start: 0, end: 3, text: "peo" };
 
     // Move focus through activation, keys, priority, and budget to the body.
     await press(key("down"));
     expect(editor.focus).toBe("activation");
     await press(key("down"));
     expect(editor.focus).toBe("keys");
-    editor.keysCutConfirmation = { start: 0, end: 1, text: "x" };
+    editor.keys.cutConfirmation = { start: 0, end: 1, text: "x" };
     await press(key("down"));
     expect(editor.focus).toBe("priority");
     // Priority borrows budget's buffer identity, same as activation borrows
     // keys' — leaving keys for priority still clears keys' own confirmation.
-    expect(editor.keysCutConfirmation).toBe(null);
-    editor.budgetCutConfirmation = { start: 0, end: 1, text: "5" };
+    expect(editor.keys.cutConfirmation).toBe(null);
+    editor.budget.cutConfirmation = { start: 0, end: 1, text: "5" };
     await press(key("down"));
     expect(editor.focus).toBe("budget");
-    expect(editor.budgetCutConfirmation).toEqual({ start: 0, end: 1, text: "5" });
+    expect(editor.budget.cutConfirmation).toEqual({ start: 0, end: 1, text: "5" });
     await press(key("down"));
     expect(editor.focus).toBe("body");
     expect(editor.tag.anchor).toBe(null);
-    expect(editor.tagCutConfirmation).toBe(null);
-    expect(editor.budgetCutConfirmation).toBe(null);
+    expect(editor.tag.cutConfirmation).toBe(null);
+    expect(editor.budget.cutConfirmation).toBe(null);
 
     // In body field, set selection and cut confirmation
     editor.composer.anchor = 0;
     editor.composer.cursor = 5;
-    editor.cutConfirmation = { start: 0, end: 5, text: "Maren" };
+    editor.composer.cutConfirmation = { start: 0, end: 5, text: "Maren" };
 
     // Move focus to budget. The body selection ownership clears immediately.
     await press(key("up"));
     expect(editor.focus).toBe("budget");
     expect(editor.composer.anchor).toBe(null);
-    expect(editor.cutConfirmation).toBe(null);
+    expect(editor.composer.cutConfirmation).toBe(null);
   });
 
   test("renders activation and keys and rejects duplicate normalized keys", async () => {

--- a/tui/test/hit-map-chrome.test.ts
+++ b/tui/test/hit-map-chrome.test.ts
@@ -385,8 +385,7 @@ describe("hit map clickable chrome", () => {
       composer: createComposer("prose"),
       initial: "prose",
       returnMode: "NAV",
-      conflict: null,
-      cutConfirmation: null
+      conflict: null
     };
     const frame = render(state, 120, 30);
     const row = frame.findIndex((line) => plainLine(line).includes(state.model));
@@ -984,8 +983,7 @@ describe("hit map clickable chrome", () => {
       composer: createComposer("editor text"),
       initial: "editor text",
       returnMode: "NAV",
-      conflict: null,
-      cutConfirmation: null
+      conflict: null
     };
     render(state);
     const editorRow = state.hitRows.findIndex((row) => row?.target.kind === "composer");

--- a/tui/test/keys-contract-fixture.ts
+++ b/tui/test/keys-contract-fixture.ts
@@ -29,6 +29,10 @@ export type ComposerSurface = (typeof COMPOSER_SURFACES)[number];
 const TEXT_SURFACE_KEY_NAMES = [
   "left",
   "right",
+  "up",
+  "down",
+  "pageup",
+  "pagedown",
   "home",
   "end",
   "backspace",
@@ -39,7 +43,12 @@ const TEXT_SURFACE_KEY_NAMES = [
   "f",
   "k",
   "u",
-  "w"
+  "w",
+  "x",
+  "y",
+  "z",
+  "-",
+  "."
 ] as const;
 
 const MODIFIER_COMBINATIONS = Array.from({ length: 32 }, (_, bits) => ({
@@ -115,11 +124,7 @@ export async function composerChangedThroughSurface(
       title: "Edit fact",
       placeholder: "Fact text",
       returnMode: "FACTS",
-      conflict: null,
-      cutConfirmation: null,
-      tagCutConfirmation: null,
-      keysCutConfirmation: null,
-      budgetCutConfirmation: null
+      conflict: null
     };
     await inlineEditorAction(resolved, state, source, context);
   } else {

--- a/tui/test/keys-paste.test.ts
+++ b/tui/test/keys-paste.test.ts
@@ -65,8 +65,7 @@ test("paste inserts at the composer cursor and flattens single-line prompts", ()
         row: "model" as const,
         mode: "text" as const,
         composer: settingsComposer,
-        initial: "ab",
-        cutConfirmation: null
+        initial: "ab"
       },
       conflict: null
     }
@@ -111,11 +110,7 @@ test("paste inserts at the composer cursor and flattens single-line prompts", ()
       title: "edit fact",
       placeholder: "fact text…",
       returnMode: "FACTS" as const,
-      conflict: { message: "changed", resolution: "overwrite" as const, armed: true },
-      cutConfirmation: null,
-      tagCutConfirmation: null,
-      keysCutConfirmation: null,
-      budgetCutConfirmation: null
+      conflict: { message: "changed", resolution: "overwrite" as const, armed: true }
     }
   };
   expect(pasteInto(editor, "line one\r\nline two")).toBeTrue();

--- a/tui/test/keys.test.ts
+++ b/tui/test/keys.test.ts
@@ -69,8 +69,6 @@ const DECLARED_DIVERGENCES = [
     actions: ["send-as-take", "save-edit-inplace", "commit-field"] },
   { label: "ctrl+c", event: key("c", { ctrl: true }),
     actions: ["none", "copy-selection", "none"] },
-  { label: "ctrl+x", event: key("x", { ctrl: true }),
-    actions: ["none", "cut-selection", "none"] },
   { label: "ctrl+v", event: key("v", { ctrl: true }),
     actions: ["paste-clipboard", "paste-clipboard", "paste-clipboard"] },
   { label: "cmd+v", event: key("v", { super: true }),
@@ -79,10 +77,6 @@ const DECLARED_DIVERGENCES = [
     actions: ["none", "delete-forward", "none"] },
   { label: "ctrl+shift+d", event: key("d", { ctrl: true, shift: true }),
     actions: ["none", "delete-line", "none"] },
-  { label: "ctrl+z", event: key("z", { ctrl: true }),
-    actions: ["none", "undo-edit", "none"] },
-  { label: "ctrl+shift+z", event: key("z", { ctrl: true, shift: true }),
-    actions: ["none", "redo-edit", "none"] },
   { label: "up", event: key("up"), actions: ["cursor-up", "cursor-up", "none"] },
   { label: "down", event: key("down"), actions: ["cursor-down", "cursor-down", "none"] },
   { label: "ctrl+up", event: key("up", { ctrl: true }),
@@ -249,6 +243,9 @@ describe("text surfaces and palette", () => {
         }
       }
       for (const [action, resolved] of emitted) {
+        if (action === "cut-selection"
+          || action === "undo-edit"
+          || action === "redo-edit") continue;
         expect({
           surface,
           action,
@@ -402,6 +399,26 @@ describe("text surfaces and palette", () => {
     expect(resolveKey(key("end", { ctrl: true }), "EDITOR").action).toBe("cursor-buffer-end");
     expect(resolveKey(key("z", { ctrl: true }), "EDITOR").action).toBe("undo-edit");
     expect(resolveKey(key("z", { ctrl: true, shift: true }), "EDITOR").action).toBe("redo-edit");
+  });
+
+  test("every editor supports cut, history, Command navigation, and page movement", () => {
+    const expected = [
+      [key("x", { ctrl: true }), "cut-selection"],
+      [key("x", { super: true }), "cut-selection"],
+      [key("z", { ctrl: true }), "undo-edit"],
+      [key("z", { super: true }), "undo-edit"],
+      [key("z", { super: true, shift: true }), "redo-edit"],
+      [key("left", { super: true }), "cursor-line-start"],
+      [key("right", { super: true, shift: true }), "cursor-line-end"],
+      [key("up", { super: true }), "cursor-buffer-start"],
+      [key("down", { super: true, shift: true }), "cursor-buffer-end"],
+      [key("backspace", { super: true }), "delete-line-start"],
+      [key("pageup"), "cursor-page-up"],
+      [key("pagedown", { shift: true }), "cursor-page-down"]
+    ] as const;
+    for (const [event, action] of expected) {
+      expect(surfaceActions(event)).toEqual([action, action, action]);
+    }
   });
 
   test("Ctrl+P and colon open commands; Ctrl+G opens context details", () => {

--- a/tui/test/presented-selection.test.ts
+++ b/tui/test/presented-selection.test.ts
@@ -272,11 +272,7 @@ test("copying an uneditable selection clears before the next key capture", () =>
     title: "edit fact",
     placeholder: "fact text…",
     returnMode: "FACTS",
-    conflict: null,
-    cutConfirmation: null,
-    tagCutConfirmation: null,
-    keysCutConfirmation: null,
-    budgetCutConfirmation: null
+    conflict: null
   };
   const selected = nativeSelection("weather", 0, 7);
   let current: typeof selected | null = selected;

--- a/tui/test/regressions.test.ts
+++ b/tui/test/regressions.test.ts
@@ -201,8 +201,7 @@ describe("review regressions", () => {
         title: "edit part",
         placeholder: "",
         returnMode: "NAV",
-        conflict: null,
-        cutConfirmation: null
+        conflict: null
       }
     }, { width: 80, height: 24 });
 

--- a/tui/test/sampling-clipboard.test.ts
+++ b/tui/test/sampling-clipboard.test.ts
@@ -4,10 +4,14 @@ import {
   basicSettingsFromDocument
 } from "../../shared/settings-basic-draft.js";
 import type { SettingsView } from "../../shared/settings-v2-types.js";
-import { composerSelection, setComposerText } from "../src/composer-model.js";
+import {
+  composerSelection,
+  setComposerText,
+  type ComposerState
+} from "../src/composer-model.js";
 
 type ClipboardReader = () => Promise<string | null>;
-type ClipboardWriter = (text: string) => Promise<"internal">;
+type ClipboardWriter = (text: string) => Promise<"command" | "internal">;
 
 const bunTest = await import("bun:test") as unknown as {
   mock: {
@@ -41,6 +45,102 @@ const { buildComposerSelectionProjection } = await import("../src/selection-proj
 const { fitLine } = await import("../src/screens/story/frame.js");
 
 describe("Direct clipboard ownership", () => {
+  test("an unconfirmed cut needs two consecutive presses", async () => {
+    const { state, press } = settingsHarness();
+    state.mode = "COMPOSE";
+    setComposerText(state.composer, "alpha beta");
+    state.composer.anchor = 6;
+    clipboardWriter = async () => "internal";
+
+    await press(key("x", { ctrl: true }));
+    expect(state.composer.text).toBe("alpha beta");
+    expect(state.toast).toBe("clipboard write unconfirmed · cut again to confirm");
+
+    await press(key("escape"));
+    await press(key("return"));
+    await press(key("x", { ctrl: true }));
+    expect(state.composer.text).toBe("alpha beta");
+    expect(state.toast).toBe("clipboard write unconfirmed · cut again to confirm");
+
+    await press(key("x", { ctrl: true }));
+    expect(state.composer.text).toBe("alpha ");
+    expect(state.toast).toBe("selection cut");
+  });
+
+  test("cut, undo, and redo operate every composer-backed editor", async () => {
+    clipboardWriter = async () => "command";
+    const cases: {
+      name: string;
+      open: () => Promise<{
+        composer: ComposerState;
+        press: ReturnType<typeof settingsHarness>["press"];
+      }>;
+      cut: ReturnType<typeof key>;
+    }[] = [
+      {
+        name: "Direct",
+        open: async () => {
+          const harness = settingsHarness();
+          harness.state.mode = "COMPOSE";
+          return { composer: harness.state.composer, press: harness.press };
+        },
+        cut: key("x", { ctrl: true })
+      },
+      {
+        name: "full editor",
+        open: async () => {
+          const harness = settingsHarness();
+          await harness.press(key("f"));
+          await harness.press(key("return"));
+          if (harness.state.editor === null) throw new Error("editor did not open");
+          return { composer: harness.state.editor.composer, press: harness.press };
+        },
+        cut: key("x", { super: true })
+      },
+      {
+        name: "Settings field",
+        open: async () => {
+          const harness = settingsHarness();
+          await openSettings(harness.press);
+          await selectRow(harness.press, harness.state, "base-url");
+          await harness.press(key("return"));
+          const edit = harness.state.settings?.edit;
+          if (edit?.kind !== "inline") throw new Error("Settings field did not open");
+          return { composer: edit.composer, press: harness.press };
+        },
+        cut: key("x", { ctrl: true })
+      },
+      {
+        name: "Sampling field",
+        open: async () => {
+          const harness = await openSamplingEdit();
+          const edit = harness.state.settings?.sampling?.edit;
+          if (edit === null || edit === undefined) throw new Error("Sampling field did not open");
+          return { composer: edit.composer, press: harness.press };
+        },
+        cut: key("x", { super: true })
+      }
+    ];
+
+    for (const editorCase of cases) {
+      const { composer, press } = await editorCase.open();
+      setComposerText(composer, "alpha beta");
+      composer.anchor = 6;
+
+      await press(editorCase.cut);
+      expect({ name: editorCase.name, text: composer.text })
+        .toEqual({ name: editorCase.name, text: "alpha " });
+
+      await press(key("z", { ctrl: true }));
+      expect({ name: editorCase.name, text: composer.text })
+        .toEqual({ name: editorCase.name, text: "alpha beta" });
+
+      await press(key("z", { super: true, shift: true }));
+      expect({ name: editorCase.name, text: composer.text })
+        .toEqual({ name: editorCase.name, text: "alpha " });
+    }
+  });
+
   test("Command+C without a selection does not quit", async () => {
     let quits = 0;
     const { state, press } = settingsHarness(() => { quits += 1; });

--- a/tui/test/selection-copy.test.ts
+++ b/tui/test/selection-copy.test.ts
@@ -409,11 +409,7 @@ describe("active selection copy", () => {
       title: "edit fact",
       placeholder: "fact text…",
       returnMode: "FACTS",
-      conflict: null,
-      cutConfirmation: null,
-      tagCutConfirmation: null,
-      keysCutConfirmation: null,
-      budgetCutConfirmation: null
+      conflict: null
     };
     const frame = renderStoryScreen(state, { width: 20, height: 12 });
     state.composerSelectionProjection = frame.derived.composerSelectionProjection;
@@ -462,11 +458,7 @@ describe("active selection copy", () => {
       title: "edit fact",
       placeholder: "fact text…",
       returnMode: "FACTS",
-      conflict: null,
-      cutConfirmation: null,
-      tagCutConfirmation: null,
-      keysCutConfirmation: null,
-      budgetCutConfirmation: null
+      conflict: null
     };
     const frame = renderStoryScreen(state, { width: 40, height: 12 });
     const projection = frame.derived.composerSelectionProjection!;
@@ -513,11 +505,7 @@ describe("active selection copy", () => {
       title: "edit fact",
       placeholder: "fact text…",
       returnMode: "FACTS",
-      conflict: null,
-      cutConfirmation: null,
-      tagCutConfirmation: null,
-      keysCutConfirmation: null,
-      budgetCutConfirmation: null
+      conflict: null
     };
     const frame = renderStoryScreen(state, { width: 40, height: 12 });
     const projection = frame.derived.composerSelectionProjection!;
@@ -566,11 +554,7 @@ describe("active selection copy", () => {
       title: "edit fact",
       placeholder: "fact text…",
       returnMode: "FACTS",
-      conflict: null,
-      cutConfirmation: null,
-      tagCutConfirmation: null,
-      keysCutConfirmation: null,
-      budgetCutConfirmation: null
+      conflict: null
     };
     const frame = renderStoryScreen(state, { width: 40, height: 12 });
     const projection = frame.derived.composerSelectionProjection!;
@@ -623,11 +607,7 @@ describe("active selection copy", () => {
       title: "edit fact",
       placeholder: "fact text…",
       returnMode: "FACTS",
-      conflict: null,
-      cutConfirmation: null,
-      tagCutConfirmation: null,
-      keysCutConfirmation: null,
-      budgetCutConfirmation: null
+      conflict: null
     };
     const frame = renderStoryScreen(state, { width: 40, height: 12 });
     const projection = frame.derived.composerSelectionProjection!;
@@ -677,11 +657,7 @@ describe("active selection copy", () => {
       title: "edit fact",
       placeholder: "fact text…",
       returnMode: "FACTS",
-      conflict: null,
-      cutConfirmation: null,
-      tagCutConfirmation: null,
-      keysCutConfirmation: null,
-      budgetCutConfirmation: null
+      conflict: null
     };
     const width = 50;
     const frame = renderStoryScreen(state, { width, height: 12 });
@@ -753,11 +729,7 @@ describe("active selection copy", () => {
       title: "edit fact",
       placeholder: "fact text…",
       returnMode: "FACTS",
-      conflict: null,
-      cutConfirmation: null,
-      tagCutConfirmation: null,
-      keysCutConfirmation: null,
-      budgetCutConfirmation: null
+      conflict: null
     };
     const width = 40;
     const frame = renderStoryScreen(state, { width, height: 12 });

--- a/tui/test/story-wrap-build.test.ts
+++ b/tui/test/story-wrap-build.test.ts
@@ -419,8 +419,7 @@ describe("sliced story wrap build", () => {
             title: "edit part",
             placeholder: "",
             returnMode: "NAV",
-            conflict: null,
-            cutConfirmation: null
+            conflict: null
           };
         } else if (surface === "system prompt") {
           state.mode = "EDITOR";


### PR DESCRIPTION
Closes #9

## What changed

- Add Cut, Undo, and Redo to each composer-backed editor.
- Add Command+Arrow navigation and Command+Backspace deletion.
- Add Page Up and Page Down movement with the visible editor height.
- Share clipboard, history, and viewport logic across editor surfaces.
- Add integration and key-contract coverage.

## How it was verified

- `npm run build`
- `npm test`
- `cd tui && bun run typecheck`
- `cd tui && bun test --timeout 30000`
- `cd tui && bun bench/perf.ts`
- `cd tui && bun run build:standalone`
- Autoreview completed. One finding was rejected because Direct does not use soft wrapping.
- Thermo-nuclear code-quality review completed. Shared reducers replaced duplicate branches.