### PR TITLE
chore(release): prepare 0.4.1-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ This file records notable changes to 1667. Product terms use the definitions in
 
 ## Unreleased
 
+- **`1667 upgrade` accepts a release that supports one more platform.** The
+  upgrade checked the packages of a new release against the platform list its
+  own build carried, and refused a release that named one more. The first
+  release with Windows support therefore stopped every earlier installation
+  from updating, and the refusal came from the installed program, where no
+  later fix could reach it. 1667 now checks that each package belongs to this
+  product and carries the exact version of the release, so a release that adds
+  a platform installs. An installation before 0.4.0 must be installed again.
+
+- **The stable channel finds the current release.** `1667 upgrade` read a
+  registry tag that a release does not write, so the stable channel stopped at
+  0.2.1 and reported a newer installation as current. The stable channel now
+  reads the tag each release writes.
+
+- **Upgrade output says less.** An installation that 1667 can update no longer
+  reads a sentence about how it was installed.
+
 - **The dependency audit is clean.** 1667 now uses `fast-uri` 3.1.5. Thanks
   @10fra for the report.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "1667-workspace",
-  "version": "0.4.0",
+  "version": "0.4.1-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "1667-workspace",
-      "version": "0.4.0",
+      "version": "0.4.1-rc.1",
       "license": "Apache-2.0",
       "dependencies": {
         "fs-ext-extra-prebuilt": "2.2.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667-workspace",
-  "version": "0.4.0",
+  "version": "0.4.1-rc.1",
   "private": true,
   "description": "Source workspace for the 1667 terminal writing environment",
   "license": "Apache-2.0",

--- a/tui/package.json
+++ b/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667",
-  "version": "0.4.0",
+  "version": "0.4.1-rc.1",
   "private": true,
   "description": "A terminal environment for writing fiction with language models",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary

- Set the root package version to `0.4.1-rc.1`.
- Set the TUI package version to `0.4.1-rc.1`.
- Keep the root lockfile version fields synchronized.
- Record the upgrade changes in the changelog.

This release carries the upgrade path fixes from #40: the launcher dependency graph is checked by rule (#36), the stable channel reads the `latest` dist-tag (#37), and the install-method sentence is gone from output an installation 1667 can update (#39). It also carries the clean dependency audit (#35).

A prerelease publishes to the `beta` dist-tag.

## Verification

- `npm run typecheck`
- `node --test test/release-identity.test.ts test/release-content.test.ts test/release-preflight.test.ts test/build-identity.test.ts`: 16 pass, 0 fail

Closes #42

https://claude.ai/code/session_01MfCTszz1WFpnUh7He5B9Mb