### PR TITLE
feat(editor): wrap the composer surfaces at words, and give the story name field a caret

### DIFF
--- a/tui/src/app.ts
+++ b/tui/src/app.ts
@@ -619,6 +619,7 @@ export async function handleKey(
     tagChoosingStatus: state.tag?.choosingStatus ?? false,
     connectionDown: state.connection.down,
     overlayTyping: overlayTextInputActive(state),
+    libraryRenaming: state.library?.prompt?.kind === "rename",
     settingsSampling: state.settings !== null && state.settings.sampling !== null,
     settingsProfileTransfer: state.settings?.profileTransfer?.phase ?? null,
     commandsTags: state.commands?.view === "tags",

--- a/tui/src/cell-width.ts
+++ b/tui/src/cell-width.ts
@@ -11,6 +11,17 @@ const EMOJI_PRESENTATION = /\p{Emoji_Presentation}|\p{Regional_Indicator}/u;
 const KEYCAP = /\u20E3/u;
 const PRINTABLE_ASCII = /^[\x20-\x7E]*$/;
 
+// A writer types a no-break space to hold two words on one row, so it is the
+// one whitespace a wrap must not break at. U+FEFF is already zero width, and
+// it joins the set for the same reason.
+const NO_BREAK_SPACE = /[\u00A0\u2007\u202F\uFEFF]/;
+
+/** True when a wrap can break the line at this cell. One spelling for the
+ *  story measure and for the composer, so both break a paragraph alike. */
+export function breaksLine(text: string): boolean {
+  return /\s/.test(text) && !NO_BREAK_SPACE.test(text);
+}
+
 export interface GraphemeCell {
   text: string;
   index: number;

--- a/tui/src/composer-editing.ts
+++ b/tui/src/composer-editing.ts
@@ -79,17 +79,22 @@ export function deleteComposerToLineBoundary(composer: ComposerState, end: boole
     Math.min(composer.cursor, boundary), Math.max(composer.cursor, boundary), "");
 }
 
-/** Move by logical rows. Direct and one-line Settings editors do not soft-wrap. */
+/** Move by logical rows. Direct and one-line Settings editors do not soft-wrap.
+ *  Returns whether the cursor actually moved, matching the soft-wrapped
+ *  `moveComposerVisualRows` this stands in for. */
 export function moveComposerPage(
   composer: ComposerState,
   direction: -1 | 1,
   rows: number,
   selecting = false
-): void {
+): boolean {
   const count = Math.max(1, Math.floor(rows));
+  let moved = false;
   for (let row = 0; row < count; row += 1) {
     if (!moveComposerVertical(composer, direction, selecting)) break;
+    moved = true;
   }
+  return moved;
 }
 
 function wordBoundary(composer: ComposerState, cursor: number, direction: -1 | 1): number {

--- a/tui/src/composer-geometry.ts
+++ b/tui/src/composer-geometry.ts
@@ -1,0 +1,53 @@
+import type { UserConfig } from "./config.js";
+import { deriveStoryFrameLayout } from "./story-frame-layout.js";
+import { visibleWidth } from "./screens/story/frame.js";
+
+/** Fixed-width left gutter reserved for story row verbs and take counters, in
+ *  cells. Shared by row layout and composer geometry so both agree on where
+ *  the prose column starts. */
+export const STORY_GUTTER = 24;
+
+export function storyProseMeasure(pageWidth: number): number {
+  return Math.max(1, Math.min(72, pageWidth < 100 ? pageWidth - 4 : pageWidth - 26));
+}
+
+/** Painted width of the composer field. */
+export function composerFieldWidth(
+  fullscreen: boolean,
+  terminalWidth: number,
+  measure: number,
+  indent: string
+): number {
+  const bounded = Math.max(8, Math.floor(terminalWidth));
+  return fullscreen
+    ? bounded
+    : Math.max(8, Math.min(
+      Math.floor(measure),
+      Math.max(8, bounded - visibleWidth(indent))
+    ));
+}
+
+/** Cells one wrapped row holds. Paint and vertical motion both read this, so a
+ *  wrapped caret lands on the row the writer sees. */
+export function composerInputWidth(fieldWidth: number): number {
+  return Math.max(1, fieldWidth - visibleWidth("┃ ") - visibleWidth("› "));
+}
+
+/** Cells the Direct composer wraps at, for the geometry it is painted with.
+ *  Vertical motion reads this so an arrow key follows the painted rows. */
+export function directComposerWrapWidth(
+  terminalWidth: number,
+  config: UserConfig,
+  fullscreen: boolean
+): number {
+  if (fullscreen) {
+    return composerInputWidth(
+      composerFieldWidth(true, terminalWidth, terminalWidth, "")
+    );
+  }
+  const pageWidth = deriveStoryFrameLayout(terminalWidth, config).pageWidth;
+  const indent = pageWidth < 100 ? "  " : " ".repeat(STORY_GUTTER);
+  return composerInputWidth(composerFieldWidth(
+    false, pageWidth, storyProseMeasure(pageWidth), indent
+  ));
+}

--- a/tui/src/composer-model.ts
+++ b/tui/src/composer-model.ts
@@ -1,4 +1,4 @@
-import { graphemeCells } from "./cell-width.js";
+import { breaksLine, graphemeCells } from "./cell-width.js";
 
 export interface ComposerState {
   text: string;
@@ -37,10 +37,6 @@ export interface ComposerLineChunk {
   readonly count: number;
   readonly width: number;
   readonly uniformWidth: number | null;
-  /** True when some cell can carry a word-wrap break. Wrapping reads this to
-   *  keep space-free runs — a pasted token, a long ideographic passage — on
-   *  their arithmetic path instead of scanning for a break that cannot exist. */
-  readonly hasWrapSpace: boolean;
 }
 
 export interface ComposerLineChange {
@@ -62,6 +58,9 @@ interface CellChunk extends ComposerLineChunk {
   width: number;
   codeUnits: number;
   uniformWidth: number | null;
+  /** True when some cell can carry a word-wrap break. Wrapping reads this to
+   *  keep space-free runs — a pasted token, a long ideographic passage — on
+   *  their arithmetic path instead of scanning for a break that cannot exist. */
   hasWrapSpace: boolean;
 }
 
@@ -776,12 +775,9 @@ function makeChunk(cells: readonly ComposerLineCell[]): CellChunk {
     uniformWidth: firstWidth !== null && cells.every((cell) => cell.width === firstWidth)
       ? firstWidth
       : null,
-    hasWrapSpace: cells.some((cell) => WRAP_SPACE.test(cell.text))
+    hasWrapSpace: cells.some((cell) => breaksLine(cell.text))
   };
 }
-
-/** A cell a word wrap can break on. Line breaks never reach a chunk. */
-const WRAP_SPACE = /\s/;
 
 function joinChunks(...groups: ReadonlyArray<readonly CellChunk[]>): CellChunk[] {
   const joined: CellChunk[] = [];

--- a/tui/src/composer-model.ts
+++ b/tui/src/composer-model.ts
@@ -37,6 +37,10 @@ export interface ComposerLineChunk {
   readonly count: number;
   readonly width: number;
   readonly uniformWidth: number | null;
+  /** True when some cell can carry a word-wrap break. Wrapping reads this to
+   *  keep space-free runs — a pasted token, a long ideographic passage — on
+   *  their arithmetic path instead of scanning for a break that cannot exist. */
+  readonly hasWrapSpace: boolean;
 }
 
 export interface ComposerLineChange {
@@ -58,6 +62,7 @@ interface CellChunk extends ComposerLineChunk {
   width: number;
   codeUnits: number;
   uniformWidth: number | null;
+  hasWrapSpace: boolean;
 }
 
 interface IndexedLine {
@@ -68,6 +73,7 @@ interface IndexedLine {
   codeUnits: number;
   breakAfter: string | null;
   uniformWidth: number | null;
+  hasWrapSpace: boolean;
 }
 
 interface ComposerDocument {
@@ -371,6 +377,11 @@ export function composerLineLength(composer: ComposerState, line: number): numbe
 
 export function composerLineUniformWidth(composer: ComposerState, line: number): number | null {
   return documentFor(composer).lines[line]?.uniformWidth ?? null;
+}
+
+/** True when the line holds a cell a word wrap can break on. */
+export function composerLineHasWrapSpace(composer: ComposerState, line: number): boolean {
+  return documentFor(composer).lines[line]?.hasWrapSpace ?? false;
 }
 
 export function composerLineSnapshot(composer: ComposerState): ComposerLineSnapshot {
@@ -735,7 +746,16 @@ function makeLine(chunks: readonly CellChunk[], breakAfter: string | null): Inde
   const firstWidth = chunks[0]?.uniformWidth ?? null;
   const uniformWidth = firstWidth !== null
     && chunks.every((chunk) => chunk.uniformWidth === firstWidth) ? firstWidth : null;
-  return { chunks, chunkStarts, count, width, codeUnits, breakAfter, uniformWidth };
+  return {
+    chunks,
+    chunkStarts,
+    count,
+    width,
+    codeUnits,
+    breakAfter,
+    uniformWidth,
+    hasWrapSpace: chunks.some((chunk) => chunk.hasWrapSpace)
+  };
 }
 
 function chunksFromCells(cells: readonly ComposerLineCell[]): CellChunk[] {
@@ -755,9 +775,13 @@ function makeChunk(cells: readonly ComposerLineCell[]): CellChunk {
     codeUnits: cells.reduce((sum, cell) => sum + cell.text.length, 0),
     uniformWidth: firstWidth !== null && cells.every((cell) => cell.width === firstWidth)
       ? firstWidth
-      : null
+      : null,
+    hasWrapSpace: cells.some((cell) => WRAP_SPACE.test(cell.text))
   };
 }
+
+/** A cell a word wrap can break on. Line breaks never reach a chunk. */
+const WRAP_SPACE = /\s/;
 
 function joinChunks(...groups: ReadonlyArray<readonly CellChunk[]>): CellChunk[] {
   const joined: CellChunk[] = [];

--- a/tui/src/composer-motion.ts
+++ b/tui/src/composer-motion.ts
@@ -1,0 +1,53 @@
+import {
+  composerPosition,
+  moveComposerVertical,
+  type ComposerState
+} from "./composer-model.js";
+import { moveComposerPage } from "./composer-editing.js";
+import { moveComposerVisualRows } from "./composer-visual-movement.js";
+import { wrappedComposerLayout } from "./composer-wrapping.js";
+
+/** Vertical motion follows the paint: wrapped rows when a surface soft-wraps,
+ *  logical lines when it does not. One policy, built once per surface from
+ *  its own `wordWrap` setting, instead of each reducer re-deciding the same
+ *  question with its own mechanism. */
+export interface ComposerVerticalMotion {
+  vertical(composer: ComposerState, direction: -1 | 1, selecting?: boolean): boolean;
+  rows(composer: ComposerState, rows: number, selecting?: boolean): boolean;
+  atFirstRow(composer: ComposerState): boolean;
+}
+
+/** `wrapWidth` is read lazily: a wrapped surface's field width can depend on
+ *  live terminal geometry the caller only wants to resolve when a motion
+ *  actually happens, not once up front for a policy that may go unused. */
+export function composerMotion(
+  softWrap: boolean,
+  wrapWidth: () => number
+): ComposerVerticalMotion {
+  return softWrap ? wrappedMotion(wrapWidth) : logicalMotion();
+}
+
+function wrappedMotion(wrapWidth: () => number): ComposerVerticalMotion {
+  return {
+    vertical: (composer, direction, selecting) =>
+      moveComposerVisualRows(composer, direction, wrapWidth(), selecting),
+    rows: (composer, rows, selecting) =>
+      moveComposerVisualRows(composer, rows, wrapWidth(), selecting),
+    atFirstRow: (composer) => wrappedComposerLayout(composer, wrapWidth()).cursorRow === 0
+  };
+}
+
+function logicalMotion(): ComposerVerticalMotion {
+  return {
+    vertical: (composer, direction, selecting) =>
+      moveComposerVertical(composer, direction, selecting),
+    rows: (composer, rows, selecting) =>
+      moveComposerPage(composer, rows < 0 ? -1 : 1, Math.abs(rows), selecting),
+    atFirstRow: (composer) => composerPosition(composer).line === 0
+  };
+}
+
+/** Fields that are always single-line — a settings row edit, the library
+ *  rename prompt, a sampling knob edit — never soft-wrap, regardless of the
+ *  word-wrap setting. Shared so those surfaces do not each build their own. */
+export const SINGLE_LINE_COMPOSER_MOTION: ComposerVerticalMotion = composerMotion(false, () => 0);

--- a/tui/src/composer-surface-action.ts
+++ b/tui/src/composer-surface-action.ts
@@ -1,3 +1,4 @@
+import { readFromClipboard } from "./clipboard.js";
 import {
   composerClipboardAction,
   type ComposerClipboardHost
@@ -5,15 +6,19 @@ import {
 import {
   applyComposerEdit,
   applyComposerHistoryEdit,
-  moveComposerPage,
   type ComposerEditKind
 } from "./composer-editing.js";
+import type { ComposerVerticalMotion } from "./composer-motion.js";
 import { insertComposerText, type ComposerState } from "./composer-model.js";
-import type { ResolvedKey } from "./keys.js";
+import { sanitizePastedText, type ResolvedKey } from "./keys.js";
 
 export interface ComposerSurfaceActionOptions {
   readonly isCurrent: () => boolean;
   readonly pageRows: number;
+  readonly motion: ComposerVerticalMotion;
+  /** Reshape pasted text before it lands. Single-line fields pass a newline
+   *  flattener so a multi-line clipboard paste cannot split the field. */
+  readonly insert?: (text: string) => string;
   readonly onEdit?: (kind: ComposerEditKind | "history") => void;
 }
 
@@ -35,12 +40,15 @@ export async function composerSurfaceAction(
     return true;
   }
   if (resolved.action === "cursor-page-up" || resolved.action === "cursor-page-down") {
-    moveComposerPage(
+    options.motion.rows(
       composer,
-      resolved.action === "cursor-page-up" ? -1 : 1,
-      options.pageRows,
+      (resolved.action === "cursor-page-up" ? -1 : 1) * options.pageRows,
       resolved.extendSelection
     );
+    return true;
+  }
+  if (resolved.action === "paste-clipboard") {
+    await pasteComposerClipboard(host, composer, options);
     return true;
   }
   const edit = applyComposerEdit(composer, resolved.action, resolved.extendSelection);
@@ -55,4 +63,39 @@ export async function composerSurfaceAction(
     ? "nothing to undo"
     : "nothing to redo";
   return true;
+}
+
+/** Snapshot the claim, read the clipboard, then re-check it before applying
+ *  the result — the read is asynchronous, and the field or the interaction
+ *  can move on before it resolves. Shared by every composer-backed surface
+ *  this reducer serves, so a stale read never lands over newer typing. */
+async function pasteComposerClipboard(
+  host: ComposerClipboardHost,
+  composer: ComposerState,
+  options: ComposerSurfaceActionOptions
+): Promise<void> {
+  const claim = {
+    interactionVersion: host.interactionVersion,
+    text: composer.text,
+    cursor: composer.cursor,
+    anchor: composer.anchor
+  };
+  const text = await readFromClipboard();
+  if (!options.isCurrent()
+    || host.interactionVersion !== claim.interactionVersion
+    || composer.text !== claim.text
+    || composer.cursor !== claim.cursor
+    || composer.anchor !== claim.anchor) {
+    return;
+  }
+  if (text === null) {
+    host.toast = "clipboard unreadable · paste with ⌘V or ctrl+shift+v";
+    return;
+  }
+  const clean = sanitizePastedText(text);
+  if (clean.length === 0) {
+    host.toast = "clipboard has no insertable text";
+    return;
+  }
+  insertComposerText(composer, options.insert?.(clean) ?? clean);
 }

--- a/tui/src/composer-visual-movement.ts
+++ b/tui/src/composer-visual-movement.ts
@@ -12,16 +12,6 @@ import {
 } from "./composer-vertical-movement.js";
 import { wrappedComposerLayout } from "./composer-wrapping.js";
 
-/** Move through ordinary soft-wrapped composer rows. */
-export function moveComposerVisualVertical(
-  composer: ComposerState,
-  direction: -1 | 1,
-  width: number,
-  selecting = false
-): boolean {
-  return moveComposerVisualRows(composer, direction, width, selecting);
-}
-
 /** Move through a page of soft-wrapped rows while retaining the visual column. */
 export function moveComposerVisualRows(
   composer: ComposerState,

--- a/tui/src/composer-wrapping.ts
+++ b/tui/src/composer-wrapping.ts
@@ -1,3 +1,5 @@
+import { breaksLine } from "./cell-width.js";
+import type { ComposerLineChunk } from "./composer-model.js";
 import {
   composerLineChunks,
   composerLineHasWrapSpace,
@@ -32,12 +34,9 @@ export interface WrappedComposerLayout {
  *  A line with no break space wraps at a fixed cell count, so `stride` holds
  *  that count and the row bounds stay arithmetic. Two million cells of one
  *  pasted token therefore cost no row array at all. Prose takes `starts`. */
-interface WrappedLineMetric {
-  length: number;
-  rowCount: number;
-  stride: number | null;
-  starts: readonly number[] | null;
-}
+type WrappedLineMetric =
+  | { kind: "stride"; length: number; rowCount: number; stride: number }
+  | { kind: "starts"; length: number; rowCount: number; starts: readonly number[] };
 
 interface WrapBlock {
   lines: readonly WrappedLineMetric[];
@@ -124,25 +123,51 @@ function strideMetric(
   width: number,
   uniformWidth: number
 ): WrappedLineMetric {
-  if (length === 0) return { length, rowCount: 1, stride: 1, starts: null };
+  if (length === 0) return { kind: "stride", length, rowCount: 1, stride: 1 };
   const stride = uniformWidth <= 0
     ? Math.max(1, length)
     : Math.max(1, Math.floor(width / uniformWidth));
   const lastRowWidth = (length % stride || stride) * Math.max(0, uniformWidth);
   return {
+    kind: "stride",
     length,
     rowCount: Math.ceil(length / stride) + (lastRowWidth >= width ? 1 : 0),
-    stride,
-    starts: null
+    stride
   };
 }
 
-/** Walk the line once and record where each row begins.
+/** Where a scan stands between two chunks. It carries no absolute column, so
+ *  an unchanged chunk keeps its answer after an edit anywhere behind it. */
+interface ScanState {
+  /** Width the current row already holds. */
+  used: number;
+  /** Width of the run of non-space cells in flight. */
+  wordWidth: number;
+  /** Cells from here back to where that run began. */
+  wordBack: number;
+  /** True when the run began after the current row did, so the row can give
+   *  the whole run to the next row instead of splitting it. */
+  wordAfterRowStart: boolean;
+}
+
+interface ChunkWrap {
+  /** Row starts inside the chunk, as offsets from its first column. */
+  offsets: readonly number[];
+  exit: ScanState;
+}
+
+const CHUNK_WRAPS = new WeakMap<ComposerLineChunk, Map<string, ChunkWrap>>();
+
+/** Walk the line by chunk and record where each row begins.
  *
  *  A row keeps the spaces that end it, so the writer sees the caret advance
  *  while typing them; those spaces can run past the field, where the field
  *  paint clips them. A word too wide for the field breaks by cell instead, so
- *  a pasted token still advances rather than stalling the wrap. */
+ *  a pasted token still advances rather than stalling the wrap.
+ *
+ *  Each chunk answers for its own cells and the composer keeps chunk objects
+ *  across an edit, so a keystroke re-scans only the chunks whose wrap can have
+ *  moved. Without this a long paragraph re-scanned every cell per keystroke. */
 function scannedMetric(
   composer: ComposerState,
   sourceIndex: number,
@@ -150,45 +175,86 @@ function scannedMetric(
   width: number
 ): WrappedLineMetric {
   const starts = [0];
-  let rowStart = 0;
-  let used = 0;
-  // The run of non-space cells in flight.
-  let wordStart = 0;
-  let wordWidth = 0;
-  let column = 0;
+  let state: ScanState = {
+    used: 0,
+    wordWidth: 0,
+    wordBack: 0,
+    wordAfterRowStart: false
+  };
+  let chunkStart = 0;
   for (const chunk of composerLineChunks(composer, sourceIndex)) {
-    for (const cell of chunk.cells) {
-      if (WRAP_SPACE.test(cell.text)) {
-        used += cell.width;
-        wordStart = column + 1;
-        wordWidth = 0;
-      } else if (used + cell.width <= width) {
-        used += cell.width;
-        wordWidth += cell.width;
-      } else if (wordStart > rowStart) {
-        // Carry the whole word down rather than splitting it.
-        starts.push(wordStart);
-        rowStart = wordStart;
-        used = wordWidth + cell.width;
-        wordWidth = used;
-      } else {
-        // The word alone outgrows the field, so break between its cells.
-        starts.push(column);
-        rowStart = column;
-        wordStart = column;
-        used = cell.width;
-        wordWidth = cell.width;
-      }
-      column += 1;
-    }
+    const wrap = chunkWrap(chunk, width, state);
+    for (const offset of wrap.offsets) starts.push(chunkStart + offset);
+    state = wrap.exit;
+    chunkStart += chunk.count;
   }
   // An exactly-full final row leaves the caret no cell of its own, so the end
   // of the line gets a row rather than a position off the right edge.
-  if (length > 0 && used >= width) starts.push(length);
-  return { length, rowCount: starts.length, stride: null, starts };
+  if (length > 0 && state.used >= width) starts.push(length);
+  return { kind: "starts", length, rowCount: starts.length, starts };
 }
 
-const WRAP_SPACE = /\s/;
+function chunkWrap(
+  chunk: ComposerLineChunk,
+  width: number,
+  entry: ScanState
+): ChunkWrap {
+  let cache = CHUNK_WRAPS.get(chunk);
+  if (cache === undefined) {
+    cache = new Map();
+    CHUNK_WRAPS.set(chunk, cache);
+  }
+  const key = `${width}:${entry.used}:${entry.wordWidth}:${entry.wordBack}:`
+    + `${entry.wordAfterRowStart ? 1 : 0}`;
+  const cached = cache.get(key);
+  if (cached !== undefined) return cached;
+  const wrap = scanChunk(chunk, width, entry);
+  cache.set(key, wrap);
+  return wrap;
+}
+
+function scanChunk(
+  chunk: ComposerLineChunk,
+  width: number,
+  entry: ScanState
+): ChunkWrap {
+  const offsets: number[] = [];
+  let used = entry.used;
+  let wordWidth = entry.wordWidth;
+  // Negative while the run in flight began in an earlier chunk.
+  let wordStart = -entry.wordBack;
+  let wordAfterRowStart = entry.wordAfterRowStart;
+  let column = 0;
+  for (const cell of chunk.cells) {
+    if (breaksLine(cell.text)) {
+      used += cell.width;
+      wordStart = column + 1;
+      wordWidth = 0;
+      wordAfterRowStart = true;
+    } else if (used + cell.width <= width) {
+      used += cell.width;
+      wordWidth += cell.width;
+    } else if (wordAfterRowStart) {
+      // Carry the whole word down rather than splitting it.
+      offsets.push(wordStart);
+      used = wordWidth + cell.width;
+      wordWidth = used;
+      wordAfterRowStart = false;
+    } else {
+      // The word alone outgrows the field, so break between its cells.
+      offsets.push(column);
+      wordStart = column;
+      used = cell.width;
+      wordWidth = cell.width;
+    }
+    column += 1;
+  }
+  return {
+    offsets,
+    exit: { used, wordWidth, wordBack: column - wordStart, wordAfterRowStart }
+  };
+}
+
 
 function createStructure(
   revision: number,
@@ -208,8 +274,8 @@ function makeBlock(lines: readonly WrappedLineMetric[]): WrapBlock {
 }
 
 function rowStartAt(line: WrappedLineMetric, index: number): number {
-  return line.starts === null
-    ? Math.min(line.length, index * line.stride!)
+  return line.kind === "stride"
+    ? Math.min(line.length, index * line.stride)
     : line.starts[index]!;
 }
 
@@ -278,10 +344,10 @@ function rowBeforeLine(blocks: readonly WrapBlock[], line: number): number {
 }
 
 function localRowForColumn(line: WrappedLineMetric, column: number): number {
-  const starts = line.starts;
-  if (starts === null) {
-    return Math.min(line.rowCount - 1, Math.max(0, Math.floor(column / line.stride!)));
+  if (line.kind === "stride") {
+    return Math.min(line.rowCount - 1, Math.max(0, Math.floor(column / line.stride)));
   }
+  const starts = line.starts;
   let low = 0;
   let high = starts.length - 1;
   while (low < high) {

--- a/tui/src/composer-wrapping.ts
+++ b/tui/src/composer-wrapping.ts
@@ -1,11 +1,11 @@
 import {
   composerLineChunks,
+  composerLineHasWrapSpace,
   composerLineIdentity,
   composerLineLength,
   composerLineSnapshot,
   composerLineUniformWidth,
   composerPosition,
-  type ComposerLineChunk,
   type ComposerState
 } from "./composer-model.js";
 
@@ -23,32 +23,20 @@ export interface WrappedComposerLayout {
   rowAt(index: number): WrappedComposerRow | undefined;
 }
 
+/** One source line's wrap points. Rows tile the line without gaps, so row `i`
+ *  ends where row `i + 1` starts and the final row ends at `length`. Every
+ *  column therefore belongs to exactly one row, which is what lets the caret
+ *  sit anywhere the writer can type — including inside the run of spaces that
+ *  a wrap point absorbs.
+ *
+ *  A line with no break space wraps at a fixed cell count, so `stride` holds
+ *  that count and the row bounds stay arithmetic. Two million cells of one
+ *  pasted token therefore cost no row array at all. Prose takes `starts`. */
 interface WrappedLineMetric {
   length: number;
   rowCount: number;
-  cellsPerRow: number | null;
-  mixed: MixedLineMetric | null;
-}
-
-interface MixedLineMetric {
-  width: number;
-  endFull: boolean;
-  finalRow: number;
-  checkpoints: readonly MixedLineCheckpoint[];
-}
-
-interface MixedLineCheckpoint {
-  chunk: ComposerLineChunk;
-  column: number;
-  row: number;
-  used: number;
-  rowStart: number;
-}
-
-interface ChunkTransition {
-  rows: number;
-  used: number;
-  lastRowStart: number;
+  stride: number | null;
+  starts: readonly number[] | null;
 }
 
 interface WrapBlock {
@@ -66,11 +54,12 @@ interface CachedWrapStructure {
 const BLOCK_LINES = 256;
 const WRAP_STRUCTURES = new WeakMap<ComposerState, CachedWrapStructure>();
 const LINE_METRICS = new WeakMap<object, { width: number; metric: WrappedLineMetric }>();
-const CHUNK_TRANSITIONS = new WeakMap<object, Map<string, ChunkTransition>>();
 
-/** Cell-accurate soft-wrap index shared by paint and visual-row movement.
- * Uniform-width prose uses arithmetic bounds. Composer line-change metadata
- * replaces only affected 256-line blocks after edits. */
+/** Cell-accurate word wrap shared by paint and visual-row movement. Lines break
+ * at the last space that fits, matching the story measure (`wrap.ts`); a word
+ * wider than the field falls back to a cell break so a long token still
+ * advances. Composer line-change metadata replaces only affected 256-line
+ * blocks after edits. */
 export function wrappedComposerLayout(
   composer: ComposerState,
   width: number
@@ -121,133 +110,85 @@ function metricForLine(
   if (cached?.width === width) return cached.metric;
   const length = composerLineLength(composer, sourceIndex);
   const uniformWidth = composerLineUniformWidth(composer, sourceIndex);
-  const cellsPerRow = uniformWidth === null
-    ? null
-    : uniformWidth <= 0 ? Math.max(1, length) : Math.max(1, Math.floor(width / uniformWidth));
-  const mixed = cellsPerRow === null
-    ? mixedLineMetric(composer, sourceIndex, width)
-    : null;
-  const endFull = mixed?.endFull
-    ?? uniformEndUsed(length, cellsPerRow, uniformWidth) >= width;
-  const rowCount = length === 0 ? 1
-    : mixed !== null ? mixed.finalRow + 1 + (endFull ? 1 : 0)
-      : Math.ceil(length / cellsPerRow!) + (endFull ? 1 : 0);
-  const metric = {
-    length,
-    rowCount,
-    cellsPerRow,
-    mixed
-  };
+  const metric = uniformWidth !== null && !composerLineHasWrapSpace(composer, sourceIndex)
+    ? strideMetric(length, width, uniformWidth)
+    : scannedMetric(composer, sourceIndex, length, width);
   LINE_METRICS.set(identity, { width, metric });
   return metric;
 }
 
-function uniformEndUsed(
+/** Rows of a fixed cell count. Without a break space every row holds as many
+ *  cells as fit, which is what the arithmetic below states directly. */
+function strideMetric(
   length: number,
-  cellsPerRow: number | null,
-  cellWidth: number | null
-): number {
-  return cellsPerRow === null || cellWidth === null || length === 0
-    ? 0
-    : (length % cellsPerRow || cellsPerRow) * cellWidth;
+  width: number,
+  uniformWidth: number
+): WrappedLineMetric {
+  if (length === 0) return { length, rowCount: 1, stride: 1, starts: null };
+  const stride = uniformWidth <= 0
+    ? Math.max(1, length)
+    : Math.max(1, Math.floor(width / uniformWidth));
+  const lastRowWidth = (length % stride || stride) * Math.max(0, uniformWidth);
+  return {
+    length,
+    rowCount: Math.ceil(length / stride) + (lastRowWidth >= width ? 1 : 0),
+    stride,
+    starts: null
+  };
 }
 
-function mixedLineMetric(
+/** Walk the line once and record where each row begins.
+ *
+ *  A row keeps the spaces that end it, so the writer sees the caret advance
+ *  while typing them; those spaces can run past the field, where the field
+ *  paint clips them. A word too wide for the field breaks by cell instead, so
+ *  a pasted token still advances rather than stalling the wrap. */
+function scannedMetric(
   composer: ComposerState,
   sourceIndex: number,
+  length: number,
   width: number
-): MixedLineMetric {
-  const checkpoints: MixedLineCheckpoint[] = [];
-  let column = 0;
-  let row = 0;
-  let used = 0;
+): WrappedLineMetric {
+  const starts = [0];
   let rowStart = 0;
-  for (const chunk of composerLineChunks(composer, sourceIndex)) {
-    checkpoints.push({ chunk, column, row, used, rowStart });
-    const transition = chunkTransition(chunk, width, used);
-    row += transition.rows;
-    used = transition.used;
-    if (transition.lastRowStart >= 0) rowStart = column + transition.lastRowStart;
-    column += chunk.count;
-  }
-  return { width, endFull: used >= width, finalRow: row, checkpoints };
-}
-
-function chunkTransition(
-  chunk: ComposerLineChunk,
-  width: number,
-  startingUsed: number
-): ChunkTransition {
-  if (chunk.uniformWidth !== null) {
-    return uniformChunkTransition(chunk.count, chunk.uniformWidth, width, startingUsed);
-  }
-  let cache = CHUNK_TRANSITIONS.get(chunk);
-  if (cache === undefined) {
-    cache = new Map();
-    CHUNK_TRANSITIONS.set(chunk, cache);
-  }
-  const key = `${width}:${startingUsed}`;
-  const cached = cache.get(key);
-  if (cached !== undefined) return cached;
-  const transition = scanChunkTransition(chunk, width, startingUsed);
-  cache.set(key, transition);
-  return transition;
-}
-
-function scanChunkTransition(
-  chunk: ComposerLineChunk,
-  width: number,
-  startingUsed: number
-): ChunkTransition {
-  let rows = 0;
-  let used = startingUsed;
-  let lastRowStart = -1;
-  for (const [column, cell] of chunk.cells.entries()) {
-    if (used > 0 && used + cell.width > width) {
-      rows += 1;
-      used = 0;
-      lastRowStart = column;
-    }
-    used += cell.width;
-  }
-  return { rows, used, lastRowStart };
-}
-
-function uniformChunkTransition(
-  count: number,
-  cellWidth: number,
-  width: number,
-  startingUsed: number
-): ChunkTransition {
-  if (count === 0 || cellWidth <= 0) {
-    return { rows: 0, used: startingUsed, lastRowStart: -1 };
-  }
-  let rows = 0;
-  let used = startingUsed;
+  let used = 0;
+  // The run of non-space cells in flight.
+  let wordStart = 0;
+  let wordWidth = 0;
   let column = 0;
-  let lastRowStart = -1;
-  if (used > 0) {
-    const capacity = cellWidth > width
-      ? 0
-      : Math.max(0, Math.floor((width - used) / cellWidth));
-    if (count <= capacity) return {
-      rows: 0,
-      used: used + count * cellWidth,
-      lastRowStart: -1
-    };
-    column = capacity;
-    rows = 1;
-    used = 0;
-    lastRowStart = column;
+  for (const chunk of composerLineChunks(composer, sourceIndex)) {
+    for (const cell of chunk.cells) {
+      if (WRAP_SPACE.test(cell.text)) {
+        used += cell.width;
+        wordStart = column + 1;
+        wordWidth = 0;
+      } else if (used + cell.width <= width) {
+        used += cell.width;
+        wordWidth += cell.width;
+      } else if (wordStart > rowStart) {
+        // Carry the whole word down rather than splitting it.
+        starts.push(wordStart);
+        rowStart = wordStart;
+        used = wordWidth + cell.width;
+        wordWidth = used;
+      } else {
+        // The word alone outgrows the field, so break between its cells.
+        starts.push(column);
+        rowStart = column;
+        wordStart = column;
+        used = cell.width;
+        wordWidth = cell.width;
+      }
+      column += 1;
+    }
   }
-  const remaining = count - column;
-  const cellsPerRow = cellWidth > width ? 1 : Math.max(1, Math.floor(width / cellWidth));
-  const additionalRows = Math.floor((remaining - 1) / cellsPerRow);
-  rows += additionalRows;
-  if (additionalRows > 0) lastRowStart = column + additionalRows * cellsPerRow;
-  used = ((remaining - 1) % cellsPerRow + 1) * cellWidth;
-  return { rows, used, lastRowStart };
+  // An exactly-full final row leaves the caret no cell of its own, so the end
+  // of the line gets a row rather than a position off the right edge.
+  if (length > 0 && used >= width) starts.push(length);
+  return { length, rowCount: starts.length, stride: null, starts };
 }
+
+const WRAP_SPACE = /\s/;
 
 function createStructure(
   revision: number,
@@ -264,6 +205,12 @@ function createStructure(
 
 function makeBlock(lines: readonly WrappedLineMetric[]): WrapBlock {
   return { lines, rowCount: lines.reduce((sum, line) => sum + line.rowCount, 0) };
+}
+
+function rowStartAt(line: WrappedLineMetric, index: number): number {
+  return line.starts === null
+    ? Math.min(line.length, index * line.stride!)
+    : line.starts[index]!;
 }
 
 function chunkMetrics(lines: readonly WrappedLineMetric[]): WrapBlock[] {
@@ -331,42 +278,18 @@ function rowBeforeLine(blocks: readonly WrapBlock[], line: number): number {
 }
 
 function localRowForColumn(line: WrappedLineMetric, column: number): number {
-  if (line.cellsPerRow !== null) {
-    return Math.min(line.rowCount - 1, Math.floor(column / line.cellsPerRow));
+  const starts = line.starts;
+  if (starts === null) {
+    return Math.min(line.rowCount - 1, Math.max(0, Math.floor(column / line.stride!)));
   }
-  const mixed = line.mixed!;
-  if (line.length === 0 || column <= 0) return 0;
-  if (column >= line.length && mixed.endFull) return line.rowCount - 1;
-  const checkpoint = checkpointForColumn(mixed.checkpoints, column);
-  if (checkpoint === undefined) return 0;
-  let row = checkpoint.row;
-  let used = checkpoint.used;
-  let at = checkpoint.column;
-  for (const cell of checkpoint.chunk.cells) {
-    if (used > 0 && used + cell.width > mixed.width) {
-      row += 1;
-      used = 0;
-    }
-    if (at >= column) break;
-    used += cell.width;
-    at += 1;
-  }
-  return row;
-}
-
-function checkpointForColumn(
-  checkpoints: readonly MixedLineCheckpoint[],
-  column: number
-): MixedLineCheckpoint | undefined {
-  if (checkpoints.length === 0) return undefined;
   let low = 0;
-  let high = checkpoints.length - 1;
+  let high = starts.length - 1;
   while (low < high) {
     const middle = Math.ceil((low + high) / 2);
-    if (checkpoints[middle]!.column <= column) low = middle;
+    if (starts[middle]! <= column) low = middle;
     else high = middle - 1;
   }
-  return checkpoints[low];
+  return low;
 }
 
 function wrappedRowAt(
@@ -389,56 +312,16 @@ function wrappedRowAt(
         sourceIndex += 1;
         continue;
       }
-      const bounds = line.cellsPerRow === null
-        ? mixedRowBounds(line, remaining)
-        : {
-          start: Math.min(line.length, remaining * line.cellsPerRow),
-          end: Math.min(line.length, (remaining + 1) * line.cellsPerRow)
-        };
+      const start = rowStartAt(line, remaining);
+      const last = remaining === line.rowCount - 1;
       return {
         sourceIndex,
-        ...bounds,
-        first: bounds.start === 0,
-        last: remaining === line.rowCount - 1
+        start,
+        end: last ? line.length : rowStartAt(line, remaining + 1),
+        first: start === 0,
+        last
       };
     }
   }
   return undefined;
-}
-
-function mixedRowBounds(
-  line: WrappedLineMetric,
-  targetRow: number
-): { start: number; end: number } {
-  const mixed = line.mixed!;
-  if (line.length === 0) return { start: 0, end: 0 };
-  if (mixed.endFull && targetRow === line.rowCount - 1) {
-    return { start: line.length, end: line.length };
-  }
-  const checkpoints = mixed.checkpoints;
-  let low = 0;
-  let high = checkpoints.length - 1;
-  while (low < high) {
-    const middle = Math.ceil((low + high) / 2);
-    if (checkpoints[middle]!.row <= targetRow) low = middle;
-    else high = middle - 1;
-  }
-  const checkpoint = checkpoints[low]!;
-  let row = checkpoint.row;
-  let used = checkpoint.used;
-  let rowStart = checkpoint.rowStart;
-  let column = checkpoint.column;
-  for (let chunk = low; chunk < checkpoints.length; chunk += 1) {
-    for (const cell of checkpoints[chunk]!.chunk.cells) {
-      if (used > 0 && used + cell.width > mixed.width) {
-        if (row === targetRow) return { start: rowStart, end: column };
-        row += 1;
-        used = 0;
-        rowStart = column;
-      }
-      used += cell.width;
-      column += 1;
-    }
-  }
-  return { start: rowStart, end: line.length };
 }

--- a/tui/src/composer-wrapping.ts
+++ b/tui/src/composer-wrapping.ts
@@ -234,8 +234,10 @@ function scanChunk(
     } else if (used + cell.width <= width) {
       used += cell.width;
       wordWidth += cell.width;
-    } else if (wordAfterRowStart) {
-      // Carry the whole word down rather than splitting it.
+    } else if (wordAfterRowStart && wordWidth + cell.width <= width) {
+      // Carry the whole word down rather than splitting it. Only a word that
+      // fits a row of its own can move; one that cannot would land just as
+      // over-wide on the next row, and clip its last cell there instead.
       offsets.push(wordStart);
       used = wordWidth + cell.width;
       wordWidth = used;

--- a/tui/src/config.ts
+++ b/tui/src/config.ts
@@ -47,6 +47,10 @@ export interface UserConfig {
   theme: ThemeName;
   factsRail: "auto" | "off";
   composeFocus: "on" | "off";
+  /** Break editor lines at word boundaries instead of clipping them. Every
+   *  composer-backed surface reads this: Direct, the document editors, and the
+   *  Fact body. */
+  wordWrap: "on" | "off";
   /** Null follows max(6, floor(terminal rows / 3)). */
   composeMaxHeight: number | null;
   quota: QuotaLedger;
@@ -57,6 +61,7 @@ const DEFAULTS: UserConfig = {
   theme: "lantern",
   factsRail: "auto",
   composeFocus: "off",
+  wordWrap: "on",
   composeMaxHeight: null,
   quota: { date: "", words: 0 },
   updates: { mode: "off", channel: "stable", skippedVersion: null }
@@ -78,6 +83,11 @@ function normalizedComposeFocus(value: unknown): UserConfig["composeFocus"] {
   return value === true || value === "on" ? "on" : "off";
 }
 
+/** Absent means on, so an existing config file keeps wrapping the editors. */
+function normalizedWordWrap(value: unknown): UserConfig["wordWrap"] {
+  return value === false || value === "off" ? "off" : "on";
+}
+
 function normalizedComposeMaxHeight(value: unknown): number | null {
   if (typeof value !== "number" || !Number.isFinite(value) || value < 1) return null;
   return Math.floor(value);
@@ -95,6 +105,7 @@ export function normalizeUserConfig(value: unknown): UserConfig {
   const theme = raw.theme;
   const factsRail = configValue(raw, "factsRail", "facts_rail");
   const composeFocus = configValue(raw, "composeFocus", "compose_focus");
+  const wordWrap = configValue(raw, "wordWrap", "word_wrap");
   const composeMaxHeight = configValue(raw, "composeMaxHeight", "compose_max_height");
   const quotaValid = typeof rawQuota.date === "string"
     && typeof rawQuota.words === "number"
@@ -103,6 +114,7 @@ export function normalizeUserConfig(value: unknown): UserConfig {
     theme: THEME_NAMES.includes(theme as ThemeName) ? theme as ThemeName : DEFAULTS.theme,
     factsRail: factsRail === "off" ? "off" : "auto",
     composeFocus: normalizedComposeFocus(composeFocus),
+    wordWrap: normalizedWordWrap(wordWrap),
     composeMaxHeight: normalizedComposeMaxHeight(composeMaxHeight),
     quota: quotaValid
       ? { date: rawQuota.date as string, words: rawQuota.words as number }

--- a/tui/src/copy-actions.ts
+++ b/tui/src/copy-actions.ts
@@ -143,12 +143,13 @@ export function handleMainCopyShortcut(
 /** Composer surfaces consume Ctrl+C even without a selection. EDITOR handles
  * the chord in its reducer; this identifies ownership before input queues. */
 export function consumesEmptyCopyShortcut(
-  state: Pick<RuntimeState, "mode" | "settings">
+  state: Pick<RuntimeState, "mode" | "settings" | "library">
 ): boolean {
   return state.mode === "COMPOSE"
     || state.mode === "EDITOR"
     || state.mode === "SETTINGS"
-      && (state.settings?.edit != null || state.settings?.sampling?.edit != null);
+      && (state.settings?.edit != null || state.settings?.sampling?.edit != null)
+    || state.mode === "LIBRARY" && state.library?.prompt?.kind === "rename";
 }
 
 /** Convert OpenTUI's painted-cell range into the same raw document selection
@@ -280,7 +281,11 @@ function activeComposer(
             ?? state.settings?.edit?.composer
             ?? null
           : null
-        : null;
+        : state.mode === "LIBRARY"
+          ? sourceId === undefined && state.library?.prompt?.kind === "rename"
+            ? state.library.prompt.composer
+            : null
+          : null;
 }
 
 /** Translate generic multi-buffer selection outcomes at the editor boundary. */

--- a/tui/src/demo.ts
+++ b/tui/src/demo.ts
@@ -842,6 +842,7 @@ export function demoAppSource(dense = false): AppSource {
       theme: "lantern",
       factsRail: "auto",
       composeFocus: "off",
+      wordWrap: "on",
       composeMaxHeight: null,
       quota: { date: "", words: 0 },
       updates: { mode: "notify", channel: "stable", skippedVersion: null }

--- a/tui/src/editor-action.ts
+++ b/tui/src/editor-action.ts
@@ -69,8 +69,9 @@ export async function inlineEditorAction(
     return;
   }
   const wrapWidth = Math.max(1, (context.renderer?.width ?? 80) - 4);
+  const softWrap = state.config.wordWrap === "on";
   if (editor.kind === "fact"
-    && handleFactEditorVerticalMove(resolved, editor, wrapWidth)) {
+    && handleFactEditorVerticalMove(resolved, editor, wrapWidth, softWrap)) {
     return;
   }
   const buffer = editor.kind === "fact" ? factEditorBuffer(editor) : editor;
@@ -78,6 +79,7 @@ export async function inlineEditorAction(
     isCurrent: () => state.mode === "EDITOR" && state.editor === editor,
     ...editorInsertionPolicy(editor),
     wrapWidth,
+    softWrap,
     pageRows: composerPageRows(context.renderer?.height ?? 24, true)
   });
   const outcome = await reduceBuffer();

--- a/tui/src/editor-action.ts
+++ b/tui/src/editor-action.ts
@@ -11,6 +11,7 @@ import { recordHumanWords } from "./config.js";
 import { parsePartFile, stripGuidance } from "./editor.js";
 import { editorBufferAction } from "./editor-buffer-action.js";
 import { composerPageRows } from "./composer-viewport.js";
+import { composerMotion } from "./composer-motion.js";
 import { editorInsertionPolicy } from "./editor-text-insertion.js";
 import { factEditorChanged, factEditorSavePayload } from "./fact-editor-draft.js";
 import {
@@ -68,18 +69,19 @@ export async function inlineEditorAction(
     && handleFactEditorHistory(resolved, state, editor)) {
     return;
   }
-  const wrapWidth = Math.max(1, (context.renderer?.width ?? 80) - 4);
-  const softWrap = state.config.wordWrap === "on";
+  const motion = composerMotion(
+    state.config.wordWrap === "on",
+    () => Math.max(1, (context.renderer?.width ?? 80) - 4)
+  );
   if (editor.kind === "fact"
-    && handleFactEditorVerticalMove(resolved, editor, wrapWidth, softWrap)) {
+    && handleFactEditorVerticalMove(resolved, editor, motion)) {
     return;
   }
   const buffer = editor.kind === "fact" ? factEditorBuffer(editor) : editor;
   const reduceBuffer = () => editorBufferAction(resolved, state, buffer, {
     isCurrent: () => state.mode === "EDITOR" && state.editor === editor,
     ...editorInsertionPolicy(editor),
-    wrapWidth,
-    softWrap,
+    motion,
     pageRows: composerPageRows(context.renderer?.height ?? 24, true)
   });
   const outcome = await reduceBuffer();

--- a/tui/src/editor-buffer-action.ts
+++ b/tui/src/editor-buffer-action.ts
@@ -1,13 +1,8 @@
 import {
   applyComposerEdit,
-  applyComposerHistoryEdit,
-  moveComposerPage
+  applyComposerHistoryEdit
 } from "./composer-editing.js";
-import { moveComposerVertical } from "./composer-model.js";
-import {
-  moveComposerVisualRows,
-  moveComposerVisualVertical
-} from "./composer-visual-movement.js";
+import type { ComposerVerticalMotion } from "./composer-motion.js";
 import { readFromClipboard } from "./clipboard.js";
 import { composerClipboardAction } from "./composer-clipboard-action.js";
 import {
@@ -33,11 +28,10 @@ export type EditorBufferOutcome =
 
 export interface EditorBufferActionOptions extends EditorTextInsertionPolicy {
   readonly isCurrent: () => boolean;
-  readonly wrapWidth: number;
   readonly pageRows: number;
   /** Vertical motion follows the paint: wrapped rows when the editor wraps,
    *  logical lines when it does not. */
-  readonly softWrap: boolean;
+  readonly motion: ComposerVerticalMotion;
 }
 
 /** Shared multiline-buffer reducer. Target owners keep save, cancel, conflict,
@@ -69,27 +63,12 @@ export async function editorBufferAction(
   }
   if (resolved.action === "cursor-up" || resolved.action === "cursor-down") {
     const direction = resolved.action === "cursor-up" ? -1 : 1;
-    if (options.softWrap) {
-      moveComposerVisualVertical(
-        buffer.composer, direction, options.wrapWidth, resolved.extendSelection
-      );
-    } else moveComposerVertical(buffer.composer, direction, resolved.extendSelection);
+    options.motion.vertical(buffer.composer, direction, resolved.extendSelection);
     return "handled";
   }
   if (resolved.action === "cursor-page-up" || resolved.action === "cursor-page-down") {
     const direction = resolved.action === "cursor-page-up" ? -1 : 1;
-    if (options.softWrap) {
-      moveComposerVisualRows(
-        buffer.composer,
-        direction * options.pageRows,
-        options.wrapWidth,
-        resolved.extendSelection
-      );
-    } else {
-      moveComposerPage(
-        buffer.composer, direction, options.pageRows, resolved.extendSelection
-      );
-    }
+    options.motion.rows(buffer.composer, direction * options.pageRows, resolved.extendSelection);
     return "handled";
   }
   const kind = applyComposerEdit(

--- a/tui/src/editor-buffer-action.ts
+++ b/tui/src/editor-buffer-action.ts
@@ -1,4 +1,9 @@
-import { applyComposerEdit, applyComposerHistoryEdit } from "./composer-editing.js";
+import {
+  applyComposerEdit,
+  applyComposerHistoryEdit,
+  moveComposerPage
+} from "./composer-editing.js";
+import { moveComposerVertical } from "./composer-model.js";
 import {
   moveComposerVisualRows,
   moveComposerVisualVertical
@@ -30,6 +35,9 @@ export interface EditorBufferActionOptions extends EditorTextInsertionPolicy {
   readonly isCurrent: () => boolean;
   readonly wrapWidth: number;
   readonly pageRows: number;
+  /** Vertical motion follows the paint: wrapped rows when the editor wraps,
+   *  logical lines when it does not. */
+  readonly softWrap: boolean;
 }
 
 /** Shared multiline-buffer reducer. Target owners keep save, cancel, conflict,
@@ -60,21 +68,28 @@ export async function editorBufferAction(
     return "handled";
   }
   if (resolved.action === "cursor-up" || resolved.action === "cursor-down") {
-    moveComposerVisualVertical(
-      buffer.composer,
-      resolved.action === "cursor-up" ? -1 : 1,
-      options.wrapWidth,
-      resolved.extendSelection
-    );
+    const direction = resolved.action === "cursor-up" ? -1 : 1;
+    if (options.softWrap) {
+      moveComposerVisualVertical(
+        buffer.composer, direction, options.wrapWidth, resolved.extendSelection
+      );
+    } else moveComposerVertical(buffer.composer, direction, resolved.extendSelection);
     return "handled";
   }
   if (resolved.action === "cursor-page-up" || resolved.action === "cursor-page-down") {
-    moveComposerVisualRows(
-      buffer.composer,
-      (resolved.action === "cursor-page-up" ? -1 : 1) * options.pageRows,
-      options.wrapWidth,
-      resolved.extendSelection
-    );
+    const direction = resolved.action === "cursor-page-up" ? -1 : 1;
+    if (options.softWrap) {
+      moveComposerVisualRows(
+        buffer.composer,
+        direction * options.pageRows,
+        options.wrapWidth,
+        resolved.extendSelection
+      );
+    } else {
+      moveComposerPage(
+        buffer.composer, direction, options.pageRows, resolved.extendSelection
+      );
+    }
     return "handled";
   }
   const kind = applyComposerEdit(

--- a/tui/src/fact-editor-policy.ts
+++ b/tui/src/fact-editor-policy.ts
@@ -372,7 +372,8 @@ export function factEditorBuffer(editor: FactEditorSession): { composer: Compose
 export function handleFactEditorVerticalMove(
   resolved: ResolvedKey,
   editor: FactEditorSession,
-  wrapWidth: number
+  wrapWidth: number,
+  softWrap: boolean
 ): boolean {
   if (resolved.action !== "cursor-up" && resolved.action !== "cursor-down") {
     return false;
@@ -382,8 +383,11 @@ export function handleFactEditorVerticalMove(
     setFactEditorFocus(editor, nextFactEditorRow(editor.focus, direction));
     return true;
   }
-  const layout = wrappedComposerLayout(editor.composer, wrapWidth);
-  if (resolved.action === "cursor-up" && layout.cursorRow === 0) {
+  // Unwrapped, the body's first row is its first logical line.
+  const atFirstRow = softWrap
+    ? wrappedComposerLayout(editor.composer, wrapWidth).cursorRow === 0
+    : composerPosition(editor.composer).line === 0;
+  if (resolved.action === "cursor-up" && atFirstRow) {
     setFactEditorFocus(editor, "budget");
     editor.budget.anchor = null;
     editor.budget.cursor = Math.min(

--- a/tui/src/fact-editor-policy.ts
+++ b/tui/src/fact-editor-policy.ts
@@ -9,7 +9,7 @@ import {
 } from "./composer-model.js";
 import { FACT_PRIORITIES, FACT_RECURSIONS, FACT_SECONDARY_MODES } from "../../shared/fact-metadata.js";
 import { graphemeCells } from "./cell-width.js";
-import { wrappedComposerLayout } from "./composer-wrapping.js";
+import type { ComposerVerticalMotion } from "./composer-motion.js";
 import { factEditorTag } from "./fact-editor-draft.js";
 import { nextFactEditorRow, type FactEditorRow } from "./fact-editor-rows.js";
 import { factTagPresets } from "./facts-model.js";
@@ -372,8 +372,7 @@ export function factEditorBuffer(editor: FactEditorSession): { composer: Compose
 export function handleFactEditorVerticalMove(
   resolved: ResolvedKey,
   editor: FactEditorSession,
-  wrapWidth: number,
-  softWrap: boolean
+  motion: ComposerVerticalMotion
 ): boolean {
   if (resolved.action !== "cursor-up" && resolved.action !== "cursor-down") {
     return false;
@@ -383,11 +382,7 @@ export function handleFactEditorVerticalMove(
     setFactEditorFocus(editor, nextFactEditorRow(editor.focus, direction));
     return true;
   }
-  // Unwrapped, the body's first row is its first logical line.
-  const atFirstRow = softWrap
-    ? wrappedComposerLayout(editor.composer, wrapWidth).cursorRow === 0
-    : composerPosition(editor.composer).line === 0;
-  if (resolved.action === "cursor-up" && atFirstRow) {
+  if (resolved.action === "cursor-up" && motion.atFirstRow(editor.composer)) {
     setFactEditorFocus(editor, "budget");
     editor.budget.anchor = null;
     editor.budget.cursor = Math.min(

--- a/tui/src/interactive-frame-runtime.ts
+++ b/tui/src/interactive-frame-runtime.ts
@@ -14,7 +14,8 @@ import {
   type TuiFrameProfileReport
 } from "./frame-profile.js";
 import type { Palette } from "./palette.js";
-import { renderStoryScreen, storyProseMeasure } from "./screens/story.js";
+import { renderStoryScreen } from "./screens/story.js";
+import { storyProseMeasure } from "./composer-geometry.js";
 import { fitLine, segment, type FrameLine } from "./screens/story/frame.js";
 import type { RuntimeState } from "./state.js";
 import type { StorySurface } from "./story-surface.js";

--- a/tui/src/keys-text-surface.ts
+++ b/tui/src/keys-text-surface.ts
@@ -7,9 +7,13 @@ import type { ResolvedKey } from "./keys.js";
  * They move and delete by character, word, line, buffer, and page.
  * They also share cut, undo, and redo.
  *
- * Four other surfaces hold a plain string, not a composer: the LIBRARY
- * prompt, the FACTS filter, the CHAPTERS rename field, and the TAG name.
- * These surfaces use `applyTextKey`. They do not use this table.
+ * Three other surfaces hold a plain string, not a composer: the FACTS
+ * filter, the CHAPTERS rename field, and the TAG name. These surfaces use
+ * `applyTextKey`. They do not use this table.
+ *
+ * The LIBRARY prompt is split: its filter and its delete confirmation are
+ * still plain strings on `applyTextKey`, but its rename field is composer-
+ * backed and reads this table, the same as Direct and the settings fields.
  *
  * Each surface checks its own chords before it checks this table.
  * This order keeps the intentional differences.

--- a/tui/src/keys.ts
+++ b/tui/src/keys.ts
@@ -213,7 +213,8 @@ export function pasteInto(
       query: string;
       prompt:
         | { kind: "filter" }
-        | { kind: "rename" | "delete"; value: string }
+        | { kind: "rename"; composer: ComposerState }
+        | { kind: "delete"; value: string }
         | null;
     } | null;
     facts: { filtering: boolean; query: string; cursor: number } | null;
@@ -292,6 +293,8 @@ export function pasteInto(
   if (state.mode === "LIBRARY" && state.library?.prompt != null) {
     if (state.library.prompt.kind === "filter") {
       setLibraryQuery(state.library, state.library.query + line);
+    } else if (state.library.prompt.kind === "rename") {
+      insertComposerText(state.library.prompt.composer, line);
     } else {
       state.library.prompt.value += line;
     }
@@ -348,6 +351,9 @@ export interface ResolveOptions {
   connectionDown?: boolean;
   /** A text prompt/filter owns the keyboard: letters are input, not hotkeys. */
   overlayTyping?: boolean;
+  /** The LIBRARY prompt open is specifically the composer-backed rename
+   *  field, not the plain-string filter or delete confirmation. */
+  libraryRenaming?: boolean;
   /** A nested Sampling panel owns list navigation and scalar controls. */
   settingsSampling?: boolean;
   /** The command palette is showing its tags sub-view. */
@@ -404,6 +410,7 @@ export function resolveKey(key: KeyEvent, mode: AppMode, options: ResolveOptions
     factEditor = false, authorsNoteEditor = false, settingsPicker = false,
     settingsProfileTransfer = null,
     textActionsOpen = false,
+    libraryRenaming = false,
     mapView = "path" } = options;
   const globalReference = resolveReferenceBinding("global", key, mode, mapView);
   if (globalReference !== null || key.name === "escape") {
@@ -566,6 +573,20 @@ export function resolveKey(key: KeyEvent, mode: AppMode, options: ResolveOptions
     if (searchReference !== null) return { action: searchReference.action };
     if (key.name === "backspace") return { action: "backspace" };
     return textInput(key) ?? { action: "none" };
+  }
+  // The LIBRARY rename field alone is composer-backed (its filter and its
+  // delete confirmation stay plain strings below). Resolved ahead of the
+  // blanket chord guard just below so cut/paste/select-all/word-motion
+  // chords reach it instead of being rejected as unknown chords.
+  if (mode === "LIBRARY" && libraryRenaming) {
+    if (key.name === "return") return { action: "open-selected" };
+    // Up/down still move the row behind the prompt, exactly as they do
+    // while filtering or confirming a delete — the composer has no vertical
+    // motion of its own to give them instead.
+    if (key.name === "down") return { action: "focus-next" };
+    if (key.name === "up") return { action: "focus-previous" };
+    if ((key.ctrl || key.super) && key.name.toLowerCase() === "v") return { action: "paste-clipboard" };
+    return composerBackedInput(key);
   }
   // A modified letter is a chord, never a plain hotkey. Keep unknown
   // terminal/application chords inert on every non-composer surface.

--- a/tui/src/library-actions.ts
+++ b/tui/src/library-actions.ts
@@ -1,7 +1,10 @@
 import type { AppSource } from "./app.js";
 import type { ActionContext } from "./action-context.js";
+import { readFromClipboard } from "./clipboard.js";
+import { createComposer, insertComposerText } from "./composer-model.js";
+import { composerSurfaceAction } from "./composer-surface-action.js";
 import { globalEditor } from "./editor-scope.js";
-import { applyTextKey, isPlainNavigation, type ResolvedKey } from "./keys.js";
+import { applyTextKey, isPlainNavigation, sanitizePastedText, type ResolvedKey } from "./keys.js";
 import {
   boundedLibraryCursor,
   libraryRows,
@@ -57,6 +60,7 @@ export async function libraryAction(
   const overlay = state.library!;
   const rows = libraryRows(overlay.stories, overlay.query);
   const selected = rows[Math.min(overlay.cursor, Math.max(0, rows.length - 1))];
+  const rename = overlay.prompt?.kind === "rename" ? overlay.prompt : null;
   if (resolved.action === "cancel") {
     if (overlay.prompt?.kind === "filter") {
       const initial = overlay.prompt.initial;
@@ -91,15 +95,30 @@ export async function libraryAction(
       }
     };
   }
-  else if (resolved.action === "rename-item" && selected !== undefined) overlay.prompt = { kind: "rename", value: selected.title, targetId: selected.id };
+  else if (resolved.action === "rename-item" && selected !== undefined) {
+    overlay.prompt = { kind: "rename", composer: createComposer(selected.title), targetId: selected.id };
+  }
   else if (resolved.action === "delete-item" && selected !== undefined) overlay.prompt = { kind: "delete", value: "", targetId: selected.id };
+  else if (rename !== null && resolved.action === "paste-clipboard") {
+    await pasteLibraryRename(state, overlay, rename);
+  }
+  else if (rename !== null && resolved.action === "input") {
+    insertComposerText(rename.composer, resolved.text ?? "");
+  }
+  else if (rename !== null && await composerSurfaceAction(resolved, state, rename.composer, {
+    isCurrent: () => state.library === overlay && overlay.prompt === rename,
+    pageRows: 1
+  })) {
+    // Cut, paste-adjacent clipboard, select-all, undo/redo, and cursor/
+    // delete motion all run through the shared composer surface action.
+  }
   else if ((resolved.action === "backspace" || resolved.action === "input") && overlay.prompt !== null) {
     if (overlay.prompt.kind === "filter") {
       setLibraryQuery(
         overlay,
         applyTextKey(overlay.query, resolved) ?? overlay.query
       );
-    } else {
+    } else if (overlay.prompt.kind === "delete") {
       overlay.prompt.value = applyTextKey(overlay.prompt.value, resolved)
         ?? overlay.prompt.value;
     }
@@ -120,6 +139,42 @@ export async function libraryAction(
 }
 
 type LibraryOverlay = NonNullable<RuntimeState["library"]>;
+
+/** Paste into the composer-backed rename field. Mirrors
+ *  `pasteSettingsInlineEdit` (settings-field-actions.ts): a stale claim — a
+ *  different interaction, or the field changed underneath the clipboard
+ *  read — drops the result instead of applying it blind. Single-line, so a
+ *  pasted newline flattens to a space rather than splitting the title. */
+async function pasteLibraryRename(
+  state: RuntimeState,
+  overlay: LibraryOverlay,
+  prompt: Extract<NonNullable<LibraryOverlay["prompt"]>, { kind: "rename" }>
+): Promise<void> {
+  const claim = {
+    interactionVersion: state.interactionVersion,
+    text: prompt.composer.text,
+    cursor: prompt.composer.cursor,
+    anchor: prompt.composer.anchor
+  };
+  const text = await readFromClipboard();
+  if (state.library !== overlay || overlay.prompt !== prompt) return;
+  if (state.interactionVersion !== claim.interactionVersion
+    || prompt.composer.text !== claim.text
+    || prompt.composer.cursor !== claim.cursor
+    || prompt.composer.anchor !== claim.anchor) {
+    return;
+  }
+  if (text === null) {
+    state.toast = "clipboard unreadable · paste with ⌘V or ctrl+shift+v";
+    return;
+  }
+  const clean = sanitizePastedText(text);
+  if (clean.length === 0) {
+    state.toast = "clipboard has no insertable text";
+    return;
+  }
+  insertComposerText(prompt.composer, clean.replace(/\n+/g, " "));
+}
 
 export async function createNewStory(
   state: RuntimeState,
@@ -200,7 +255,7 @@ async function renameStory(
   prompt: Extract<NonNullable<LibraryOverlay["prompt"]>, { kind: "rename" }>,
   target: AppSource["stories"][number]
 ): Promise<void> {
-  const title = prompt.value.trim();
+  const title = prompt.composer.text.trim();
   if (title.length === 0) return void (state.toast = "story title required");
   await context.backend.run("renaming story", async (task) => {
     const payload = await source.api.renameStory(target.id, title);
@@ -208,7 +263,7 @@ async function renameStory(
     if (target.id === task.storyId) {
       adoptSameStoryPayload(state, payload, context.cache);
     }
-    if (state.library === overlay && overlay.prompt === prompt && prompt.value.trim() === title) {
+    if (state.library === overlay && overlay.prompt === prompt && prompt.composer.text.trim() === title) {
       overlay.prompt = null;
       state.toast = `renamed ${title}`;
     }

--- a/tui/src/library-actions.ts
+++ b/tui/src/library-actions.ts
@@ -1,10 +1,10 @@
 import type { AppSource } from "./app.js";
 import type { ActionContext } from "./action-context.js";
-import { readFromClipboard } from "./clipboard.js";
 import { createComposer, insertComposerText } from "./composer-model.js";
 import { composerSurfaceAction } from "./composer-surface-action.js";
+import { SINGLE_LINE_COMPOSER_MOTION } from "./composer-motion.js";
 import { globalEditor } from "./editor-scope.js";
-import { applyTextKey, isPlainNavigation, sanitizePastedText, type ResolvedKey } from "./keys.js";
+import { applyTextKey, isPlainNavigation, type ResolvedKey } from "./keys.js";
 import {
   boundedLibraryCursor,
   libraryRows,
@@ -99,18 +99,19 @@ export async function libraryAction(
     overlay.prompt = { kind: "rename", composer: createComposer(selected.title), targetId: selected.id };
   }
   else if (resolved.action === "delete-item" && selected !== undefined) overlay.prompt = { kind: "delete", value: "", targetId: selected.id };
-  else if (rename !== null && resolved.action === "paste-clipboard") {
-    await pasteLibraryRename(state, overlay, rename);
-  }
   else if (rename !== null && resolved.action === "input") {
     insertComposerText(rename.composer, resolved.text ?? "");
   }
   else if (rename !== null && await composerSurfaceAction(resolved, state, rename.composer, {
     isCurrent: () => state.library === overlay && overlay.prompt === rename,
-    pageRows: 1
+    pageRows: 1,
+    motion: SINGLE_LINE_COMPOSER_MOTION,
+    // The title is single-line, so a pasted newline flattens to a space
+    // rather than splitting it.
+    insert: (text) => text.replace(/\n+/g, " ")
   })) {
-    // Cut, paste-adjacent clipboard, select-all, undo/redo, and cursor/
-    // delete motion all run through the shared composer surface action.
+    // Cut, paste, select-all, undo/redo, and cursor/delete motion all run
+    // through the shared composer surface action.
   }
   else if ((resolved.action === "backspace" || resolved.action === "input") && overlay.prompt !== null) {
     if (overlay.prompt.kind === "filter") {
@@ -139,42 +140,6 @@ export async function libraryAction(
 }
 
 type LibraryOverlay = NonNullable<RuntimeState["library"]>;
-
-/** Paste into the composer-backed rename field. Mirrors
- *  `pasteSettingsInlineEdit` (settings-field-actions.ts): a stale claim — a
- *  different interaction, or the field changed underneath the clipboard
- *  read — drops the result instead of applying it blind. Single-line, so a
- *  pasted newline flattens to a space rather than splitting the title. */
-async function pasteLibraryRename(
-  state: RuntimeState,
-  overlay: LibraryOverlay,
-  prompt: Extract<NonNullable<LibraryOverlay["prompt"]>, { kind: "rename" }>
-): Promise<void> {
-  const claim = {
-    interactionVersion: state.interactionVersion,
-    text: prompt.composer.text,
-    cursor: prompt.composer.cursor,
-    anchor: prompt.composer.anchor
-  };
-  const text = await readFromClipboard();
-  if (state.library !== overlay || overlay.prompt !== prompt) return;
-  if (state.interactionVersion !== claim.interactionVersion
-    || prompt.composer.text !== claim.text
-    || prompt.composer.cursor !== claim.cursor
-    || prompt.composer.anchor !== claim.anchor) {
-    return;
-  }
-  if (text === null) {
-    state.toast = "clipboard unreadable · paste with ⌘V or ctrl+shift+v";
-    return;
-  }
-  const clean = sanitizePastedText(text);
-  if (clean.length === 0) {
-    state.toast = "clipboard has no insertable text";
-    return;
-  }
-  insertComposerText(prompt.composer, clean.replace(/\n+/g, " "));
-}
 
 export async function createNewStory(
   state: RuntimeState,

--- a/tui/src/mouse-actions.ts
+++ b/tui/src/mouse-actions.ts
@@ -208,7 +208,12 @@ export function captureMouseActionState(state: RuntimeState): MouseActionState {
               ...state.library.prompt,
               initial: { ...state.library.prompt.initial }
             }
-          : { ...state.library.prompt }
+          // The rename composer mutates in place (insertComposerText et al.),
+          // like sampling's edit.composer below — a bare spread would keep
+          // pointing at the live object and silently "see" every later edit.
+          : state.library.prompt.kind === "rename"
+            ? { ...state.library.prompt, composer: { ...state.library.prompt.composer } }
+            : { ...state.library.prompt }
     },
     facts: state.facts === null ? null : { ...state.facts },
     commands: state.commands === null ? null : { ...state.commands },

--- a/tui/src/overlay-actions.ts
+++ b/tui/src/overlay-actions.ts
@@ -6,6 +6,7 @@ import {
   type PaletteCommand
 } from "./command-model.js";
 import { connectionFailed, connectionSucceeded } from "./connection.js";
+import { createComposer } from "./composer-model.js";
 import { writeExportFile, writeStoryExport } from "./export-file.js";
 import { exportGenerationProfile } from "../../server/import-profile-export.js";
 import { selectSettingsRoute } from "../../shared/settings-route.js";
@@ -439,7 +440,7 @@ async function runCommand(command: PaletteCommand, state: RuntimeState, source: 
     const title = state.payload.title;
     await openLibrary(state, source, context, {
       selectedStoryId: targetId,
-      prompt: { kind: "rename", value: title, targetId }
+      prompt: { kind: "rename", composer: createComposer(title), targetId }
     });
   }
   else if (command.id === "direct-take") openDirectComposer(state);

--- a/tui/src/sampling-actions.ts
+++ b/tui/src/sampling-actions.ts
@@ -1,4 +1,5 @@
 import { composerSurfaceAction } from "./composer-surface-action.js";
+import { SINGLE_LINE_COMPOSER_MOTION } from "./composer-motion.js";
 import { insertComposerText } from "./composer-model.js";
 import { readFromClipboard } from "./clipboard.js";
 import { sanitizePastedText, type ResolvedKey } from "./keys.js";
@@ -198,6 +199,7 @@ async function samplingEditAction(
       && settings.sampling === nested
       && nested.edit === edit,
     pageRows: 1,
+    motion: SINGLE_LINE_COMPOSER_MOTION,
     onEdit: () => disarmSettingsConflict(settings)
   });
 }

--- a/tui/src/screens/panels.ts
+++ b/tui/src/screens/panels.ts
@@ -1,6 +1,7 @@
 import type { StoryPayload, StorySummary } from "../../../shared/types.js";
 import { nextAgeChange } from "../../../shared/story-model.js";
 import type { FrameDeadlineCollector } from "../animation-deadline.js";
+import { composerPosition, type ComposerState } from "../composer-model.js";
 import {
   commandContext,
   commandPaletteModel,
@@ -46,6 +47,7 @@ import {
   type LibraryColumns
 } from "./panel-table-layout.js";
 import { truncate, truncateTail, visibleWidth, TYPING_CARET, type FrameComposition, type FrameLine } from "./story/frame.js";
+import { renderComposerInput } from "./story/composer.js";
 import { renderSettingsPanel } from "./settings-panel.js";
 import { renderFactsPanel } from "./facts-panel.js";
 import { renderSamplingPanel } from "./sampling-panel.js";
@@ -319,7 +321,10 @@ function renderLibrary(
   // C-17: a filter always states `n of m`. Rename and delete prompts are not
   // filters and carry no count.
   const filterCount = `${rows.length} of ${overlay.stories.length}`;
-  if (overlay.prompt !== null) {
+  if (overlay.prompt?.kind === "rename") {
+    content.push(renameLine(overlay.prompt.composer, contentWidth));
+  }
+  else if (overlay.prompt !== null) {
     content.push(promptLine(
       overlay.prompt.kind,
       overlay.prompt.kind === "filter" ? overlay.query : overlay.prompt.value,
@@ -383,6 +388,17 @@ function libraryLine(
     ...(columns.updated === 0 ? [] : [
       raisedSegment(cellPad(libraryAge(story.updatedAt, now), columns.updated), "chrome")
     ])
+  ];
+}
+
+function renameLine(composer: ComposerState, width: number): FrameLine {
+  const prefix = truncate("  › rename: ", Math.max(0, width - 1));
+  const valueWidth = Math.max(1, width - visibleWidth(prefix));
+  return [
+    raisedSegment(prefix, "accent · deep"),
+    ...renderComposerInput(
+      composer, 0, composerPosition(composer).column, valueWidth, "focused", false, ""
+    )
   ];
 }
 

--- a/tui/src/screens/story.ts
+++ b/tui/src/screens/story.ts
@@ -31,6 +31,7 @@ import type {
   DocumentEditorSession,
   StoryScreenState
 } from "../state.js";
+import type { UserConfig } from "../config.js";
 import { deriveStoryFrameLayout, type StoryFrameLayout } from "../story-frame-layout.js";
 import { createWrapCache, type ProseStyle, type WrapCache } from "../wrap.js";
 import { renderFactsRail } from "./story/facts-rail.js";
@@ -68,6 +69,8 @@ import { stickFocusedGutter, type FocusedStickyGutter } from "./story/sticky-gut
 import { stickStoryPrompt } from "./story/sticky-prompt.js";
 import {
   applyComposePageMode,
+  composerFieldWidth,
+  composerInputWidth,
   renderComposerLayout,
   type ComposerLayout
 } from "./story/composer.js";
@@ -375,6 +378,25 @@ export function storyProseMeasure(pageWidth: number): number {
   return Math.max(1, Math.min(72, pageWidth < 100 ? pageWidth - 4 : pageWidth - 26));
 }
 
+/** Cells the Direct composer wraps at, for the geometry it is painted with.
+ *  Vertical motion reads this so an arrow key follows the painted rows. */
+export function directComposerWrapWidth(
+  terminalWidth: number,
+  config: UserConfig,
+  fullscreen: boolean
+): number {
+  if (fullscreen) {
+    return composerInputWidth(
+      composerFieldWidth(true, terminalWidth, terminalWidth, "")
+    );
+  }
+  const pageWidth = deriveStoryFrameLayout(terminalWidth, config).pageWidth;
+  const indent = pageWidth < 100 ? "  " : " ".repeat(STORY_GUTTER);
+  return composerInputWidth(composerFieldWidth(
+    false, pageWidth, storyProseMeasure(pageWidth), indent
+  ));
+}
+
 function fullBleedDerived(
   state: StoryScreenState,
   hitRows: HitRows,
@@ -559,7 +581,8 @@ function renderPageComposer(state: StoryScreenState, view: StoryViewModel, width
     promptKind: state.retakePrompt?.intent.kind ?? null,
     scrollTop: state.composerScrollTop,
     focusDim: state.config.composeFocus === "on",
-    narrow
+    narrow,
+    softWrap: state.config.wordWrap === "on"
   });
   return { lines: composer.lines, scrollTop: composer.scrollTop };
 }
@@ -672,7 +695,8 @@ function renderFullscreenComposer(
     promptKind: state.retakePrompt?.intent.kind ?? null,
     scrollTop: state.composerScrollTop,
     focusDim: state.config.composeFocus === "on",
-    narrow: width < 100
+    narrow: width < 100,
+    softWrap: state.config.wordWrap === "on"
   });
   const lines = [...composer.lines, renderStoryStatus(state, view, width, width < 100, estimate)]
     .slice(0, height)
@@ -741,7 +765,8 @@ function renderInlineEditor(
         height,
         footerNotice,
         scrollTop: state.editorScrollTop,
-        narrow: width < 100
+        narrow: width < 100,
+        softWrap: state.config.wordWrap === "on"
       })
     : renderComposerLayout({
         composer: host.composer,
@@ -756,7 +781,7 @@ function renderInlineEditor(
         footerNotice,
         scrollTop: state.editorScrollTop,
         narrow: width < 100,
-        softWrap: true
+        softWrap: state.config.wordWrap === "on"
       });
   return renderEditorLayoutFrame(state, view, width, height, estimate, layout, deadlines);
 }

--- a/tui/src/screens/story.ts
+++ b/tui/src/screens/story.ts
@@ -31,7 +31,6 @@ import type {
   DocumentEditorSession,
   StoryScreenState
 } from "../state.js";
-import type { UserConfig } from "../config.js";
 import { deriveStoryFrameLayout, type StoryFrameLayout } from "../story-frame-layout.js";
 import { createWrapCache, type ProseStyle, type WrapCache } from "../wrap.js";
 import { renderFactsRail } from "./story/facts-rail.js";
@@ -63,17 +62,16 @@ import {
   type HintItem
 } from "./story/frame.js";
 import { addInlineHits } from "./story/hits.js";
-import { layoutStoryRow, renderChapterOneHeading, STORY_GUTTER, type StickyStoryPrompt } from "./story/row-layout.js";
+import { layoutStoryRow, renderChapterOneHeading, type StickyStoryPrompt } from "./story/row-layout.js";
 import { paintStorySelection } from "./story/selection-highlight.js";
 import { stickFocusedGutter, type FocusedStickyGutter } from "./story/sticky-gutter.js";
 import { stickStoryPrompt } from "./story/sticky-prompt.js";
 import {
   applyComposePageMode,
-  composerFieldWidth,
-  composerInputWidth,
   renderComposerLayout,
   type ComposerLayout
 } from "./story/composer.js";
+import { storyProseMeasure, STORY_GUTTER } from "../composer-geometry.js";
 import type { ComposerStatus as ComposerChromeStatus } from "./story/composer-chrome.js";
 import { renderStatus as renderCanonicalStatus } from "./story/status.js";
 import { viewportLines, type ViewportBlock } from "./story/viewport.js";
@@ -372,29 +370,6 @@ export function renderStoryScreen(state: StoryScreenState, options: StoryScreenO
       request: state.request
     }
   };
-}
-
-export function storyProseMeasure(pageWidth: number): number {
-  return Math.max(1, Math.min(72, pageWidth < 100 ? pageWidth - 4 : pageWidth - 26));
-}
-
-/** Cells the Direct composer wraps at, for the geometry it is painted with.
- *  Vertical motion reads this so an arrow key follows the painted rows. */
-export function directComposerWrapWidth(
-  terminalWidth: number,
-  config: UserConfig,
-  fullscreen: boolean
-): number {
-  if (fullscreen) {
-    return composerInputWidth(
-      composerFieldWidth(true, terminalWidth, terminalWidth, "")
-    );
-  }
-  const pageWidth = deriveStoryFrameLayout(terminalWidth, config).pageWidth;
-  const indent = pageWidth < 100 ? "  " : " ".repeat(STORY_GUTTER);
-  return composerInputWidth(composerFieldWidth(
-    false, pageWidth, storyProseMeasure(pageWidth), indent
-  ));
 }
 
 function fullBleedDerived(

--- a/tui/src/screens/story/composer.ts
+++ b/tui/src/screens/story/composer.ts
@@ -96,6 +96,28 @@ export interface ComposerLayout {
   dimsStory: boolean;
 }
 
+/** Painted width of the composer field. */
+export function composerFieldWidth(
+  fullscreen: boolean,
+  terminalWidth: number,
+  measure: number,
+  indent: string
+): number {
+  const bounded = Math.max(8, Math.floor(terminalWidth));
+  return fullscreen
+    ? bounded
+    : Math.max(8, Math.min(
+      Math.floor(measure),
+      Math.max(8, bounded - visibleWidth(indent))
+    ));
+}
+
+/** Cells one wrapped row holds. Paint and vertical motion both read this, so a
+ *  wrapped caret lands on the row the writer sees. */
+export function composerInputWidth(fieldWidth: number): number {
+  return Math.max(1, fieldWidth - visibleWidth("┃ ") - visibleWidth("› "));
+}
+
 /**
  * Pure COMPOSE field renderer. Its lines exclude the app status row: inline
  * callers subtract `lines.length` from the prose viewport; fullscreen callers
@@ -107,14 +129,13 @@ export function renderComposerLayout(options: ComposerLayoutOptions): ComposerLa
   const terminalWidth = Math.max(8, Math.floor(options.terminalWidth));
   const fullscreen = options.fullscreen ?? composer.fullscreen;
   const indent = fullscreen ? "" : options.indent ?? "";
-  const availableWidth = Math.max(8, terminalWidth - visibleWidth(indent));
-  const fieldWidth = fullscreen
-    ? terminalWidth
-    : Math.max(8, Math.min(Math.floor(options.measure), availableWidth));
+  const fieldWidth = composerFieldWidth(
+    fullscreen, terminalWidth, options.measure, indent
+  );
   const cap = composerHeightCap(terminalHeight, options.composeMaxHeight);
   const lineCount = composerLineCount(composer);
   const cursor = composerPosition(composer);
-  const inputWidth = Math.max(1, fieldWidth - visibleWidth("┃ ") - visibleWidth("› "));
+  const inputWidth = composerInputWidth(fieldWidth);
   const wrapped = options.softWrap === true
     ? wrappedComposerLayout(composer, inputWidth)
     : null;

--- a/tui/src/screens/story/composer.ts
+++ b/tui/src/screens/story/composer.ts
@@ -37,6 +37,10 @@ import {
   composerHeightCap,
   composerPageRows
 } from "../../composer-viewport.js";
+import {
+  composerFieldWidth,
+  composerInputWidth
+} from "../../composer-geometry.js";
 
 export { composerHeightCap } from "../../composer-viewport.js";
 
@@ -94,28 +98,6 @@ export interface ComposerLayout {
   fieldWidth: number;
   fullscreen: boolean;
   dimsStory: boolean;
-}
-
-/** Painted width of the composer field. */
-export function composerFieldWidth(
-  fullscreen: boolean,
-  terminalWidth: number,
-  measure: number,
-  indent: string
-): number {
-  const bounded = Math.max(8, Math.floor(terminalWidth));
-  return fullscreen
-    ? bounded
-    : Math.max(8, Math.min(
-      Math.floor(measure),
-      Math.max(8, bounded - visibleWidth(indent))
-    ));
-}
-
-/** Cells one wrapped row holds. Paint and vertical motion both read this, so a
- *  wrapped caret lands on the row the writer sees. */
-export function composerInputWidth(fieldWidth: number): number {
-  return Math.max(1, fieldWidth - visibleWidth("┃ ") - visibleWidth("› "));
 }
 
 /**

--- a/tui/src/screens/story/fact-editor-layout.ts
+++ b/tui/src/screens/story/fact-editor-layout.ts
@@ -33,6 +33,7 @@ interface FactEditorLayoutOptions {
   footerNotice: string | null;
   scrollTop: number;
   narrow: boolean;
+  softWrap: boolean;
 }
 
 /** Render the typed tag field as a sibling of the Fact body composer. */
@@ -53,7 +54,7 @@ export function renderFactEditorLayout(
     footerNotice: options.footerNotice,
     scrollTop: options.scrollTop,
     narrow: options.narrow,
-    softWrap: true,
+    softWrap: options.softWrap,
     caret: editor.focus === "body" ? "focused" : "none"
   });
   const tagLabel = factEditorTagLabel(editor);

--- a/tui/src/screens/story/row-layout.ts
+++ b/tui/src/screens/story/row-layout.ts
@@ -36,8 +36,8 @@ import {
 } from "../../animation-deadline.js";
 import { streamTrimBounds } from "../../stream-text.js";
 import type { WrapContentIdentity } from "../../wrap.js";
+import { STORY_GUTTER } from "../../composer-geometry.js";
 
-export const STORY_GUTTER = 24;
 const STREAM_LIVENESS_MARKS = ["⠋", "⠙", "⠹", "⠸"] as const;
 const STREAM_LIVENESS_FRAME_MS = 250;
 

--- a/tui/src/settings-field-actions.ts
+++ b/tui/src/settings-field-actions.ts
@@ -15,6 +15,7 @@ import {
 import { settingsTextDraftWithGeneration } from "./settings-text.js";
 import {
   applySettingsComposeFocus,
+  applySettingsWordWrap,
   applySettingsTheme
 } from "./settings-selector-actions.js";
 import type { RuntimeState, SettingsOverlayState } from "./state.js";
@@ -137,6 +138,10 @@ export async function settingsInlineEditAction(
     }
     if (applied.kind === "theme") {
       applySettingsTheme(state, context, applied.value);
+      return;
+    }
+    if (applied.kind === "word-wrap") {
+      applySettingsWordWrap(state, source, applied.value);
       return;
     }
     if (applied.kind === "compose-focus") {

--- a/tui/src/settings-field-actions.ts
+++ b/tui/src/settings-field-actions.ts
@@ -1,6 +1,7 @@
 import type { AppSource } from "./app.js";
 import { insertComposerText } from "./composer-model.js";
 import { composerSurfaceAction } from "./composer-surface-action.js";
+import { SINGLE_LINE_COMPOSER_MOTION } from "./composer-motion.js";
 import { readFromClipboard } from "./clipboard.js";
 import { applyTextKey, sanitizePastedText, type ResolvedKey } from "./keys.js";
 import {
@@ -14,8 +15,7 @@ import {
 } from "./settings-overlay-model.js";
 import { settingsTextDraftWithGeneration } from "./settings-text.js";
 import {
-  applySettingsComposeFocus,
-  applySettingsWordWrap,
+  applySettingsLocalToggle,
   applySettingsTheme
 } from "./settings-selector-actions.js";
 import type { RuntimeState, SettingsOverlayState } from "./state.js";
@@ -140,12 +140,8 @@ export async function settingsInlineEditAction(
       applySettingsTheme(state, context, applied.value);
       return;
     }
-    if (applied.kind === "word-wrap") {
-      applySettingsWordWrap(state, source, applied.value);
-      return;
-    }
-    if (applied.kind === "compose-focus") {
-      applySettingsComposeFocus(state, source, applied.value);
+    if (applied.kind === "local") {
+      applySettingsLocalToggle(state, source, applied.row, applied.value);
       return;
     }
     disarmSettingsConflict(overlay);
@@ -162,6 +158,7 @@ export async function settingsInlineEditAction(
   await composerSurfaceAction(resolved, state, edit.composer, {
     isCurrent: () => state.settings === overlay && overlay.edit === edit,
     pageRows: 1,
+    motion: SINGLE_LINE_COMPOSER_MOTION,
     onEdit: (kind) => {
       if (kind !== "move") disarmSettingsConflict(overlay);
     }

--- a/tui/src/settings-local-rows.ts
+++ b/tui/src/settings-local-rows.ts
@@ -1,0 +1,14 @@
+import type { SettingsRowId } from "./state.js";
+
+/** Settings rows kept in the user config instead of the server-backed draft.
+ *  One list, because both the overlay model and its reconciliation ask the same
+ *  question, and a row that appears in only one of them reads as a draft change
+ *  that never saves. This module holds no other state so that both can import
+ *  it without depending on each other. */
+export const LOCAL_CONFIG_ROWS = ["theme", "compose-focus", "word-wrap"] as const;
+
+export type LocalConfigRow = typeof LOCAL_CONFIG_ROWS[number];
+
+export function settingsRowIsLocal(row: SettingsRowId): row is LocalConfigRow {
+  return (LOCAL_CONFIG_ROWS as readonly SettingsRowId[]).includes(row);
+}

--- a/tui/src/settings-overlay-actions.ts
+++ b/tui/src/settings-overlay-actions.ts
@@ -77,7 +77,6 @@ import {
   settingsModelPickerAction
 } from "./settings-field-actions.js";
 import {
-  applySettingsComposeFocus,
   applySettingsTheme,
   cycleSettingsRow
 } from "./settings-selector-actions.js";

--- a/tui/src/settings-overlay-model.ts
+++ b/tui/src/settings-overlay-model.ts
@@ -3,6 +3,13 @@ import {
   type SettingsPresetV2,
   type SettingsView
 } from "../../shared/settings-v2-types.js";
+import {
+  LOCAL_CONFIG_ROWS,
+  settingsRowIsLocal,
+  type LocalConfigRow
+} from "./settings-local-rows.js";
+
+export { LOCAL_CONFIG_ROWS, settingsRowIsLocal, type LocalConfigRow };
 import { resolveSettingsProfile } from "../../shared/settings-route.js";
 import type { UserConfig } from "./config.js";
 import { THEME_NAMES, type ThemeName } from "./config.js";
@@ -84,6 +91,11 @@ export const SETTINGS_ROW_IDS = [
 export function settingsRowIndex(row: SettingsRowId): number {
   return (SETTINGS_ROW_IDS as readonly SettingsRowId[]).indexOf(row);
 }
+
+/** Rows that live in the user config rather than a server-backed settings
+ *  revision. One list backs every "is this row local?" test in the overlay,
+ *  instead of each site naming the same three rows by hand. */
+
 
 export {
   reconcileSettingsOverlay,
@@ -204,8 +216,7 @@ export function applySettingsRowEdit(
   overlay: SettingsOverlayState,
   config: UserConfig
 ): { kind: "theme"; value: ThemeName }
-  | { kind: "compose-focus"; value: UserConfig["composeFocus"] }
-  | { kind: "word-wrap"; value: UserConfig["wordWrap"] }
+  | { kind: "local"; row: "compose-focus" | "word-wrap"; value: "on" | "off" }
   | { kind: "draft" }
   | { kind: "error"; message: string } {
   const edit = overlay.edit;
@@ -221,19 +232,13 @@ export function applySettingsRowEdit(
     overlay.edit = null;
     return { kind: "theme", value: value as ThemeName };
   }
-  if (edit.row === "compose-focus") {
+  if (edit.row === "compose-focus" || edit.row === "word-wrap") {
     if (value !== "on" && value !== "off") {
-      return { kind: "error", message: "compose focus must be on or off" };
+      const label = edit.row === "compose-focus" ? "compose focus" : "word wrap";
+      return { kind: "error", message: `${label} must be on or off` };
     }
     overlay.edit = null;
-    return { kind: "compose-focus", value };
-  }
-  if (edit.row === "word-wrap") {
-    if (value !== "on" && value !== "off") {
-      return { kind: "error", message: "word wrap must be on or off" };
-    }
-    overlay.edit = null;
-    return { kind: "word-wrap", value };
+    return { kind: "local", row: edit.row, value };
   }
   if (edit.row === "api-key") {
     const result = applyStoredApiKeyEdit(overlay, rawValue);
@@ -366,7 +371,7 @@ export function settingsRowHasArrows(
 /** Local-only rows live in the user config; every other row edits a
  * server-backed settings revision. */
 export function settingsRowUsesServer(row: SettingsRowId): boolean {
-  return row !== "theme" && row !== "compose-focus" && row !== "word-wrap";
+  return !settingsRowIsLocal(row);
 }
 
 export function cycleSettingsProvider(

--- a/tui/src/settings-overlay-model.ts
+++ b/tui/src/settings-overlay-model.ts
@@ -57,6 +57,7 @@ export {
 export const SETTINGS_ROW_IDS = [
   "theme",
   "compose-focus",
+  "word-wrap",
   "provider",
   "text-prompt-format",
   "base-url",
@@ -132,6 +133,7 @@ export function settingsRowEditValue(
 ): string {
   if (row === "theme") return config.theme;
   if (row === "compose-focus") return config.composeFocus;
+  if (row === "word-wrap") return config.wordWrap;
   if (row === "allow-insecure-http") {
     return overlay.draft.generation.allowInsecureHttp === true ? "on" : "off";
   }
@@ -203,6 +205,7 @@ export function applySettingsRowEdit(
   config: UserConfig
 ): { kind: "theme"; value: ThemeName }
   | { kind: "compose-focus"; value: UserConfig["composeFocus"] }
+  | { kind: "word-wrap"; value: UserConfig["wordWrap"] }
   | { kind: "draft" }
   | { kind: "error"; message: string } {
   const edit = overlay.edit;
@@ -224,6 +227,13 @@ export function applySettingsRowEdit(
     }
     overlay.edit = null;
     return { kind: "compose-focus", value };
+  }
+  if (edit.row === "word-wrap") {
+    if (value !== "on" && value !== "off") {
+      return { kind: "error", message: "word wrap must be on or off" };
+    }
+    overlay.edit = null;
+    return { kind: "word-wrap", value };
   }
   if (edit.row === "api-key") {
     const result = applyStoredApiKeyEdit(overlay, rawValue);
@@ -324,6 +334,7 @@ export function boundedSettingsCursor(value: number): number {
 export function settingsRowCycles(row: SettingsRowId): boolean {
   return row === "theme"
     || row === "compose-focus"
+    || row === "word-wrap"
     || row === "provider"
     || row === "text-prompt-format"
     || row === "allow-insecure-http"
@@ -355,7 +366,7 @@ export function settingsRowHasArrows(
 /** Local-only rows live in the user config; every other row edits a
  * server-backed settings revision. */
 export function settingsRowUsesServer(row: SettingsRowId): boolean {
-  return row !== "theme" && row !== "compose-focus";
+  return row !== "theme" && row !== "compose-focus" && row !== "word-wrap";
 }
 
 export function cycleSettingsProvider(

--- a/tui/src/settings-overlay-reconciliation.ts
+++ b/tui/src/settings-overlay-reconciliation.ts
@@ -3,6 +3,10 @@ import type { GenerationSettings } from "../../shared/types.js";
 import { samplingSettingsEqual } from "../../shared/sampling-capabilities.js";
 import { setComposerText } from "./composer-model.js";
 import type { ActiveSettingsEdit } from "./settings-edit-state.js";
+import {
+  settingsRowIsLocal,
+  type LocalConfigRow
+} from "./settings-local-rows.js";
 import { renameSettingsProfile } from "./settings-profile-draft.js";
 import { sameConnectionSecrets } from "./settings-secret-sidecar.js";
 import {
@@ -76,7 +80,7 @@ export function reconcileSettingsOverlay(
   const draftWasClean = !settingsDraftChanged(overlay);
   const editAffectsServer = edit !== null && (
     edit.kind === "sampling"
-    || edit.row !== "theme" && edit.row !== "compose-focus" && edit.row !== "word-wrap"
+    || !settingsRowIsLocal(edit.row)
   );
   const editWasClean = !editAffectsServer
     || edit.composer.text === edit.initialText();
@@ -162,8 +166,7 @@ export function sameGenerationSettings(
 
 export function draftRowEditValue(
   draft: SettingsTextDraft,
-  row: Exclude<SettingsRowId,
-    "theme" | "compose-focus" | "word-wrap" | "allow-insecure-http" | "profile" | "sampling">
+  row: Exclude<SettingsRowId, LocalConfigRow | "allow-insecure-http" | "profile" | "sampling">
 ): string {
   const settings = draft.generation;
   if (row === "provider") return settings.provider;
@@ -191,7 +194,7 @@ function draftWithActiveEdit(
     return edit.composer.text === edit.initialText() ? draft : null;
   }
   const row = edit.row;
-  if (row === "theme" || row === "compose-focus" || row === "word-wrap") return draft;
+  if (settingsRowIsLocal(row)) return draft;
   if (row === "profile") {
     if (draft.document === null || draft.selectedProfileId === null) return null;
     const renamed = renameSettingsProfile(
@@ -224,11 +227,9 @@ function settingsDraftTextRow(
   row: SettingsRowId
 ): row is Exclude<
   SettingsRowId,
-  "theme" | "compose-focus" | "word-wrap" | "allow-insecure-http" | "profile" | "sampling"
+  LocalConfigRow | "allow-insecure-http" | "profile" | "sampling"
 > {
-  return row !== "theme"
-    && row !== "compose-focus"
-    && row !== "word-wrap"
+  return !settingsRowIsLocal(row)
     && row !== "allow-insecure-http"
     && row !== "profile"
     && row !== "sampling";

--- a/tui/src/settings-overlay-reconciliation.ts
+++ b/tui/src/settings-overlay-reconciliation.ts
@@ -76,7 +76,7 @@ export function reconcileSettingsOverlay(
   const draftWasClean = !settingsDraftChanged(overlay);
   const editAffectsServer = edit !== null && (
     edit.kind === "sampling"
-    || edit.row !== "theme" && edit.row !== "compose-focus"
+    || edit.row !== "theme" && edit.row !== "compose-focus" && edit.row !== "word-wrap"
   );
   const editWasClean = !editAffectsServer
     || edit.composer.text === edit.initialText();
@@ -162,7 +162,8 @@ export function sameGenerationSettings(
 
 export function draftRowEditValue(
   draft: SettingsTextDraft,
-  row: Exclude<SettingsRowId, "theme" | "compose-focus" | "allow-insecure-http" | "profile" | "sampling">
+  row: Exclude<SettingsRowId,
+    "theme" | "compose-focus" | "word-wrap" | "allow-insecure-http" | "profile" | "sampling">
 ): string {
   const settings = draft.generation;
   if (row === "provider") return settings.provider;
@@ -190,7 +191,7 @@ function draftWithActiveEdit(
     return edit.composer.text === edit.initialText() ? draft : null;
   }
   const row = edit.row;
-  if (row === "theme" || row === "compose-focus") return draft;
+  if (row === "theme" || row === "compose-focus" || row === "word-wrap") return draft;
   if (row === "profile") {
     if (draft.document === null || draft.selectedProfileId === null) return null;
     const renamed = renameSettingsProfile(
@@ -223,10 +224,11 @@ function settingsDraftTextRow(
   row: SettingsRowId
 ): row is Exclude<
   SettingsRowId,
-  "theme" | "compose-focus" | "allow-insecure-http" | "profile" | "sampling"
+  "theme" | "compose-focus" | "word-wrap" | "allow-insecure-http" | "profile" | "sampling"
 > {
   return row !== "theme"
     && row !== "compose-focus"
+    && row !== "word-wrap"
     && row !== "allow-insecure-http"
     && row !== "profile"
     && row !== "sampling";

--- a/tui/src/settings-profile-controls.ts
+++ b/tui/src/settings-profile-controls.ts
@@ -116,6 +116,11 @@ export function settingsRows(
       hint: "dim the page while you type"
     },
     {
+      id: "word-wrap", section: "app", label: "word wrap",
+      value: `[ ${config.wordWrap} ]`,
+      hint: "break editor lines at words, not at the edge"
+    },
+    {
       id: "provider", section: "connection", label: "provider",
       value: `‹ ${providerChoice.label} ›`,
       dots: providerPositionDots(settings, selectedPreset),

--- a/tui/src/settings-selector-actions.ts
+++ b/tui/src/settings-selector-actions.ts
@@ -49,15 +49,17 @@ export async function cycleSettingsRow(
         THEME_NAMES[(index + step + THEME_NAMES.length) % THEME_NAMES.length]!
       );
     } else if (row === "compose-focus") {
-      applySettingsComposeFocus(
+      applySettingsLocalToggle(
         state,
         source,
+        "compose-focus",
         state.config.composeFocus === "on" ? "off" : "on"
       );
     } else if (row === "word-wrap") {
-      applySettingsWordWrap(
+      applySettingsLocalToggle(
         state,
         source,
+        "word-wrap",
         state.config.wordWrap === "on" ? "off" : "on"
       );
     } else if (row === "provider") {
@@ -114,24 +116,20 @@ export function applySettingsTheme(
   state.toast = `theme · ${theme}`;
 }
 
-export function applySettingsComposeFocus(
+/** Compose focus and word wrap are both a plain on/off toggle stored on the
+ *  user config, saved and toasted the same way — the only difference is which
+ *  field and which label. One function for both instead of two clones. */
+export function applySettingsLocalToggle(
   state: RuntimeState,
   source: AppSource,
-  composeFocus: "on" | "off"
+  row: "compose-focus" | "word-wrap",
+  value: "on" | "off"
 ): void {
-  state.config = { ...state.config, composeFocus };
+  state.config = row === "compose-focus"
+    ? { ...state.config, composeFocus: value }
+    : { ...state.config, wordWrap: value };
   source.config = state.config;
   if (!state.demo) saveConfig(state.config);
-  state.toast = `compose focus · ${composeFocus}`;
-}
-
-export function applySettingsWordWrap(
-  state: RuntimeState,
-  source: AppSource,
-  wordWrap: "on" | "off"
-): void {
-  state.config = { ...state.config, wordWrap };
-  source.config = state.config;
-  if (!state.demo) saveConfig(state.config);
-  state.toast = `word wrap · ${wordWrap}`;
+  const label = row === "compose-focus" ? "compose focus" : "word wrap";
+  state.toast = `${label} · ${value}`;
 }

--- a/tui/src/settings-selector-actions.ts
+++ b/tui/src/settings-selector-actions.ts
@@ -54,6 +54,12 @@ export async function cycleSettingsRow(
         source,
         state.config.composeFocus === "on" ? "off" : "on"
       );
+    } else if (row === "word-wrap") {
+      applySettingsWordWrap(
+        state,
+        source,
+        state.config.wordWrap === "on" ? "off" : "on"
+      );
     } else if (row === "provider") {
       const choice = cycleSettingsProvider(overlay, step);
       state.toast = `provider · ${choice.label} · s saves settings`;
@@ -117,4 +123,15 @@ export function applySettingsComposeFocus(
   source.config = state.config;
   if (!state.demo) saveConfig(state.config);
   state.toast = `compose focus · ${composeFocus}`;
+}
+
+export function applySettingsWordWrap(
+  state: RuntimeState,
+  source: AppSource,
+  wordWrap: "on" | "off"
+): void {
+  state.config = { ...state.config, wordWrap };
+  source.config = state.config;
+  if (!state.demo) saveConfig(state.config);
+  state.toast = `word wrap · ${wordWrap}`;
 }

--- a/tui/src/state.ts
+++ b/tui/src/state.ts
@@ -148,6 +148,7 @@ export interface ChaptersOverlayState {
 export type SettingsRowId =
   | "theme"
   | "compose-focus"
+  | "word-wrap"
   | "provider"
   | "text-prompt-format"
   | "base-url"

--- a/tui/src/state.ts
+++ b/tui/src/state.ts
@@ -108,7 +108,7 @@ export type TextPrompt =
     }
   | {
       kind: "rename";
-      value: string;
+      composer: ComposerState;
       /** Frozen at prompt-open so later movement or refresh cannot retarget it. */
       targetId: string;
     }

--- a/tui/src/story-actions.ts
+++ b/tui/src/story-actions.ts
@@ -7,6 +7,11 @@ import { copyToClipboard } from "./clipboard.js";
 import { pasteClipboardIntoComposer } from "./compose-clipboard.js";
 import { composerSurfaceAction } from "./composer-surface-action.js";
 import { composerPageRows } from "./composer-viewport.js";
+import {
+  moveComposerVisualRows,
+  moveComposerVisualVertical
+} from "./composer-visual-movement.js";
+import { directComposerWrapWidth } from "./screens/story.js";
 import { copyStoryText } from "./copy-actions.js";
 import { recordHumanWords, saveConfig } from "./config.js";
 import { rememberFocus } from "./reading-position-persist.js";
@@ -414,9 +419,20 @@ export async function composeAction(
     return;
   }
   if (resolved.action === "newline") { insertComposerText(state.composer, "\n"); return; }
+  // Wrapped, an arrow follows the painted rows; unwrapped, it follows logical
+  // lines. Direct alone reads the failure to move as "open history".
+  const softWrap = state.config.wordWrap === "on";
+  const wrapWidth = () => directComposerWrapWidth(
+    context.renderer?.width ?? 80, state.config, state.composer.fullscreen
+  );
   if (resolved.action === "cursor-up" || resolved.action === "cursor-down") {
     const direction = resolved.action === "cursor-up" ? -1 : 1;
-    if (!moveComposerVertical(state.composer, direction, resolved.extendSelection)
+    const moved = softWrap
+      ? moveComposerVisualVertical(
+        state.composer, direction, wrapWidth(), resolved.extendSelection
+      )
+      : moveComposerVertical(state.composer, direction, resolved.extendSelection);
+    if (!moved
       && state.composer.text.length === 0
       && resolved.extendSelection !== true) {
       historyMove(state, direction);
@@ -424,13 +440,24 @@ export async function composeAction(
     return;
   }
   const composer = state.composer;
+  const pageRows = composerPageRows(
+    context.renderer?.height ?? 24,
+    composer.fullscreen,
+    state.config.composeMaxHeight
+  );
+  if (softWrap
+    && (resolved.action === "cursor-page-up" || resolved.action === "cursor-page-down")) {
+    moveComposerVisualRows(
+      composer,
+      (resolved.action === "cursor-page-up" ? -1 : 1) * pageRows,
+      wrapWidth(),
+      resolved.extendSelection
+    );
+    return;
+  }
   if (await composerSurfaceAction(resolved, state, composer, {
     isCurrent: () => state.mode === "COMPOSE" && state.composer === composer,
-    pageRows: composerPageRows(
-      context.renderer?.height ?? 24,
-      composer.fullscreen,
-      state.config.composeMaxHeight
-    )
+    pageRows
   })) return;
   if (resolved.action === "history-previous") return historyMove(state, -1);
   if (resolved.action === "history-next") return historyMove(state, 1);

--- a/tui/src/story-actions.ts
+++ b/tui/src/story-actions.ts
@@ -7,11 +7,8 @@ import { copyToClipboard } from "./clipboard.js";
 import { pasteClipboardIntoComposer } from "./compose-clipboard.js";
 import { composerSurfaceAction } from "./composer-surface-action.js";
 import { composerPageRows } from "./composer-viewport.js";
-import {
-  moveComposerVisualRows,
-  moveComposerVisualVertical
-} from "./composer-visual-movement.js";
-import { directComposerWrapWidth } from "./screens/story.js";
+import { composerMotion } from "./composer-motion.js";
+import { directComposerWrapWidth } from "./composer-geometry.js";
 import { copyStoryText } from "./copy-actions.js";
 import { recordHumanWords, saveConfig } from "./config.js";
 import { rememberFocus } from "./reading-position-persist.js";
@@ -20,7 +17,6 @@ import { createNewStory } from "./library-actions.js";
 import { resolveRerouteTarget } from "./path-layout.js";
 import {
   insertComposerText,
-  moveComposerVertical,
   setComposerText
 } from "./composer-model.js";
 import {
@@ -421,17 +417,15 @@ export async function composeAction(
   if (resolved.action === "newline") { insertComposerText(state.composer, "\n"); return; }
   // Wrapped, an arrow follows the painted rows; unwrapped, it follows logical
   // lines. Direct alone reads the failure to move as "open history".
-  const softWrap = state.config.wordWrap === "on";
-  const wrapWidth = () => directComposerWrapWidth(
-    context.renderer?.width ?? 80, state.config, state.composer.fullscreen
+  const motion = composerMotion(
+    state.config.wordWrap === "on",
+    () => directComposerWrapWidth(
+      context.renderer?.width ?? 80, state.config, state.composer.fullscreen
+    )
   );
   if (resolved.action === "cursor-up" || resolved.action === "cursor-down") {
     const direction = resolved.action === "cursor-up" ? -1 : 1;
-    const moved = softWrap
-      ? moveComposerVisualVertical(
-        state.composer, direction, wrapWidth(), resolved.extendSelection
-      )
-      : moveComposerVertical(state.composer, direction, resolved.extendSelection);
+    const moved = motion.vertical(state.composer, direction, resolved.extendSelection);
     if (!moved
       && state.composer.text.length === 0
       && resolved.extendSelection !== true) {
@@ -445,19 +439,10 @@ export async function composeAction(
     composer.fullscreen,
     state.config.composeMaxHeight
   );
-  if (softWrap
-    && (resolved.action === "cursor-page-up" || resolved.action === "cursor-page-down")) {
-    moveComposerVisualRows(
-      composer,
-      (resolved.action === "cursor-page-up" ? -1 : 1) * pageRows,
-      wrapWidth(),
-      resolved.extendSelection
-    );
-    return;
-  }
   if (await composerSurfaceAction(resolved, state, composer, {
     isCurrent: () => state.mode === "COMPOSE" && state.composer === composer,
-    pageRows
+    pageRows,
+    motion
   })) return;
   if (resolved.action === "history-previous") return historyMove(state, -1);
   if (resolved.action === "history-next") return historyMove(state, 1);

--- a/tui/src/story-wrap-build.ts
+++ b/tui/src/story-wrap-build.ts
@@ -1,7 +1,7 @@
 import type { StoryNode, StoryPayload } from "../../shared/types.js";
 import { createAppendPlanWrap } from "./append-wrap.js";
 import { projectedPart } from "./stream-projection.js";
-import { storyProseMeasure } from "./screens/story.js";
+import { storyProseMeasure } from "./composer-geometry.js";
 import {
   storyPartWrapPlan,
   type StoryPartWrapInput,

--- a/tui/src/text-actions.ts
+++ b/tui/src/text-actions.ts
@@ -26,7 +26,7 @@ export function availableTextActions(
   return overlay.copyOnly ? TEXT_ACTIONS.slice(0, 1) : TEXT_ACTIONS;
 }
 
-type TextOwnerState = Pick<RuntimeState, "mode" | "composer" | "editor" | "settings">;
+type TextOwnerState = Pick<RuntimeState, "mode" | "composer" | "editor" | "settings" | "library">;
 
 /** Find the composer-backed field that currently owns text input. */
 export function activeTextComposer(state: TextOwnerState): ComposerState | null {
@@ -35,6 +35,9 @@ export function activeTextComposer(state: TextOwnerState): ComposerState | null 
     return state.editor.kind === "fact"
       ? factEditorActiveTextComposer(state.editor)
       : state.editor.composer;
+  }
+  if (state.mode === "LIBRARY") {
+    return state.library?.prompt?.kind === "rename" ? state.library.prompt.composer : null;
   }
   if (state.mode !== "SETTINGS" || state.settings === null) return null;
   const sampling = state.settings.sampling?.edit;

--- a/tui/src/wrap.ts
+++ b/tui/src/wrap.ts
@@ -1,4 +1,4 @@
-import { graphemeCells, iterateGraphemeCells } from "./cell-width.js";
+import { breaksLine, graphemeCells, iterateGraphemeCells } from "./cell-width.js";
 
 /** The prose-layer styles carried through wrapping: human-edited spans, spans
  *  a rewrite replaced (issue #319), and the freshly-streaming suffix of an
@@ -478,7 +478,7 @@ function nextWrappedLine(
   if (fitted === cell) fitted = cell + 1;
   let breakCell = -1;
   for (let probe = fitted; probe > cell; probe -= 1) {
-    if (probe < cells.length && /\s/.test(cells[probe]!.text)) {
+    if (probe < cells.length && breaksLine(cells[probe]!.text)) {
       breakCell = probe;
       break;
     }

--- a/tui/test/actions-runtime.test.ts
+++ b/tui/test/actions-runtime.test.ts
@@ -622,7 +622,7 @@ describe("demo action runtime and input", () => {
       stories: source.stories,
       cursor: 0,
       query: "",
-      prompt: { kind: "rename", value: "renamed while streaming", targetId: payload.id }
+      prompt: { kind: "rename", composer: createComposer("renamed while streaming"), targetId: payload.id }
     };
     let renamed = 0;
     source.api.renameStory = async () => { renamed += 1; return { ...payload, title: "wrong" }; };

--- a/tui/test/composer-renderer.test.ts
+++ b/tui/test/composer-renderer.test.ts
@@ -31,10 +31,7 @@ import {
   moveComposerPage,
   moveComposerWord
 } from "../src/composer-editing.js";
-import {
-  moveComposerVisualRows,
-  moveComposerVisualVertical
-} from "../src/composer-visual-movement.js";
+import { moveComposerVisualRows } from "../src/composer-visual-movement.js";
 import { composerPageRows } from "../src/composer-viewport.js";
 import { wrappedComposerLayout } from "../src/composer-wrapping.js";
 import {
@@ -232,6 +229,49 @@ describe("composer renderer", () => {
     expect(rows.join("")).toBe(text);
   });
 
+  test("does not break at a no-break space", () => {
+    // A writer types U+00A0 to hold two words together, so the wrap must not
+    // treat it as a break point even though it is whitespace.
+    const text = "call Mrs.\u00A0Dalloway now";
+    const composer = createComposer(text);
+    // Wide enough to hold the joined pair, so a break there would be a choice.
+    const wrapped = wrappedComposerLayout(composer, 16);
+    const rows = Array.from(
+      { length: wrapped.rowCount },
+      (_, row) => {
+        const bound = wrapped.rowAt(row)!;
+        return text.slice(bound.start, bound.end);
+      }
+    );
+
+    expect(rows).toEqual(["call ", "Mrs.\u00A0Dalloway ", "now"]);
+    expect(rows.join("")).toBe(text);
+  });
+
+  test("keeps a long paragraph's wrap incremental across edits", () => {
+    // Chunk-level wrap answers are cached against chunk identity. An edit must
+    // still land the same rows a fresh composer would.
+    const paragraph = "lantern keeper ".repeat(4_000);
+    const composer = createComposer(paragraph);
+    const rowsOf = (state: ReturnType<typeof createComposer>) => {
+      const wrapped = wrappedComposerLayout(state, 37);
+      return Array.from(
+        { length: wrapped.rowCount },
+        (_, row) => wrapped.rowAt(row)!
+      );
+    };
+
+    rowsOf(composer);
+    composer.cursor = composer.text.length;
+    insertComposerText(composer, "!");
+    const incremental = rowsOf(composer);
+    expect(incremental).toEqual(rowsOf(createComposer(composer.text)));
+
+    moveComposerTo(composer, 0);
+    insertComposerText(composer, "A ");
+    expect(rowsOf(composer)).toEqual(rowsOf(createComposer(composer.text)));
+  });
+
   test("breaks a word wider than the field by cell", () => {
     const text = "hi supercalifragilistic";
     const composer = createComposer(text);
@@ -274,9 +314,9 @@ describe("composer renderer", () => {
     expect(wrapped.rowAt(2)).toMatchObject({ sourceIndex: 1, start: 0, end: 4 });
     expect(wrapped.rowAt(3)).toMatchObject({ sourceIndex: 1, start: 4, end: 4 });
 
-    expect(moveComposerVisualVertical(composer, -1, 4)).toBeTrue();
+    expect(moveComposerVisualRows(composer, -1, 4)).toBeTrue();
     expect(composerPosition(composer)).toEqual({ line: 0, column: 0 });
-    expect(moveComposerVisualVertical(composer, 1, 4)).toBeTrue();
+    expect(moveComposerVisualRows(composer, 1, 4)).toBeTrue();
     expect(composerPosition(composer)).toEqual({ line: 0, column: 4 });
   });
 
@@ -291,7 +331,7 @@ describe("composer renderer", () => {
     moveComposerTo(composer, 3);
     expect(wrappedComposerLayout(composer, 4).cursorRow).toBe(1);
     moveComposerTo(composer, 6);
-    expect(moveComposerVisualVertical(composer, -1, 4)).toBeTrue();
+    expect(moveComposerVisualRows(composer, -1, 4)).toBeTrue();
     expect(composerPosition(composer)).toEqual({ line: 0, column: 3 });
     expect(wrappedComposerLayout(composer, 4).cursorRow).toBe(1);
   });
@@ -380,7 +420,7 @@ describe("composer renderer", () => {
 
   test("moves and extends selection by soft-wrapped visual rows", () => {
     const composer = createComposer("abcdefghij");
-    expect(moveComposerVisualVertical(composer, -1, 4, true)).toBeTrue();
+    expect(moveComposerVisualRows(composer, -1, 4, true)).toBeTrue();
     expect(composer).toMatchObject({ cursor: 6, anchor: 10 });
     expect(selectedComposerText(composer)).toBe("ghij");
   });
@@ -391,7 +431,7 @@ describe("composer renderer", () => {
     moveComposerBufferBoundary(composer, true, true);
     expect(composerSelection(composer)).not.toBe(null);
 
-    expect(moveComposerVisualVertical(composer, 1, 20)).toBeFalse();
+    expect(moveComposerVisualRows(composer, 1, 20)).toBeFalse();
     expect(composerSelection(composer)).toBe(null);
     insertComposerText(composer, "!");
     expect(composer.text).toBe("keep me!");
@@ -401,7 +441,7 @@ describe("composer renderer", () => {
     const composer = createComposer("one\nlast line");
     moveComposerTo(composer, 6);
 
-    expect(moveComposerVisualVertical(composer, 1, 20)).toBeTrue();
+    expect(moveComposerVisualRows(composer, 1, 20)).toBeTrue();
     expect(composerPosition(composer)).toEqual({ line: 1, column: 9 });
     insertComposerText(composer, "\n");
     expect(composer.text).toBe("one\nlast line\n");
@@ -418,14 +458,14 @@ describe("composer renderer", () => {
 
   test("retains the preferred column across short visual rows", () => {
     const composer = createComposer("abcdef\nx\nabcdef");
-    expect(moveComposerVisualVertical(composer, -1, 20)).toBeTrue();
+    expect(moveComposerVisualRows(composer, -1, 20)).toBeTrue();
     expect(composerPosition(composer)).toEqual({ line: 1, column: 1 });
-    expect(moveComposerVisualVertical(composer, -1, 20)).toBeTrue();
+    expect(moveComposerVisualRows(composer, -1, 20)).toBeTrue();
     expect(composerPosition(composer)).toEqual({ line: 0, column: 6 });
 
     moveComposerHorizontal(composer, -1);
-    expect(moveComposerVisualVertical(composer, 1, 20)).toBeTrue();
-    expect(moveComposerVisualVertical(composer, 1, 20)).toBeTrue();
+    expect(moveComposerVisualRows(composer, 1, 20)).toBeTrue();
+    expect(moveComposerVisualRows(composer, 1, 20)).toBeTrue();
     expect(composerPosition(composer)).toEqual({ line: 2, column: 5 });
   });
 

--- a/tui/test/composer-renderer.test.ts
+++ b/tui/test/composer-renderer.test.ts
@@ -215,6 +215,53 @@ describe("composer renderer", () => {
     expect(layout.lines.slice(1, 4).flat().some(({ text }) => text === "…")).toBeFalse();
   });
 
+  test("wraps at word boundaries and keeps the space on the row it ends", () => {
+    const text = "the lantern guttered against the wind";
+    const composer = createComposer(text);
+    const wrapped = wrappedComposerLayout(composer, 14);
+    const rows = Array.from(
+      { length: wrapped.rowCount },
+      (_, row) => {
+        const bound = wrapped.rowAt(row)!;
+        return text.slice(bound.start, bound.end);
+      }
+    );
+
+    expect(rows).toEqual(["the lantern ", "guttered ", "against the ", "wind"]);
+    // Rows tile the line, so every column the writer can type in has a row.
+    expect(rows.join("")).toBe(text);
+  });
+
+  test("breaks a word wider than the field by cell", () => {
+    const text = "hi supercalifragilistic";
+    const composer = createComposer(text);
+    const wrapped = wrappedComposerLayout(composer, 8);
+    const rows = Array.from(
+      { length: wrapped.rowCount },
+      (_, row) => {
+        const bound = wrapped.rowAt(row)!;
+        return text.slice(bound.start, bound.end);
+      }
+    );
+
+    expect(rows).toEqual(["hi ", "supercal", "ifragili", "stic"]);
+  });
+
+  test("paints wrapped editor rows at whole words", () => {
+    const composer = createComposer("the lantern guttered against the wind");
+    composer.fullscreen = true;
+    const layout = renderComposerLayout({
+      composer, terminalWidth: 18, terminalHeight: 14, measure: 18, softWrap: true
+    });
+    const body = frameText(layout.lines.slice(1, 1 + layout.bodyRows));
+
+    expect(body).toContain("┃ › the lantern");
+    expect(body).toContain("┃   guttered");
+    expect(body).toContain("┃   against the");
+    // Wrapped rows run on, so no row is clipped.
+    expect(body).not.toContain("…");
+  });
+
   test("keeps exact-width line endpoints as stable continuation rows", () => {
     const composer = createComposer("1234\nnext");
     moveComposerTo(composer, 4);

--- a/tui/test/composer-renderer.test.ts
+++ b/tui/test/composer-renderer.test.ts
@@ -34,6 +34,7 @@ import {
 import { moveComposerVisualRows } from "../src/composer-visual-movement.js";
 import { composerPageRows } from "../src/composer-viewport.js";
 import { wrappedComposerLayout } from "../src/composer-wrapping.js";
+import { graphemeCells } from "../src/cell-width.js";
 import {
   applyComposeMode,
   composerHeightCap,
@@ -227,6 +228,28 @@ describe("composer renderer", () => {
     expect(rows).toEqual(["the lantern ", "guttered ", "against the ", "wind"]);
     // Rows tile the line, so every column the writer can type in has a row.
     expect(rows.join("")).toBe(text);
+  });
+
+  test("keeps a carried word inside the field when a wide cell ends it", () => {
+    // The word is 15 cells against a 14-cell field, so it cannot fit a row of
+    // its own. Carrying it down would land it just as over-wide and clip the
+    // emoji, so the break belongs between its cells instead.
+    const text = " abcdefghijklm\u{1F600}";
+    const composer = createComposer(text);
+    const cells = graphemeCells(text);
+    const wrapped = wrappedComposerLayout(composer, 14);
+    const rows = Array.from({ length: wrapped.rowCount }, (_, row) => {
+      const bound = wrapped.rowAt(row)!;
+      return cells.slice(bound.start, bound.end);
+    });
+
+    expect(rows.map((row) => row.map((cell) => cell.text).join("")))
+      .toEqual([" abcdefghijklm", "\u{1F600}"]);
+    // No row of visible text runs past the field.
+    const widest = Math.max(...rows.map(
+      (row) => row.reduce((sum, cell) => sum + cell.width, 0)
+    ));
+    expect(widest).toBe(14);
   });
 
   test("does not break at a no-break space", () => {

--- a/tui/test/generation-deadline-recovery.test.ts
+++ b/tui/test/generation-deadline-recovery.test.ts
@@ -198,6 +198,7 @@ describe("deadline recovery through the real worker transport", () => {
           theme: "lantern",
           factsRail: "auto",
           composeFocus: "off",
+          wordWrap: "on",
           composeMaxHeight: null,
           quota: { date: "", words: 0 },
           updates: { mode: "notify", channel: "stable", skippedVersion: null }

--- a/tui/test/generation-stop-save.test.ts
+++ b/tui/test/generation-stop-save.test.ts
@@ -62,6 +62,7 @@ describe("stop save through the real worker transport", () => {
           theme: "lantern",
           factsRail: "auto",
           composeFocus: "off",
+          wordWrap: "on",
           composeMaxHeight: null,
           quota: { date: "", words: 0 },
           updates: { mode: "notify", channel: "stable", skippedVersion: null }

--- a/tui/test/golden-panels.test.ts
+++ b/tui/test/golden-panels.test.ts
@@ -346,8 +346,11 @@ describe("run C overlay frames", () => {
     const clean = await renderOnce(demoAppSource(), 120, 36, ",");
     expect(clean).not.toContain("revision");
 
+    // Down past theme, focus, and word wrap, which are local rows: only the
+    // server-backed provider below them can dirty the draft.
     const dirty = await renderWithKeys(demoAppSource(), 120, 36, [
       key(","),
+      key("down"),
       key("down"),
       key("down"),
       key("right")

--- a/tui/test/hit-map-chrome.test.ts
+++ b/tui/test/hit-map-chrome.test.ts
@@ -714,7 +714,7 @@ describe("hit map clickable chrome", () => {
     const isArrow = (region: { target: HitTarget }, index: number) =>
       region.target.kind === "action" && region.target.index === index
       && (region.target.action === "take-previous" || region.target.action === "take-next");
-    for (const index of [0, 2]) {
+    for (const index of [0, 3]) {
       const selectorRow = state.hitRows.findIndex((row) =>
         row?.overrides?.some((region) => isArrow(region, index)) === true);
       const arrows = state.hitRows[selectorRow]!.overrides!.filter((region) =>
@@ -749,10 +749,10 @@ describe("hit map clickable chrome", () => {
       }
     }
 
-    // Theme, compose focus, provider, insecure HTTP, profile, effort, cache,
-    // alternatives, and three routes — plus the three C-08 scalars, whose
-    // chips open on the same column.
-    expect(opens.size).toBe(14);
+    // Theme, compose focus, word wrap, provider, insecure HTTP, profile,
+    // effort, cache, alternatives, and three routes — plus the three C-08
+    // scalars, whose chips open on the same column.
+    expect(opens.size).toBe(15);
     expect(new Set(opens.values()).size).toBe(1);
   });
 

--- a/tui/test/hit-map-chrome.test.ts
+++ b/tui/test/hit-map-chrome.test.ts
@@ -435,7 +435,7 @@ describe("hit map clickable chrome", () => {
         state.mode = "LIBRARY";
         state.library = {
           stories: source.stories, cursor: 0, query: "",
-          prompt: { kind: "rename" as const, value: "new title", targetId: source.payload.id }
+          prompt: { kind: "rename" as const, composer: createComposer("new title"), targetId: source.payload.id }
         };
       },
       (state: State) => {

--- a/tui/test/input-lanes.test.ts
+++ b/tui/test/input-lanes.test.ts
@@ -14,7 +14,7 @@ import { startSummary } from "../src/summary-action.js";
 import { RecoveryWarningFeed } from "../src/recovery-warning-feed.js";
 import { startRecoveryOrchestration } from "../src/recovery-orchestration.js";
 import { createWrapCache, type ProseStyle } from "../src/wrap.js";
-import { setComposerText } from "../src/composer-model.js";
+import { createComposer, setComposerText } from "../src/composer-model.js";
 
 function deferred<T>() {
   let resolve!: (value: T | PromiseLike<T>) => void;
@@ -232,7 +232,7 @@ describe("responsive input lanes", () => {
 
     const prompt = app.state.library?.prompt;
     expect(app.state.mode).toBe("LIBRARY");
-    expect(prompt).toEqual({ kind: "rename", value: currentTitle, targetId: currentId });
+    expect(prompt).toEqual({ kind: "rename", composer: createComposer(currentTitle), targetId: currentId });
     expect(libraryRows(app.state.library!.stories, "")[app.state.library!.cursor]?.id).toBe(currentId);
     expect(renderStoryScreen(app.state, { width: 120, height: 36 }).lines.map(plainLine).join("\n"))
       .toContain(`rename: ${currentTitle}`);

--- a/tui/test/library-filter.test.ts
+++ b/tui/test/library-filter.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import type { KeyEvent } from "@opentui/core";
 import { handleKey, initialState, type AppSource } from "../src/app.js";
+import { createComposer } from "../src/composer-model.js";
 import { demoAppSource } from "../src/demo.js";
 import { pasteInto } from "../src/keys.js";
 import { publishStories } from "../src/overlay-publication.js";
@@ -16,11 +17,22 @@ const key = (name: string, sequence = name): KeyEvent => ({
   meta: false
 }) as KeyEvent;
 
+const modifiedKey = (
+  name: string,
+  options: { sequence?: string; shift?: boolean; ctrl?: boolean; meta?: boolean } = {}
+): KeyEvent => ({
+  name,
+  sequence: options.sequence ?? name,
+  shift: options.shift ?? false,
+  ctrl: options.ctrl ?? false,
+  meta: options.meta ?? false
+}) as KeyEvent;
+
 function harness() {
   const source: AppSource = demoAppSource();
   const state = initialState(source, false);
-  const press = (name: string, sequence = name) => handleKey(
-    key(name, sequence),
+  const pressKey = (event: KeyEvent) => handleKey(
+    event,
     state,
     source,
     createWrapCache(),
@@ -28,7 +40,15 @@ function harness() {
     async () => {},
     () => {}
   );
-  return { source, state, press };
+  const press = (name: string, sequence = name) => pressKey(key(name, sequence));
+  return { source, state, press, pressKey };
+}
+
+/** Narrow the open LIBRARY prompt to its composer-backed rename shape. */
+function renamePrompt(state: ReturnType<typeof harness>["state"]) {
+  const prompt = state.library?.prompt;
+  if (prompt?.kind !== "rename") throw new Error("expected an open rename prompt");
+  return prompt;
 }
 
 describe("live Library filter", () => {
@@ -196,7 +216,7 @@ describe("live Library filter", () => {
     await press("o");
     state.library!.prompt = {
       kind: "rename",
-      value: "wrong target",
+      composer: createComposer("wrong target"),
       targetId: "missing-story"
     };
 
@@ -205,5 +225,79 @@ describe("live Library filter", () => {
     expect(renames).toBe(0);
     expect(state.library?.prompt).toBe(null);
     expect(state.toast).toBe("story changed · action cancelled");
+  });
+});
+
+describe("composer-backed Library rename field", () => {
+  test("alt+left jumps a word left, and typing lands there instead of at the end", async () => {
+    const { state, press, pressKey } = harness();
+    await press("o");
+    const currentTitle = state.payload.title;
+    await press("e");
+    expect(renamePrompt(state).composer.text).toBe(currentTitle);
+
+    // "the lantern keeper" -> jump behind "the lantern " and insert there.
+    await pressKey(modifiedKey("left", { meta: true }));
+    for (const character of "co") await press(character);
+
+    expect(renamePrompt(state).composer.text).toBe("the lantern cokeeper");
+  });
+
+  test("ctrl+a selects the whole title, so the next character replaces it", async () => {
+    const { state, press, pressKey } = harness();
+    await press("o");
+    await press("e");
+
+    await pressKey(modifiedKey("a", { ctrl: true }));
+    await press("x");
+
+    expect(renamePrompt(state).composer.text).toBe("x");
+  });
+
+  test("pasting into the rename field inserts at the cursor and flattens a newline", async () => {
+    const { state, press } = harness();
+    await press("o");
+    const currentTitle = state.payload.title;
+    await press("e");
+
+    await press("home");
+    expect(pasteInto(state, "front matter\nsecond line")).toBeTrue();
+
+    expect(renamePrompt(state).composer.text).toBe(`front matter second line${currentTitle}`);
+  });
+
+  test("enter still commits an edited rename", async () => {
+    const { source, state, press, pressKey } = harness();
+    const currentId = state.payload.id;
+    let renamedTo: string | null = null;
+    source.api.renameStory = async (id, title) => {
+      renamedTo = title;
+      return { ...state.payload, id, title };
+    };
+    await press("o");
+    await press("e");
+
+    await pressKey(modifiedKey("a", { ctrl: true }));
+    for (const character of "a whole new title") await press(character);
+    await press("return", "\r");
+
+    expect(renamedTo).toBe("a whole new title");
+    expect(state.payload.id).toBe(currentId);
+    expect(state.payload.title).toBe("a whole new title");
+    expect(state.library?.prompt).toBe(null);
+  });
+
+  test("escape still cancels, discarding the edit", async () => {
+    const { state, press } = harness();
+    await press("o");
+    const currentTitle = state.payload.title;
+    await press("e");
+    for (const character of "ruined") await press(character);
+    expect(renamePrompt(state).composer.text).not.toBe(currentTitle);
+
+    await press("escape");
+
+    expect(state.library?.prompt).toBe(null);
+    expect(state.payload.title).toBe(currentTitle);
   });
 });

--- a/tui/test/palette-config.test.ts
+++ b/tui/test/palette-config.test.ts
@@ -314,6 +314,7 @@ describe("user config normalization", () => {
       theme: "bond",
       factsRail: "off",
       composeFocus: "off",
+      wordWrap: "on",
       composeMaxHeight: null,
       quota: { date: "2026-07-21", words: 42 },
       updates: { mode: "off", channel: "stable", skippedVersion: null }
@@ -368,10 +369,19 @@ describe("user config normalization", () => {
       theme: "lantern",
       factsRail: "auto",
       composeFocus: "off",
+      wordWrap: "on",
       composeMaxHeight: null,
       quota: { date: "", words: 0 },
       updates: { mode: "off", channel: "stable", skippedVersion: null }
     });
     expect(normalizeUserConfig(null)).toEqual(normalizeUserConfig([]));
+  });
+
+  test("keeps word wrap on unless the config turns it off", () => {
+    // An existing config file predates the key, and its editors already wrapped.
+    expect(normalizeUserConfig({}).wordWrap).toBe("on");
+    expect(normalizeUserConfig({ wordWrap: "off" }).wordWrap).toBe("off");
+    expect(normalizeUserConfig({ word_wrap: "off" }).wordWrap).toBe("off");
+    expect(normalizeUserConfig({ wordWrap: "sometimes" }).wordWrap).toBe("on");
   });
 });

--- a/tui/test/regressions.test.ts
+++ b/tui/test/regressions.test.ts
@@ -604,16 +604,24 @@ describe("review regressions", () => {
   });
 
   test("multiline compose input stays inside its fixed viewport", () => {
-    const frame = renderStoryScreen({
+    const compose = (wordWrap: "on" | "off") => renderStoryScreen({
       ...baseState,
+      config: { ...baseState.config, wordWrap },
       mode: "COMPOSE",
       composer: createComposer(`first line\n${"x".repeat(100)}`)
     }, { width: 80, height: 24 }).lines;
-    expect(frame).toHaveLength(24);
-    expect(frame.every((line) => !plainLine(line).includes("\n"))).toBeTrue();
-    expect(plainLine(frame.at(-1)!)).toContain("COMPOSE");
-    expect(plainLine(frame.at(-2)!)).toContain("⇧enter newline");
-    expect(plainLine(frame.at(-3)!)).toContain("…");
+
+    for (const wordWrap of ["on", "off"] as const) {
+      const frame = compose(wordWrap);
+      expect(frame).toHaveLength(24);
+      expect(frame.every((line) => !plainLine(line).includes("\n"))).toBeTrue();
+      expect(plainLine(frame.at(-1)!)).toContain("COMPOSE");
+      expect(plainLine(frame.at(-2)!)).toContain("⇧enter newline");
+    }
+    // The line is one unbroken token, so unwrapped it clips and wrapped it
+    // runs on into further rows. Either way the frame stays 24 rows.
+    expect(plainLine(compose("off").at(-3)!)).toContain("…");
+    expect(plainLine(compose("on").at(-3)!)).not.toContain("…");
   });
 
   test("supports equals forms and rejects prefixed typos", () => {

--- a/tui/test/replacement-adoption.test.ts
+++ b/tui/test/replacement-adoption.test.ts
@@ -9,7 +9,7 @@ import { publishStories } from "../src/overlay-publication.js";
 import { RecoveryWarningFeed } from "../src/recovery-warning-feed.js";
 import { startRecoveryOrchestration } from "../src/recovery-orchestration.js";
 import { createWrapCache, type ProseStyle } from "../src/wrap.js";
-import { setComposerText } from "../src/composer-model.js";
+import { createComposer, setComposerText } from "../src/composer-model.js";
 import { applyOpeningFocus } from "../src/reading-position.js";
 import { adoptReconciliationSnapshot } from "../src/story-adoption.js";
 import { SETTINGS_ROW_IDS } from "../src/settings-overlay-model.js";
@@ -58,7 +58,7 @@ async function launchDelete(app: ReturnType<typeof harness>, fixture: ReturnType
   await app.press(key("d"));
   const overlay = app.state.library!;
   const prompt = overlay.prompt!;
-  if (prompt.kind === "filter") throw new Error("expected delete prompt");
+  if (prompt.kind !== "delete") throw new Error("expected delete prompt");
   prompt.value = fixture.current.title;
   const pending = app.press(key("return", "\r"));
   await fixture.entered.promise;
@@ -83,7 +83,7 @@ describe("forced story replacement adoption", () => {
     publishStories(app.state, source, [survivor]);
     expect(app.state.library.prompt).toBe(filterPrompt);
 
-    const survivingPrompt = { kind: "rename" as const, value: survivor.title, targetId: survivor.id };
+    const survivingPrompt = { kind: "rename" as const, composer: createComposer(survivor.title), targetId: survivor.id };
     app.state.library.prompt = survivingPrompt;
     publishStories(app.state, source, [survivor]);
     expect(app.state.library.prompt).toBe(survivingPrompt);
@@ -208,7 +208,7 @@ describe("forced story replacement adoption", () => {
     overlay.cursor = 1;
     await app.press(key("d"));
     const submittedPrompt = overlay.prompt!;
-    if (submittedPrompt.kind === "filter") throw new Error("expected delete prompt");
+    if (submittedPrompt.kind !== "delete") throw new Error("expected delete prompt");
     submittedPrompt.value = doomed.title;
     const pending = app.press(key("return", "\r"));
     await listEntered.promise;

--- a/tui/test/rewrite-stop-save.test.ts
+++ b/tui/test/rewrite-stop-save.test.ts
@@ -85,6 +85,7 @@ describe("partial rewrite commit through the real worker transport", () => {
           theme: "lantern",
           factsRail: "auto",
           composeFocus: "off",
+          wordWrap: "on",
           composeMaxHeight: null,
           quota: { date: "", words: 0 },
           updates: { mode: "notify", channel: "stable", skippedVersion: null }

--- a/tui/test/token-probabilities-e2e.test.ts
+++ b/tui/test/token-probabilities-e2e.test.ts
@@ -89,6 +89,7 @@ function appSource(api: WorkerStoryApi["api"], settingsView: Awaited<ReturnType<
       theme: "lantern",
       factsRail: "auto",
       composeFocus: "off",
+      wordWrap: "on",
       composeMaxHeight: null,
       quota: { date: "", words: 0 },
       updates: { mode: "notify", channel: "stable", skippedVersion: null }


### PR DESCRIPTION
## Summary

Three commits. The first two are the features; the third is the structural work a review asked for.

**Word wrap (#55).** The document editors and the Fact body always wrapped, and they broke a line at whichever cell passed the edge, so a word split in half. Direct did not wrap at all: a long line clipped with an ellipsis. Both now break at the last space that fits, the way `wrap.ts` already breaks the story. A word wider than the field still breaks by cell. A no-break space is no longer a break point, in the composer and in the story measure alike.

A `wordWrap` config key drives every composer surface, with a settings row beside compose focus. It is on by default, because the document editors and the Fact body already wrapped. Vertical motion follows the paint: wrapped rows when the surface wraps, logical lines when it does not.

```
┏━ word wrap off ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
┃ › …fore answering, and the dark one was his.

┏━ word wrap on ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
┃ › Maren counted the lanterns twice before
┃   answering, and the dark one was his.
```

**Story name field (#56).** The Library rename prompt held a plain string and added each keystroke to its end, so it had no caret: no motion, no selection, no clipboard. A blanket ctrl/meta guard in `resolveKey` also refused every chord before the Library block read it. The field is composer-backed now and routes through `composerSurfaceAction`, so copy, cut, paste, word jump, and select-all work, and typing lands at the caret. Enter still renames, esc still cancels, and a pasted line break becomes a space.

That work also closed a reachable bug: ctrl+c with no selection while renaming reached the interrupt path and quit the TUI. The rename composer claims that shortcut now, as the other composer surfaces already do.

**Structure.** `directComposerWrapWidth` had closed an import cycle from the reducer through the story screen and back; it moves to a new `composer-geometry.ts` with the field measure and the gutter. Vertical motion asked the same question in three places, and one caller reached over `composerSurfaceAction` to take page motion from it; one `ComposerVerticalMotion` answers it now. Rows kept in the user config were spelled out nine times and are one list. Paste moves into `composerSurfaceAction`, so the rename field carries no seventh copy of the clipboard claim.

## Performance

Word wrap cannot use the old arithmetic path, because a break depends on where the spaces are. Two things keep it cheap:

- A line with no break space keeps the arithmetic path, so a multi-megabyte pasted token costs no row array. `hasWrapSpace` answers that in O(1) off the line index.
- A line with spaces is scanned per chunk, and chunks survive an edit behind them. On a 2 MiB paragraph a keystroke went 54.5ms → 5.2ms at the end of the line and 48.8ms → 12.9ms at its start.

The budgeted case in the suite improved as well: `insert into a wrapped 2 MiB line` runs at about 4ms, from about 67ms on main.

## Verification

- `cd tui && bun test`: 1576 pass, 0 fail
- `npm test`: 2199 pass, 0 fail, 17 skipped
- `cd tui && bun x tsc --noEmit` and `npm run typecheck`: clean

New tests cover word-boundary breaking, the cell-break fallback, the no-break space, incremental wrap against a fresh rebuild, both wrap modes through `renderStoryScreen`, the `wordWrap` config default and its snake-case alias, and the rename field's word jump, select-all, paste, commit, and cancel.

Closes #55
Closes #56