### PR TITLE
fix(install): stop refusing an Install Root over permission bits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ This file records notable changes to 1667. Product terms use the definitions in
 
 ## Unreleased
 
+- **1667 installs and updates in a directory that other software also uses.**
+  The Installer and `1667 upgrade` refused an Install Root when any directory
+  above it was group-writable or world-writable, was a symbolic link, or
+  belonged to another user. Debian and Ubuntu ship `/usr/local` this way,
+  Ubuntu gives each user a private group, and Homebrew ships its `bin`
+  directory this way, so the refusal named a real permission bit and no real
+  exposure. 1667 now checks that the Install Root is a directory the current
+  user owns. These rules never protected against a program that already runs as
+  the user, because such a program can write to the Install Root whatever its
+  mode is.
+
 - **`1667 upgrade` accepts a release that supports one more platform.** The
   upgrade checked the packages of a new release against the platform list its
   own build carried, and refused a release that named one more. The first

--- a/scripts/release-install-script-shell-lib.ts
+++ b/scripts/release-install-script-shell-lib.ts
@@ -50,34 +50,25 @@ assert_json_safe_path() {
   fi
 }
 
+# The Install Root must be a name this Installer can write into the Ownership
+# Record, and a directory this user owns. It walked every directory up to the
+# file-system root before, and refused a symbolic link, a directory owned by
+# another user, and a group-writable or world-writable directory. Those rules
+# refused the layout that Debian, Ubuntu, and Homebrew ship, and they never
+# stopped a program that already runs as this user.
 validate_install_root() {
   root=\$1
   assert_json_safe_path "\$root" "Install Root"
-  path=\$root
-  while [ "\$path" != "/" ]; do
-    if [ -e "\$path" ] || [ -L "\$path" ]; then
-      if [ -L "\$path" ]; then
-        die "Install path component is a symbolic link: \$path"
-      fi
-      if [ ! -d "\$path" ]; then
-        die "Install path component is not a directory: \$path"
-      fi
-      owner=\$(owner_uid "\$path") || return 1
-      me=\$(id -u)
-      if [ "\$owner" != "\$me" ] && [ "\$owner" != 0 ]; then
-        die "Install path is not owned by you or root: \$path"
-      fi
-      mode=\$(file_mode "\$path") || return 1
-      group_write=\$(( (mode / 10) % 10 ))
-      world_write=\$(( mode % 10 ))
-      if [ \$((group_write & 2)) -ne 0 ] || [ \$((world_write & 2)) -ne 0 ]; then
-        die "Install path is group-writable or world-writable: \$path"
-      fi
+  if [ -e "\$root" ]; then
+    if [ ! -d "\$root" ]; then
+      die "Install Root is not a directory: \$root"
     fi
-    parent=\$(dirname "\$path")
-    [ "\$parent" != "\$path" ] || break
-    path=\$parent
-  done
+    owner=\$(owner_uid "\$root") || return 1
+    me=\$(id -u)
+    if [ "\$owner" != "\$me" ]; then
+      die "Install Root is not owned by you: \$root"
+    fi
+  fi
 }
 
 ensure_install_root() {
@@ -104,14 +95,6 @@ owner_uid() {
     stat -f %u "\$1" 9>&-
   else
     stat -c %u "\$1" 9>&-
-  fi
-}
-
-file_mode() {
-  if stat -f %Lp "\$1" >/dev/null 2>&1; then
-    stat -f %Lp "\$1" 9>&-
-  else
-    stat -c %a "\$1" 9>&-
   fi
 }
 

--- a/test/release-install-script.test.ts
+++ b/test/release-install-script.test.ts
@@ -360,13 +360,19 @@ test("Shell Installer installs, probes identity, refuses existing binaries, reco
   );
   await rm(path.join(prefix, "1667"));
 
-  // Unsafe group-writable ancestor refusal.
-  const unsafe = path.join(root, "unsafe");
-  await mkdir(unsafe, { mode: 0o755 });
-  await chmod(unsafe, 0o775);
-  await assert.rejects(
-    execFileAsync("sh", [scriptPath, "--prefix", path.join(unsafe, "bin")], { cwd: root }),
-    /group-writable|world-writable/i
+  // A group-writable ancestor installs. Debian, Ubuntu, and Homebrew all ship a
+  // directory like this, and refusing it stopped an install that exposed nobody.
+  const groupWritable = path.join(root, "group-writable");
+  await mkdir(groupWritable, { mode: 0o755 });
+  await chmod(groupWritable, 0o775);
+  const groupWritableRun = await execFileAsync(
+    "sh",
+    [scriptPath, "--prefix", path.join(groupWritable, "bin")],
+    { cwd: root }
+  );
+  assert.match(
+    groupWritableRun.stdout,
+    new RegExp(`Installed 1667 ${INSTALL_VERSION} \\(beta\\)`)
   );
 
   const safePrefix = path.join(root, "safe-prefix");

--- a/tui/src/install-path-safety.ts
+++ b/tui/src/install-path-safety.ts
@@ -1,7 +1,6 @@
 import {
   constants as fsConstants,
-  lstatSync,
-  realpathSync,
+  statSync,
   type Stats
 } from "node:fs";
 import path from "node:path";
@@ -12,8 +11,19 @@ export interface SafePathObservation {
 }
 
 /**
- * Validates absolute, canonical, non-symlink paths with safe ownership and modes.
- * Matches ADR 010 Ownership Record path rules for macOS and Linux.
+ * Validates that a path is absolute and canonical, has the shape the caller
+ * needs, and belongs to the current user. Matches the ADR 010 Ownership Record
+ * path rules for macOS and Linux.
+ *
+ * These checks find a mistake the current user made, such as an Install Root
+ * that an earlier `sudo` left owned by root. They never protected against a
+ * program that already runs as the current user, because such a program can
+ * write to the Install Root whatever its mode is.
+ *
+ * The mode and path-component rules are gone. They refused a directory layout
+ * that Debian, Ubuntu, and Homebrew all ship: a group-writable directory whose
+ * group holds nobody except the owner. The refusal named a real bit and no real
+ * exposure, and it sent a person to a different prefix for no gain.
  */
 export function assertSafeOwnedPath(
   value: string,
@@ -31,16 +41,14 @@ export function assertSafeOwnedPath(
   if (/(^|\/)\.\.?($|\/)/u.test(value) || value.includes("//")) {
     throw new Error(`${options.label} must be a canonical path`);
   }
-  assertAncestorChain(value, options.label);
   let stats: Stats;
   try {
-    stats = lstatSync(value);
+    // Follows a symbolic link, so a person can keep a linked bin directory and
+    // still have the shape and the owner of the real target checked.
+    stats = statSync(value);
   } catch (error) {
     if (options.allowMissing === true && isNotFound(error)) return null;
     throw new Error(`${options.label} is missing`);
-  }
-  if (stats.isSymbolicLink()) {
-    throw new Error(`${options.label} must not be a symbolic link`);
   }
   if (options.requireFile === true && !stats.isFile()) {
     throw new Error(`${options.label} must be a regular file`);
@@ -48,17 +56,13 @@ export function assertSafeOwnedPath(
   if (options.requireDirectory === true && !stats.isDirectory()) {
     throw new Error(`${options.label} must be a directory`);
   }
-  assertOwnerAndMode(stats, options.label);
-  if (options.expectedModeMask !== undefined) {
-    if ((stats.mode & 0o777) !== options.expectedModeMask) {
-      throw new Error(`${options.label} has an unsafe mode`);
-    }
-  } else if ((stats.mode & 0o022) !== 0) {
-    throw new Error(`${options.label} is group-writable or world-writable`);
-  }
-  const canonical = realpathSync(value);
-  if (canonical !== value) {
-    throw new Error(`${options.label} must be a canonical path`);
+  assertOwner(stats, options.label);
+  // An exact mode still applies to a file 1667 writes itself, such as the
+  // Ownership Record at 0600. That check reads 1667's own work, and refuses no
+  // layout that a person chose.
+  if (options.expectedModeMask !== undefined
+    && (stats.mode & 0o777) !== options.expectedModeMask) {
+    throw new Error(`${options.label} has an unsafe mode`);
   }
   return Object.freeze({ path: value, stats });
 }
@@ -70,54 +74,11 @@ export function assertSafeInstallRoot(installRoot: string): void {
   });
 }
 
-function assertAncestorChain(value: string, label: string): void {
-  const uid = process.geteuid?.() ?? process.getuid?.();
-  if (uid === undefined) throw new Error(`${label} requires POSIX user identity`);
-  let current = path.resolve(value);
-  const seen = new Set<string>();
-  while (current !== path.parse(current).root) {
-    if (seen.has(current)) throw new Error(`${label} path chain is invalid`);
-    seen.add(current);
-    let stats: Stats;
-    try {
-      stats = lstatSync(current);
-    } catch (error) {
-      if (isNotFound(error)) {
-        current = path.dirname(current);
-        continue;
-      }
-      throw error;
-    }
-    if (stats.isSymbolicLink()) {
-      throw new Error(`${label} path component must not be a symbolic link`);
-    }
-    if (!stats.isDirectory() && current !== path.resolve(value)) {
-      throw new Error(`${label} path component must be a directory`);
-    }
-    if (stats.uid !== uid && stats.uid !== 0) {
-      throw new Error(`${label} path component must be owned by the current user or root`);
-    }
-    if ((stats.mode & 0o022) !== 0) {
-      throw new Error(`${label} path component is group-writable or world-writable`);
-    }
-    current = path.dirname(current);
-  }
-  // Root itself may be root-owned; only check it exists and is not a symlink.
-  const root = path.parse(value).root || "/";
-  const rootStats = lstatSync(root);
-  if (rootStats.isSymbolicLink()) {
-    throw new Error(`${label} file-system root must not be a symbolic link`);
-  }
-}
-
-function assertOwnerAndMode(stats: Stats, label: string): void {
+function assertOwner(stats: Stats, label: string): void {
   const uid = process.geteuid?.() ?? process.getuid?.();
   if (uid === undefined) throw new Error(`${label} requires POSIX user identity`);
   if (stats.uid !== uid) {
     throw new Error(`${label} must be owned by the current user`);
-  }
-  if ((stats.mode & 0o022) !== 0) {
-    throw new Error(`${label} is group-writable or world-writable`);
   }
 }
 

--- a/tui/test/managed-install-upgrade.test.ts
+++ b/tui/test/managed-install-upgrade.test.ts
@@ -127,6 +127,42 @@ test("managed output tells the reader what to do and not how it was installed", 
   }
 });
 
+test("a group-writable Install Root upgrades", async () => {
+  // Debian, Ubuntu, and Homebrew each ship a directory like this, and Ubuntu
+  // gives every user a private group, so the group holds nobody but the owner.
+  // Refusing the upgrade here protected nobody and stranded the installation.
+  const root = managedScratchRoot();
+  try {
+    const installRoot = path.join(root, "bin");
+    mkdirSync(installRoot, { mode: 0o755 });
+    const { authority } = shellManagedAuthority(installRoot, "stable");
+    chmodSync(installRoot, 0o775);
+    const pkg = buildCanonicalPlatformPackage({
+      packageName: PACKAGE,
+      version: NEXT,
+      target: TARGET
+    });
+    const result = await executeUpgradeCli(["--json"], {
+      authority,
+      observation: {
+        currentVersion: CURRENT,
+        platformPackage: PACKAGE,
+        },
+      registry: fakeManagedRegistry(NEXT, PACKAGE, pkg.integrity, pkg.tarballUrl),
+      fetcher: async () => new Response(new Uint8Array(pkg.bytes), { status: 200 })
+    });
+    expect(result.exitCode).toBe(0);
+    expect(result.envelope).toMatchObject({
+      status: "applied",
+      method: "shell",
+      current: CURRENT,
+      target: NEXT
+    });
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("custom registry platform metadata is used without live npm access", async () => {
   // Regression: apply must use injected registry.platform only. A silent
   // NpmUpgradeRegistry fallback would request live registry metadata.


### PR DESCRIPTION
Hit on Ubuntu:

```text
Install path is group-writable or world-writable: <path>
```

## What was checked

The Installer's `validate_install_root` and the upgrade path's `assertSafeOwnedPath` each walked every directory from the file-system root down to the Install Root, refusing:

- a group-writable or world-writable directory;
- a directory owned by someone other than the current user or root;
- a path component that is a symbolic link.

## Why it goes

These rules addressed one threat: another person with an account on the same machine. They did not address the threat this product's users have — a program that already runs as the user, which can write to the Install Root whatever its mode is. ADR 010 said as much itself: "They do not protect against a process that already has the same user authority."

The mode rule also could not separate a real exposure from a harmless one:

| Layout | Mode | Who else can write |
| --- | --- | --- |
| Debian and Ubuntu `/usr/local` | `drwxrwsr-x root staff` | members of `staff` |
| Ubuntu home directory at 775 | private user group | nobody: the group holds the owner |
| Homebrew `/opt/homebrew/bin` | 775, group `admin` | nobody: `admin` holds root and the owner |

Two of those three refusals name a directory no other person can write. A check that refuses a stock layout sends a person to a different prefix or stops them, which helps nobody.

## What stays

The Install Root must be a directory this user owns — that one catches a real mistake, such as an Install Root an earlier `sudo` left owned by root, where an unprivileged upgrade would fail partway through replacing the executable. The Ownership Record keeps its regular-file and `0600` rules, which read a file 1667 wrote rather than a layout a person chose. Path strings must still be absolute and canonical.

`file_mode` in the shell library had no caller left and is gone.

## ADR

ADR 010 specified these rules, so this needs 1667-ai/architecture#9 to land as well. Without it the document and the code disagree, and the next reader restores the checks.

## Verification

- `npm run typecheck`, `cd tui && bun run typecheck`: clean
- `node --test` over the five installer and upgrade suites: 31 pass, 0 fail
- `cd tui && bun test`: 1560 pass, 0 fail before the new test, and the managed suite passes with it
- Both new tests were confirmed to fail against the old code rather than pass vacuously: the shell test installs into a 775 ancestor, and the TUI test upgrades inside a 775 Install Root

Closes #46

https://claude.ai/code/session_01MfCTszz1WFpnUh7He5B9Mb
