### PR TITLE
fix: preserve valid profile bias entries

### DIFF
--- a/shared/generation-profile-transfer.ts
+++ b/shared/generation-profile-transfer.ts
@@ -269,23 +269,25 @@ function omitBlockedTextBias(
   if (!omittedPhrase && !omittedBanned) {
     return { sampling, importedCount, candidateCount, omitted: false };
   }
+  const phraseBiasLabel = phraseBias.length === 0 ? "phrase bias" : "phrase bias entry";
+  const bannedStringsLabel = bannedStrings.length === 0 ? "banned strings" : "banned string";
 
   for (const [index, resolution] of precomputedResolution.phraseBias.entries()) {
     if (index >= sampling.phraseBias.length) break;
     if (resolution.kind === "rejected" || resolution.kind === "shadowed") {
-      fidelity.push(`phrase bias not imported; ${samplingBiasEntryRejectionMessage(resolution)}`);
+      fidelity.push(`${phraseBiasLabel} not imported; ${samplingBiasEntryRejectionMessage(resolution)}`);
     }
   }
   for (const [index, resolution] of precomputedResolution.bannedStrings.entries()) {
     if (index >= sampling.bannedStrings.length) break;
     if (resolution.kind === "rejected" || resolution.kind === "shadowed") {
-      fidelity.push(`banned strings not imported; ${samplingBiasEntryRejectionMessage(resolution)}`);
+      fidelity.push(`${bannedStringsLabel} not imported; ${samplingBiasEntryRejectionMessage(resolution)}`);
     }
   }
   for (const [index, resolution] of precomputedResolution.nativeBannedStrings.entries()) {
     if (index >= sampling.bannedStrings.length) break;
     if (resolution.kind === "blocked") {
-      fidelity.push(`banned strings not imported; ${samplingBiasNativeBlockedMessage(resolution)}`);
+      fidelity.push(`${bannedStringsLabel} not imported; ${samplingBiasNativeBlockedMessage(resolution)}`);
     }
   }
   const fittedSampling = { ...sampling, phraseBias, bannedStrings };

--- a/shared/generation-profile-transfer.ts
+++ b/shared/generation-profile-transfer.ts
@@ -15,8 +15,6 @@ import {
 } from "./model-scalar-resolution.js";
 import {
   applySamplingSettings,
-  firstBlockedNativeBannedString,
-  firstBlockingSamplingBiasEntry,
   isLogitBiasFamilyKnob,
   resolveSamplingKnob,
   samplingBiasPresetRules,
@@ -255,30 +253,47 @@ function omitBlockedTextBias(
   if (precomputedResolution?.kind !== "resolved") {
     return { sampling, importedCount, candidateCount, omitted: false };
   }
-  const blockedPhrase = firstBlockingSamplingBiasEntry(precomputedResolution.phraseBias, []);
-  const blockedBanned = firstBlockingSamplingBiasEntry([], precomputedResolution.bannedStrings);
-  const blockedNative = firstBlockedNativeBannedString(precomputedResolution.nativeBannedStrings);
-  const omitPhrase = blockedPhrase !== undefined && samplingKnobValueIsSet(sampling, "phraseBias");
-  const omitBanned = (blockedBanned !== undefined || blockedNative !== undefined)
-    && samplingKnobValueIsSet(sampling, "bannedStrings");
-  if (!omitPhrase && !omitBanned) return { sampling, importedCount, candidateCount, omitted: false };
+  const phraseBias = sampling.phraseBias.filter((_entry, index) => {
+    const resolution = precomputedResolution.phraseBias[index];
+    return resolution?.kind !== "rejected" && resolution?.kind !== "shadowed";
+  });
+  const bannedStrings = sampling.bannedStrings.filter((_entry, index) => {
+    const resolution = precomputedResolution.bannedStrings[index];
+    const nativeResolution = precomputedResolution.nativeBannedStrings[index];
+    return resolution?.kind !== "rejected"
+      && resolution?.kind !== "shadowed"
+      && nativeResolution?.kind !== "blocked";
+  });
+  const omittedPhrase = phraseBias.length !== sampling.phraseBias.length;
+  const omittedBanned = bannedStrings.length !== sampling.bannedStrings.length;
+  if (!omittedPhrase && !omittedBanned) {
+    return { sampling, importedCount, candidateCount, omitted: false };
+  }
 
-  if (omitPhrase) {
-    fidelity.push(`phrase bias not imported; ${samplingBiasEntryRejectionMessage(blockedPhrase!)}`);
+  for (const [index, resolution] of precomputedResolution.phraseBias.entries()) {
+    if (index >= sampling.phraseBias.length) break;
+    if (resolution.kind === "rejected" || resolution.kind === "shadowed") {
+      fidelity.push(`phrase bias not imported; ${samplingBiasEntryRejectionMessage(resolution)}`);
+    }
   }
-  if (blockedBanned !== undefined && omitBanned) {
-    fidelity.push(`banned strings not imported; ${samplingBiasEntryRejectionMessage(blockedBanned)}`);
+  for (const [index, resolution] of precomputedResolution.bannedStrings.entries()) {
+    if (index >= sampling.bannedStrings.length) break;
+    if (resolution.kind === "rejected" || resolution.kind === "shadowed") {
+      fidelity.push(`banned strings not imported; ${samplingBiasEntryRejectionMessage(resolution)}`);
+    }
   }
-  if (blockedNative !== undefined && omitBanned) {
-    fidelity.push(`banned strings not imported; ${samplingBiasNativeBlockedMessage(blockedNative)}`);
+  for (const [index, resolution] of precomputedResolution.nativeBannedStrings.entries()) {
+    if (index >= sampling.bannedStrings.length) break;
+    if (resolution.kind === "blocked") {
+      fidelity.push(`banned strings not imported; ${samplingBiasNativeBlockedMessage(resolution)}`);
+    }
   }
+  const fittedSampling = { ...sampling, phraseBias, bannedStrings };
   return {
-    sampling: {
-      ...sampling,
-      ...(omitPhrase ? { phraseBias: EMPTY_SAMPLING_V2.phraseBias } : {}),
-      ...(omitBanned ? { bannedStrings: EMPTY_SAMPLING_V2.bannedStrings } : {})
-    },
-    importedCount: importedCount - Number(omitPhrase) - Number(omitBanned),
+    sampling: fittedSampling,
+    importedCount: importedCount
+      - Number(omittedPhrase && !samplingKnobValueIsSet(fittedSampling, "phraseBias"))
+      - Number(omittedBanned && !samplingKnobValueIsSet(fittedSampling, "bannedStrings")),
     candidateCount,
     omitted: true
   };

--- a/shared/generation-profile-transfer.ts
+++ b/shared/generation-profile-transfer.ts
@@ -234,12 +234,14 @@ function fitSamplingToRoute(
     withoutBlocking.importedCount,
     withoutBlocking.candidateCount,
     fidelity,
-    withoutBlocking.omitted ? undefined : matchingResolution
+    withoutBlocking.omitted ? undefined : matchingResolution,
+    withoutBlocking.retainedResolvedEntryCount
   );
 }
 
 interface BlockingTextBiasFit extends SamplingFit {
   readonly omitted: boolean;
+  readonly retainedResolvedEntryCount?: number;
 }
 
 /** A supplied canonical result can name text values the target route rejects. */
@@ -297,8 +299,33 @@ function omitBlockedTextBias(
       - Number(omittedPhrase && !samplingKnobValueIsSet(fittedSampling, "phraseBias"))
       - Number(omittedBanned && !samplingKnobValueIsSet(fittedSampling, "bannedStrings")),
     candidateCount,
-    omitted: true
+    omitted: true,
+    retainedResolvedEntryCount: retainedResolvedEntryCount(sampling, precomputedResolution)
   };
+}
+
+/** The supplied resolution starts with this profile's entries. Reuse their
+ * exact token IDs after filtering, rather than re-tokenizing or using a bound. */
+function retainedResolvedEntryCount(
+  sampling: SamplingSettingsV2,
+  resolution: Extract<SamplingBiasResolutionResult, { readonly kind: "resolved" }>
+): number {
+  const tokenIds = new Set(Object.keys(sampling.logitBias).map(Number));
+  for (const [index, entry] of resolution.phraseBias.entries()) {
+    if (index >= sampling.phraseBias.length) break;
+    if (entry.kind === "resolved" || entry.kind === "overridden") {
+      for (const tokenId of entry.tokenIds) tokenIds.add(tokenId);
+    }
+  }
+  // KoboldCpp's native banned strings are intentionally absent from this
+  // resolution array and from logit_bias, so they cannot consume this limit.
+  for (const [index, entry] of resolution.bannedStrings.entries()) {
+    if (index >= sampling.bannedStrings.length) break;
+    if (entry.kind === "resolved" || entry.kind === "overridden") {
+      for (const tokenId of entry.tokenIds) tokenIds.add(tokenId);
+    }
+  }
+  return tokenIds.size;
 }
 
 /**
@@ -312,7 +339,8 @@ function omitOverLimitTextBias(
   importedCount: number,
   candidateCount: number,
   fidelity: string[],
-  precomputedResolution: SamplingBiasResolutionResult | undefined
+  precomputedResolution: SamplingBiasResolutionResult | undefined,
+  retainedResolvedEntryCount: number | undefined
 ): SamplingFit {
   const configured = (["phraseBias", "bannedStrings"] as const).filter((knob) =>
     samplingKnobValueIsSet(sampling, knob)
@@ -329,9 +357,10 @@ function omitOverLimitTextBias(
   );
   if (bounded.length === 0) return { sampling, importedCount, candidateCount };
   const limit = maxResolvedLogitBiasEntries(preset);
-  const resolvedEntries = precomputedResolution?.kind === "resolved"
-    ? precomputedResolution.resolvedEntryCount
-    : undefined;
+  const resolvedEntries = retainedResolvedEntryCount
+    ?? (precomputedResolution?.kind === "resolved"
+      ? precomputedResolution.resolvedEntryCount
+      : undefined);
   const possibleEntries = resolvedEntries ?? maximumTextBiasEntries(sampling, preset);
   if (possibleEntries <= limit) return { sampling, importedCount, candidateCount };
 

--- a/test/generation-profile-bias-omission.integration.test.ts
+++ b/test/generation-profile-bias-omission.integration.test.ts
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  combineSamplingBiasSources,
+  resolveSamplingLogitBias
+} from "../server/sampling-phrase-bias.js";
+import { validateSamplingRoute } from "../server/settings-v2-sampling-validation.js";
+import { fitProfileToRoute } from "../shared/generation-profile-transfer.js";
+import { EMPTY_SAMPLING_V2 } from "../shared/settings-v2-types.js";
+import { samplingBiasPresetRules } from "../shared/sampling-capabilities.js";
+import { openAiDocument } from "./generation-profile-transfer-fixtures.js";
+
+test("Profile transfer keeps text bias that fits after one rejected entry is removed", () => {
+  const phraseBias = Array.from(
+    { length: 30 },
+    (_, index) => ({ phrase: `phrase-${index}`, weight: index + 1 })
+  );
+  const bannedStrings = [
+    "rejected ban",
+    ...Array.from({ length: 24 }, (_, index) => `ban-${index}`)
+  ];
+  const sampling = { ...EMPTY_SAMPLING_V2, phraseBias, bannedStrings };
+  const tokenize = (text: string) => {
+    const value = text.trim().toLowerCase();
+    if (value === "rejected ban") return { kind: "unencodable" as const };
+    const phrase = /^phrase-(\d+)$/u.exec(value);
+    if (phrase !== null) return { kind: "single-token" as const, tokenId: Number(phrase[1]) + 1 };
+    const banned = /^ban-(\d+)$/u.exec(value);
+    if (banned !== null) return { kind: "single-token" as const, tokenId: Number(banned[1]) + 31 };
+    throw new Error(`unexpected text bias value: ${text}`);
+  };
+  const rules = samplingBiasPresetRules("llama-cpp");
+  const resolution = resolveSamplingLogitBias(
+    combineSamplingBiasSources(sampling),
+    tokenize,
+    rules
+  );
+  const fitted = fitProfileToRoute(openAiDocument(), "default", {
+    name: "Retained text bias",
+    sampling: { phraseBias, bannedStrings }
+  }, { samplingBiasResolution: resolution });
+  const profile = fitted.document.profiles.default!;
+
+  assert.deepEqual(profile.sampling?.phraseBias, phraseBias);
+  assert.deepEqual(profile.sampling?.bannedStrings, bannedStrings.slice(1));
+  assert.equal(fitted.importedCount, 2);
+  assert.equal(fitted.candidateCount, 2);
+  assert.match(
+    fitted.fidelity.join("; "),
+    /banned string not imported; "rejected ban" has no exact token/u
+  );
+  assert.doesNotMatch(fitted.fidelity.join("; "), /exceeding the 200-entry limit/u);
+
+  const fittedResolution = resolveSamplingLogitBias(
+    combineSamplingBiasSources(profile.sampling!),
+    tokenize,
+    rules
+  );
+  if (fittedResolution.kind !== "resolved") throw new Error("fitted text bias did not resolve");
+  assert.equal(fittedResolution.resolvedEntryCount, 54);
+  validateSamplingRoute(
+    "default",
+    profile,
+    fitted.document.models[profile.modelId]!,
+    fitted.document.connections[fitted.document.models[profile.modelId]!.connectionId]!,
+    fittedResolution
+  );
+});

--- a/test/generation-profile-bias.integration.test.ts
+++ b/test/generation-profile-bias.integration.test.ts
@@ -187,19 +187,26 @@ test("Profile transfer keeps text bias within the target resolved logit-bias lim
 test("Profile transfer omits canonical text-bias rejections before fitting", () => {
   const rejectedSampling = {
     ...EMPTY_SAMPLING_V2,
-    phraseBias: [{ phrase: "unknown-token", weight: 1 }]
+    phraseBias: [
+      { phrase: "unknown-token", weight: 1 },
+      { phrase: "known-token", weight: 2 }
+    ]
   };
   const rejectedResolution = resolveSamplingLogitBias(
     combineSamplingBiasSources(rejectedSampling),
-    () => ({ kind: "unencodable" as const }),
+    (text) => text.includes("unknown")
+      ? { kind: "unencodable" as const }
+      : { kind: "single-token" as const, tokenId: 2 },
     samplingBiasPresetRules("llama-cpp")
   );
   const rejected = fitProfileToRoute(openAiDocument(), "default", {
     name: "Rejected phrase",
     sampling: { phraseBias: rejectedSampling.phraseBias }
   }, { samplingBiasResolution: rejectedResolution });
-  assert.equal(rejected.document.profiles.default?.sampling, undefined);
-  assert.equal(rejected.importedCount, 0);
+  assert.deepEqual(rejected.document.profiles.default?.sampling?.phraseBias, [
+    { phrase: "known-token", weight: 2 }
+  ]);
+  assert.equal(rejected.importedCount, 1);
   assert.equal(rejected.candidateCount, 1);
   assert.match(
     rejected.fidelity.join("; "),
@@ -212,11 +219,48 @@ test("Profile transfer omits canonical text-bias rejections before fitting", () 
     rejected.document.connections[rejected.document.models[rejected.document.profiles.default!.modelId]!.connectionId]!
   );
 
+  const shadowedSampling = {
+    ...EMPTY_SAMPLING_V2,
+    logitBias: { "1": 1 },
+    phraseBias: [
+      { phrase: "shadowed", weight: 2 },
+      { phrase: "kept", weight: 3 }
+    ]
+  };
+  const shadowedResolution = resolveSamplingLogitBias(
+    combineSamplingBiasSources(shadowedSampling),
+    (text) => ({ kind: "single-token" as const, tokenId: text.includes("shadowed") ? 1 : 2 }),
+    samplingBiasPresetRules("llama-cpp")
+  );
+  const shadowed = fitProfileToRoute(openAiDocument(), "default", {
+    name: "Shadowed phrase",
+    sampling: {
+      logitBias: shadowedSampling.logitBias,
+      phraseBias: shadowedSampling.phraseBias
+    }
+  }, { samplingBiasResolution: shadowedResolution });
+  assert.deepEqual(shadowed.document.profiles.default?.sampling?.phraseBias, [
+    { phrase: "kept", weight: 3 }
+  ]);
+  assert.deepEqual(shadowed.document.profiles.default?.sampling?.logitBias, { "1": 1 });
+  assert.equal(shadowed.importedCount, 2);
+  assert.equal(shadowed.candidateCount, 2);
+  assert.match(
+    shadowed.fidelity.join("; "),
+    /phrase bias not imported; "shadowed" loses its bias/u
+  );
+  validateSamplingRoute(
+    "default",
+    shadowed.document.profiles.default!,
+    shadowed.document.models[shadowed.document.profiles.default!.modelId]!,
+    shadowed.document.connections[shadowed.document.models[shadowed.document.profiles.default!.modelId]!.connectionId]!
+  );
+
   const nativeSampling = {
     ...EMPTY_SAMPLING_V2,
     logitBias: { "1": 1 },
     phraseBias: [{ phrase: "ember", weight: 1 }],
-    bannedStrings: ["ember"]
+    bannedStrings: ["ember", "kept native ban"]
   };
   const nativeResolution = resolveSamplingLogitBias(
     combineSamplingBiasSources(nativeSampling),
@@ -241,9 +285,9 @@ test("Profile transfer omits canonical text-bias rejections before fitting", () 
     }
   }, { samplingBiasResolution: nativeResolution });
   assert.deepEqual(native.document.profiles.default?.sampling?.phraseBias, nativeSampling.phraseBias);
-  assert.deepEqual(native.document.profiles.default?.sampling?.bannedStrings, []);
+  assert.deepEqual(native.document.profiles.default?.sampling?.bannedStrings, ["kept native ban"]);
   assert.deepEqual(native.document.profiles.default?.sampling?.logitBias, nativeSampling.logitBias);
-  assert.equal(native.importedCount, 2);
+  assert.equal(native.importedCount, 3);
   assert.equal(native.candidateCount, 3);
   assert.match(
     native.fidelity.join("; "),
@@ -380,4 +424,3 @@ test("Profile transfer applies the native banned-string limit only to KoboldCpp"
   assert.equal(tokenized.document.profiles.default?.sampling?.bannedStrings.length, 50);
   assert.equal(tokenized.importedCount, tokenized.candidateCount);
 });
-

--- a/test/generation-profile-bias.integration.test.ts
+++ b/test/generation-profile-bias.integration.test.ts
@@ -210,13 +210,72 @@ test("Profile transfer omits canonical text-bias rejections before fitting", () 
   assert.equal(rejected.candidateCount, 1);
   assert.match(
     rejected.fidelity.join("; "),
-    /phrase bias not imported; "unknown-token" has no exact token/u
+    /phrase bias entry not imported; "unknown-token" has no exact token/u
   );
   validateSamplingRoute(
     "default",
     rejected.document.profiles.default!,
     rejected.document.models[rejected.document.profiles.default!.modelId]!,
     rejected.document.connections[rejected.document.models[rejected.document.profiles.default!.modelId]!.connectionId]!
+  );
+
+  const fullyRejectedSampling = {
+    ...EMPTY_SAMPLING_V2,
+    phraseBias: [
+      { phrase: "unknown-one", weight: 1 },
+      { phrase: "unknown-two", weight: 2 }
+    ]
+  };
+  const fullyRejectedResolution = resolveSamplingLogitBias(
+    combineSamplingBiasSources(fullyRejectedSampling),
+    () => ({ kind: "unencodable" as const }),
+    samplingBiasPresetRules("llama-cpp")
+  );
+  const fullyRejected = fitProfileToRoute(openAiDocument(), "default", {
+    name: "Rejected phrase bias",
+    sampling: { phraseBias: fullyRejectedSampling.phraseBias }
+  }, { samplingBiasResolution: fullyRejectedResolution });
+  assert.equal(fullyRejected.document.profiles.default?.sampling, undefined);
+  assert.equal(fullyRejected.importedCount, 0);
+  assert.equal(fullyRejected.candidateCount, 1);
+  assert.match(
+    fullyRejected.fidelity.join("; "),
+    /phrase bias not imported; "unknown-one" has no exact token/u
+  );
+  assert.match(
+    fullyRejected.fidelity.join("; "),
+    /phrase bias not imported; "unknown-two" has no exact token/u
+  );
+
+  const rejectedBannedSampling = {
+    ...EMPTY_SAMPLING_V2,
+    bannedStrings: ["unknown banned string", "kept banned string"]
+  };
+  const rejectedBannedResolution = resolveSamplingLogitBias(
+    combineSamplingBiasSources(rejectedBannedSampling),
+    (text) => text.includes("unknown")
+      ? { kind: "unencodable" as const }
+      : { kind: "single-token" as const, tokenId: 3 },
+    samplingBiasPresetRules("llama-cpp")
+  );
+  const rejectedBanned = fitProfileToRoute(openAiDocument(), "default", {
+    name: "Rejected banned string",
+    sampling: { bannedStrings: rejectedBannedSampling.bannedStrings }
+  }, { samplingBiasResolution: rejectedBannedResolution });
+  assert.deepEqual(rejectedBanned.document.profiles.default?.sampling?.bannedStrings, [
+    "kept banned string"
+  ]);
+  assert.equal(rejectedBanned.importedCount, 1);
+  assert.equal(rejectedBanned.candidateCount, 1);
+  assert.match(
+    rejectedBanned.fidelity.join("; "),
+    /banned string not imported; "unknown banned string" has no exact token/u
+  );
+  validateSamplingRoute(
+    "default",
+    rejectedBanned.document.profiles.default!,
+    rejectedBanned.document.models[rejectedBanned.document.profiles.default!.modelId]!,
+    rejectedBanned.document.connections[rejectedBanned.document.models[rejectedBanned.document.profiles.default!.modelId]!.connectionId]!
   );
 
   const shadowedSampling = {
@@ -247,7 +306,7 @@ test("Profile transfer omits canonical text-bias rejections before fitting", () 
   assert.equal(shadowed.candidateCount, 2);
   assert.match(
     shadowed.fidelity.join("; "),
-    /phrase bias not imported; "shadowed" loses its bias/u
+    /phrase bias entry not imported; "shadowed" loses its bias/u
   );
   validateSamplingRoute(
     "default",
@@ -291,7 +350,7 @@ test("Profile transfer omits canonical text-bias rejections before fitting", () 
   assert.equal(native.candidateCount, 3);
   assert.match(
     native.fidelity.join("; "),
-    /banned strings not imported; "ember" conflicts with an explicit numeric logit-bias entry in the same scope/u
+    /banned string not imported; "ember" conflicts with an explicit numeric logit-bias entry in the same scope/u
   );
   validateSamplingRoute(
     "default",

--- a/test/generation-profile-bias.integration.test.ts
+++ b/test/generation-profile-bias.integration.test.ts
@@ -212,13 +212,13 @@ test("Profile transfer omits canonical text-bias rejections before fitting", () 
     rejected.fidelity.join("; "),
     /phrase bias entry not imported; "unknown-token" has no exact token/u
   );
-  validateSamplingRoute(
-    "default",
-    rejected.document.profiles.default!,
-    rejected.document.models[rejected.document.profiles.default!.modelId]!,
-    rejected.document.connections[rejected.document.models[rejected.document.profiles.default!.modelId]!.connectionId]!
+  validateFittedSampling(
+    rejected,
+    (text) => text.includes("unknown")
+      ? { kind: "unencodable" as const }
+      : { kind: "single-token" as const, tokenId: 2 },
+    "llama-cpp"
   );
-
   const fullyRejectedSampling = {
     ...EMPTY_SAMPLING_V2,
     phraseBias: [
@@ -246,7 +246,6 @@ test("Profile transfer omits canonical text-bias rejections before fitting", () 
     fullyRejected.fidelity.join("; "),
     /phrase bias not imported; "unknown-two" has no exact token/u
   );
-
   const rejectedBannedSampling = {
     ...EMPTY_SAMPLING_V2,
     bannedStrings: ["unknown banned string", "kept banned string"]
@@ -271,13 +270,13 @@ test("Profile transfer omits canonical text-bias rejections before fitting", () 
     rejectedBanned.fidelity.join("; "),
     /banned string not imported; "unknown banned string" has no exact token/u
   );
-  validateSamplingRoute(
-    "default",
-    rejectedBanned.document.profiles.default!,
-    rejectedBanned.document.models[rejectedBanned.document.profiles.default!.modelId]!,
-    rejectedBanned.document.connections[rejectedBanned.document.models[rejectedBanned.document.profiles.default!.modelId]!.connectionId]!
+  validateFittedSampling(
+    rejectedBanned,
+    (text) => text.includes("unknown")
+      ? { kind: "unencodable" as const }
+      : { kind: "single-token" as const, tokenId: 3 },
+    "llama-cpp"
   );
-
   const shadowedSampling = {
     ...EMPTY_SAMPLING_V2,
     logitBias: { "1": 1 },
@@ -308,13 +307,11 @@ test("Profile transfer omits canonical text-bias rejections before fitting", () 
     shadowed.fidelity.join("; "),
     /phrase bias entry not imported; "shadowed" loses its bias/u
   );
-  validateSamplingRoute(
-    "default",
-    shadowed.document.profiles.default!,
-    shadowed.document.models[shadowed.document.profiles.default!.modelId]!,
-    shadowed.document.connections[shadowed.document.models[shadowed.document.profiles.default!.modelId]!.connectionId]!
+  validateFittedSampling(
+    shadowed,
+    (text) => ({ kind: "single-token" as const, tokenId: text.includes("shadowed") ? 1 : 2 }),
+    "llama-cpp"
   );
-
   const nativeSampling = {
     ...EMPTY_SAMPLING_V2,
     logitBias: { "1": 1 },
@@ -352,14 +349,12 @@ test("Profile transfer omits canonical text-bias rejections before fitting", () 
     native.fidelity.join("; "),
     /banned string not imported; "ember" conflicts with an explicit numeric logit-bias entry in the same scope/u
   );
-  validateSamplingRoute(
-    "default",
-    native.document.profiles.default!,
-    native.document.models[native.document.profiles.default!.modelId]!,
-    native.document.connections[native.document.models[native.document.profiles.default!.modelId]!.connectionId]!
+  validateFittedSampling(
+    native,
+    () => ({ kind: "single-token" as const, tokenId: 1 }),
+    "koboldcpp"
   );
 });
-
 test("Profile transfer invalidates stale bias resolution after omitting native bans", () => {
   const bannedStrings = Array.from({ length: 201 }, (_, index) => index === 0 ? "ember" : `ban-${index}`);
   const sampling = {
@@ -474,7 +469,6 @@ test("Profile transfer applies the native banned-string limit only to KoboldCpp"
     dropped.document.models[droppedProfile.modelId]!,
     dropped.document.connections[dropped.document.models[droppedProfile.modelId]!.connectionId]!
   );
-
   const tokenized = fitProfileToRoute(
     openAiDocument(),
     "default",
@@ -483,3 +477,24 @@ test("Profile transfer applies the native banned-string limit only to KoboldCpp"
   assert.equal(tokenized.document.profiles.default?.sampling?.bannedStrings.length, 50);
   assert.equal(tokenized.importedCount, tokenized.candidateCount);
 });
+
+function validateFittedSampling(
+  fitted: ReturnType<typeof fitProfileToRoute>,
+  tokenize: Parameters<typeof resolveSamplingLogitBias>[1],
+  preset: Parameters<typeof samplingBiasPresetRules>[0]
+): void {
+  const profile = fitted.document.profiles.default!;
+  if (profile.sampling === undefined) throw new Error("fitted profile has no sampling settings");
+  const resolution = resolveSamplingLogitBias(
+    combineSamplingBiasSources(profile.sampling),
+    tokenize,
+    samplingBiasPresetRules(preset)
+  );
+  validateSamplingRoute(
+    "default",
+    profile,
+    fitted.document.models[profile.modelId]!,
+    fitted.document.connections[fitted.document.models[profile.modelId]!.connectionId]!,
+    resolution
+  );
+}


### PR DESCRIPTION
## Summary

- remove rejected or shadowed text-bias entries individually
- preserve valid phrase-bias and banned-string siblings
- cover rejected, shadowed, and native-blocked mixed collections

## Verification

- profile-bias integration tests: 5 passed
- root typecheck passed
- TUI typecheck passed
- autoreview finding reproduced and fixed

Fixes #27
Tracks 1667-ai/1667-archive2#290