### PR TITLE
chore(release): prepare 0.5.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "1667-workspace",
-  "version": "0.5.4-rc.1",
+  "version": "0.5.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "1667-workspace",
-      "version": "0.5.4-rc.1",
+      "version": "0.5.4",
       "license": "Apache-2.0",
       "dependencies": {
         "fs-ext-extra-prebuilt": "2.2.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667-workspace",
-  "version": "0.5.4-rc.1",
+  "version": "0.5.4",
   "private": true,
   "description": "Source workspace for the 1667 terminal writing environment",
   "license": "Apache-2.0",

--- a/tui/package.json
+++ b/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667",
-  "version": "0.5.4-rc.1",
+  "version": "0.5.4",
   "private": true,
   "description": "A terminal environment for writing fiction with language models",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary

- Set the root package version to `0.5.4`.
- Set the TUI package version to `0.5.4`.
- Keep the root lockfile version fields synchronized.

Same product contents as `0.5.4-rc.1`: live download progress for managed upgrades and the Windows Installer.

A stable version publishes to `latest`. After publication, the homepage stable Shell and PowerShell Installers will promote to 0.5.4.

## Verification

- `npm run typecheck`
- TUI `npm run typecheck`
- Release identity, content, preflight, and build tests: 16 pass, 0 fail
- `v0.5.4-rc.1` release run: success
- GitHub prerelease: immutable, 27 assets
- npm `beta`: `0.5.4-rc.1`

Closes #86