### PR TITLE
chore(release): prepare 0.4.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "1667-workspace",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "1667-workspace",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "license": "Apache-2.0",
       "dependencies": {
         "fs-ext-extra-prebuilt": "2.2.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667-workspace",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "private": true,
   "description": "Source workspace for the 1667 terminal writing environment",
   "license": "Apache-2.0",

--- a/tui/package.json
+++ b/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "private": true,
   "description": "A terminal environment for writing fiction with language models",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary

- Set the root package version to `0.4.2`.
- Set the TUI package version to `0.4.2`.
- Keep the root lockfile version fields synchronized.

This release carries the Install Root rules and `--force` from #49: an Install Root another account can write is refused, the private-group layouts that Debian, Ubuntu, and Homebrew ship are accepted, each refusal names the mode and the fix, and `--force` accepts the directory anyway without waiving any release verification.

0.4.1 already carries the upgrade path fixes, so a 0.4.1 installation can take this release through `1667 upgrade`.

## Verification

- `npm run typecheck`
- `node --test test/release-identity.test.ts test/release-content.test.ts test/release-preflight.test.ts test/build-identity.test.ts`: 16 pass, 0 fail

Closes #51

https://claude.ai/code/session_01MfCTszz1WFpnUh7He5B9Mb