### PR TITLE
fix(stream): detect silent HTTP generations

### DIFF
--- a/docs/generation-boundaries.md
+++ b/docs/generation-boundaries.md
@@ -21,6 +21,12 @@ a short exact right anchor followed by a request-specific terminator. Streaming
 withholds that suffix. A missing required anchor rejects the generation and keeps
 the original passage unchanged.
 
+## HTTP stream liveness
+
+An HTTP generation sends one heartbeat comment each second while its SSE stream
+stays open. A heartbeat does not change the story prose. The attached TUI stops
+the HTTP generation after four seconds without stream bytes.
+
 ## Text Completions boundary
 
 Text Completions converts the provider-neutral request into one text prompt.

--- a/server/http.ts
+++ b/server/http.ts
@@ -1,4 +1,5 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
+import { SSE_HEARTBEAT_INTERVAL_MS } from "../shared/sse.js";
 import { MAX_JSON_BODY_BYTES } from "../shared/types.js";
 import { ServiceError } from "./errors.js";
 export { optionalString, requireString } from "./validation.js";
@@ -123,6 +124,8 @@ export async function waitForResponseSettlement(
 
 export interface SseSession {
   send: (event: Record<string, unknown>) => Promise<void>;
+  heartbeat: () => Promise<void>;
+  close: () => Promise<void>;
   abort: AbortController;
 }
 
@@ -147,9 +150,11 @@ export function openSse(response: ServerResponse, abort: AbortController): SseSe
     "cache-control": "no-store",
     connection: "keep-alive"
   });
-  const send = async (event: Record<string, unknown>) => {
+  let active = true;
+  let writes = Promise.resolve();
+  const write = async (chunk: string) => {
     if (response.writableEnded || abort.signal.aborted) return;
-    const accepted = response.write(`data: ${JSON.stringify(event)}\n\n`);
+    const accepted = response.write(chunk);
     if (accepted) return;
     await new Promise<void>((resolve) => {
       let settled = false;
@@ -167,5 +172,26 @@ export function openSse(response: ServerResponse, abort: AbortController): SseSe
       if (response.destroyed || response.closed || abort.signal.aborted) finish();
     });
   };
-  return { send, abort };
+  const enqueue = (chunk: string): Promise<void> => {
+    if (!active) return Promise.resolve();
+    const next = writes.then(() => write(chunk));
+    writes = next.catch(() => undefined);
+    return next;
+  };
+  const stopHeartbeats = () => clearInterval(heartbeatTimer);
+  const heartbeat = () => enqueue(": heartbeat\n\n");
+  const heartbeatTimer = setInterval(() => { void heartbeat(); }, SSE_HEARTBEAT_INTERVAL_MS);
+  abort.signal.addEventListener("abort", stopHeartbeats, { once: true });
+  return {
+    send: async (event) => await enqueue(`data: ${JSON.stringify(event)}\n\n`),
+    heartbeat,
+    close: async () => {
+      if (!active) return;
+      active = false;
+      stopHeartbeats();
+      abort.signal.removeEventListener("abort", stopHeartbeats);
+      await writes;
+    },
+    abort
+  };
 }

--- a/server/stream-response.ts
+++ b/server/stream-response.ts
@@ -8,6 +8,7 @@ import {
 } from "../shared/failure-envelope.js";
 import { GenerationStoppedError } from "./errors.js";
 import { DeltaBatcher } from "./delta-batcher.js";
+import { SSE_HEARTBEAT_INTERVAL_MS } from "../shared/sse.js";
 
 export async function streamResponse<T>(
   request: IncomingMessage,
@@ -32,7 +33,22 @@ export async function streamResponse<T>(
     ? abort.signal
     : AbortSignal.any([operationSignal, abort.signal]);
   let session: ReturnType<typeof openSse> | null = null;
-  const open = () => session ??= openSse(response, abort);
+  let firstHeartbeat: ReturnType<typeof setTimeout> | null = null;
+  const stopFirstHeartbeat = () => {
+    if (firstHeartbeat === null) return;
+    clearTimeout(firstHeartbeat);
+    firstHeartbeat = null;
+  };
+  const open = () => {
+    stopFirstHeartbeat();
+    return session ??= openSse(response, abort);
+  };
+  firstHeartbeat = setTimeout(() => {
+    firstHeartbeat = null;
+    if (!signal.aborted) void open().heartbeat();
+  }, SSE_HEARTBEAT_INTERVAL_MS);
+  if (signal.aborted) stopFirstHeartbeat();
+  else signal.addEventListener("abort", stopFirstHeartbeat, { once: true });
   // Batches deltas at the same byte/time thresholds the embedded worker path
   // uses (server/worker-delta-batcher.ts), over the same DeltaBatcher. An
   // HTTP write already carries its own backpressure (openSse.send awaits
@@ -79,7 +95,10 @@ export async function streamResponse<T>(
     });
     response.end();
   } finally {
+    stopFirstHeartbeat();
+    signal.removeEventListener("abort", stopFirstHeartbeat);
     deltas.dispose();
+    await (session as ReturnType<typeof openSse> | null)?.close();
   }
 }
 

--- a/shared/sse.ts
+++ b/shared/sse.ts
@@ -1,6 +1,11 @@
 // "\r\n\r\n", the longest form the event separator can take.
 const MAX_SEPARATOR_LENGTH = 4;
 
+/** Keep an idle HTTP stream visible through proxies and detectable by clients. */
+export const SSE_HEARTBEAT_INTERVAL_MS = 1_000;
+/** Four missed loopback heartbeats identify a stream that no longer carries data. */
+export const SSE_IDLE_TIMEOUT_MS = SSE_HEARTBEAT_INTERVAL_MS * 4;
+
 /**
  * Split complete SSE events off the front of a stream buffer, returning
  * their data payloads and the unconsumed remainder.

--- a/test/generation-disconnect.test.ts
+++ b/test/generation-disconnect.test.ts
@@ -19,6 +19,7 @@ import type { Story } from "../shared/types.js";
 import { streamResponse } from "../server/stream-response.js";
 import { PromptCacheRuntime } from "../server/provider-cache-policy.js";
 import { MAX_DELTA_BATCH_BYTES } from "../shared/worker-protocol.js";
+import { SSE_HEARTBEAT_INTERVAL_MS } from "../shared/sse.js";
 import { FakeResponse } from "./fake-http-response.js";
 import { mkdtemp, readFile, realpath, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -213,6 +214,11 @@ test("HTTP stream adapter aborts generation before and after SSE opens", async (
     response.closed = true;
     response.emit("close");
     assert.equal((observedSignal as AbortSignal | null)?.aborted, true);
+    if (phase === "preflight") {
+      await new Promise((resolve) => setTimeout(resolve, SSE_HEARTBEAT_INTERVAL_MS * 2));
+      assert.equal(response.headersWritten, 0);
+      assert.equal(response.writes, 0);
+    }
     release();
     await running;
 

--- a/test/http-delta-batching.test.ts
+++ b/test/http-delta-batching.test.ts
@@ -3,7 +3,7 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import { Readable } from "node:stream";
 import test from "node:test";
 import { streamResponse } from "../server/stream-response.js";
-import { splitSseEvents } from "../shared/sse.js";
+import { SSE_HEARTBEAT_INTERVAL_MS, splitSseEvents } from "../shared/sse.js";
 import { DELTA_BATCH_WINDOW_MS } from "../shared/worker-protocol.js";
 import { FakeResponse } from "./fake-http-response.js";
 import { platformPerformanceBudget } from "./performance-budget.js";
@@ -153,6 +153,32 @@ test("a slow stream still delivers its first token promptly, without waiting for
   releaseModel();
   await running;
   assert.equal(response.ends, 1);
+});
+
+test("a silent stream sends an SSE comment heartbeat before the model responds", async () => {
+  const request = Readable.from([]) as unknown as IncomingMessage;
+  const response = new FakeResponse();
+  let releaseModel!: () => void;
+  const modelGate = new Promise<void>((resolve) => { releaseModel = resolve; });
+  const running = streamResponse(
+    request,
+    response as unknown as ServerResponse,
+    async () => {
+      await modelGate;
+      return { ok: true };
+    },
+    (value) => value
+  );
+
+  const heartbeatCount = () => response.output.match(/: heartbeat\n\n/g)?.length ?? 0;
+  const deadline = Date.now() + SSE_HEARTBEAT_INTERVAL_MS * 4;
+  while (heartbeatCount() < 2 && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  assert.ok(heartbeatCount() >= 2, "the silent stream must keep sending heartbeats");
+
+  releaseModel();
+  await running;
 });
 
 test("a stream that ends mid-batch flushes rather than dropping the tail", async () => {

--- a/tui/src/api.ts
+++ b/tui/src/api.ts
@@ -1,7 +1,12 @@
-import { splitSseEvents } from "../../shared/sse.js";
 import { httpCapabilityScopeForApiPath } from "../../shared/http-capability-scope.js";
 import { parseCanonicalLoopbackOrigin } from "../../shared/http-loopback-origin.js";
 import type { HttpFetch } from "./direct-loopback-http.js";
+import {
+  readSseEvents,
+  readSseText,
+  SseIdleTimeoutError,
+  withSseIdleTimeout
+} from "./sse-stream-reader.js";
 import {
   decodeChapterBreakCreatedResponse,
   decodeChapterBreakRemovalPreview,
@@ -426,7 +431,8 @@ export function createApi(
                   signal,
                   lease.headers
                 ),
-              shouldRetry: (error) => !(error instanceof ApiError)
+              shouldRetry: (error) => !(error instanceof ApiError
+                || error instanceof SseIdleTimeoutError)
             });
           },
           true,
@@ -960,13 +966,17 @@ async function streamSse(
   protocolHeaders: Readonly<Record<string, string>>
 ): Promise<Record<string, unknown> | null> {
   let response: Response;
+  const streamAbort = new AbortController();
+  const transportSignal = AbortSignal.any([signal, streamAbort.signal]);
   try {
-    response = await transport(endpoint, {
+    response = await withSseIdleTimeout(transport(endpoint, {
       method: "POST",
       headers: { ...protocolHeaders, "content-type": "application/json" },
       body: JSON.stringify(payload),
       redirect: "error",
-      signal
+      signal: transportSignal
+    }), {
+      onTimeout: (error) => streamAbort.abort(error)
     });
   } catch (error) {
     if (callerSignal.aborted) return null;
@@ -974,54 +984,47 @@ async function streamSse(
     throw error instanceof Error ? error : new Error(String(error));
   }
   if (!response.ok || response.body === null) {
-    const errorPayload: unknown = await response.json().catch(() => null);
+    let errorPayload: unknown = null;
+    if (response.body !== null) {
+      try {
+        errorPayload = parseJson(await readSseText(response.body));
+      } catch (error) {
+        streamAbort.abort(error);
+        if (callerSignal.aborted) return null;
+        if (signal.aborted) throw operationDeadlineError();
+        throw error instanceof Error ? error : new Error(String(error));
+      }
+    }
     throw apiHttpErrorFromPayload(
       errorPayload,
       `Request failed (${response.status})`,
       response.status
     );
   }
-  const reader = response.body.getReader();
-  const decoder = new TextDecoder();
-  let buffer = "";
-  // Resumes each search where the last one left off (shared/sse.ts), so a
-  // large payload with no line break until its final byte costs one scan
-  // over the buffer, not one rescan per network chunk.
-  let searchFrom = 0;
   let completed: Record<string, unknown> | null = null;
   try {
-    for (;;) {
-      const { done, value } = await reader.read();
-      if (done) break;
-      buffer += decoder.decode(value, { stream: true });
-      const split = splitSseEvents(buffer, searchFrom);
-      buffer = split.rest;
-      searchFrom = split.nextSearchFrom;
-      for (const data of split.events) {
-        const event = JSON.parse(data) as {
-          type: string;
-          text?: string;
-          message?: string;
-          code?: unknown;
-          status?: unknown;
-          diagnosticRef?: unknown;
-        };
-        if (event.type === "delta" && typeof event.text === "string") onDelta(event.text);
-        if (event.type === "error") {
-          throw apiHttpErrorFromPayload(
-            event,
-            "Generation failed.",
-            event.status
-          );
-        }
-        if (event.type === "done") completed = event as Record<string, unknown>;
+    await readSseEvents(response.body, (data) => {
+      const event = JSON.parse(data) as {
+        type: string;
+        text?: string;
+        message?: string;
+        code?: unknown;
+        status?: unknown;
+        diagnosticRef?: unknown;
+      };
+      if (event.type === "delta" && typeof event.text === "string") onDelta(event.text);
+      if (event.type === "error") {
+        throw apiHttpErrorFromPayload(
+          event,
+          "Generation failed.",
+          event.status
+        );
       }
-      if (completed !== null) {
-        void reader.cancel().catch(() => undefined);
-        return completed;
-      }
-    }
+      if (event.type === "done") completed = event as Record<string, unknown>;
+      return completed === null;
+    });
   } catch (error) {
+    streamAbort.abort(error);
     if (callerSignal.aborted) return null;
     if (signal.aborted) throw operationDeadlineError();
     throw error instanceof Error ? error : new Error(String(error));

--- a/tui/src/screens/story/row-layout.ts
+++ b/tui/src/screens/story/row-layout.ts
@@ -38,6 +38,8 @@ import { streamTrimBounds } from "../../stream-text.js";
 import type { WrapContentIdentity } from "../../wrap.js";
 
 export const STORY_GUTTER = 24;
+const STREAM_LIVENESS_MARKS = ["⠋", "⠙", "⠹", "⠸"] as const;
+const STREAM_LIVENESS_FRAME_MS = 250;
 
 export interface StoryRowLayout {
   height: number;
@@ -140,7 +142,7 @@ export function layoutStoryRow(
       : 0;
   let prefix: FrameLine[] | null = null;
   const preparePrefix = () => prefix ??= partPrefix(
-    row, rowIndex, allParts, state, measure, narrow, focused, streaming, prefixMask
+    row, rowIndex, allParts, state, measure, narrow, focused, streaming, prefixMask, deadlines
   );
   const expandedPrompt = (prefixMask & 2) !== 0 && state.expandedPromptIds.has(row.id);
   const prefixRows = expandedPrompt ? preparePrefix().length : prefixHeight(prefixMask);
@@ -148,7 +150,7 @@ export function layoutStoryRow(
     ? {
         start: prefixRows,
         lines: Array.from({ length: gutterRows }, (_, lineIndex) =>
-          gutterFor(row, true, false, lineIndex))
+          gutterFor(row, true, false, lineIndex, state.now, deadlines))
       }
     : null;
   const promptRowIndex = narrow ? 1 : 0;
@@ -234,10 +236,11 @@ function partPrefix(
   narrow: boolean,
   focused: boolean,
   streaming: boolean,
-  mask: number
+  mask: number,
+  deadlines?: FrameDeadlineCollector
 ): FrameLine[] {
   const lines: FrameLine[] = [];
-  if ((mask & 1) !== 0) lines.push(renderBoundary(part, measure, focused, streaming));
+  if ((mask & 1) !== 0) lines.push(renderBoundary(part, measure, focused, streaming, state.now, deadlines));
   if ((mask & 2) !== 0) {
     lines.push(...renderPrompt(part, rowIndex, state.expandedPromptIds.has(part.id), measure, narrow));
   }
@@ -327,19 +330,19 @@ function renderPartBody(
   if (compactLogo) {
     lines.push(prefixLine(
       narrow,
-      gutterFor(part, focused, streaming, 0),
+      gutterFor(part, focused, streaming, 0, state.now, deadlines),
       compactStarterLogo(focused)
     ));
   }
   for (const line of wrapped) {
     const lineIndex = lines.length;
-    lines.push(prefixLine(narrow, gutterFor(part, focused, streaming, lineIndex),
+    lines.push(prefixLine(narrow, gutterFor(part, focused, streaming, lineIndex, state.now, deadlines),
       styledWrapped(line, focused ? "prose" : "prose · dim", focused ? "human edit" : "human edit dim",
         "rewritten", state, part, streaming && !appending, deadlines, sourceStart)));
   }
   const proseTip = lines.length - 1;
   for (let lineIndex = lines.length; lineIndex < gutterRows; lineIndex += 1) {
-    lines.push(prefixLine(narrow, gutterFor(part, focused, streaming, lineIndex), []));
+    lines.push(prefixLine(narrow, gutterFor(part, focused, streaming, lineIndex, state.now, deadlines), []));
   }
   // Machine insertion stays visually distinct from the writer's solid block.
   if (streaming && proseTip >= 0) lines[proseTip]!.push(segment("▏", "chrome"));
@@ -731,9 +734,16 @@ function gutterVerbSegments(row: readonly GutterVerb[]): FrameLine {
   return fitLine(line, GUTTER_VERB_WIDTH);
 }
 
-function gutterFor(part: StoryPart, focused: boolean, streaming: boolean, lineIndex: number): FrameLine {
+function gutterFor(
+  part: StoryPart,
+  focused: boolean,
+  streaming: boolean,
+  lineIndex: number,
+  now = 0,
+  deadlines?: FrameDeadlineCollector
+): FrameLine {
   if (streaming) {
-    if (lineIndex === 0) return [segment("⟳ writing", "focus / accent")];
+    if (lineIndex === 0) return [segment(`${streamLivenessMark(now, deadlines)} writing`, "focus / accent")];
     if (lineIndex === 1) return [actionHint("esc stops", "cancel")];
     return [];
   }
@@ -817,9 +827,16 @@ export function replaceStoryProse(
   return [...gutter, ...prose];
 }
 
-function renderBoundary(part: StoryPart, measure: number, focused: boolean, streaming: boolean): FrameLine {
+function renderBoundary(
+  part: StoryPart,
+  measure: number,
+  focused: boolean,
+  streaming: boolean,
+  now = 0,
+  deadlines?: FrameDeadlineCollector
+): FrameLine {
   if (streaming) {
-    const lead = `── ¶ ${part.number} · ⟳ writing · `;
+    const lead = `── ¶ ${part.number} · ${streamLivenessMark(now, deadlines)} writing · `;
     const stop = "esc stops";
     const used = visibleWidth(lead) + visibleWidth(stop) + 1;
     return [segment("  "), segment(lead, "chrome"), actionHint(stop, "cancel"), segment(" ", "chrome"),
@@ -833,6 +850,16 @@ function renderBoundary(part: StoryPart, measure: number, focused: boolean, stre
   const prefix = `── ${marker} `;
   return [segment("  "), segment(prefix, "chrome"),
     segment("─".repeat(Math.max(0, measure - visibleWidth(prefix))), "chrome")];
+}
+
+/** One indicator owns both stream labels and their next visible frame. */
+export function streamLivenessMark(
+  now: number,
+  deadlines?: FrameDeadlineCollector
+): string {
+  const frame = Math.floor(now / STREAM_LIVENESS_FRAME_MS);
+  deadlines?.at((frame + 1) * STREAM_LIVENESS_FRAME_MS);
+  return STREAM_LIVENESS_MARKS[frame % STREAM_LIVENESS_MARKS.length]!;
 }
 
 function prefixLine(narrow: boolean, gutter: FrameLine, prose: FrameLine): FrameLine {

--- a/tui/src/sse-stream-reader.ts
+++ b/tui/src/sse-stream-reader.ts
@@ -1,0 +1,96 @@
+import {
+  SSE_IDLE_TIMEOUT_MS,
+  splitSseEvents
+} from "../../shared/sse.js";
+
+export class SseIdleTimeoutError extends Error {
+  constructor(timeoutMs: number) {
+    super(`The stream was silent for ${Math.ceil(timeoutMs / 1_000)} seconds.`);
+    this.name = "SseIdleTimeoutError";
+  }
+}
+
+interface SseIdleTimeoutOptions {
+  timeoutMs?: number;
+  onTimeout?: (error: SseIdleTimeoutError) => void;
+}
+
+/** Give an SSE response or read one bounded interval to produce its next byte. */
+export async function withSseIdleTimeout<T>(
+  operation: Promise<T>,
+  options: SseIdleTimeoutOptions = {}
+): Promise<T> {
+  const timeoutMs = options.timeoutMs ?? SSE_IDLE_TIMEOUT_MS;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  const stalled = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(() => {
+      const error = new SseIdleTimeoutError(timeoutMs);
+      reject(error);
+      options.onTimeout?.(error);
+    }, timeoutMs);
+  });
+  try {
+    return await Promise.race([operation, stalled]);
+  } finally {
+    if (timer !== null) clearTimeout(timer);
+  }
+}
+
+/** Read arbitrary HTTP bytes with the same per-read liveness bound as SSE. */
+export async function readSseText(
+  body: ReadableStream<Uint8Array>,
+  idleTimeoutMs = SSE_IDLE_TIMEOUT_MS
+): Promise<string> {
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let text = "";
+  try {
+    for (;;) {
+      const { done, value } = await withSseIdleTimeout(reader.read(), {
+        timeoutMs: idleTimeoutMs
+      });
+      if (done) return text + decoder.decode();
+      text += decoder.decode(value, { stream: true });
+    }
+  } catch (error) {
+    await reader.cancel().catch(() => undefined);
+    throw error;
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+/** Consume SSE data frames while each network read remains inside one idle bound. */
+export async function readSseEvents(
+  body: ReadableStream<Uint8Array>,
+  onEvent: (data: string) => boolean | Promise<boolean>,
+  idleTimeoutMs = SSE_IDLE_TIMEOUT_MS
+): Promise<void> {
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  let searchFrom = 0;
+  try {
+    for (;;) {
+      const { done, value } = await withSseIdleTimeout(reader.read(), {
+        timeoutMs: idleTimeoutMs
+      });
+      if (done) return;
+      buffer += decoder.decode(value, { stream: true });
+      const split = splitSseEvents(buffer, searchFrom);
+      buffer = split.rest;
+      searchFrom = split.nextSearchFrom;
+      for (const data of split.events) {
+        if (!await onEvent(data)) {
+          await reader.cancel().catch(() => undefined);
+          return;
+        }
+      }
+    }
+  } catch (error) {
+    await reader.cancel().catch(() => undefined);
+    throw error;
+  } finally {
+    reader.releaseLock();
+  }
+}

--- a/tui/test/animation-deadline.test.ts
+++ b/tui/test/animation-deadline.test.ts
@@ -11,6 +11,8 @@ import { demoAppSource } from "../src/demo.js";
 import { createStoryViewModel, rowIndexForNode } from "../src/model.js";
 import { renderConnectionBanner } from "../src/screens/connection-banner.js";
 import { renderStoryScreen } from "../src/screens/story.js";
+import { plainLine } from "../src/screens/story/frame.js";
+import { emptyStreamText } from "../src/stream-text.js";
 
 function fakeClock(start = 0) {
   let now = start;
@@ -79,6 +81,33 @@ describe("animation deadlines", () => {
     renderStoryScreen(state, { width: 120, height: 36, deadlines });
 
     expect(deadlines.next()).toBe(1_330);
+  });
+
+  test("a silent stream advances one visible liveness mark per frame deadline", () => {
+    const state = initialState(demoAppSource(false), false);
+    const leaf = state.payload.path.at(-1)!;
+    state.focusIndex = rowIndexForNode(createStoryViewModel(state.payload), leaf.id);
+    state.stream = {
+      targetId: leaf.id,
+      parentId: leaf.parentId,
+      append: true,
+      startedAt: "2026-07-22T00:00:00.000Z",
+      instruction: "",
+      ...emptyStreamText()
+    };
+    state.now = 0;
+    const firstDeadlines = createFrameDeadlineCollector(state.now);
+    const first = renderStoryScreen(state, {
+      width: 120, height: 36, deadlines: firstDeadlines
+    }).lines.map(plainLine).join("\n");
+
+    state.now = 250;
+    const second = renderStoryScreen(state, { width: 120, height: 36 })
+      .lines.map(plainLine).join("\n");
+
+    expect(first).toContain("⠋ writing");
+    expect(second).toContain("⠙ writing");
+    expect(firstDeadlines.next()).toBe(250);
   });
 
   test("compose focus suppresses the growth pulse when phases collapse to chrome", () => {

--- a/tui/test/golden.test.ts
+++ b/tui/test/golden.test.ts
@@ -51,7 +51,8 @@ describe("deterministic demo frames", () => {
   test("80x24 folds state into boundary rules", async () => {
     const frame = await renderOnce(demoSource(), 80, 24);
     expect(frame).toContain("── ¶ 12 · ‹ take 3/5 ›");
-    expect(frame).toContain("── ¶ 13 · ⟳ writing · esc stops");
+    expect(frame).toContain("── ¶ 13 ·");
+    expect(frame).toContain("writing · esc stops");
     expect(frame).toContain("space continues · enter directs · n new story · m map");
     expect(frame).toContain("NAV   the lantern keeper · ⚑ canon-storm · ¶ 12/13 · 3/5");
     expect(frame).not.toContain("307 words");

--- a/tui/test/hit-map.test.ts
+++ b/tui/test/hit-map.test.ts
@@ -470,7 +470,7 @@ describe("hit map from rendered frames", () => {
     expect(clickText(narrow, state, "esc stops")).toEqual({ action: "cancel" });
     const boundaryRow = narrow.findIndex((line) => plainLine(line).includes("esc stops"));
     const boundaryText = plainLine(narrow[boundaryRow]!);
-    const writing = visibleWidth(boundaryText.slice(0, boundaryText.indexOf("⟳ writing"))) + 1;
+    const writing = visibleWidth(boundaryText.slice(0, boundaryText.indexOf("writing"))) + 1;
     expect(mouseToAction(click(writing, boundaryRow), state)?.action).not.toBe("cancel");
   });
 
@@ -524,7 +524,7 @@ describe("hit map from rendered frames", () => {
       : []));
 
     expect(proseRows.length).toBeGreaterThan(2);
-    expect(streamRows.some((line) => plainLine(line).includes("⟳ writing"))).toBeTrue();
+    expect(streamRows.some((line) => plainLine(line).includes("writing"))).toBeTrue();
     expect(streamRows.some((line) => plainLine(line).includes("esc stops"))).toBeTrue();
     expect(gutterActions).toEqual([{ text: "esc stops", action: "cancel" }]);
   });

--- a/tui/test/regressions.test.ts
+++ b/tui/test/regressions.test.ts
@@ -591,7 +591,7 @@ describe("review regressions", () => {
     const rendered = renderStoryScreen(state, { width: 120, height: 36 }).lines.map(plainLine).join("\n");
 
     expect(view.activeLeafId).toBe(stream.targetId);
-    expect(rendered).toContain("⟳ writing");
+    expect(rendered).toContain("writing");
     expect(rendered).toContain("esc stops");
     expect(rendered).toContain("▏");
   });

--- a/tui/test/sse-stream-scan.test.ts
+++ b/tui/test/sse-stream-scan.test.ts
@@ -11,6 +11,7 @@ import {
   cpuBudget,
   startTiming
 } from "../../test/performance-budget.js";
+import { SSE_IDLE_TIMEOUT_MS } from "../../shared/sse.js";
 
 const originalFetch = globalThis.fetch;
 afterEach(() => { globalThis.fetch = originalFetch; });
@@ -147,3 +148,115 @@ test("a large final payload with no line break until the end still parses in bou
 
   expect(nodeId).toBe(hugeNodeId);
 });
+
+test("an attached HTTP stream that stops sending data fails before its generation lease", async () => {
+  let generationRequests = 0;
+  let cancels = 0;
+  globalThis.fetch = (async (input, init) => {
+    const path = new URL(String(input)).pathname;
+    if (path === "/api/health") return Response.json(metadata());
+    if (path === "/api/stories/story" && (init?.method ?? "GET") === "GET") {
+      return Response.json(storyPayload("story"));
+    }
+    if (path === "/api/stories/story/summary-take") {
+      generationRequests += 1;
+      const encoder = new TextEncoder();
+      return new Response(new ReadableStream<Uint8Array>({
+        start(controller) { controller.enqueue(encoder.encode(": heartbeat\n\n")); },
+        cancel() { cancels += 1; }
+      }), { headers: { "content-type": "text/event-stream" } });
+    }
+    throw new Error(`Unexpected API path: ${path}`);
+  }) as typeof fetch;
+  const api = createApi("http://127.0.0.1:7373");
+  await api.loadStory("story");
+
+  const started = Date.now();
+  const error = await rejection(api.createSummaryTake(
+    "story", { nodeId: "root" }, () => {}, new AbortController().signal
+  ));
+
+  expect(error).toMatchObject({ name: "SseIdleTimeoutError" });
+  expect(generationRequests).toBe(1);
+  expect(cancels).toBe(1);
+  expect(Date.now() - started).toBeLessThan(SSE_IDLE_TIMEOUT_MS * 2);
+});
+
+test("an attached HTTP generation that stalls before its SSE response fails before its lease", async () => {
+  let generationRequests = 0;
+  let transportSignal: AbortSignal | null = null;
+  globalThis.fetch = (async (input, init) => {
+    const path = new URL(String(input)).pathname;
+    if (path === "/api/health") return Response.json(metadata());
+    if (path === "/api/stories/story" && (init?.method ?? "GET") === "GET") {
+      return Response.json(storyPayload("story"));
+    }
+    if (path === "/api/stories/story/summary-take") {
+      generationRequests += 1;
+      transportSignal = init?.signal ?? null;
+      return await new Promise<Response>((_resolve, reject) => {
+        transportSignal?.addEventListener("abort", () => {
+          reject(transportSignal?.reason);
+        }, { once: true });
+      });
+    }
+    throw new Error(`Unexpected API path: ${path}`);
+  }) as typeof fetch;
+  const api = createApi("http://127.0.0.1:7373");
+  await api.loadStory("story");
+
+  const started = Date.now();
+  const error = await rejection(api.createSummaryTake(
+    "story", { nodeId: "root" }, () => {}, new AbortController().signal
+  ));
+
+  expect(error).toMatchObject({ name: "SseIdleTimeoutError" });
+  expect(generationRequests).toBe(1);
+  expect((transportSignal as AbortSignal | null)?.aborted).toBeTrue();
+  expect(Date.now() - started).toBeLessThan(SSE_IDLE_TIMEOUT_MS * 2);
+});
+
+test("a non-OK generation response that stalls mid-body fails before its lease", async () => {
+  let generationRequests = 0;
+  let cancels = 0;
+  globalThis.fetch = (async (input, init) => {
+    const path = new URL(String(input)).pathname;
+    if (path === "/api/health") return Response.json(metadata());
+    if (path === "/api/stories/story" && (init?.method ?? "GET") === "GET") {
+      return Response.json(storyPayload("story"));
+    }
+    if (path === "/api/stories/story/summary-take") {
+      generationRequests += 1;
+      const encoder = new TextEncoder();
+      return new Response(new ReadableStream<Uint8Array>({
+        start(controller) { controller.enqueue(encoder.encode('{"error":"slow')); },
+        cancel() { cancels += 1; }
+      }), {
+        status: 503,
+        headers: { "content-type": "application/json" }
+      });
+    }
+    throw new Error(`Unexpected API path: ${path}`);
+  }) as typeof fetch;
+  const api = createApi("http://127.0.0.1:7373");
+  await api.loadStory("story");
+
+  const started = Date.now();
+  const error = await rejection(api.createSummaryTake(
+    "story", { nodeId: "root" }, () => {}, new AbortController().signal
+  ));
+
+  expect(error).toMatchObject({ name: "SseIdleTimeoutError" });
+  expect(generationRequests).toBe(1);
+  expect(cancels).toBe(1);
+  expect(Date.now() - started).toBeLessThan(SSE_IDLE_TIMEOUT_MS * 2);
+});
+
+async function rejection(promise: Promise<unknown>): Promise<Error> {
+  try {
+    await promise;
+  } catch (error) {
+    return error instanceof Error ? error : new Error(String(error));
+  }
+  throw new Error("Expected promise to reject");
+}


### PR DESCRIPTION
Closes #24

## Summary

- Send one SSE comment heartbeat each second during model silence.
- Animate the TUI writing mark every 250 ms.
- Stop an attached HTTP generation after four seconds without response bytes.
- Prevent an uncertain timed-out mutation from replay.

## Verification

- Root typecheck and full Node test suite: 2,092 passed; 17 skipped.
- TUI typecheck and full Bun test suite: 1,492 passed.
- Post-rebase root integration tests: 25 passed.
- Post-rebase TUI integration tests: 13 passed.
- TUI performance benchmark: passed.
- Structured closeout review: clean.
- Thermo-nuclear maintainability review: clean.