### PR TITLE
chore(release): prepare 0.5.1-rc.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "1667-workspace",
-  "version": "0.5.0",
+  "version": "0.5.1-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "1667-workspace",
-      "version": "0.5.0",
+      "version": "0.5.1-rc.1",
       "license": "Apache-2.0",
       "dependencies": {
         "fs-ext-extra-prebuilt": "2.2.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667-workspace",
-  "version": "0.5.0",
+  "version": "0.5.1-rc.1",
   "private": true,
   "description": "Source workspace for the 1667 terminal writing environment",
   "license": "Apache-2.0",

--- a/tui/package.json
+++ b/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667",
-  "version": "0.5.0",
+  "version": "0.5.1-rc.1",
   "private": true,
   "description": "A terminal environment for writing fiction with language models",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary

- Set the root package version to `0.5.1-rc.1`.
- Set the TUI package version to `0.5.1-rc.1`.
- Keep the root lockfile version fields synchronized.

Two fixes landed after `v0.5.0`, so this is a patch prerelease: the writing mark turns the whole way around (#63), and an embedded worker host failure is logged (#65).

A prerelease publishes to the `beta` dist-tag. The homepage keeps serving the stable Installers, which name 0.5.0.

## Verification

- `npm run typecheck`
- `node --test test/release-identity.test.ts test/release-content.test.ts test/release-preflight.test.ts test/build-identity.test.ts`: 16 pass, 0 fail

Closes #66

https://claude.ai/code/session_01MfCTszz1WFpnUh7He5B9Mb