### PR TITLE
feat(upgrade): show download progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This file records notable changes to 1667. Product terms use the definitions in
 
 ## Unreleased
 
+- Show live download progress for managed upgrades and the Windows Installer.
+  Thanks to @10fra.
+
 - **Prompt-token counting stops for all active provider work.** A count could
   continue before a generation showed its stream. It could also restart while
   a stopped generation was still settling. 1667 now stops an active count when

--- a/README.md
+++ b/README.md
@@ -54,8 +54,9 @@ Installer supports macOS and Linux. The PowerShell Installer supports Windows
 x64.
 
 Run `1667 upgrade` to update a Managed Installation that the Shell Installer
-created. On Windows, exit 1667 and run the PowerShell Installer again. `1667
-upgrade` shows the required command.
+created. The command shows download progress in a terminal. On Windows, exit
+1667 and run the PowerShell Installer again. The Installer shows download
+progress. `1667 upgrade` shows the required command.
 
 Install with npm:
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -526,9 +526,11 @@ a valid Ownership Record grants installation authority. npm, source, and copied
 installations stay read-only to `1667 upgrade`.
 
 `1667 upgrade` downloads the Platform Package from the canonical npm registry.
-It verifies the SHA-512 integrity value. It extracts the Candidate. It probes
-the build identity. It uses a recoverable transaction to replace the
-executable. The transaction stays in the Install Root.
+It shows download progress when standard error is a terminal. It writes no
+progress when output is redirected or when `--json` is active. It verifies the
+SHA-512 integrity value. It extracts the Candidate. It probes the build
+identity. It uses a recoverable transaction to replace the executable. The
+transaction stays in the Install Root.
 
 `1667 upgrade --rollback` works offline.
 
@@ -538,7 +540,8 @@ command. The command downloads `install-stable.ps1` from the exact, immutable
 `v<version>` GitHub release that the plan selected; it does not re-resolve the
 moving homepage route. Exit 1667 before you run that command. Run the same
 command again for an upgrade. The PowerShell Installer keeps the Installation
-ID. Windows does not support `1667 upgrade --rollback`.
+ID. The PowerShell Installer shows archive download progress. Windows does not
+support `1667 upgrade --rollback`.
 
 Background update checks stay notify-only. They never install a Candidate.
 

--- a/scripts/release-install-powershell-body.ts
+++ b/scripts/release-install-powershell-body.ts
@@ -48,7 +48,7 @@ param(
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
-$ProgressPreference = 'SilentlyContinue'
+$ProgressPreference = 'Continue'
 
 $ProductVersion = '${input.version}'
 $InstallChannel = '${input.channel}'
@@ -198,6 +198,8 @@ function Download-Archive([string]$Url, [string]$Destination) {
       $Destination, [IO.FileMode]::CreateNew, [IO.FileAccess]::Write, [IO.FileShare]::None)
     $buffer = New-Object byte[] 65536
     $total = 0L
+    $lastProgress = -1L
+    $activity = "Downloading 1667 $ProductVersion"
     while (($count = $inputStream.Read($buffer, 0, $buffer.Length)) -gt 0) {
       $total += $count
       if ($total -gt $MaxArchiveBytes) { Fail 'Release Archive is too large.' }
@@ -206,9 +208,25 @@ function Download-Archive([string]$Url, [string]$Destination) {
         Fail 'Release Archive download exceeded its time limit.'
       }
       $outputStream.Write($buffer, 0, $count)
+      if ($response.ContentLength -gt 0) {
+        $percent = [Math]::Min(100, [Math]::Floor(100 * $total / $response.ContentLength))
+        if ($percent -ne $lastProgress) {
+          Write-Progress -Activity $activity -Status "$percent%" -PercentComplete $percent
+          $lastProgress = $percent
+        }
+      } else {
+        $bucket = [Math]::Floor($total / 1MB)
+        if ($bucket -ne $lastProgress) {
+          Write-Progress -Activity $activity -Status "$total bytes" -PercentComplete -1
+          $lastProgress = $bucket
+        }
+      }
     }
     $outputStream.Flush($true)
   } finally {
+    if ($null -ne $response) {
+      Write-Progress -Activity "Downloading 1667 $ProductVersion" -Completed
+    }
     $deadline.Stop()
     if ($null -ne $outputStream) { $outputStream.Dispose() }
     if ($null -ne $inputStream) { $inputStream.Dispose() }

--- a/test/release-install-powershell.test.ts
+++ b/test/release-install-powershell.test.ts
@@ -34,6 +34,7 @@ test("PowerShell Installer handles install, repeat, and upgrade cases", async (t
   const scratch = await mkdtemp(path.join(tmpdir(), "1667-powershell-install-"));
   t.after(() => rm(scratch, { recursive: true, force: true }));
   const assets = new Map<string, Buffer>();
+  let chunkedAssetPath: string | null = null;
   const server = createServer((request, response) => {
     const asset = assets.get(request.url ?? "");
     if (asset === undefined) {
@@ -42,6 +43,21 @@ test("PowerShell Installer handles install, repeat, and upgrade cases", async (t
       return;
     }
     response.writeHead(200, { "content-length": asset.byteLength });
+    if (request.url === chunkedAssetPath) {
+      const chunkSize = Math.max(1, Math.floor(asset.byteLength / 3));
+      let offset = 0;
+      const send = () => {
+        if (offset >= asset.byteLength) {
+          response.end();
+          return;
+        }
+        response.write(asset.subarray(offset, offset + chunkSize));
+        offset += chunkSize;
+        setTimeout(send, 20);
+      };
+      send();
+      return;
+    }
     response.end(asset);
   });
   await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
@@ -55,6 +71,7 @@ test("PowerShell Installer handles install, repeat, and upgrade cases", async (t
 
   const v1 = await addRelease(assets, scratch, base, "1.2.3", "v1");
   const v2 = await addRelease(assets, scratch, base, "1.2.4", "v2");
+  chunkedAssetPath = `/v2/${v2.archiveName}`;
   const installRoot = path.join(scratch, "managed");
 
   const fresh = await runInstaller(v1.url, installRoot);
@@ -127,10 +144,14 @@ test("PowerShell Installer handles install, repeat, and upgrade cases", async (t
   held.kill();
   await heldExit;
 
-  const upgraded = await runInstaller(v2.url, installRoot);
+  const progressLog = path.join(scratch, "upgrade-progress.log");
+  const upgraded = await runInstaller(v2.url, installRoot, false, progressLog);
   assert.match(upgraded.stdout, /Installed 1667 1\.2\.4 \(stable\)/u);
   assert.equal(await installedVersion(installRoot), "1.2.4");
   assert.equal((await ownershipRecord(installRoot)).installationId, firstRecord.installationId);
+  const progress = (await readFile(progressLog, "utf8")).trim().split(/\r?\n/u);
+  assert.ok(progress.filter((line) => line.startsWith("active|")).length >= 2);
+  assert.match(progress.at(-1)!, /^complete\|Downloading 1667 1\.2\.4$/u);
 
   const unmanagedRoot = path.join(scratch, "unmanaged");
   await mkdir(unmanagedRoot);
@@ -330,7 +351,8 @@ Add-Type -Path $Source -OutputAssembly $Output -OutputType ConsoleApplication
 async function runInstaller(
   url: string,
   installRoot: string,
-  updatePath = false
+  updatePath = false,
+  progressLog?: string
 ) {
   const environment: NodeJS.ProcessEnv = {
     ...process.env,
@@ -341,13 +363,22 @@ async function runInstaller(
   } else {
     environment.AI_1667_SKIP_PATH_UPDATE = "1";
   }
+  if (progressLog !== undefined) environment.AI_1667_PROGRESS_LOG = progressLog;
+  const progressCapture = progressLog === undefined
+    ? ""
+    : `function Write-Progress {
+  param([string]$Activity, [string]$Status, [int]$PercentComplete, [switch]$Completed)
+  $state = if ($Completed) { 'complete' } else { 'active' }
+  Add-Content -LiteralPath $env:AI_1667_PROGRESS_LOG -Value "$state|$Activity"
+}
+`;
   return execFileAsync("powershell.exe", [
     "-NoLogo",
     "-NoProfile",
     "-ExecutionPolicy",
     "Bypass",
     "-Command",
-    `irm '${url}' | iex`
+    `${progressCapture}irm '${url}' | iex`
   ], {
     env: environment,
     timeout: 15_000

--- a/test/release-install-script.test.ts
+++ b/test/release-install-script.test.ts
@@ -80,6 +80,12 @@ test("generated install scripts embed exact digests and never resolve latest", (
   });
   assert.match(powershellBody, /^# 1667 PowerShell Installer/u);
   assert.match(powershellBody, /windows-x64/u);
+  assert.match(powershellBody, /\$ProgressPreference = 'Continue'/u);
+  assert.match(powershellBody, /Write-Progress -Activity \$activity/u);
+  assert.match(
+    powershellBody,
+    /Write-Progress -Activity "Downloading 1667 \$ProductVersion" -Completed/u
+  );
   // Both URL branches embed portable connect and overall transfer deadlines.
   assert.match(body, /DOWNLOAD_CONNECT_TIMEOUT_SEC=30/);
   assert.match(body, /DOWNLOAD_MAX_TIME_SEC=600/);

--- a/tui/src/upgrade-apply.ts
+++ b/tui/src/upgrade-apply.ts
@@ -21,6 +21,7 @@ import {
   type UpgradeRegistry
 } from "./upgrade-plan.js";
 import { downloadPlatformPackage } from "./upgrade-download.js";
+import type { PackageDownloadProgressHandler } from "./upgrade-download.js";
 import {
   materializeCandidate,
   probeCandidateVersion
@@ -42,6 +43,7 @@ export interface UpgradeApplyDependencies {
   readonly registry?: UpgradeRegistry;
   readonly fetcher?: RegistryFetch;
   readonly signal?: AbortSignal;
+  readonly onDownloadProgress?: PackageDownloadProgressHandler;
   /** `--force`: accept an Install Root another account can write. */
   readonly force?: boolean;
 }
@@ -117,7 +119,8 @@ export async function applyUpgrade(
         integrity: meta.integrity,
         destinationPath: paths.packageStaging,
         signal: lockedSignal,
-        fetcher: dependencies.fetcher
+        fetcher: dependencies.fetcher,
+        onProgress: dependencies.onDownloadProgress
       });
       await materializeCandidate({
         packagePath: paths.packageStaging,

--- a/tui/src/upgrade-cli.ts
+++ b/tui/src/upgrade-cli.ts
@@ -16,6 +16,8 @@ import {
   type RegistryFetch
 } from "./npm-upgrade-registry.js";
 import { applyRollback, applyUpgrade } from "./upgrade-apply.js";
+import type { PackageDownloadProgressHandler } from "./upgrade-download.js";
+import { createUpgradeProgressRenderer } from "./upgrade-progress.js";
 import {
   parseUpgradeArguments,
   upgradeCommandChannel,
@@ -88,6 +90,7 @@ export interface UpgradeCliDependencies {
   readonly fetcher?: RegistryFetch;
   readonly signal?: AbortSignal;
   readonly defaultChannel?: UpgradeChannel;
+  readonly onDownloadProgress?: PackageDownloadProgressHandler;
 }
 
 export interface UpgradeCliOutput {
@@ -156,7 +159,8 @@ export async function executeUpgradeCli(
       method,
       registry,
       dependencies,
-      parsed.force
+      parsed.force,
+      parsed.json ? undefined : dependencies.onDownloadProgress
     );
     return {
       exitCode: 0,
@@ -187,7 +191,8 @@ async function dispatchUpgradeCommand(
   method: UpgradeMethod,
   registry: UpgradeRegistry,
   dependencies: UpgradeCliDependencies,
-  force: boolean
+  force: boolean,
+  onDownloadProgress: PackageDownloadProgressHandler | undefined
 ): Promise<UpgradeSuccessEnvelope> {
   switch (command.kind) {
     case "rollback": {
@@ -232,6 +237,7 @@ async function dispatchUpgradeCommand(
           registry,
           fetcher: dependencies.fetcher,
           signal: dependencies.signal,
+          onDownloadProgress,
           force
         });
       }
@@ -348,11 +354,17 @@ export async function runProcessUpgrade(
   process.once("SIGINT", onSigInt);
   process.once("SIGTERM", onSigTerm);
   try {
+    const onDownloadProgress = process.stderr.isTTY
+      ? createUpgradeProgressRenderer((text) => {
+          process.stderr.write(text);
+        }, process.stderr.columns ?? 80)
+      : undefined;
     const output = await executeUpgradeCli(argv, {
       signal: controller.signal,
       registry: new NpmUpgradeRegistry(fetcher),
       fetcher,
-      defaultChannel: loadConfig().updates.channel
+      defaultChannel: loadConfig().updates.channel,
+      onDownloadProgress
     });
     if (output.stdout.length > 0) process.stdout.write(output.stdout);
     if (output.stderr.length > 0) process.stderr.write(output.stderr);

--- a/tui/src/upgrade-download.ts
+++ b/tui/src/upgrade-download.ts
@@ -16,6 +16,16 @@ import { UpgradeFailure } from "./upgrade-contract.js";
 
 export type PackageFetch = (input: string, init: RequestInit) => Promise<Response>;
 
+export interface PackageDownloadProgress {
+  readonly downloadedBytes: number;
+  readonly totalBytes: number | null;
+  readonly state: "active" | "complete" | "failed";
+}
+
+export type PackageDownloadProgressHandler = (
+  progress: PackageDownloadProgress
+) => void;
+
 /** Cumulative wall-clock deadline for headers plus the complete body (600s). */
 export const DEFAULT_PACKAGE_DOWNLOAD_TIMEOUT_MS = RELEASE_TRANSFER_TOTAL_TIMEOUT_MS;
 /** Body-idle bound between chunks; independent of the wall-clock deadline (60s). */
@@ -34,6 +44,7 @@ export async function downloadPlatformPackage(options: {
   readonly signal: AbortSignal;
   readonly fetcher?: PackageFetch;
   readonly maximumBytes?: number;
+  readonly onProgress?: PackageDownloadProgressHandler;
   /** Deterministic short wall-clock timeout for tests; defaults to production. */
   readonly requestTimeoutMs?: number;
   /** Deterministic short body-idle timeout for tests; defaults to production. */
@@ -68,6 +79,26 @@ export async function downloadPlatformPackage(options: {
     () => wallTimeout.abort(new DOMException("Package download timed out", "TimeoutError")),
     wallTimeoutMs
   );
+  let progressStarted = false;
+  let progressEnded = false;
+  let lastProgressBucket = -1;
+  let downloadedBytes = 0;
+  let totalBytes: number | null = null;
+  const reportProgress = (state: PackageDownloadProgress["state"]): void => {
+    if (!progressStarted || options.onProgress === undefined) return;
+    if (state === "active") {
+      const bucket = totalBytes === null
+        ? Math.floor(downloadedBytes / (1024 * 1024))
+        : Math.floor(100 * downloadedBytes / totalBytes);
+      if (bucket === lastProgressBucket) return;
+      lastProgressBucket = bucket;
+    }
+    try {
+      options.onProgress(Object.freeze({ downloadedBytes, totalBytes, state }));
+    } catch {
+      // Progress is advisory. A closed terminal must not change the upgrade.
+    }
+  };
   let response: Response | undefined;
   try {
     try {
@@ -97,6 +128,9 @@ export async function downloadPlatformPackage(options: {
       await cancelResponseBody(response);
       throw new UpgradeFailure("verification_failed", "Release package size is outside the bound.");
     }
+    totalBytes = declared !== null && Number(declared) > 0 ? Number(declared) : null;
+    progressStarted = true;
+    reportProgress("active");
 
     const hash = createHash("sha512");
     let fd: number | null = null;
@@ -152,6 +186,8 @@ export async function downloadPlatformPackage(options: {
           bytes += chunk.byteLength;
           hash.update(chunk);
           writeAll(fd, chunk);
+          downloadedBytes = bytes;
+          reportProgress("active");
         }
       } finally {
         if (idleTimer !== null) clearTimeout(idleTimer);
@@ -189,9 +225,12 @@ export async function downloadPlatformPackage(options: {
         "Release package integrity did not match the registry metadata."
       );
     }
+    reportProgress("complete");
+    progressEnded = true;
     return Object.freeze({ bytes, sha512Hex });
   } finally {
     clearTimeout(wallTimer);
+    if (!progressEnded) reportProgress("failed");
   }
 }
 

--- a/tui/src/upgrade-progress.ts
+++ b/tui/src/upgrade-progress.ts
@@ -1,0 +1,51 @@
+import type {
+  PackageDownloadProgress,
+  PackageDownloadProgressHandler
+} from "./upgrade-download.js";
+
+const MAX_BAR_WIDTH = 24;
+
+/** Render one in-place download bar. The caller owns terminal detection. */
+export function createUpgradeProgressRenderer(
+  write: (text: string) => void,
+  columns = 80
+): PackageDownloadProgressHandler {
+  const availableColumns = Math.max(8, Math.floor(columns));
+  let previousWidth = 0;
+  return (progress) => {
+    const line = progressLine(progress, availableColumns);
+    const padding = " ".repeat(Math.max(0, previousWidth - line.length));
+    const ended = progress.state !== "active";
+    write(`\r${line}${padding}${ended ? "\n" : ""}`);
+    previousWidth = ended ? 0 : line.length;
+  };
+}
+
+function progressLine(progress: PackageDownloadProgress, columns: number): string {
+  const total = progress.totalBytes;
+  const complete = progress.state === "complete";
+  const percent = total === null
+    ? complete ? "100%" : ""
+    : `${Math.round(Math.min(1, progress.downloadedBytes / total) * 100)}%`;
+  const label = columns >= 24 ? "Downloading " : "";
+  const suffix = percent.length > 0 ? ` ${percent}` : "";
+  const barWidth = Math.max(
+    1,
+    Math.min(MAX_BAR_WIDTH, columns - label.length - suffix.length - 2)
+  );
+
+  if (total === null) {
+    const filled = complete
+      ? barWidth
+      : Math.min(barWidth - 1, Math.floor(progress.downloadedBytes / 65_536) % barWidth);
+    const bar = complete
+      ? "#".repeat(barWidth)
+      : `${"#".repeat(filled)}>${".".repeat(barWidth - filled - 1)}`;
+    return `${label}[${bar}]${suffix}`;
+  }
+
+  const ratio = Math.min(1, progress.downloadedBytes / total);
+  const filled = Math.round(barWidth * ratio);
+  const bar = `${"#".repeat(filled)}${".".repeat(barWidth - filled)}`;
+  return `${label}[${bar}]${suffix}`;
+}

--- a/tui/test/managed-install-policy.test.ts
+++ b/tui/test/managed-install-policy.test.ts
@@ -1,9 +1,11 @@
 import { expect, test } from "bun:test";
+import { createHash } from "node:crypto";
 import { rmSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { canonicalNpmTarballUrl } from "../../shared/npm-tarball-url.js";
 import { downloadPlatformPackage } from "../src/upgrade-download.js";
 import { executeUpgradeCli } from "../src/upgrade-cli.js";
+import { createUpgradeProgressRenderer } from "../src/upgrade-progress.js";
 import {
   MANAGED_TEST_CURRENT as CURRENT,
   MANAGED_TEST_NEXT as NEXT,
@@ -67,6 +69,41 @@ test("oversized download is refused with a small injected bound", async () => {
   }
 });
 
+test("download progress is bounded when transport chunks are tiny", async () => {
+  const root = managedScratchRoot("policy-progress-");
+  try {
+    const destination = path.join(root, "pkg.tgz");
+    const body = new Uint8Array(1_000).fill(7);
+    const progress: import("../src/upgrade-download.js").PackageDownloadProgress[] = [];
+    await downloadPlatformPackage({
+      tarballUrl: canonicalNpmTarballUrl(PACKAGE, "1.0.0"),
+      packageName: PACKAGE,
+      version: "1.0.0",
+      integrity: `sha512-${createHash("sha512").update(body).digest("base64")}`,
+      destinationPath: destination,
+      signal: new AbortController().signal,
+      onProgress: (event) => progress.push(event),
+      fetcher: async () => new Response(new ReadableStream({
+        start(controller) {
+          for (const byte of body) controller.enqueue(new Uint8Array([byte]));
+          controller.close();
+        }
+      }), {
+        status: 200,
+        headers: { "content-length": String(body.byteLength) }
+      })
+    });
+    expect(progress.length <= 102).toBe(true);
+    expect(progress[0]).toMatchObject({ downloadedBytes: 0, state: "active" });
+    expect(progress.at(-1)).toMatchObject({
+      downloadedBytes: body.byteLength,
+      state: "complete"
+    });
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("stalled package download headers are a retryable network failure", async () => {
   const root = managedScratchRoot("policy-headers-");
   try {
@@ -114,6 +151,7 @@ test("stalled package download body idle is a retryable network failure", async 
     const destination = path.join(root, "pkg.tgz");
     let bodyCancelled = false;
     let failed: unknown;
+    const progressWrites: string[] = [];
     try {
       await downloadPlatformPackage({
         tarballUrl: canonicalNpmTarballUrl(PACKAGE, "1.0.0"),
@@ -125,6 +163,7 @@ test("stalled package download body idle is a retryable network failure", async 
         // Short idle; long wall so body silence is an idle failure, not wall-clock.
         requestTimeoutMs: 5_000,
         idleTimeoutMs: 40,
+        onProgress: createUpgradeProgressRenderer((text) => progressWrites.push(text)),
         fetcher: async () => new Response(new ReadableStream({
           start(controller) {
             // Headers resolve; body never emits a chunk so the idle deadline fires.
@@ -142,6 +181,9 @@ test("stalled package download body idle is a retryable network failure", async 
     const failure = failed as import("../src/upgrade-contract.js").UpgradeFailure;
     expect(failure.code).toBe("network_error");
     expect(failure.retryable).toBe(true);
+    const progress = progressWrites.join("");
+    expect(progress).not.toContain("100%");
+    expect(progress.endsWith("\n")).toBe(true);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/tui/test/managed-install-upgrade.test.ts
+++ b/tui/test/managed-install-upgrade.test.ts
@@ -18,6 +18,7 @@ import {
 } from "../src/install-transaction.js";
 import { downloadPlatformPackage } from "../src/upgrade-download.js";
 import { executeUpgradeCli } from "../src/upgrade-cli.js";
+import { createUpgradeProgressRenderer } from "../src/upgrade-progress.js";
 import {
   MANAGED_TEST_CURRENT as CURRENT,
   MANAGED_TEST_NEXT as NEXT,
@@ -43,6 +44,7 @@ test("unqualified managed upgrade defaults to Ownership Record channel beta", as
       version: NEXT,
       target: TARGET
     });
+    let progressEvents = 0;
     const result = await executeUpgradeCli(["--json"], {
       authority,
       observation: {
@@ -51,6 +53,9 @@ test("unqualified managed upgrade defaults to Ownership Record channel beta", as
         },
       registry: fakeManagedRegistry(NEXT, PACKAGE, pkg.integrity, pkg.tarballUrl),
       fetcher: async () => new Response(new Uint8Array(pkg.bytes), { status: 200 }),
+      onDownloadProgress: () => {
+        progressEvents += 1;
+      },
       defaultChannel: "stable"
     });
     expect(result.exitCode).toBe(0);
@@ -59,6 +64,48 @@ test("unqualified managed upgrade defaults to Ownership Record channel beta", as
       channel: "beta",
       method: "shell"
     });
+    expect(progressEvents).toBe(0);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("managed human upgrade renders live download progress", async () => {
+  const root = managedScratchRoot("progress-");
+  try {
+    const installRoot = path.join(root, "bin");
+    mkdirSync(installRoot, { mode: 0o755 });
+    chmodSync(installRoot, 0o755);
+    const { authority } = shellManagedAuthority(installRoot, "stable");
+    const pkg = buildCanonicalPlatformPackage({
+      packageName: PACKAGE,
+      version: NEXT,
+      target: TARGET
+    });
+    const writes: string[] = [];
+    const result = await executeUpgradeCli([], {
+      authority,
+      observation: {
+        currentVersion: CURRENT,
+        platformPackage: PACKAGE
+      },
+      registry: fakeManagedRegistry(NEXT, PACKAGE, pkg.integrity, pkg.tarballUrl),
+      fetcher: async () => new Response(new Uint8Array(pkg.bytes), {
+        status: 200,
+        headers: { "content-length": String(pkg.bytes.byteLength) }
+      }),
+      onDownloadProgress: createUpgradeProgressRenderer((text) => writes.push(text), 32)
+    });
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain(`Upgraded 1667 from ${CURRENT} to ${NEXT}.`);
+    expect(result.stderr).toBe("");
+    const progress = writes.join("");
+    expect(progress).toContain("\rDownloading [");
+    expect(progress).toContain("100%");
+    expect(progress.endsWith("\n")).toBe(true);
+    for (const update of progress.split("\r").filter(Boolean)) {
+      expect(update.replace(/\n$/u, "").length <= 32).toBe(true);
+    }
   } finally {
     rmSync(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
Closes #82.

## What changed

- show a bounded in-place download bar for shell-managed upgrades on a terminal
- keep redirected output and `--json` free of progress records
- show native PowerShell download progress for Windows installs and upgrades
- fit the terminal bar to narrow widths and end it cleanly on failure

## Why

Managed upgrades were silent while downloading, verifying, and staging the release package. A slow download looked like a frozen command.

## Verification

- root and TUI typechecks
- 41 focused managed-upgrade tests
- six Shell Installer integration tests
- full TUI suite: 1,592 passed
- isolated root settings suite: 19 passed
- isolated tokenizer probe suite passed
- thermo-nuclear review clean after three accepted hardening findings
- autoreview clean with no actionable findings

The broad root suite under local Node 24 hit two unrelated concurrency/runtime flakes. Both failing files passed in isolation. Protected CI uses Node 22 as the full merge gate.
