### PR TITLE
fix(upgrade): unwedge the upgrade path

### DIFF
--- a/scripts/release-npm-registry.ts
+++ b/scripts/release-npm-registry.ts
@@ -1,4 +1,5 @@
 import { execFile } from "node:child_process";
+import { distTagForChannel } from "../shared/release-dist-tags.js";
 import { isPrereleaseVersion } from "./release-publication-assets.js";
 import { lstatSync, realpathSync } from "node:fs";
 import {
@@ -396,12 +397,16 @@ function npmFailureStdout(error: unknown): string | null {
  * project does not have. Choosing the tag here means the tag is right the first
  * time and no version ever has to change channel.
  *
- * A prerelease is a release candidate and publishes to `beta`. Everything else
- * publishes to `latest`. This is the split `installScriptChannelsForVersion`
- * already applies to Installer file names.
+ * A prerelease is a release candidate and publishes into the beta channel.
+ * Everything else publishes into the stable channel. This is the split
+ * `installScriptChannelsForVersion` already applies to Installer file names.
+ *
+ * The dist-tag for each channel comes from `CHANNEL_DIST_TAG`, which the
+ * upgrade client reads as well, so a client cannot look for a dist-tag that a
+ * release does not write.
  */
 export function npmDistTagForVersion(version: string): "beta" | "latest" {
-  return isPrereleaseVersion(version) ? "beta" : "latest";
+  return distTagForChannel(isPrereleaseVersion(version) ? "beta" : "stable");
 }
 
 function npmVersionAlreadyExists(error: unknown): boolean {

--- a/shared/release-dist-tags.ts
+++ b/shared/release-dist-tags.ts
@@ -1,0 +1,27 @@
+/**
+ * The npm dist-tag that each installation channel reads.
+ *
+ * `npm publish` writes the dist-tag inside its Trusted Publishing exchange, and
+ * this project holds no credential that can move a dist-tag after publication.
+ * The dist-tags a release writes are therefore the only dist-tags that stay
+ * current: a prerelease writes `beta`, and every other release writes `latest`.
+ *
+ * No release writes a dist-tag with the name `stable`. A client that reads a
+ * dist-tag with that name reads whatever a person set by hand, which is why the
+ * stable channel reads `latest`. The publisher and the client both read this
+ * map, so the two cannot disagree about the dist-tag for a channel.
+ */
+export const CHANNEL_DIST_TAG = Object.freeze({
+  stable: "latest",
+  beta: "beta"
+} as const);
+
+/** The channels an installation can follow. */
+export type ReleaseChannel = keyof typeof CHANNEL_DIST_TAG;
+
+/** The dist-tag to read for one channel. */
+export function distTagForChannel<Channel extends ReleaseChannel>(
+  channel: Channel
+): (typeof CHANNEL_DIST_TAG)[Channel] {
+  return CHANNEL_DIST_TAG[channel];
+}

--- a/tui/src/npm-upgrade-registry.ts
+++ b/tui/src/npm-upgrade-registry.ts
@@ -3,13 +3,13 @@ import {
   assertCanonicalNpmTarballUrl,
   NPM_REGISTRY_ORIGIN as SHARED_NPM_REGISTRY_ORIGIN
 } from "../../shared/npm-tarball-url.js";
+import { distTagForChannel } from "../../shared/release-dist-tags.js";
 import { isSemVer, parseSemVer } from "../../shared/semver.js";
 import { parseJsonRejectingDuplicateKeys } from "../../shared/strict-json.js";
 import {
   PUBLISHED_PLATFORM_PACKAGES,
   RELEASE_LAUNCHER_PACKAGE,
   registryPathForPackage,
-  releasePlatformDependencyGraph,
   releaseTargetForPackage,
   type PublishedPlatformPackage
 } from "../../shared/release-targets.js";
@@ -28,10 +28,21 @@ export const PLATFORM_PACKAGES = PUBLISHED_PLATFORM_PACKAGES;
 export type PlatformPackage = PublishedPlatformPackage;
 export type RegistryFetch = (input: string, init: RequestInit) => Promise<Response>;
 
+/** The scope every package of this product is published under. */
+const RELEASE_SCOPE = `${LAUNCHER_PACKAGE.slice(0, LAUNCHER_PACKAGE.indexOf("/"))}/`;
+
+/** The name part an npm package in that scope can have. */
+const SCOPED_NAME = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
 interface ExactMetadataExpectation {
   name: string;
   version: string;
   optionalDependencies?: Readonly<Record<string, string>>;
+  /**
+   * Verify the launcher graph by rule, and keep the platform package named here
+   * a required member of it.
+   */
+  launcherGraph?: Readonly<{ requiredPlatformPackage: string }>;
   platform?: Readonly<{
     os: string;
     cpu: string;
@@ -62,6 +73,7 @@ export class NpmUpgradeRegistry {
 
   async launcher(
     version: string,
+    platformPackage: PlatformPackage,
     signal: AbortSignal
   ): Promise<NpmVersionMetadata> {
     return parseNpmExactVersionMetadata(
@@ -72,7 +84,7 @@ export class NpmUpgradeRegistry {
       {
         name: LAUNCHER_PACKAGE,
         version,
-        optionalDependencies: releasePlatformDependencyGraph(version)
+        launcherGraph: { requiredPlatformPackage: platformPackage }
       }
     );
   }
@@ -174,7 +186,7 @@ export function parseNpmDistTags(
       throw metadataFailure();
     }
   }
-  const selected = value[channel];
+  const selected = value[distTagForChannel(channel)];
   if (typeof selected !== "string") {
     throw new UpgradeFailure("unsupported_target", `The ${channel} channel has no release.`);
   }
@@ -209,7 +221,7 @@ export function parseNpmExactVersionMetadata(
   } catch {
     throw new UpgradeFailure("verification_failed", "Registry tarball URL is invalid.");
   }
-  verifyDependencyGraph(value, expected.optionalDependencies ?? {});
+  verifyDependencyGraph(value, expected);
   if (expected.platform !== undefined) {
     verifyPlatformIdentity(
       value,
@@ -225,13 +237,20 @@ export function parseNpmExactVersionMetadata(
 
 function verifyDependencyGraph(
   metadata: Record<string, unknown>,
-  expected: Readonly<Record<string, string>>
+  expected: ExactMetadataExpectation
 ): void {
   const value = metadata.optionalDependencies;
-  if (value === undefined && Object.keys(expected).length === 0) {
+  if (expected.launcherGraph !== undefined) {
+    verifyLauncherGraph(
+      value,
+      expected.version,
+      expected.launcherGraph.requiredPlatformPackage
+    );
+  } else if (value === undefined
+    && Object.keys(expected.optionalDependencies ?? {}).length === 0) {
     // Omitted and empty are equivalent for an intentionally dependency-free package.
   } else {
-    verifyOptionalDependencies(value, expected);
+    verifyOptionalDependencies(value, expected.optionalDependencies ?? {});
   }
   for (const field of ["dependencies", "peerDependencies"] as const) {
     const graph = metadata[field];
@@ -245,6 +264,43 @@ function verifyDependencyGraph(
       throw dependencyFailure();
     }
   }
+}
+
+/**
+ * The launcher graph is verified by rule, and never against a list of platform
+ * packages that this build carries.
+ *
+ * A later release publishes a platform target that an earlier build knows
+ * nothing about. A list refuses that release, and every release after it, for
+ * the life of the installation, and the refusal happens inside the installed
+ * build, where no fix can reach it. A rule accepts the new name and keeps what
+ * the check is for: the launcher depends on packages of this product alone,
+ * each one pinned to the exact version this upgrade verified.
+ */
+function verifyLauncherGraph(
+  value: unknown,
+  version: string,
+  requiredPlatformPackage: string
+): void {
+  if (!isRecord(value)) throw dependencyFailure();
+  const entries = Object.entries(value);
+  if (entries.length > 64) throw metadataFailure();
+  for (const [name, pinned] of entries) {
+    boundedString(name, 214);
+    boundedSemVer(pinned);
+    if (!isReleaseScopePackage(name) || name === LAUNCHER_PACKAGE || pinned !== version) {
+      throw dependencyFailure();
+    }
+  }
+  // A release that no longer carries this installation's platform must stop
+  // here, and not at a later request for a package the registry never received.
+  if (!Object.hasOwn(value, requiredPlatformPackage)) throw dependencyFailure();
+}
+
+/** True for a package this product publishes, such as `@1667-ai/linux-x64`. */
+function isReleaseScopePackage(name: string): boolean {
+  return name.startsWith(RELEASE_SCOPE)
+    && SCOPED_NAME.test(name.slice(RELEASE_SCOPE.length));
 }
 
 function verifyOptionalDependencies(

--- a/tui/src/upgrade-cli.ts
+++ b/tui/src/upgrade-cli.ts
@@ -379,11 +379,12 @@ function renderUpgrade(
       lines.push(`1667 ${envelope.target} is available on ${envelope.channel}.`);
       break;
   }
-  lines.push(
-    envelope.method === "shell"
-      ? "1667 installed this copy, so it can update it."
-      : "1667 did not install this copy, so it cannot update it."
-  );
+  // A Managed Installation says nothing about itself: the update it can do is
+  // the command the reader just ran. Only an installation 1667 cannot update
+  // has to say so, because that fact is why the instructions below differ.
+  if (envelope.method !== "shell") {
+    lines.push("1667 did not install this copy, so it cannot update it.");
+  }
   if (envelope.restartRequired) {
     lines.push("Restart 1667 to run the new version.");
   }

--- a/tui/src/upgrade-plan.ts
+++ b/tui/src/upgrade-plan.ts
@@ -22,7 +22,11 @@ export interface UpgradeObservation {
 
 export interface UpgradeRegistry {
   channelHead(channel: UpgradeChannel, signal: AbortSignal): Promise<string>;
-  launcher(version: string, signal: AbortSignal): Promise<NpmVersionMetadata>;
+  launcher(
+    version: string,
+    platformPackage: PlatformPackage,
+    signal: AbortSignal
+  ): Promise<NpmVersionMetadata>;
   platform(
     packageName: PlatformPackage,
     version: string,
@@ -122,7 +126,7 @@ export async function planUpgrade(
   let platformMetadata: NpmVersionMetadata;
   try {
     const [, platform] = await Promise.all([
-      registry.launcher(latest, exactSignal),
+      registry.launcher(latest, observation.platformPackage, exactSignal),
       registry.platform(observation.platformPackage, latest, exactSignal)
     ]);
     platformMetadata = platform;

--- a/tui/test/managed-install-upgrade.test.ts
+++ b/tui/test/managed-install-upgrade.test.ts
@@ -96,6 +96,37 @@ test("managed check reports available for shell installs", async () => {
   }
 });
 
+test("managed output tells the reader what to do and not how it was installed", async () => {
+  const root = managedScratchRoot();
+  try {
+    const installRoot = path.join(root, "bin");
+    mkdirSync(installRoot, { mode: 0o755 });
+    chmodSync(installRoot, 0o755);
+    const { authority } = shellManagedAuthority(installRoot, "stable");
+    const result = await executeUpgradeCli(["--check"], {
+      authority,
+      observation: {
+        currentVersion: CURRENT,
+        platformPackage: PACKAGE,
+        },
+      registry: fakeManagedRegistry(
+        NEXT,
+        PACKAGE,
+        "sha512-" + "A".repeat(86) + "==",
+        `https://registry.npmjs.org/${PACKAGE}/-/${path.basename(PACKAGE)}-${NEXT}.tgz`
+      )
+    });
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain(`1667 ${NEXT} is available`);
+    expect(result.stdout).toContain("Run '1667 upgrade' to install it.");
+    // The reader can update this installation, so a sentence about who
+    // installed it tells them nothing they can act on.
+    expect(result.stdout).not.toContain("this copy");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("custom registry platform metadata is used without live npm access", async () => {
   // Regression: apply must use injected registry.platform only. A silent
   // NpmUpgradeRegistry fallback would request live registry metadata.

--- a/tui/test/npm-upgrade-registry.test.ts
+++ b/tui/test/npm-upgrade-registry.test.ts
@@ -1,9 +1,5 @@
 import { expect, test } from "bun:test";
-import {
-  RELEASE_TARGETS,
-  releasePlatformDependencyGraph,
-  releaseTargetForArtifact
-} from "../../shared/release-targets.js";
+import { releaseTargetForArtifact } from "../../shared/release-targets.js";
 import {
   LAUNCHER_PACKAGE,
   NPM_METADATA_MAX_BYTES,
@@ -30,28 +26,33 @@ const TARBALL = tarballUrl(LAUNCHER_PACKAGE, "2.0.0");
 
 test("npm dist tags select strict stable and beta channel heads", () => {
   const body = JSON.stringify({
-    stable: "2.0.0",
+    // A stale hand-set tag, as the registry holds today. Reading it would give
+    // an installation a version two releases behind the stable channel head.
+    stable: "1.0.0",
     beta: "2.1.0-beta.2",
     latest: "2.0.0",
     next_build: "2.1.0+build-1"
   });
+  // A release writes `latest` and `beta`, and writes no dist-tag with the name
+  // `stable`, so the stable channel reads `latest` and ignores that name.
   expect(parseNpmDistTags(body, "stable")).toBe("2.0.0");
   expect(parseNpmDistTags(body, "beta")).toBe("2.1.0-beta.2");
   expect(parseNpmDistTags(
-    JSON.stringify({ stable: "2.0.0+build-1" }),
+    JSON.stringify({ latest: "2.0.0+build-1" }),
     "stable"
   )).toBe("2.0.0+build-1");
+  expect(() => parseNpmDistTags(JSON.stringify({ stable: "2.0.0" }), "stable")).toThrow();
 });
 
 test("npm dist tags reject malformed, hostile, and over-bound metadata", () => {
   const bodies = [
     "",
     "[]",
-    JSON.stringify({ stable: "v1.0.0" }),
-    JSON.stringify({ stable: "1.0.0-beta.1" }),
-    JSON.stringify({ stable: "1.0.0", "bad tag": "1.0.0" }),
-    JSON.stringify({ stable: "1.0.0", beta: "1.0.0\u001b" }),
-    '{"stable":"1.0.0","\\u0073table":"2.0.0"}',
+    JSON.stringify({ latest: "v1.0.0" }),
+    JSON.stringify({ latest: "1.0.0-beta.1" }),
+    JSON.stringify({ latest: "1.0.0", "bad tag": "1.0.0" }),
+    JSON.stringify({ latest: "1.0.0", beta: "1.0.0\u001b" }),
+    '{"latest":"1.0.0","\\u006catest":"2.0.0"}',
     new Uint8Array(NPM_METADATA_MAX_BYTES + 1)
   ];
   for (const body of bodies) expect(() => parseNpmDistTags(body, "stable")).toThrow();
@@ -70,7 +71,7 @@ test("exact npm metadata validates identity, integrity, and the complete platfor
   }), {
     name: LAUNCHER_PACKAGE,
     version: "2.0.0",
-    optionalDependencies
+    launcherGraph: { requiredPlatformPackage: PLATFORM_PACKAGE }
   });
   expect(metadata).toEqual({
     name: LAUNCHER_PACKAGE,
@@ -81,23 +82,49 @@ test("exact npm metadata validates identity, integrity, and the complete platfor
   expect(Object.isFrozen(metadata)).toBeTrue();
 });
 
-test("the launcher graph a client expects never names a held target's package", () => {
-  const graph = releasePlatformDependencyGraph("2.0.0");
-  expect(Object.keys(graph).sort()).toEqual([...PLATFORM_PACKAGES].sort());
-  for (const descriptor of RELEASE_TARGETS) {
-    if (descriptor.heldFromPublication === null) continue;
-    expect(Object.hasOwn(graph, descriptor.packageName)).toBeFalse();
-    // A published launcher that did name it would be verified against a package
-    // the registry never received, so the check has to refuse the pairing.
+test("a launcher that names a platform this build never heard of still verifies", () => {
+  // A release that publishes a new target names one more platform package than
+  // the installed build knows. A build that refused this refused every later
+  // release as well, and refused it inside itself, where no fix could reach it.
+  const graph = Object.fromEntries(PLATFORM_PACKAGES.map((name) => [name, "2.0.0"]));
+  const metadata = parseNpmExactVersionMetadata(JSON.stringify({
+    name: LAUNCHER_PACKAGE,
+    version: "2.0.0",
+    dist: { integrity: INTEGRITY, tarball: TARBALL },
+    optionalDependencies: { ...graph, "@1667-ai/freebsd-x64": "2.0.0" }
+  }), {
+    name: LAUNCHER_PACKAGE,
+    version: "2.0.0",
+    launcherGraph: { requiredPlatformPackage: PLATFORM_PACKAGE }
+  });
+  expect(metadata.version).toBe("2.0.0");
+});
+
+test("the launcher graph refuses a foreign package, a skewed pin, or a dropped platform", () => {
+  const graph = Object.fromEntries(PLATFORM_PACKAGES.map((name) => [name, "2.0.0"]));
+  const { [PLATFORM_PACKAGE]: _dropped, ...withoutOwnPlatform } = graph;
+  for (const optionalDependencies of [
+    // A package outside the release scope is never part of this graph.
+    { ...graph, "surprise-runtime": "2.0.0" },
+    { ...graph, "@other-scope/linux-x64": "2.0.0" },
+    // A platform package pinned to another version is a graph this upgrade
+    // did not verify.
+    { ...graph, "@1667-ai/freebsd-x64": "2.0.1" },
+    // The launcher cannot depend on itself.
+    { ...graph, [LAUNCHER_PACKAGE]: "2.0.0" },
+    // A release that no longer carries this installation's platform stops here.
+    withoutOwnPlatform,
+    {}
+  ]) {
     expect(() => parseNpmExactVersionMetadata(JSON.stringify({
       name: LAUNCHER_PACKAGE,
       version: "2.0.0",
       dist: { integrity: INTEGRITY, tarball: TARBALL },
-      optionalDependencies: { ...graph, [descriptor.packageName]: "2.0.0" }
+      optionalDependencies
     }), {
       name: LAUNCHER_PACKAGE,
       version: "2.0.0",
-      optionalDependencies: graph
+      launcherGraph: { requiredPlatformPackage: PLATFORM_PACKAGE }
     })).toThrow();
   }
 });
@@ -113,7 +140,7 @@ test("exact npm metadata rejects deprecated targets and graph or identity drift"
   const expected = {
     name: LAUNCHER_PACKAGE,
     version: "2.0.0",
-    optionalDependencies: graph
+    launcherGraph: { requiredPlatformPackage: PLATFORM_PACKAGE }
   };
   for (const value of [
     { ...valid, name: "other" },
@@ -138,7 +165,7 @@ test("registry client fixes the canonical origin and bounds streamed responses",
     calls.push(input);
     expect(init.method).toBe("GET");
     expect(init.redirect).toBe("error");
-    return Response.json({ stable: "2.0.0" });
+    return Response.json({ latest: "2.0.0" });
   });
   expect(await registry.channelHead("stable", new AbortController().signal)).toBe("2.0.0");
   expect(calls).toEqual([
@@ -154,10 +181,10 @@ test("registry client fixes the canonical origin and bounds streamed responses",
   expect((error as UpgradeFailure).code).toBe("metadata_invalid");
 
   for (const response of [
-    new Response('{"stable":"2.0.0"}', {
+    new Response('{"latest":"2.0.0"}', {
       headers: { "content-type": "text/plain" }
     }),
-    new Response('{"stable":"2.0.0"}', {
+    new Response('{"latest":"2.0.0"}', {
       headers: {
         "content-type": "application/json",
         "content-length": String(NPM_METADATA_MAX_BYTES + 1)
@@ -190,7 +217,7 @@ test("registry client derives exact launcher and platform endpoints locally", as
     });
   });
   const signal = new AbortController().signal;
-  await registry.launcher("2.0.0+build.1", signal);
+  await registry.launcher("2.0.0+build.1", PLATFORM_PACKAGE, signal);
   await registry.platform(PLATFORM_PACKAGE, "2.0.0+build.1", signal);
   expect(calls).toEqual([
     "https://registry.npmjs.org/@1667-ai%2fcli/2.0.0%2Bbuild.1",
@@ -265,7 +292,7 @@ test("registry client rejects libc metadata on the launcher package", async () =
     libc: ["glibc"]
   }));
   const error = await rejection(
-    registry.launcher("2.0.0", new AbortController().signal)
+    registry.launcher("2.0.0", PLATFORM_PACKAGE, new AbortController().signal)
   );
   expect((error as UpgradeFailure).code).toBe("verification_failed");
 });


### PR DESCRIPTION
Three defects on the same path. A Managed Installation of 0.1.2 cannot upgrade at all, and the stable channel cannot see 0.3.0 or 0.4.0.

## The launcher graph was a list, and lists expire

`NpmUpgradeRegistry.launcher()` verified the launcher metadata against `releasePlatformDependencyGraph(version)` — the platform package list **that build carried** — and demanded an exact set match. 0.1.2 was built while `@1667-ai/windows-x64` was still `heldFromPublication`, so it expects 4 optional dependencies. Every release from 0.2.1 on publishes 5:

```console
$ 1667 upgrade --json
{"status":"error","current":"0.1.2", ... "error":{"code":"verification_failed",
 "message":"The package dependency graph is invalid.","retryable":false}}
```

The refusal is permanent, and it runs inside the installed build where no later fix can reach it. Reinstalling is the only exit. Every installation that exists today would be wedged the same way by the sixth platform target.

Now verified by rule: an optional dependency must be a package in the release scope, pinned to the exact version this upgrade verified, and the installation's own platform package must be present. A foreign package, a skewed pin, a self-dependency, and a release that drops this platform are all still refused. The publication side keeps its exact check — at publication the repository does know its own target list.

This replaces the held-target test, whose premise was that a launcher naming a held package must be refused. That holds within one release and breaks across releases: a later release un-holds the target and publishes it, and an older client cannot know. The new test asserts the opposite for an unknown scoped package, and keeps every refusal.

## The stable channel read a tag nobody writes

`parseNpmDistTags()` read `value[channel]`, so the stable channel read a dist-tag named `stable`. `npmDistTagForVersion()` writes `latest` or `beta` and nothing else — its own comment explains that Trusted Publishing leaves no credential to move a tag afterwards. The `stable` tag holds 0.2.1 because somebody set it by hand once:

```json
{"stable":"0.2.1","next":"0.2.1","latest":"0.4.0","beta":"0.4.0-rc.1"}
```

So a stable installation newer than 0.2.1 reports `up-to-date` forever. `shared/release-dist-tags.ts` now holds one channel-to-dist-tag map that the publisher and the client both read, and stable reads `latest`.

## The output explained the install model

`1667 installed this copy, so it can update it.` printed on every managed check and upgrade. It described the command the reader had just run. It prints only in the negative case now, where it explains why the following instructions are manual.

## Checks

- `bun test` in `tui/`: 1560 pass, 0 fail
- `bun run typecheck` in `tui/`: clean
- `npm run typecheck` at the root: clean
- `node --test test/release-npm.test.ts test/release-npm-registry-errors.test.ts test/release-package-policy.test.ts`: 34 pass, 0 fail
- The new copy test was confirmed to fail against the old line, not to pass vacuously.

The full root suite was not run locally; CI covers it.

Closes #36
Closes #37
Closes #39

https://claude.ai/code/session_01MfCTszz1WFpnUh7He5B9Mb