### PR TITLE
chore(release): prepare 0.4.0-rc.1

### DIFF
--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -25,7 +25,8 @@ the hosted workflow. Do not publish held targets. Do not move registry tags
 outside a controlled operation. Do not describe a candidate as an official
 release.
 
-Publication also requires an explicit maintainer decision.
+A repository administrator starts publication with a manual dispatch. The
+release needs no other approval.
 
 ## Technical terms
 
@@ -38,7 +39,7 @@ This document uses these Technical Names:
 | release package | One npm tarball in the release matrix |
 | launcher package | The JavaScript package named `@1667-ai/cli` |
 | platform package | A package that contains one native executable |
-| candidate | A possible release package that has not received publication approval |
+| candidate | A possible release package that the workflow has not published |
 | Installer | A Shell Installer or a PowerShell Installer |
 | Shell Installer | A channel-specific release script that installs one native executable |
 | PowerShell Installer | A Windows release script that installs one native executable |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "1667-workspace",
-  "version": "0.3.0",
+  "version": "0.4.0-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "1667-workspace",
-      "version": "0.3.0",
+      "version": "0.4.0-rc.1",
       "license": "Apache-2.0",
       "dependencies": {
         "fs-ext-extra-prebuilt": "2.2.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667-workspace",
-  "version": "0.3.0",
+  "version": "0.4.0-rc.1",
   "private": true,
   "description": "Source workspace for the 1667 terminal writing environment",
   "license": "Apache-2.0",

--- a/tui/package.json
+++ b/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667",
-  "version": "0.3.0",
+  "version": "0.4.0-rc.1",
   "private": true,
   "description": "A terminal environment for writing fiction with language models",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary

- Set the root package version to `0.4.0-rc.1`.
- Set the TUI package version to `0.4.0-rc.1`.
- Keep the root lockfile version fields synchronized.
- Correct the release documentation. The release needs no tag signature and no second approval.

## Verification

- `npm run build`
- `npm test` (2198 pass, 0 fail)
- `cd tui && bun run typecheck`
- `cd tui && bun test` (1558 pass, 0 fail)

Closes #29
Refs #30