### PR TITLE
fix(diagnostics): log embedded worker host failures

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -32,6 +32,10 @@ Add `--print-logs` to print new diagnostics to stderr:
 contain local paths and exception messages. 1667 resets the active log before
 it exceeds 5 MiB. Inspect the log before you share it.
 
+1667 also saves a diagnostic when the embedded backend stops unexpectedly.
+The host-state fields contain operation names and numeric stream progress.
+These fields do not contain request input or streamed text.
+
 ## Development gates
 
 Run the backend gates from the repository root:

--- a/tui/src/worker-api.ts
+++ b/tui/src/worker-api.ts
@@ -7,6 +7,8 @@ import { releaseOrRetainDataLock } from "./worker-data-lock.js";
 import { storyApiFromWorkerTransport } from "./worker-story-api.js";
 import { WorkerTransport } from "./worker-transport.js";
 import type { WorkerStoryApi, WorkerStoryApiOptions } from "./worker-api-contract.js";
+import { reportEmbeddedWorkerHostFailure } from "./worker-host-diagnostics.js";
+import { BackendRestartRequiredError } from "./worker-error.js";
 
 export { WorkerExitUnconfirmedError } from "./worker-data-lock.js";
 export {
@@ -51,6 +53,19 @@ export async function createWorkerStoryApi(options: WorkerStoryApiOptions = {}):
         freshDataDirectory: dataLock.initializedNewDirectory
       };
   let transport: WorkerTransport;
+  let failureReport: Promise<Error> | null = null;
+  const reportFailure = (error: Error): Promise<Error> => {
+    if (!(error instanceof BackendRestartRequiredError)
+      || error.diagnosticRef !== null) {
+      return Promise.resolve(error);
+    }
+    failureReport ??= reportEmbeddedWorkerHostFailure(
+      error,
+      transportOptions.machineDir,
+      options.printLogs === true
+    );
+    return failureReport;
+  };
   try {
     const outbox = options.outbox ?? (lockedDataDir === null
       ? null
@@ -60,17 +75,21 @@ export async function createWorkerStoryApi(options: WorkerStoryApiOptions = {}):
     await transport.start();
   } catch (error) {
     await releaseOrRetainDataLock(dataLock, error);
-    throw error;
+    throw error instanceof Error ? await reportFailure(error) : error;
   }
   const api = storyApiFromWorkerTransport(transport);
+  const failure = transport.failure.then(reportFailure);
   let disposal: Promise<void> | null = null;
   const dispose = (): Promise<void> => {
     disposal ??= (async () => {
       try {
         await transport.dispose();
       } catch (error) {
-        await releaseOrRetainDataLock(dataLock, error);
-        throw error;
+        const reported = error instanceof Error
+          ? await reportFailure(error)
+          : error;
+        await releaseOrRetainDataLock(dataLock, reported);
+        throw reported;
       }
       await dataLock?.release();
     })();
@@ -80,7 +99,7 @@ export async function createWorkerStoryApi(options: WorkerStoryApiOptions = {}):
     api,
     recovery: transport.recovery,
     recoveryWarnings: transport.recoveryWarnings,
-    failure: transport.failure,
+    failure,
     dispose
   };
 }

--- a/tui/src/worker-error.ts
+++ b/tui/src/worker-error.ts
@@ -10,7 +10,7 @@ export const BACKEND_RESTART_REQUIRED_EXIT_CODE = 75;
 
 export class BackendRestartRequiredError extends Error {
   readonly code = "backend_restart_required";
-  readonly diagnosticRef: string | null;
+  private attachedDiagnosticRef: string | null;
 
   constructor(
     message: string,
@@ -18,9 +18,19 @@ export class BackendRestartRequiredError extends Error {
   ) {
     super(`backend_restart_required: ${message}`, options);
     this.name = "BackendRestartRequiredError";
-    this.diagnosticRef = isDiagnosticReference(options.diagnosticRef)
+    this.attachedDiagnosticRef = isDiagnosticReference(options.diagnosticRef)
       ? options.diagnosticRef
       : null;
+  }
+
+  get diagnosticRef(): string | null {
+    return this.attachedDiagnosticRef;
+  }
+
+  attachDiagnosticReference(reference: unknown): void {
+    if (this.attachedDiagnosticRef === null && isDiagnosticReference(reference)) {
+      this.attachedDiagnosticRef = reference;
+    }
   }
 }
 

--- a/tui/src/worker-host-diagnostics.ts
+++ b/tui/src/worker-host-diagnostics.ts
@@ -1,0 +1,54 @@
+import {
+  diagnosticReferenceFromFailure
+} from "../../shared/failure-envelope.js";
+import { InternalErrorReporter } from "../../server/internal-error-reporter.js";
+import type { PendingRequestDiagnostic } from "./worker-pending.js";
+import { BackendRestartRequiredError } from "./worker-error.js";
+
+export interface EmbeddedWorkerHostSnapshot {
+  readonly pendingCount: number;
+  readonly omittedCount: number;
+  readonly operations: readonly PendingRequestDiagnostic[];
+}
+
+/** Add content-free host state to a failure that the worker cannot report. */
+export function embeddedWorkerHostCause(
+  cause: unknown,
+  snapshot: EmbeddedWorkerHostSnapshot
+): Error {
+  const diagnostic = new Error(
+    `Embedded backend host state: ${JSON.stringify(snapshot)}`,
+    cause === undefined ? undefined : { cause }
+  );
+  diagnostic.name = "EmbeddedWorkerHostDiagnostic";
+  return diagnostic;
+}
+
+/** Persist the final host-side hard fence before the CLI exits. */
+export async function reportEmbeddedWorkerHostFailure(
+  error: Error,
+  machineDir: string | undefined,
+  print: boolean
+): Promise<Error> {
+  if (!(error instanceof BackendRestartRequiredError)
+    || error.diagnosticRef !== null
+    || machineDir === undefined) {
+    return error;
+  }
+  let reporter: InternalErrorReporter | undefined;
+  try {
+    reporter = await InternalErrorReporter.open(machineDir, { print });
+    const incident = await reporter.report(error, {
+      service: "embedded-worker-host",
+      operation: "restart-required"
+    });
+    error.attachDiagnosticReference(
+      diagnosticReferenceFromFailure(incident.failure)
+    );
+  } catch {
+    // A failed diagnostic cannot replace the hard fence that it describes.
+  } finally {
+    await reporter?.close().catch(() => undefined);
+  }
+  return error;
+}

--- a/tui/src/worker-pending.ts
+++ b/tui/src/worker-pending.ts
@@ -19,6 +19,9 @@ export interface PendingCall {
   cancelled: boolean;
   settling: boolean;
   expectedSequence: number;
+  readonly openedAtMs: number;
+  receivedDeltaBatches: number;
+  receivedUtf16Units: number;
   /** Stream text that arrived after this call's signal aborted. The
    * transport never calls `onDelta` past that point; it collects the text
    * here and hands the whole tail to `onStopped` at terminal settlement,
@@ -31,6 +34,20 @@ export interface PendingCall {
   startCancellationGrace(timeoutMs: number, onTimeout: () => void): void;
   cleanup(): void;
 }
+
+export interface PendingRequestDiagnostic {
+  readonly method: WorkerMethod;
+  readonly replay: boolean;
+  readonly stream: boolean;
+  readonly cancelled: boolean;
+  readonly settling: boolean;
+  readonly expectedSequence: number;
+  readonly receivedDeltaBatches: number;
+  readonly receivedUtf16Units: number;
+  readonly ageMs: number;
+}
+
+const MAX_DIAGNOSTIC_OPERATIONS = 16;
 
 interface OpenPendingCall {
   method: WorkerMethod;
@@ -122,6 +139,9 @@ export class PendingRequestRegistry {
       cancelled: false,
       settling: false,
       expectedSequence: 0,
+      openedAtMs: Date.now(),
+      receivedDeltaBatches: 0,
+      receivedUtf16Units: 0,
       stoppedTail: "",
       ...(options.mutationId === undefined ? {} : { mutationId: options.mutationId }),
       ...(options.onDelta === undefined ? {} : { onDelta: options.onDelta }),
@@ -146,6 +166,31 @@ export class PendingRequestRegistry {
 
   *ids(): IterableIterator<WorkerOperationId> {
     for (const call of this.calls.values()) yield call.id;
+  }
+
+  diagnosticSnapshot(now = Date.now()): {
+    pendingCount: number;
+    omittedCount: number;
+    operations: PendingRequestDiagnostic[];
+  } {
+    const operations = [...this.calls.values()]
+      .slice(0, MAX_DIAGNOSTIC_OPERATIONS)
+      .map((call) => ({
+        method: call.method,
+        replay: call.replay,
+        stream: call.stream,
+        cancelled: call.cancelled,
+        settling: call.settling,
+        expectedSequence: call.expectedSequence,
+        receivedDeltaBatches: call.receivedDeltaBatches,
+        receivedUtf16Units: call.receivedUtf16Units,
+        ageMs: Math.max(0, now - call.openedAtMs)
+      }));
+    return {
+      pendingCount: this.calls.size,
+      omittedCount: Math.max(0, this.calls.size - operations.length),
+      operations
+    };
   }
 
   discard(id: WorkerOperationId): PendingCall | undefined {

--- a/tui/src/worker-transport.ts
+++ b/tui/src/worker-transport.ts
@@ -48,6 +48,7 @@ import { settleWorkerTerminal } from "./worker-terminal.js";
 import { openPendingWorkerCall } from "./worker-call-allocation.js";
 import { prepareWorkerMutationIntent } from "./worker-mutation-publication.js";
 import type { WorkerRecoveryWarning, WorkerStoryApiOptions } from "./worker-api-contract.js";
+import { embeddedWorkerHostCause } from "./worker-host-diagnostics.js";
 
 declare const __AI_1667_EMBEDDED_WORKER_SOURCE__: string | undefined;
 
@@ -442,6 +443,8 @@ export class WorkerTransport {
         return this.fail(new Error("Embedded backend stream sequence mismatch"), false);
       }
       pending.expectedSequence += 1;
+      pending.receivedDeltaBatches += 1;
+      pending.receivedUtf16Units += message.text.length;
       try {
         // After the caller's signal aborts, `onDelta` must never run again.
         // The text still arrived from the server, so it is withheld into
@@ -598,11 +601,15 @@ export class WorkerTransport {
   }
   private requireRestart(message: string, cause?: unknown): BackendRestartRequiredError {
     if (this.restartRequired === null) {
+      const diagnosticRef = cause instanceof WorkerApiError
+        ? cause.diagnosticRef
+        : null;
       this.restartRequired = new BackendRestartRequiredError(message, {
-        cause,
-        diagnosticRef: cause instanceof WorkerApiError
-          ? cause.diagnosticRef
-          : null
+        cause: embeddedWorkerHostCause(
+          cause,
+          this.pending.diagnosticSnapshot()
+        ),
+        diagnosticRef
       });
       this.resolveRestartSignal(this.restartRequired);
     }

--- a/tui/test/worker-error-log.test.ts
+++ b/tui/test/worker-error-log.test.ts
@@ -12,6 +12,7 @@ import { SETTINGS_STATE_V2_FILE } from "../../server/data-directory-layout.js";
 import { internalErrorLogPath } from "../../server/internal-error-log.js";
 import { MutationOutbox } from "../../server/mutation-outbox.js";
 import {
+  BackendRestartRequiredError,
   createWorkerStoryApi,
   WorkerApiError
 } from "../src/worker-api.js";
@@ -21,6 +22,9 @@ import {
   platformPerformanceBudget
 } from "../../test/performance-budget.js";
 import { FakeWorker, waitForRequest } from "./fixtures/fake-worker.js";
+import { createDemoController } from "../src/demo.js";
+import type { StoryPayload } from "../../shared/types.js";
+import { InternalErrorReporter } from "../../server/internal-error-reporter.js";
 
 test("embedded internal errors carry the reference written to the private log", async () => {
   const dataDir = await temporaryDirectory("1667-worker-error-data-");
@@ -57,6 +61,128 @@ test("embedded internal errors carry the reference written to the private log", 
       rm(dataDir, { recursive: true, force: true }),
       rm(machineDir, { recursive: true, force: true })
     ]);
+  }
+}, platformPerformanceBudget(10_000));
+
+test("unexpected worker exits log content-free host and stream progress", async () => {
+  const machineDir = await temporaryDirectory("1667-worker-host-machine-");
+  const worker = new FakeWorker();
+  const backend = await createWorkerStoryApi({
+    worker,
+    machineDir,
+    readyTimeoutMs: 100
+  });
+  const privateInstruction = "private-instruction-that-must-not-reach-the-log";
+  const privateDelta = "private-streamed-prose-that-must-not-reach-the-log";
+  try {
+    const payload: StoryPayload = {
+      ...createDemoController().payload(),
+      aggregateVersion: {
+        kind: "v6",
+        revision: "00000000000000000001"
+      }
+    };
+    const loading = backend.api.loadStory(payload.id);
+    const loadRequest = await waitForRequest(worker, "loadStory");
+    worker.message({ type: "result", id: loadRequest.id, value: payload });
+    await loading;
+
+    const received: string[] = [];
+    const generationFailure = rejection(backend.api.continueStory(
+      payload.id,
+      privateInstruction,
+      "private-generation-id",
+      { parentId: payload.path.at(-1)?.id ?? null },
+      (delta) => received.push(delta),
+      new AbortController().signal
+    ));
+    const request = await waitForRequest(worker, "continueStory");
+    worker.message({
+      type: "delta",
+      id: request.id,
+      sequence: 0,
+      text: privateDelta
+    });
+    expect(received).toEqual([privateDelta]);
+
+    worker.crash("injected worker runtime crash");
+    const failure = await backend.failure;
+    expect(failure instanceof BackendRestartRequiredError).toBeTrue();
+    expect((failure as BackendRestartRequiredError).diagnosticRef)
+      .toMatch(/^err_[0-9a-f]{24}$/);
+    expect(await generationFailure).toBe(failure);
+
+    const entries = (await readFile(internalErrorLogPath(machineDir), "utf8"))
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+    const entry = entries.at(-1) as {
+      service: string;
+      operation: string;
+      error: {
+        name: string;
+        cause: { name: string; message: string };
+      };
+    };
+    expect(entry).toMatchObject({
+      service: "embedded-worker-host",
+      operation: "restart-required",
+      error: {
+        name: "BackendRestartRequiredError",
+        cause: { name: "EmbeddedWorkerHostDiagnostic" }
+      }
+    });
+    const prefix = "Embedded backend host state: ";
+    expect(entry.error.cause.message.startsWith(prefix)).toBeTrue();
+    const snapshot = JSON.parse(entry.error.cause.message.slice(prefix.length)) as {
+      pendingCount: number;
+      omittedCount: number;
+      operations: Array<Record<string, unknown>>;
+    };
+    expect(snapshot).toMatchObject({
+      pendingCount: 1,
+      omittedCount: 0,
+      operations: [{
+        method: "continueStory",
+        replay: false,
+        stream: true,
+        cancelled: false,
+        settling: false,
+        expectedSequence: 1,
+        receivedDeltaBatches: 1,
+        receivedUtf16Units: privateDelta.length
+      }]
+    });
+    expect(typeof snapshot.operations[0]?.ageMs).toBe("number");
+    const stored = JSON.stringify(entry);
+    expect(stored).not.toContain(privateInstruction);
+    expect(stored).not.toContain(privateDelta);
+    expect(stored).not.toContain("private-generation-id");
+  } finally {
+    await backend.dispose().catch(() => undefined);
+    await rm(machineDir, { recursive: true, force: true });
+  }
+}, platformPerformanceBudget(10_000));
+
+test("host diagnostic failures preserve the backend hard fence", async () => {
+  const worker = new FakeWorker();
+  const backend = await createWorkerStoryApi({
+    worker,
+    machineDir: "/unused-diagnostic-machine-directory",
+    readyTimeoutMs: 100
+  });
+  const openReporter = InternalErrorReporter.open;
+  InternalErrorReporter.open = async () => {
+    throw new Error("injected diagnostic open failure");
+  };
+  try {
+    worker.crash("injected worker runtime crash");
+    const failure = await backend.failure;
+    expect(failure instanceof BackendRestartRequiredError).toBeTrue();
+    expect((failure as BackendRestartRequiredError).diagnosticRef).toBe(null);
+  } finally {
+    InternalErrorReporter.open = openReporter;
+    await backend.dispose().catch(() => undefined);
   }
 }, platformPerformanceBudget(10_000));
 


### PR DESCRIPTION
Closes #64\n\n## Summary\n- persist a host-side diagnostic when an embedded worker stops unexpectedly\n- record bounded operation and numeric stream-progress metadata without request input or streamed text\n- preserve the original restart hard fence when diagnostic persistence fails\n\n## Verification\n- npm run typecheck\n- npm test\n- cd tui; bun run typecheck\n- cd tui; bun test --timeout 30000\n- cd tui; bun bench/perf.ts\n- autoreview: clean\n- thermo-nuclear maintainability review: clean