### PR TITLE
fix(install): refuse an Install Root another account can write, and add --force

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,19 @@ This file records notable changes to 1667. Product terms use the definitions in
   belonged to another user. Debian and Ubuntu ship `/usr/local` this way,
   Ubuntu gives each user a private group, and Homebrew ships its `bin`
   directory this way, so the refusal named a real permission bit and no real
-  exposure. 1667 now checks that the Install Root is a directory the current
-  user owns. These rules never protected against a program that already runs as
-  the user, because such a program can write to the Install Root whatever its
-  mode is.
+  exposure. 1667 now judges the Install Root alone: it must be a directory this
+  user owns, and no other account can be able to write it. A group-writable
+  directory is accepted when the group holds nobody except this user and root,
+  which is what those layouts are.
+
+- **A refusal about an Install Root says what is wrong and how to fix it.**
+  Each message names the directory, its mode, the account or group that can
+  write it, and the command that corrects it.
+
+- **`--force` installs or updates into an Install Root 1667 refused.** The
+  Installer and `1667 upgrade` accept it after printing what they accepted. It
+  waives no checksum, no attestation, no release identity, and no version
+  check.
 
 - **`1667 upgrade` accepts a release that supports one more platform.** The
   upgrade checked the packages of a new release against the platform list its

--- a/scripts/release-install-script-body.ts
+++ b/scripts/release-install-script-body.ts
@@ -89,6 +89,10 @@ main() {
   prefix=
   prefix_set=0
   dry_run=0
+  # --force waives the Install Root permission refusals only. It never waives a
+  # checksum, an attestation, a release identity, or the version probe: those
+  # decide whether the bytes are the release, which no local layout can answer.
+  force=0
   while [ "\$#" -gt 0 ]; do
     case "\$1" in
       --prefix)
@@ -104,6 +108,10 @@ main() {
         ;;
       --dry-run)
         dry_run=1
+        shift
+        ;;
+      --force)
+        force=1
         shift
         ;;
       -h|--help)
@@ -141,7 +149,7 @@ ${input.digestLines}
   if [ "\$prefix" = "/" ]; then
     die "--prefix must not be the filesystem root"
   fi
-  validate_install_root "\$prefix" || exit 1
+  validate_install_root "\$prefix" "\$force" || exit 1
 
   if [ "\$dry_run" -eq 1 ]; then
     printf 'dry-run: would install 1667 %s (%s) for %s into %s\\n' \\
@@ -247,9 +255,11 @@ ${input.digestLines}
 }
 
 usage() {
-  printf 'Usage: install-%s.sh [--prefix /absolute/path] [--dry-run]\\n' "\$INSTALL_CHANNEL"
+  printf 'Usage: install-%s.sh [--prefix /absolute/path] [--dry-run] [--force]\\n' "\$INSTALL_CHANNEL"
   printf 'Installs 1667 %s from the pinned GitHub release archive.\\n' "\$PRODUCT_VERSION"
   printf 'This installer is for a fresh Install Root only. Use 1667 upgrade later.\\n'
+  printf -- '--force installs into an Install Root that another account can write.\\n'
+  printf 'It waives no checksum, attestation, or version check.\\n'
 }
 
 cleanup_install() {

--- a/scripts/release-install-script-shell-lib.ts
+++ b/scripts/release-install-script-shell-lib.ts
@@ -50,14 +50,71 @@ assert_json_safe_path() {
   fi
 }
 
+# Members of a group other than this user and root. Sets GROUP_NAME and
+# GROUP_OTHERS. Returns 1 when the platform cannot answer, which is not the same
+# as a group with nobody else in it.
+#
+# /etc/group cannot answer on macOS: it lists 'admin:*:80:root' while Directory
+# Services holds the account that is really a member, so a reader of that file
+# says a shared group is private. Each platform is asked through the interface
+# that knows.
+group_other_members() {
+  gid=\$1
+  me=\$2
+  GROUP_NAME=
+  GROUP_OTHERS=
+  members=
+  if [ -x /usr/bin/getent ] || [ -x /bin/getent ]; then
+    getent_bin=/usr/bin/getent
+    [ -x "\$getent_bin" ] || getent_bin=/bin/getent
+    line=\$("\$getent_bin" group "\$gid" 2>/dev/null) || return 1
+    [ -n "\$line" ] || return 1
+    GROUP_NAME=\${line%%:*}
+    members=\${line##*:}
+  elif [ -x /usr/bin/dscl ]; then
+    GROUP_NAME=\$(/usr/bin/dscl . -search /Groups PrimaryGroupID "\$gid" 2>/dev/null \\
+      | awk 'NR==1{print \$1}') || return 1
+    [ -n "\$GROUP_NAME" ] || return 1
+    # A group with nobody in it has no GroupMembership key, and dscl exits
+    # nonzero. That is an empty membership, not a failed lookup.
+    members=\$(/usr/bin/dscl . -read "/Groups/\$GROUP_NAME" GroupMembership 2>/dev/null \\
+      | sed -n 's/^GroupMembership: //p') || members=
+  else
+    return 1
+  fi
+  GROUP_OTHERS=\$(printf '%s' "\$members" | tr ', ' '\\n\\n' \\
+    | grep -v -e '^\$' -e "^root\\\$" -e "^\$me\\\$" | tr '\\n' ' ' || true)
+  GROUP_OTHERS=\${GROUP_OTHERS% }
+  return 0
+}
+
 # The Install Root must be a name this Installer can write into the Ownership
-# Record, and a directory this user owns. It walked every directory up to the
-# file-system root before, and refused a symbolic link, a directory owned by
-# another user, and a group-writable or world-writable directory. Those rules
-# refused the layout that Debian, Ubuntu, and Homebrew ship, and they never
-# stopped a program that already runs as this user.
+# Record, a directory this user owns, and a directory no other account can
+# write. 1667 stages a candidate here, checks its digest, runs it once, and then
+# renames it into place; an account that can write here can replace the
+# candidate inside that window.
+#
+# Writable to everybody always fails. Writable to a group fails only when the
+# group holds somebody else, because Ubuntu gives each user a private group and
+# Homebrew's admin group holds root and the owner. Reading the bit alone refused
+# those layouts and named no exposure.
+
+# Refuse, or warn and continue when the caller passed --force. A waived refusal
+# still prints, so the reader who forced it can read what they accepted.
+refuse_root() {
+  forced=\$1
+  message=\$2
+  if [ "\$forced" -eq 1 ]; then
+    printf 'warning: %s\\n' "\$message" >&2
+    printf 'warning: --force accepted this Install Root anyway.\\n' >&2
+    return 0
+  fi
+  die "\$message"
+}
+
 validate_install_root() {
   root=\$1
+  forced=\${2:-0}
   assert_json_safe_path "\$root" "Install Root"
   if [ -e "\$root" ]; then
     if [ ! -d "\$root" ]; then
@@ -66,7 +123,21 @@ validate_install_root() {
     owner=\$(owner_uid "\$root") || return 1
     me=\$(id -u)
     if [ "\$owner" != "\$me" ]; then
-      die "Install Root is not owned by you: \$root"
+      refuse_root "\$forced" "Install Root \$root belongs to user \$owner, and you are \$(id -un). 1667 replaces files there during an upgrade, which it cannot do as another user. Run: sudo chown \$(id -un) \$root, choose another Install Root, or pass --force to install here anyway."
+    fi
+    mode=\$(file_mode "\$root") || return 1
+    if [ \$(( \$(printf '%d' "0\$mode") & 2 )) -ne 0 ]; then
+      refuse_root "\$forced" "Install Root \$root is writable by every account on this machine (mode \$mode). Any of them could replace what 1667 installs there. Run: chmod o-w \$root - or pass --force to install here anyway."
+    fi
+    if [ \$(( \$(printf '%d' "0\$mode") & 16 )) -ne 0 ]; then
+      gid=\$(file_gid "\$root") || return 1
+      if group_other_members "\$gid" "\$(id -un)"; then
+        if [ -n "\$GROUP_OTHERS" ]; then
+          refuse_root "\$forced" "Install Root \$root is writable by group \${GROUP_NAME:-\$gid} (mode \$mode), which also holds \$GROUP_OTHERS. That account could replace what 1667 installs there. Run: chmod g-w \$root, choose another Install Root, or pass --force to install here anyway."
+        fi
+      else
+        refuse_root "\$forced" "Install Root \$root is writable by group \$gid (mode \$mode), and this Installer could not read that group's members to see whether anybody else is in it. Run: chmod g-w \$root - or pass --force to install here anyway."
+      fi
     fi
   fi
 }
@@ -95,6 +166,23 @@ owner_uid() {
     stat -f %u "\$1" 9>&-
   else
     stat -c %u "\$1" 9>&-
+  fi
+}
+
+file_gid() {
+  if stat -f %g "\$1" >/dev/null 2>&1; then
+    stat -f %g "\$1" 9>&-
+  else
+    stat -c %g "\$1" 9>&-
+  fi
+}
+
+# Permission bits as octal digits, such as 775.
+file_mode() {
+  if stat -f %Lp "\$1" >/dev/null 2>&1; then
+    stat -f %Lp "\$1" 9>&-
+  else
+    stat -c %a "\$1" 9>&-
   fi
 }
 

--- a/test/release-install-script.test.ts
+++ b/test/release-install-script.test.ts
@@ -361,7 +361,7 @@ test("Shell Installer installs, probes identity, refuses existing binaries, reco
   await rm(path.join(prefix, "1667"));
 
   // A group-writable ancestor installs. Debian, Ubuntu, and Homebrew all ship a
-  // directory like this, and refusing it stopped an install that exposed nobody.
+  // directory like this, and only the Install Root itself is judged now.
   const groupWritable = path.join(root, "group-writable");
   await mkdir(groupWritable, { mode: 0o755 });
   await chmod(groupWritable, 0o775);
@@ -374,6 +374,37 @@ test("Shell Installer installs, probes identity, refuses existing binaries, reco
     groupWritableRun.stdout,
     new RegExp(`Installed 1667 ${INSTALL_VERSION} \\(beta\\)`)
   );
+
+  // An Install Root every account can write is refused, and the refusal names
+  // the mode, the command that fixes it, and the flag that accepts it anyway.
+  const worldWritable = path.join(root, "world-writable");
+  await mkdir(worldWritable, { mode: 0o755 });
+  await chmod(worldWritable, 0o777);
+  await assert.rejects(
+    execFileAsync("sh", [scriptPath, "--prefix", worldWritable], { cwd: root }),
+    (error: unknown) => {
+      const failure = error as { stderr?: string; message?: string };
+      const text = String(failure.stderr ?? failure.message ?? "");
+      assert.match(text, /writable by every account/i);
+      assert.match(text, /mode 777/);
+      assert.match(text, new RegExp(`chmod o-w ${worldWritable}`));
+      assert.match(text, /--force/);
+      return true;
+    }
+  );
+
+  // --force accepts exactly that Install Root, and warns about what it accepted.
+  const forced = await execFileAsync(
+    "sh",
+    [scriptPath, "--prefix", worldWritable, "--force"],
+    { cwd: root }
+  );
+  assert.match(
+    forced.stdout,
+    new RegExp(`Installed 1667 ${INSTALL_VERSION} \\(beta\\)`)
+  );
+  assert.match(forced.stderr, /writable by every account/i);
+  assert.match(forced.stderr, /--force accepted this Install Root anyway/);
 
   const safePrefix = path.join(root, "safe-prefix");
   await mkdir(safePrefix, { mode: 0o755 });

--- a/tui/src/install-path-group.ts
+++ b/tui/src/install-path-group.ts
@@ -1,0 +1,103 @@
+import { execFileSync } from "node:child_process";
+
+/**
+ * Who, other than this user, can write through a group.
+ *
+ * A group-writable directory is only an exposure when the group holds somebody
+ * else. Ubuntu gives each user a private group, and Homebrew's `admin` group
+ * holds root and the owner, so a rule that reads the group-write bit alone
+ * refuses a directory that no other person can write.
+ *
+ * `/etc/group` cannot answer this. macOS keeps group membership in Directory
+ * Services and lists `admin:*:80:root` in the file, without the account that is
+ * really a member, so a reader of that file fails open on macOS. Each platform
+ * is asked through the interface that knows the answer.
+ */
+export interface GroupMembership {
+  /** The group name, when the platform resolved one. */
+  readonly name: string | null;
+  /** Members other than this user and root, sorted. Never null when resolved. */
+  readonly others: readonly string[];
+}
+
+const LOOKUP_TIMEOUT_MS = 2_000;
+const LOOKUP_MAX_BYTES = 64 * 1024;
+
+function run(file: string, args: readonly string[]): string | null {
+  try {
+    return execFileSync(file, [...args], {
+      encoding: "utf8",
+      timeout: LOOKUP_TIMEOUT_MS,
+      maxBuffer: LOOKUP_MAX_BYTES,
+      stdio: ["ignore", "pipe", "ignore"],
+      windowsHide: true
+    });
+  } catch {
+    return null;
+  }
+}
+
+/** Split a member list that arrives comma-separated or space-separated. */
+export function parseMembers(value: string): readonly string[] {
+  return value
+    .split(/[\s,]+/u)
+    .map((member) => member.trim())
+    .filter((member) => member.length > 0);
+}
+
+/** `getent group <gid>` prints `name:x:gid:member,member`. */
+export function parseGetentGroup(line: string): GroupMembership | null {
+  const fields = line.trim().split(":");
+  if (fields.length < 4 || fields[0] === undefined) return null;
+  return {
+    name: fields[0],
+    others: parseMembers(fields.slice(3).join(":"))
+  };
+}
+
+/** `dscl . -read /Groups/<name> GroupMembership` prints one labelled line. */
+export function parseDsclMembership(output: string): readonly string[] {
+  const marker = "GroupMembership:";
+  const at = output.indexOf(marker);
+  if (at < 0) return [];
+  return parseMembers(output.slice(at + marker.length).split("\n")[0] ?? "");
+}
+
+function darwinMembership(gid: number): GroupMembership | null {
+  const search = run("/usr/bin/dscl", [".", "-search", "/Groups", "PrimaryGroupID", String(gid)]);
+  const name = search?.trim().split(/\s+/u)[0];
+  if (name === undefined || name.length === 0) return null;
+  const read = run("/usr/bin/dscl", [".", "-read", `/Groups/${name}`, "GroupMembership"]);
+  // A group with no members has no GroupMembership key at all, and `dscl` exits
+  // nonzero. That is an empty membership, not a failed lookup.
+  return { name, others: read === null ? [] : [...parseDsclMembership(read)] };
+}
+
+function linuxMembership(gid: number): GroupMembership | null {
+  // `getent` answers for every source in nsswitch, including LDAP and SSSD,
+  // which a reader of `/etc/group` would miss. Only an absolute path is run, so
+  // the answer cannot come from a directory on PATH.
+  //
+  // A supplementary member list omits an account that holds this group as its
+  // primary group. Finding those means reading every account, which is
+  // unbounded on a directory-backed host, so this check does not claim to.
+  const line = run("/usr/bin/getent", ["group", String(gid)])
+    ?? run("/bin/getent", ["group", String(gid)]);
+  return line === null ? null : parseGetentGroup(line);
+}
+
+/**
+ * Members of `gid` other than this user and root, or null when the platform
+ * could not answer. Root already holds the authority this check is about, so it
+ * is not somebody else.
+ */
+export function groupOtherMembers(gid: number, user: string): GroupMembership | null {
+  const resolved = process.platform === "darwin"
+    ? darwinMembership(gid)
+    : linuxMembership(gid);
+  if (resolved === null) return null;
+  const others = resolved.others
+    .filter((member) => member !== user && member !== "root")
+    .sort();
+  return { name: resolved.name, others };
+}

--- a/tui/src/install-path-safety.ts
+++ b/tui/src/install-path-safety.ts
@@ -3,7 +3,9 @@ import {
   statSync,
   type Stats
 } from "node:fs";
+import os from "node:os";
 import path from "node:path";
+import { groupOtherMembers } from "./install-path-group.js";
 
 export interface SafePathObservation {
   readonly path: string;
@@ -16,14 +18,20 @@ export interface SafePathObservation {
  * path rules for macOS and Linux.
  *
  * These checks find a mistake the current user made, such as an Install Root
- * that an earlier `sudo` left owned by root. They never protected against a
+ * that an earlier `sudo` left owned by root. They do not protect against a
  * program that already runs as the current user, because such a program can
  * write to the Install Root whatever its mode is.
  *
- * The mode and path-component rules are gone. They refused a directory layout
- * that Debian, Ubuntu, and Homebrew all ship: a group-writable directory whose
- * group holds nobody except the owner. The refusal named a real bit and no real
- * exposure, and it sent a person to a different prefix for no gain.
+ * They do refuse a path that a *different* account can write, because 1667
+ * stages a candidate in the Install Root, verifies its digest, runs it once,
+ * and then renames it into place. Another account that can write there can
+ * replace the candidate inside that window, and the reader then runs bytes that
+ * no check saw.
+ *
+ * Writable to everybody always fails. Writable to a group fails only when the
+ * group holds somebody besides this user, because Ubuntu gives each user a
+ * private group and Homebrew's `admin` group holds root and the owner. Reading
+ * the bit alone refused those layouts while naming no exposure at all.
  */
 export function assertSafeOwnedPath(
   value: string,
@@ -33,6 +41,12 @@ export function assertSafeOwnedPath(
     readonly requireDirectory?: boolean;
     readonly allowMissing?: boolean;
     readonly expectedModeMask?: number;
+    /**
+     * Accept a path another account can write. `--force` sets this. A reader
+     * who has looked at the directory and decided may proceed; nothing else
+     * about a release is waived by it.
+     */
+    readonly force?: boolean;
   }
 ): SafePathObservation | null {
   if (!path.isAbsolute(value) || value.includes("\0")) {
@@ -56,7 +70,10 @@ export function assertSafeOwnedPath(
   if (options.requireDirectory === true && !stats.isDirectory()) {
     throw new Error(`${options.label} must be a directory`);
   }
-  assertOwner(stats, options.label);
+  if (options.force !== true) {
+    assertOwner(stats, options.label, value);
+    assertNoOtherWriter(stats, options.label, value);
+  }
   // An exact mode still applies to a file 1667 writes itself, such as the
   // Ownership Record at 0600. That check reads 1667's own work, and refuses no
   // layout that a person chose.
@@ -67,19 +84,72 @@ export function assertSafeOwnedPath(
   return Object.freeze({ path: value, stats });
 }
 
-export function assertSafeInstallRoot(installRoot: string): void {
+export function assertSafeInstallRoot(installRoot: string, force = false): void {
   assertSafeOwnedPath(installRoot, {
     label: "Install Root",
-    requireDirectory: true
+    requireDirectory: true,
+    force
   });
 }
 
-function assertOwner(stats: Stats, label: string): void {
+/** `755`, the form a reader types back into chmod. */
+function octal(mode: number): string {
+  return (mode & 0o777).toString(8).padStart(3, "0");
+}
+
+function currentUser(): string {
+  try {
+    return os.userInfo().username;
+  } catch {
+    return "you";
+  }
+}
+
+function assertOwner(stats: Stats, label: string, file: string): void {
   const uid = process.geteuid?.() ?? process.getuid?.();
   if (uid === undefined) throw new Error(`${label} requires POSIX user identity`);
-  if (stats.uid !== uid) {
-    throw new Error(`${label} must be owned by the current user`);
+  if (stats.uid === uid) return;
+  const user = currentUser();
+  throw new Error(
+    `${label} ${file} belongs to user ${stats.uid}, and you are ${user}. `
+    + "1667 replaces files there during an upgrade, which it cannot do as "
+    + `another user. Run: sudo chown ${user} ${file} — choose another `
+    + "Install Root, or pass --force to use it anyway."
+  );
+}
+
+/**
+ * Refuse a path that an account other than this one can write. The message
+ * names the bit, the mode, and the accounts, so a reader can act on it without
+ * running `stat` and `getent` to find out what 1667 objected to.
+ */
+function assertNoOtherWriter(stats: Stats, label: string, file: string): void {
+  const mode = octal(stats.mode);
+  if ((stats.mode & 0o002) !== 0) {
+    throw new Error(
+      `${label} ${file} is writable by every account on this machine `
+      + `(mode ${mode}). Any of them could replace what 1667 installs there. `
+      + `Run: chmod o-w ${file} — or pass --force to use it anyway.`
+    );
   }
+  if ((stats.mode & 0o020) === 0) return;
+  const user = currentUser();
+  const group = groupOtherMembers(stats.gid, user);
+  if (group === null) {
+    throw new Error(
+      `${label} ${file} is writable by group ${stats.gid} (mode ${mode}), and `
+      + "1667 could not read that group's members to see whether anybody else "
+      + `is in it. Run: chmod g-w ${file} — or pass --force to use it anyway.`
+    );
+  }
+  if (group.others.length === 0) return;
+  const name = group.name ?? String(stats.gid);
+  throw new Error(
+    `${label} ${file} is writable by group ${name} (mode ${mode}), which also `
+    + `holds ${group.others.join(", ")}. That account could replace what 1667 `
+    + `installs there. Run: chmod g-w ${file} — choose another Install Root, `
+    + "or pass --force to use it anyway."
+  );
 }
 
 function isNotFound(error: unknown): boolean {

--- a/tui/src/install-transaction.ts
+++ b/tui/src/install-transaction.ts
@@ -287,9 +287,10 @@ export async function activateCandidate(input: {
 }
 
 export function revalidateAuthorityAfterLock(
-  expected: Extract<InstallationAuthority, { kind: "shell" }>
+  expected: Extract<InstallationAuthority, { kind: "shell" }>,
+  force = false
 ): Extract<InstallationAuthority, { kind: "shell" }> {
-  const record = readManagedOwnershipUnderLock(expected);
+  const record = readManagedOwnershipUnderLock(expected, force);
   if (record.channel !== expected.record.channel
     || record.product !== expected.record.product) {
     throw new Error("Managed Installation authority changed under the lock");
@@ -299,24 +300,31 @@ export function revalidateAuthorityAfterLock(
 
 /** Reload Ownership after opposite-operation recovery (channel may change). */
 export function reloadAuthorityAfterRecovery(
-  expected: Extract<InstallationAuthority, { kind: "shell" }>
+  expected: Extract<InstallationAuthority, { kind: "shell" }>,
+  force = false
 ): Extract<InstallationAuthority, { kind: "shell" }> {
-  return shellAuthorityFromOwnership(expected, readManagedOwnershipUnderLock(expected));
+  return shellAuthorityFromOwnership(
+    expected,
+    readManagedOwnershipUnderLock(expected, force)
+  );
 }
 
 function readManagedOwnershipUnderLock(
-  expected: Extract<InstallationAuthority, { kind: "shell" }>
+  expected: Extract<InstallationAuthority, { kind: "shell" }>,
+  force = false
 ): InstallOwnershipRecord {
-  assertSafeInstallRoot(expected.installRoot);
+  assertSafeInstallRoot(expected.installRoot, force);
   const ownershipPath = path.join(expected.installRoot, INSTALL_OWNERSHIP_FILE);
   assertSafeOwnedPath(ownershipPath, {
     label: "Ownership Record",
     requireFile: true,
-    expectedModeMask: 0o600
+    expectedModeMask: 0o600,
+    force
   });
   assertSafeOwnedPath(expected.executable, {
     label: "managed executable",
-    requireFile: true
+    requireFile: true,
+    force
   });
   const record = parseInstallOwnershipRecordText(readFileSync(ownershipPath, "utf8"));
   if (record.installationId !== expected.record.installationId

--- a/tui/src/managed-install-mutation.ts
+++ b/tui/src/managed-install-mutation.ts
@@ -48,11 +48,12 @@ export async function withManagedInstallMutation(
   authority: ShellAuthority,
   signal: AbortSignal,
   recoveryEarly: RecoveryEarlyResult,
-  work: (context: ManagedMutationContext) => Promise<UpgradeSuccessEnvelope>
+  work: (context: ManagedMutationContext) => Promise<UpgradeSuccessEnvelope>,
+  force = false
 ): Promise<UpgradeSuccessEnvelope> {
   const lock: InstallationLock = await acquireInstallationLock(authority.installRoot);
   try {
-    let current = revalidateAuthorityAfterLock(authority);
+    let current = revalidateAuthorityAfterLock(authority, force);
     let recovery: RecoveryOutcome;
     try {
       recovery = await recoverInstallationTransaction(current, lock.paths, signal);
@@ -65,7 +66,7 @@ export async function withManagedInstallMutation(
         const early = recoveryEarly(recovery, current);
         if (early !== null) return early;
         // Opposite-operation (or unsatisfied) completion may have rewritten Ownership.
-        current = reloadAuthorityAfterRecovery(current);
+        current = reloadAuthorityAfterRecovery(current, force);
         break;
       }
       case "clean":

--- a/tui/src/upgrade-apply.ts
+++ b/tui/src/upgrade-apply.ts
@@ -42,6 +42,8 @@ export interface UpgradeApplyDependencies {
   readonly registry?: UpgradeRegistry;
   readonly fetcher?: RegistryFetch;
   readonly signal?: AbortSignal;
+  /** `--force`: accept an Install Root another account can write. */
+  readonly force?: boolean;
 }
 
 /**
@@ -141,7 +143,8 @@ export async function applyUpgrade(
         target: targetVersion,
         channel: command.channel
       });
-    }
+    },
+    dependencies.force === true
   );
 }
 
@@ -150,6 +153,7 @@ export async function applyRollback(
     readonly authority: Extract<InstallationAuthority, { kind: "shell" }>;
     readonly observation: UpgradeObservation;
     readonly signal?: AbortSignal;
+    readonly force?: boolean;
   }
 ): Promise<UpgradeSuccessEnvelope> {
   const signal = dependencies.signal ?? new AbortController().signal;
@@ -205,7 +209,8 @@ export async function applyRollback(
         target: previousIdentity.productVersion,
         channel: authority.record.channel
       });
-    }
+    },
+    dependencies.force === true
   );
 }
 

--- a/tui/src/upgrade-cli.ts
+++ b/tui/src/upgrade-cli.ts
@@ -49,8 +49,11 @@ export type {
 
 export const UPGRADE_HELP = `Usage:
   1667 upgrade --check [--channel <stable|beta>] [--json]
-  1667 upgrade [--version <semver>] [--channel <stable|beta>] [--json]
-  1667 upgrade --rollback [--json]
+  1667 upgrade [--version <semver>] [--channel <stable|beta>] [--json] [--force]
+  1667 upgrade --rollback [--json] [--force]
+
+--force accepts an Install Root that another account on this machine can write.
+It waives no checksum, attestation, or version check.
 
 If you installed 1667 with npm, or you built it from source, update it the same
 way you installed it.
@@ -152,7 +155,8 @@ export async function executeUpgradeCli(
       observation,
       method,
       registry,
-      dependencies
+      dependencies,
+      parsed.force
     );
     return {
       exitCode: 0,
@@ -182,7 +186,8 @@ async function dispatchUpgradeCommand(
   observation: UpgradeObservation,
   method: UpgradeMethod,
   registry: UpgradeRegistry,
-  dependencies: UpgradeCliDependencies
+  dependencies: UpgradeCliDependencies,
+  force: boolean
 ): Promise<UpgradeSuccessEnvelope> {
   switch (command.kind) {
     case "rollback": {
@@ -203,7 +208,8 @@ async function dispatchUpgradeCommand(
       return await applyRollback({
         authority,
         observation,
-        signal: dependencies.signal
+        signal: dependencies.signal,
+        force
       });
     }
     case "check": {
@@ -225,7 +231,8 @@ async function dispatchUpgradeCommand(
           observation,
           registry,
           fetcher: dependencies.fetcher,
-          signal: dependencies.signal
+          signal: dependencies.signal,
+          force
         });
       }
       // External installs stay read-only: verify metadata, emit manual envelope.

--- a/tui/src/upgrade-command.ts
+++ b/tui/src/upgrade-command.ts
@@ -39,6 +39,13 @@ export type UpgradePlanCommand = UpgradeCheckCommand | UpgradeApplyCommand;
 export interface ParsedUpgradeArguments {
   readonly command: UpgradeCommand;
   readonly json: boolean;
+  /**
+   * `--force`: accept an Install Root that another account can write. It waives
+   * that refusal and nothing else. A checksum, an attestation, a release
+   * identity, and the version probe all still decide whether the bytes are the
+   * release, which no local decision can answer.
+   */
+  readonly force: boolean;
 }
 
 /**
@@ -57,6 +64,7 @@ export function parseUpgradeArguments(
   let version: string | null = null;
   let channel = defaultChannel;
   let channelSeen = false;
+  let forceSeen = false;
   for (let index = 0; index < argv.length; index += 1) {
     const argument = argv[index]!;
     if (argument === "-h" || argument === "--help") {
@@ -74,6 +82,9 @@ export function parseUpgradeArguments(
     } else if (argument === "--json") {
       if (jsonSeen) throw invalidArguments("--json may be specified only once.");
       jsonSeen = true;
+    } else if (argument === "--force") {
+      if (forceSeen) throw invalidArguments("--force may be specified only once.");
+      forceSeen = true;
     } else if (argument === "--version" || argument.startsWith("--version=")) {
       if (version !== null) throw invalidArguments("--version may be specified only once.");
       version = optionValue(argument, "--version", () => argv[++index]);
@@ -98,18 +109,29 @@ export function parseUpgradeArguments(
   if (rollback && (check || version !== null || channelSeen)) {
     throw invalidArguments("--rollback cannot be combined with --check, --version, or --channel.");
   }
+  // A read-only check writes nothing, so waiving a write refusal means nothing
+  // there. Saying so beats accepting a flag that does nothing.
+  if (forceSeen && check) {
+    throw invalidArguments("--force cannot be used with --check, which changes no file.");
+  }
   if (rollback) {
-    return Object.freeze({ command: Object.freeze({ kind: "rollback" as const }), json: jsonSeen });
+    return Object.freeze({
+      command: Object.freeze({ kind: "rollback" as const }),
+      json: jsonSeen,
+      force: forceSeen
+    });
   }
   if (check) {
     return Object.freeze({
       command: Object.freeze({ kind: "check" as const, channel }),
-      json: jsonSeen
+      json: jsonSeen,
+      force: false
     });
   }
   return Object.freeze({
     command: Object.freeze({ kind: "apply" as const, channel, version }),
-    json: jsonSeen
+    json: jsonSeen,
+    force: forceSeen
   });
 }
 

--- a/tui/test/install-path-group.test.ts
+++ b/tui/test/install-path-group.test.ts
@@ -19,8 +19,8 @@ test("a getent line yields the group name and its supplementary members", () => 
   });
   // Ubuntu's private user group: the owner is not repeated in the member list.
   expect(parseGetentGroup("chris:x:1000:")).toEqual({ name: "chris", others: [] });
-  expect(parseGetentGroup("")).toBeNull();
-  expect(parseGetentGroup("nonsense")).toBeNull();
+  expect(parseGetentGroup("")).toBe(null);
+  expect(parseGetentGroup("nonsense")).toBe(null);
 });
 
 test("dscl membership is read from its labelled line", () => {

--- a/tui/test/install-path-group.test.ts
+++ b/tui/test/install-path-group.test.ts
@@ -1,0 +1,38 @@
+import { expect, test } from "bun:test";
+import {
+  parseDsclMembership,
+  parseGetentGroup,
+  parseMembers
+} from "../src/install-path-group.js";
+
+/*
+ * A test cannot create a system group, so the decision that depends on one is
+ * covered where it can be: the two platform answers this product parses. The
+ * refusal and the --force waiver are covered end to end against a
+ * world-writable Install Root, which needs no group at all.
+ */
+
+test("a getent line yields the group name and its supplementary members", () => {
+  expect(parseGetentGroup("staff:x:50:alice,bob")).toEqual({
+    name: "staff",
+    others: ["alice", "bob"]
+  });
+  // Ubuntu's private user group: the owner is not repeated in the member list.
+  expect(parseGetentGroup("chris:x:1000:")).toEqual({ name: "chris", others: [] });
+  expect(parseGetentGroup("")).toBeNull();
+  expect(parseGetentGroup("nonsense")).toBeNull();
+});
+
+test("dscl membership is read from its labelled line", () => {
+  // macOS answers this way, and /etc/group does not: that file carries
+  // `admin:*:80:root` while Directory Services holds the real membership.
+  expect(parseDsclMembership("GroupMembership: root chris\n")).toEqual(["root", "chris"]);
+  // A group with nobody in it has no such key at all.
+  expect(parseDsclMembership("No such key: GroupMembership\n")).toEqual([]);
+  expect(parseDsclMembership("")).toEqual([]);
+});
+
+test("member lists split on either separator and drop empty entries", () => {
+  expect(parseMembers("alice, bob   carol")).toEqual(["alice", "bob", "carol"]);
+  expect(parseMembers("   ")).toEqual([]);
+});

--- a/tui/test/upgrade-cli.test.ts
+++ b/tui/test/upgrade-cli.test.ts
@@ -41,15 +41,18 @@ test("upgrade argument parser preserves global version semantics and rejects amb
     "--version", "2.0.0-beta.1", "--channel=beta", "--json"
   ])).toEqual({
     command: { kind: "apply", version: "2.0.0-beta.1", channel: "beta" },
-    json: true
+    json: true,
+    force: false
   });
   expect(parseUpgradeArguments(["--check"])).toEqual({
     command: { kind: "check", channel: "stable" },
-    json: false
+    json: false,
+    force: false
   });
   expect(parseUpgradeArguments(["--rollback", "--json"])).toEqual({
     command: { kind: "rollback" },
-    json: true
+    json: true,
+    force: false
   });
   expect(() => parseUpgradeArguments(["--check", "--version", "2.0.0"])).toThrow();
   expect(() => parseUpgradeArguments(["--version", "v2.0.0"])).toThrow();
@@ -57,6 +60,22 @@ test("upgrade argument parser preserves global version semantics and rejects amb
   expect(() => parseUpgradeArguments(["--json", "--json"])).toThrow();
   expect(() => parseUpgradeArguments(["--rollback", "--check"])).toThrow();
   expect(() => parseUpgradeArguments(["--rollback", "--channel", "beta"])).toThrow();
+});
+
+test("--force is an apply-time waiver and says so when it would do nothing", () => {
+  expect(parseUpgradeArguments(["--force"])).toEqual({
+    command: { kind: "apply", version: null, channel: "stable" },
+    json: false,
+    force: true
+  });
+  expect(parseUpgradeArguments(["--rollback", "--force"])).toEqual({
+    command: { kind: "rollback" },
+    json: false,
+    force: true
+  });
+  // A read-only check writes nothing, so the flag would waive nothing there.
+  expect(() => parseUpgradeArguments(["--check", "--force"])).toThrow(/--check/u);
+  expect(() => parseUpgradeArguments(["--force", "--force"])).toThrow(/only once/u);
 });
 
 test("persisted channel is the default and an explicit flag wins", () => {


### PR DESCRIPTION
Follow-up to #47, which a structured review found had gone one step too far, plus the `--force` escape hatch and much clearer messages.

## The gap #47 opened

1667 stages a candidate in the Install Root, verifies its digest, runs it once, then renames it into place. An account that can write there can replace the candidate inside that window. After #47 an owner check alone let a user-owned `0777` directory through.

## The rule

| Bit | Before #47 | After #47 | Now |
| --- | --- | --- | --- |
| other-write | refused | allowed | refused |
| group-write, group holds only you and root | refused | allowed | allowed |
| group-write, group holds somebody else | refused | allowed | refused |
| ancestor bits, symlinks, ancestor owners | refused | not checked | not checked |

That keeps every layout #47 was about — Ubuntu's private user groups, Homebrew's `admin` group of root plus the owner — and refuses a directory another person can write.

## `/etc/group` cannot answer this

macOS keeps membership in Directory Services and lists only `admin:*:80:root` in the file, so a reader of `/etc/group` calls a shared group private and fails open. `dscl` answers on macOS, `getent` on Linux (which also covers LDAP and SSSD), and a group neither can resolve is refused. A supplementary member list omits an account holding the group as its *primary* group; finding those means reading every account, which is unbounded on a directory-backed host, and the code says so rather than pretending otherwise.

## Messages

Before: `Install path is group-writable or world-writable: /opt/homebrew/bin`

Now, naming the mode, the principal, the fix, and the flag:

```text
Install Root /srv/tools is writable by group staff (mode 775), which also holds
alice, bob. That account could replace what 1667 installs there.
Run: chmod g-w /srv/tools, choose another Install Root, or pass --force to
install here anyway.
```

## `--force`

`install.sh --force` and `1667 upgrade --force` accept the directory and print what they accepted. `--force` with `--check` is rejected, because a read-only check writes nothing and would waive nothing.

It waives these path refusals and nothing else. The checksum, the attestation, the release identity, and the version probe decide whether the bytes are the release, which no local decision can answer.

## Verification

- `npm run typecheck`, `cd tui && bun run typecheck`: clean
- `cd tui && bun test`: 1565 pass, 0 fail
- Installer suites, including the PowerShell one: 23 pass, 0 fail
- End to end against a `0777` Install Root: refused with the message above, then installed under `--force` with the waiver printed to stderr
- Group parsing is covered per platform answer, since a test cannot create a system group

Closes #48
Follows #46, #47

https://claude.ai/code/session_01MfCTszz1WFpnUh7He5B9Mb