### PR TITLE
fix(tui): fence token counts by provider owner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ This file records notable changes to 1667. Product terms use the definitions in
 
 ## Unreleased
 
+- **Prompt-token counting stops for all active provider work.** A count could
+  continue before a generation showed its stream. It could also restart while
+  a stopped generation was still settling. 1667 now stops an active count when
+  provider work starts. It counts once after the provider owner releases the
+  operation. This behavior also applies to rewrites and summaries. Thanks
+  @10fra for the report.
+
 - **1667 installs and updates in a directory that other software also uses.**
   The Installer and `1667 upgrade` refused an Install Root when any directory
   above it was group-writable or world-writable, was a symbolic link, or

--- a/docs/model-providers.md
+++ b/docs/model-providers.md
@@ -178,6 +178,8 @@ counted number. Each category and each message keeps its estimate.
 1667 counts the request after you stop typing. It counts the request again when
 you open the request viewer. A count never delays a keystroke. If the model
 server does not answer, 1667 keeps the estimate and shows no error.
+1667 does not count while a generation, rewrite, or summary is active. It
+counts again after the operation ends.
 
 ## Request viewer
 

--- a/tui/src/generation-action.ts
+++ b/tui/src/generation-action.ts
@@ -103,6 +103,10 @@ export async function generate(
     stopInteractionVersion: null as number | null
   };
   state.abort = active;
+  // Publish the provider claim before textHash() yields. ActionRuntime's
+  // start repaint happens before this claim exists, and prompt-token work
+  // already in flight must stop for the complete provider-work lifetime.
+  repaint();
   const signal = controller.signal;
   const storyId = task.storyId;
   const composerClaimEpoch = state.composerClaimEpoch;

--- a/tui/src/prompt-token-count.ts
+++ b/tui/src/prompt-token-count.ts
@@ -108,10 +108,11 @@ export function startPromptTokenCountLane(
    *  timer makes that bound real: an idle session repaints rarely, and a bound
    *  nothing observes is a promise the meter does not keep. */
   let expiryTimer: TimerHandle | null = null;
-  /** Whether the previous `notify()` saw a stream in flight, so the one
-   *  notification that carries generation from active to finished is told
-   *  apart from the many that arrived while it was still streaming. */
-  let wasGenerating = state.stream !== null;
+  /** Whether the previous `notify()` saw provider work in flight, so the one
+   *  notification that releases its owner is told apart from the many that
+   *  arrived while it was still active. A stopped request clears its visible
+   *  stream before its abort owner finishes settlement. */
+  let providerWorkActive = hasProviderOwner(state);
 
   const clearTimer = () => {
     if (timer !== null) cancel(timer);
@@ -159,15 +160,13 @@ export function startPromptTokenCountLane(
 
   const runCount = (onDemand = false) => {
     if (disposed) return;
-    // A generation in flight rewrites `state.stream.text` on every delta, so
-    // any count a probe answered here would already be describing a shorter
-    // draft by the time it lands. `notify()` already keeps the debounce from
-    // firing during a stream; this is the backstop for the two paths that
-    // reach `runCount` without going through `notify()` at all: the cooldown
-    // and expiry timers, armed earlier, calling `queueDebounced()` straight
-    // from their own callbacks. Generation ending is what lets them through
-    // again, via the `wasGenerating` branch below.
-    if (state.stream !== null) return;
+    // Provider work can rewrite the projected prompt or still own settlement.
+    // `notify()` already keeps the debounce from firing while that owner is
+    // active; this is the backstop for the two paths that reach `runCount`
+    // without going through `notify()` at all: the cooldown and expiry timers,
+    // armed earlier, calling `queueDebounced()` from their own callbacks. The
+    // provider owner ending is what lets them through again.
+    if (hasProviderOwner(state)) return;
     const projected = projectNextRequest(state);
     const estimate = nextRequestEstimate(projected.payload, projected.context);
     const route = state.generationRoute;
@@ -306,12 +305,11 @@ export function startPromptTokenCountLane(
     const openedRequestViewer = state.mode === "REQUEST" && lastMode !== "REQUEST";
     lastMode = state.mode;
 
-    if (state.stream !== null) {
-      // Every delta repaints, and the streamed prompt is different on each
-      // one: asking about it would only launch a probe the very next delta
-      // immediately supersedes, the abort/relaunch churn this lane exists to
-      // avoid. No debounce is even queued: there is nothing to answer until
-      // the stream stops moving.
+    if (hasProviderOwner(state)) {
+      // A stream repaints on every delta. Summary and post-Stop settlement can
+      // also repaint before their provider owner clears. A count during any of
+      // these phases is stale or competes with work that is still settling.
+      // No debounce is queued until that owner clears.
       clearTimer();
       abortInFlight();
       clearExpiryTimer();
@@ -329,15 +327,15 @@ export function startPromptTokenCountLane(
         state.promptTokenCount = null;
         repaint();
       }
-      wasGenerating = true;
+      providerWorkActive = true;
       return;
     }
-    if (wasGenerating) {
-      // The stream just ended. Every repaint it produced was swallowed above
-      // without queuing anything, so this is the one debounce that answers
-      // for all of them, not an on-demand call even if the request viewer
-      // happens to already be open.
-      wasGenerating = false;
+    if (providerWorkActive) {
+      // The provider owner just cleared. Every repaint it produced was
+      // swallowed above without queuing anything, so this is the one debounce
+      // that answers for all of them, not an on-demand call even if the
+      // request viewer happens to already be open.
+      providerWorkActive = false;
       queueDebounced();
       return;
     }
@@ -361,4 +359,10 @@ export function startPromptTokenCountLane(
       abortInFlight();
     }
   };
+}
+
+/** The abort claim is the provider-work lifetime. It starts before a stream,
+ * remains through settlement, and excludes a preserved ownerless stream. */
+function hasProviderOwner(state: Pick<RuntimeState, "abort">): boolean {
+  return state.abort !== null;
 }

--- a/tui/test/fixtures/prompt-token-count.ts
+++ b/tui/test/fixtures/prompt-token-count.ts
@@ -56,9 +56,10 @@ export function promptTokenCountStream(text: string): StreamView {
 }
 
 export function promptTokenCountFixture() {
-  const state = initialState(demoAppSource(), false);
+  const source = demoAppSource();
+  const state = initialState(source, false);
   const clock = promptTokenCountClock();
   let repaints = 0;
   const repaint = () => { repaints += 1; };
-  return { state, clock, repaint, repaints: () => repaints };
+  return { state, source, clock, repaint, repaints: () => repaints };
 }

--- a/tui/test/prompt-token-count-generation.test.ts
+++ b/tui/test/prompt-token-count-generation.test.ts
@@ -1,15 +1,27 @@
 import { describe, expect, test } from "bun:test";
 import type { PromptTokenCount } from "../../shared/tokenize-source.js";
+import { ActionRuntime } from "../src/action-runtime.js";
+import { generate, requestGenerationStop } from "../src/generation-action.js";
+import { createStoryViewModel, rowIndexForNode } from "../src/model.js";
 import {
   startPromptTokenCountLane,
   type PromptTokenCountApi
 } from "../src/prompt-token-count.js";
+import { createWrapCache } from "../src/wrap.js";
 import {
   countedPromptTokenAnswer as countedAnswer,
   flushPromptTokenCount as flush,
   promptTokenCountFixture as fixture,
   promptTokenCountStream as streamView
 } from "./fixtures/prompt-token-count.js";
+
+function generationOwner() {
+  return {
+    kind: "generation" as const,
+    controller: new AbortController(),
+    stopInteractionVersion: null
+  };
+}
 
 describe("prompt token count during generation", () => {
   test("many stream deltas never call the backend and leave no debounce pending", () => {
@@ -22,6 +34,7 @@ describe("prompt token count during generation", () => {
       state, api, repaint, schedule: clock.schedule, cancel: clock.cancel
     });
 
+    state.abort = generationOwner();
     state.stream = streamView("");
     for (let delta = 0; delta < 20; delta += 1) {
       state.stream.text += `chunk ${delta} `;
@@ -43,12 +56,14 @@ describe("prompt token count during generation", () => {
       state, api, repaint, schedule: clock.schedule, cancel: clock.cancel
     });
 
+    state.abort = generationOwner();
     state.stream = streamView("");
     for (let delta = 0; delta < 10; delta += 1) {
       state.stream.text += `chunk ${delta} `;
       lane.notify();
     }
     state.stream = null;
+    state.abort = null;
     lane.notify();
     expect(calls).toBe(0);
     expect(clock.pendingCount()).toBe(1);
@@ -60,6 +75,92 @@ describe("prompt token count during generation", () => {
     clock.fireDelay(250);
     await flush();
     expect(calls).toBe(1);
+    lane.dispose();
+  });
+
+  test("generation settlement keeps counts paused after its visible stream ends", async () => {
+    const { state, clock, repaint } = fixture();
+    let calls = 0;
+    const api: PromptTokenCountApi = {
+      countPromptTokens: async () => { calls += 1; return countedAnswer(1); }
+    };
+    const lane = startPromptTokenCountLane({
+      state, api, repaint, schedule: clock.schedule, cancel: clock.cancel
+    });
+
+    state.abort = generationOwner();
+    state.stream = streamView("");
+    lane.notify();
+
+    state.stream = null;
+    lane.notify();
+    expect(calls).toBe(0);
+    expect(clock.pendingCount()).toBe(0);
+
+    state.abort = null;
+    lane.notify();
+    expect(clock.pendingCount()).toBe(1);
+    clock.fireDelay(250);
+    await flush();
+    expect(calls).toBe(1);
+    lane.dispose();
+  });
+
+  test("an ownerless preserved stream refreshes after failed Stop settlement", async () => {
+    const { state, clock, repaint } = fixture();
+    let calls = 0;
+    const api: PromptTokenCountApi = {
+      countPromptTokens: async () => { calls += 1; return countedAnswer(1); }
+    };
+    const lane = startPromptTokenCountLane({
+      state, api, repaint, schedule: clock.schedule, cancel: clock.cancel
+    });
+
+    state.abort = generationOwner();
+    state.stream = streamView("partial prose preserved for recovery");
+    lane.notify();
+
+    state.abort = null;
+    lane.notify();
+    expect(state.stream).not.toBe(null);
+    expect(clock.pendingCount()).toBe(1);
+
+    clock.fireDelay(250);
+    await flush();
+    expect(calls).toBe(1);
+    lane.dispose();
+  });
+
+  test("generation claim aborts an existing count before its first await", async () => {
+    const { state, source, clock, repaint } = fixture();
+    const signals: AbortSignal[] = [];
+    const api: PromptTokenCountApi = {
+      countPromptTokens: async (_messages, signal) => {
+        if (signal !== undefined) signals.push(signal);
+        return await new Promise<PromptTokenCount>(() => { /* never settles */ });
+      }
+    };
+    const lane = startPromptTokenCountLane({
+      state, api, repaint, schedule: clock.schedule, cancel: clock.cancel
+    });
+    state.mode = "REQUEST";
+    lane.notify();
+    expect(signals).toHaveLength(1);
+    expect(signals[0]!.aborted).toBeFalse();
+
+    state.focusIndex = rowIndexForNode(createStoryViewModel(state.payload), "p13");
+    const runtime = new ActionRuntime(state, lane.notify);
+    const pending = runtime.run("generating prose", (task) =>
+      generate(state, source, createWrapCache(), lane.notify, "", null, null, task));
+
+    expect(state.abort?.kind).toBe("generation");
+    expect(state.stream).toBe(null);
+    expect(signals[0]!.aborted).toBeTrue();
+    expect(clock.pendingCount()).toBe(0);
+
+    requestGenerationStop(state, lane.notify);
+    await pending;
+    runtime.dispose();
     lane.dispose();
   });
 
@@ -79,12 +180,14 @@ describe("prompt token count during generation", () => {
     expect(calls).toBe(1);
     expect(state.promptTokenCount).not.toBe(null);
 
+    state.abort = generationOwner();
     state.stream = streamView("");
     lane.notify();
     expect(state.promptTokenCount).toBe(null);
 
     // An empty or stopped generation can leave the settled prompt unchanged.
     state.stream = null;
+    state.abort = null;
     lane.notify();
     clock.fireDelay(250);
     await flush();
@@ -111,6 +214,7 @@ describe("prompt token count during generation", () => {
     expect(signals).toHaveLength(1);
     expect(signals[0]!.aborted).toBeFalse();
 
+    state.abort = generationOwner();
     state.stream = streamView("");
     lane.notify();
 
@@ -134,12 +238,14 @@ describe("prompt token count during generation", () => {
     await flush();
     expect(calls).toBe(1);
 
+    state.abort = generationOwner();
     state.stream = streamView("");
     lane.notify();
     state.stream.text += "more";
     lane.notify();
     state.systemPrompt = `${state.systemPrompt} plus generated text`;
     state.stream = null;
+    state.abort = null;
     lane.notify();
 
     expect(calls).toBe(1);


### PR DESCRIPTION
## Summary

- Fence prompt-token counting with the provider owner instead of visible stream state.
- Publish generation ownership before the first asynchronous step.
- Refresh once after settlement, including an ownerless preserved stopped stream.
- Document the provider-independent behavior.

## Root cause

Visible stream state is shorter than provider work. Generation owns the provider before a stream exists, and Stop can remove the stream before settlement ends. Failed Stop recovery can also preserve a static stream after ownership ends.

## User impact

Prompt-token counting no longer competes with active generation, rewrite, or summary work. It resumes once after the operation ends.

## Verification

- `cd tui && bun test --timeout 30000`: 1,590 pass, 0 fail
- `cd tui && bun run typecheck`
- `npm run typecheck`
- `autoreview --mode local`: clean, zero findings

The root suite reached 2,048 pass and 0 fail under local Node 24.12, then its existing provider-deadline fixture remained pending. Protected CI uses Node 22.22.

Closes #76

