### PR TITLE
fix: update fast-uri audit dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This file records notable changes to 1667. Product terms use the definitions in
 
 ## Unreleased
 
+- **The dependency audit is clean.** 1667 now uses `fast-uri` 3.1.5. Thanks
+  @10fra for the report.
+
 - **Generation Profiles can move between projects.** Import a NovelAI Sampler
   Preset or a Profile Export with `1667 profile import`. Export a shareable
   Profile Export with `1667 profile export`. The command creates a new profile

--- a/package-lock.json
+++ b/package-lock.json
@@ -868,9 +868,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
Fixes #38

Update the locked fast-uri dependency from 3.1.4 to 3.1.5.

Verification:
- npm audit (0 vulnerabilities)
- npm test
- npm run typecheck