### PR TITLE
chore(release): prepare 0.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "1667-workspace",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "1667-workspace",
-      "version": "0.4.2",
+      "version": "0.5.0",
       "license": "Apache-2.0",
       "dependencies": {
         "fs-ext-extra-prebuilt": "2.2.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667-workspace",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "private": true,
   "description": "Source workspace for the 1667 terminal writing environment",
   "license": "Apache-2.0",

--- a/tui/package.json
+++ b/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "private": true,
   "description": "A terminal environment for writing fiction with language models",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary

- Set the root package version to `0.5.0`.
- Set the TUI package version to `0.5.0`.
- Keep the root lockfile version fields synchronized.

This release contains the import retry history and copy story lines feature (#59), and the composer word wrap and story name caret feature (#57).

## Verification

- `npm run build`
- `npm test`
- `cd tui && bun run typecheck`
- `cd tui && bun test`

Closes #60