### PR TITLE
feat(vault): encrypt project storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ repository contains the terminal user interface (TUI) and its backend runtime.
 - Manage chapter boundaries and chapter summaries in the Chapters view.
 - Edit story parts, facts, and chapter summaries in the full-screen editor.
 - Use the embedded backend worker without a network port.
+- Seal project files at rest with a Vault Password.
 - Stop a generation and save model text that already arrived.
 - Connect to OpenAI-compatible endpoints or Anthropic Messages endpoints.
 

--- a/docs/story-storage.md
+++ b/docs/story-storage.md
@@ -47,6 +47,59 @@ HTTP server mode requires the machine tier outside the project.
 The project `.gitignore` excludes machine-local provider secret files. It also
 excludes `lock` and `run.json`.
 
+## Vault encryption
+
+Use `1667 encrypt` to seal the project files of a stopped vault:
+
+```sh
+1667 encrypt
+```
+
+1667 asks for the Vault Password two times. A non-interactive command must use
+`--passphrase-file <path>`. The passphrase file must be outside `.1667/`.
+
+Use `1667 decrypt` to unseal the project files:
+
+```sh
+1667 decrypt
+```
+
+A start in a sealed vault asks for the Vault Password. The prompt permits three
+attempts. The `export`, `import`, `import-card`, `import-lorebook`, and `profile`
+commands accept `--passphrase-file <path>`. The `serve` command does not open a
+sealed vault.
+
+Keep the Vault Password in a safe location. 1667 cannot recover a lost Vault
+Password. An interrupted operation stays safe. Run the same `encrypt` or
+`decrypt` command again to complete the operation.
+
+Vault encryption protects new project file contents on disk. It does not remove
+plaintext from old backups, snapshots, sync history, or freed disk blocks. It
+does not protect process memory or operating system swap. Generation sends the
+required story content to the selected provider. An export writes plaintext to
+the working tier.
+
+File names and directory names stay plaintext. They show story identifiers,
+object counts, object sizes, and writing activity. Object file names also show
+content hashes.
+
+These control files stay plaintext:
+
+- `lock`
+- `data-id` and its scratch file
+- `owner.json` and its publication files
+- `run.json`
+- `.gitignore`
+- `vault.json`
+- `.1667-vault-unseal-progress/` during an unseal operation
+- `stories/<id>/.1667-cleanup-needed`
+
+The unseal progress directory contains one record for each file that 1667
+unsealed. 1667 removes the directory after it publishes the format-4 marker.
+
+Provider secrets stay in the machine tier. Vault encryption does not change the
+machine tier.
+
 ## Story objects
 
 1667 stores story prose in the project tier as text revisions and chunks. A

--- a/docs/technical-terms.md
+++ b/docs/technical-terms.md
@@ -16,6 +16,15 @@ read_when:
 | backend | The service that stores stories and sends provider requests |
 | character card | A V1 or V2 character card file that another tool wrote |
 | project | A project root and its `.1667/` directory |
+| vault | One project whose project files can be sealed |
+| sealed file | A project file that contains ciphertext on disk |
+| seal | To encrypt the bytes of one project file with the Vault Key |
+| unseal | To decrypt the bytes of one sealed file with the Vault Key |
+| Vault Key | The random key that seals the files of one vault |
+| Vault Password | The secret text that opens the Vault Key |
+| Keyslot | The plaintext `vault.json` control file that contains the sealed Vault Key |
+| control file | A project file that must stay plaintext so that 1667 can open a vault |
+| unseal progress directory | The plaintext `.1667-vault-unseal-progress/` directory that records an interrupted unseal operation |
 | reserved file | A control file that 1667 writes one time and does not change |
 | scratch file | The temporary publication copy of one reserved file |
 | story part | One unit of story prose |

--- a/schema/vault-cipher.corpus.json
+++ b/schema/vault-cipher.corpus.json
@@ -1,0 +1,22 @@
+{
+  "sealedFile": {
+    "magicHex": "0031363637560101",
+    "overheadBytes": 36,
+    "nonceBytes": 12,
+    "tagBytes": 16
+  },
+  "keyslot": {
+    "format": 1,
+    "kdf": {
+      "name": "scrypt",
+      "n": 131072,
+      "r": 8,
+      "p": 1,
+      "saltBytes": 32
+    },
+    "sealedKey": {
+      "nonceBytes": 12,
+      "dataBytes": 48
+    }
+  }
+}

--- a/server/bounded-file.ts
+++ b/server/bounded-file.ts
@@ -2,6 +2,10 @@ import { constants } from "node:fs";
 import { open, type FileHandle } from "node:fs/promises";
 import { noFollowFlag } from "./data-directory-file-read.js";
 import { StoryFormatError } from "./story-format-facts.js";
+import {
+  unsealVaultFileForPath,
+  vaultStoredByteLimit
+} from "./vault-key-registry.js";
 
 export class FileSizeLimitError extends StoryFormatError {
   constructor(message: string) {
@@ -12,12 +16,13 @@ export class FileSizeLimitError extends StoryFormatError {
 
 /** Read one regular file while bounding allocation and detecting size races. */
 export async function readBoundedFile(file: string, maxBytes: number, label: string): Promise<Buffer> {
+  const storedMaxBytes = vaultStoredByteLimit(file, maxBytes);
   let handle: FileHandle | undefined;
   try {
     handle = await open(file, constants.O_RDONLY | noFollowFlag());
     const info = await handle.stat();
     if (!info.isFile()) throw new StoryFormatError(`${label} is not a regular file`);
-    if (info.size > maxBytes) throw new FileSizeLimitError(`${label} exceeds its ${maxBytes}-byte size limit`);
+    if (info.size > storedMaxBytes) throw new FileSizeLimitError(`${label} exceeds its ${maxBytes}-byte size limit`);
     const allocation = Buffer.alloc(info.size + 1);
     let total = 0;
     while (total < allocation.length) {
@@ -26,7 +31,11 @@ export async function readBoundedFile(file: string, maxBytes: number, label: str
       total += bytesRead;
     }
     if (total !== info.size) throw new StoryFormatError(`${label} changed size while being read`);
-    return allocation.subarray(0, total);
+    const plaintext = unsealVaultFileForPath(file, allocation.subarray(0, total));
+    if (plaintext.byteLength > maxBytes) {
+      throw new FileSizeLimitError(`${label} exceeds its ${maxBytes}-byte size limit`);
+    }
+    return plaintext;
   } finally {
     await handle?.close();
   }

--- a/server/data-directory-file-read.ts
+++ b/server/data-directory-file-read.ts
@@ -1,5 +1,9 @@
 import { constants, type Stats } from "node:fs";
 import { lstat, open, type FileHandle } from "node:fs/promises";
+import {
+  unsealVaultFileForPath,
+  vaultStoredByteLimit
+} from "./vault-key-registry.js";
 
 export interface BoundedRegularFileOptions {
   readonly requirePrivate?: boolean;
@@ -19,6 +23,7 @@ export async function readBoundedRegularFile(
   maxBytes: number,
   options: BoundedRegularFileOptions = {}
 ): Promise<Buffer> {
+  const storedMaxBytes = vaultStoredByteLimit(file, maxBytes);
   const policy = {
     ...options,
     requirePrivate: options.requirePrivate ?? false,
@@ -27,10 +32,10 @@ export async function readBoundedRegularFile(
   let handle: FileHandle | undefined;
   try {
     const pathInfo = await lstat(file);
-    requireBoundedRegularFile(pathInfo, file, maxBytes, policy);
+    requireBoundedRegularFile(pathInfo, file, storedMaxBytes, policy);
     handle = await open(file, constants.O_RDONLY | noFollowFlag());
     const before = await handle.stat();
-    requireBoundedRegularFile(before, file, maxBytes, policy);
+    requireBoundedRegularFile(before, file, storedMaxBytes, policy);
     requireSameFileIdentity(pathInfo, before, file);
 
     const bytes = Buffer.alloc(Number(before.size) + 1);
@@ -42,7 +47,7 @@ export async function readBoundedRegularFile(
     }
 
     const after = await handle.stat();
-    requireBoundedRegularFile(after, file, maxBytes, policy);
+    requireBoundedRegularFile(after, file, storedMaxBytes, policy);
     if (
       total !== Number(before.size)
       || !sameFileSnapshot(before, after)
@@ -50,9 +55,13 @@ export async function readBoundedRegularFile(
       throw new Error(`Reserved data-directory file changed while being read: ${file}`);
     }
     const finalPathInfo = await lstat(file);
-    requireBoundedRegularFile(finalPathInfo, file, maxBytes, policy);
+    requireBoundedRegularFile(finalPathInfo, file, storedMaxBytes, policy);
     requireSameFileIdentity(after, finalPathInfo, file);
-    return bytes.subarray(0, total);
+    const plaintext = unsealVaultFileForPath(file, bytes.subarray(0, total));
+    if (plaintext.byteLength > maxBytes) {
+      throw new Error(`Reserved data-directory file exceeds its ${maxBytes}-byte size limit: ${file}`);
+    }
+    return plaintext;
   } finally {
     await handle?.close();
   }
@@ -72,6 +81,7 @@ export async function readBoundedMutableAuthorityFile(
   maxBytes: number,
   options: MutableAuthorityFileOptions = {}
 ): Promise<Buffer> {
+  const storedMaxBytes = vaultStoredByteLimit(file, maxBytes);
   const linkedPolicy = {
     requirePrivate: options.requirePrivate ?? false,
     allowedLinkCounts: [1]
@@ -101,11 +111,11 @@ export async function readBoundedMutableAuthorityFile(
     try {
       const pathInfo = await lstat(file);
       if (replacementInFlight(pathInfo, attempt)) continue;
-      requireBoundedRegularFile(pathInfo, file, maxBytes, linkedPolicy);
+      requireBoundedRegularFile(pathInfo, file, storedMaxBytes, linkedPolicy);
       handle = await open(file, constants.O_RDONLY | noFollowFlag());
       const before = await handle.stat();
       if (replacementInFlight(before, attempt)) continue;
-      requireBoundedRegularFile(before, file, maxBytes, openedPolicy);
+      requireBoundedRegularFile(before, file, storedMaxBytes, openedPolicy);
       if (!sameFileIdentity(pathInfo, before)) continue;
 
       const bytes = Buffer.alloc(Number(before.size) + 1);
@@ -118,7 +128,7 @@ export async function readBoundedMutableAuthorityFile(
 
       const after = await handle.stat();
       if (replacementInFlight(after, attempt)) continue;
-      requireBoundedRegularFile(after, file, maxBytes, openedPolicy);
+      requireBoundedRegularFile(after, file, storedMaxBytes, openedPolicy);
       if (
         total !== Number(before.size)
         || !sameMutableAuthoritySnapshot(before, after)
@@ -129,11 +139,15 @@ export async function readBoundedMutableAuthorityFile(
         await requireDistinctLinkedReplacement(
           file,
           after,
-          maxBytes,
+          storedMaxBytes,
           linkedPolicy
         );
       }
-      return bytes.subarray(0, total);
+      const plaintext = unsealVaultFileForPath(file, bytes.subarray(0, total));
+      if (plaintext.byteLength > maxBytes) {
+        throw new Error(`Mutable data-directory authority exceeds its ${maxBytes}-byte size limit: ${file}`);
+      }
+      return plaintext;
     } finally {
       await handle?.close();
     }

--- a/server/data-directory-format.ts
+++ b/server/data-directory-format.ts
@@ -119,7 +119,9 @@ export async function readDataDirectoryFormatSource(
   }
   const dataFormat = parseDataDirectoryOwnerMarkerBytes(ownerBytes, ownerMarker).dataFormat;
   requireSupportedDataDirectoryFormat(dataFormat, options.supportedFormats);
-  if (dataFormat >= 2) await validateSettingsStateV2(dataDir);
+  // Format 5 seals settings state. The owner marker is deliberately plaintext
+  // so callers can identify a locked vault before they have its Vault Key.
+  if (dataFormat >= 2 && dataFormat !== 5) await validateSettingsStateV2(dataDir);
   return { dataFormat, source: "owner-marker" };
 }
 
@@ -131,7 +133,7 @@ export async function discardOwnerMarkerNextResidue(dataDir: string): Promise<vo
   const nextPath = path.join(dataDir, DATA_DIRECTORY_OWNER_MARKER_NEXT);
   await inspectTypedPrivatePublicationResidue(
     nextPath,
-    ([1, 2, 3, 4] as const).map((dataFormat) =>
+    ([1, 2, 3, 4, 5] as const).map((dataFormat) =>
       Buffer.from(dataDirectoryOwnerMarkerText(dataFormat), "utf8")),
     OWNER_MARKER_POLICY,
     (detail, cause) => invalidMarkerError(nextPath, detail, cause)
@@ -179,8 +181,8 @@ export function parseDataDirectoryOwnerMarkerBytes(
     literal(marker.product, "1667", "data-directory owner marker.product");
     literal(marker.markerSchema, 1, "data-directory owner marker.markerSchema");
     literal(marker.lockProtocol, 1, "data-directory owner marker.lockProtocol");
-    if (marker.dataFormat !== 1 && marker.dataFormat !== 2 && marker.dataFormat !== 3 && marker.dataFormat !== 4) {
-      throw new Error("data-directory owner marker.dataFormat must be 1, 2, 3, or 4");
+    if (marker.dataFormat !== 1 && marker.dataFormat !== 2 && marker.dataFormat !== 3 && marker.dataFormat !== 4 && marker.dataFormat !== 5) {
+      throw new Error("data-directory owner marker.dataFormat must be 1, 2, 3, 4, or 5");
     }
     assertNfcJsonStrings(value, "data-directory owner marker");
     if (canonicalJson(value) !== text) {

--- a/server/data-directory-layout.ts
+++ b/server/data-directory-layout.ts
@@ -1,10 +1,10 @@
 import { privatePublicationScratchPath } from "./private-file-publication.js";
 
-/** Format 4 is format 3 plus the optional author note on a story. Nothing
- * moved on disk, so the number is the whole fence — an older executable
+/** Format 5 is format 4 plus sealed vault files. The file layout does not
+ * change, so the number is the whole fence — an older executable
  * refuses the directory at the marker rather than failing later on data it
  * believed it understood. */
-export type DataDirectoryFormat = 1 | 2 | 3 | 4;
+export type DataDirectoryFormat = 1 | 2 | 3 | 4 | 5;
 
 /**
  * Project-tier names. The product prefix these once carried existed to
@@ -23,6 +23,8 @@ export const DATA_DIRECTORY_OWNER_MARKER = "owner.json";
 export const DATA_DIRECTORY_OWNER_MARKER_NEXT = "owner.json.next";
 /** Advisory record of the process serving this project. Never authoritative. */
 export const PROJECT_RUN_RECORD_FILE = "run.json";
+/** Plaintext Keyslot for a sealed vault. */
+export const VAULT_KEYSLOT_FILE = "vault.json";
 
 /**
  * Names written by older builds. Nothing creates them; `1667 init
@@ -105,6 +107,7 @@ export const PROJECT_CONTROL_ENTRY_NAMES = Object.freeze([
   DATA_DIRECTORY_OWNER_MARKER_NEXT,
   DATA_DIRECTORY_OWNER_MARKER_NEXT_SCRATCH,
   PROJECT_RUN_RECORD_FILE,
+  VAULT_KEYSLOT_FILE,
   LEGACY_DATA_OWNER_MARKER,
   LEGACY_DATA_OWNER_MARKER_NEXT,
   LEGACY_EXCLUSION_FENCE,

--- a/server/json-schema-version.ts
+++ b/server/json-schema-version.ts
@@ -1,8 +1,10 @@
 import { constants, type BigIntStats } from "node:fs";
 import { open, type FileHandle } from "node:fs/promises";
 import { noFollowFlag } from "./data-directory-file-read.js";
+import { readBoundedFile } from "./bounded-file.js";
 import { StoryFormatError } from "./story-format-facts.js";
 import { SchemaVersionNumberScanner } from "./schema-version-number.js";
+import { hasVaultKeyForPath } from "./vault-key-registry.js";
 
 const READ_CHUNK_BYTES = 64 * 1024;
 const MAX_SCHEMA_KEY_BYTES = "schemaVersion".length * 6;
@@ -22,6 +24,12 @@ export async function readOversizeLegacyManifestBytes(
   file: string,
   label: string
 ): Promise<Buffer | null> {
+  // Ciphertext has a fixed prefix and cannot be classified by the streaming
+  // JSON scanner. The bounded reader restores its plaintext size contract.
+  if (hasVaultKeyForPath(file)) {
+    const plaintext = await readBoundedFile(file, MAX_LEGACY_STORY_MANIFEST_BYTES, label);
+    return hasLegacyTopLevelSchemaVersion(plaintext) ? plaintext : null;
+  }
   let handle: FileHandle | undefined;
   try {
     handle = await open(file, constants.O_RDONLY | noFollowFlag());

--- a/server/legacy-data-directory.ts
+++ b/server/legacy-data-directory.ts
@@ -111,7 +111,11 @@ async function validateRetainedLegacyDataDirectory(
 /** Retain, lock, and validate one legacy directory as one authority. */
 export async function acquireLegacyDataDirectoryLease(
   dataDirInput: string,
-  machineDirectory: string
+  machineDirectory: string,
+  options: {
+    /** Checked before validation and again after this function owns all data locks. */
+    readonly validateAuthority?: (authorityPath: string) => Promise<void>;
+  } = {}
 ): Promise<LegacyDataDirectoryLease> {
   assertLegacyDataDirectoryPlatform();
   const authorityInput = path.resolve(dataDirInput);
@@ -149,12 +153,17 @@ export async function acquireLegacyDataDirectoryLease(
       dataDir,
       directoryHandle.fd
     );
+    await options.validateAuthority?.(authorityPath);
     await validateRetainedLegacyDataDirectory(authorityPath, dataDir);
     for (const fileName of LEGACY_LEASE_FILES) {
       leases.push(await acquireLegacyFileLock(
         path.join(authorityPath, fileName)
       ));
     }
+    // A peer can publish the format fence after the first validation and
+    // before this process takes the lease. Check it again through the retained
+    // authority before any service setup starts.
+    await options.validateAuthority?.(authorityPath);
     await assertLockingFilesystem(
       path.join(authorityPath, DATA_DIRECTORY_LOCK),
       dataDir

--- a/server/mutation-outbox.ts
+++ b/server/mutation-outbox.ts
@@ -1,4 +1,4 @@
-import { readFile, readdir } from "node:fs/promises";
+import { readdir } from "node:fs/promises";
 import path from "node:path";
 import { isDeepStrictEqual } from "node:util";
 import { exactStringPattern } from "./story-wire-patterns.js";
@@ -31,6 +31,7 @@ import {
   unlinkDurable,
   writeDurableAtomic
 } from "./story-lifecycle.js";
+import { readUnsealedFile } from "./vault-file-read.js";
 
 const LEGACY_MUTATION_ID_PATTERN = exactStringPattern("m1-[0-9a-z]+-[0-9a-f]{32}");
 const CANCELLATION_MARKER_SUFFIX = ".cancelled.json";
@@ -170,7 +171,7 @@ export class MutationOutbox {
     let intent: MutationOutboxRecord;
     try {
       intent = parseRecord(
-        JSON.parse(await readFile(this.file(mutationId), "utf8")) as unknown,
+        JSON.parse((await readUnsealedFile(this.file(mutationId))).toString("utf8")) as unknown,
         mutationId
       );
     } catch (error) {
@@ -195,7 +196,7 @@ export class MutationOutbox {
   ): Promise<ArchivedMutationOutboxRecord> {
     validateMutationId(mutationId);
     const intent = parseRecord(
-      JSON.parse(await readFile(this.file(mutationId), "utf8")) as unknown,
+      JSON.parse((await readUnsealedFile(this.file(mutationId))).toString("utf8")) as unknown,
       mutationId
     );
     const archiveDir = this.archiveDir();
@@ -235,7 +236,7 @@ export class MutationOutbox {
     for (const name of names) {
       const mutationId = name.slice(0, -5);
       validateMutationId(mutationId);
-      const value: unknown = JSON.parse(await readFile(path.join(this.dir, name), "utf8"));
+      const value: unknown = JSON.parse((await readUnsealedFile(path.join(this.dir, name))).toString("utf8"));
       records.push(parseRecord(value, mutationId));
     }
     const seenSequences = new Set<number>();
@@ -261,7 +262,7 @@ export class MutationOutbox {
       const mutationId = name.slice(0, -CANCELLATION_MARKER_SUFFIX.length);
       validateMutationId(mutationId);
       const value: unknown = JSON.parse(
-        await readFile(path.join(this.dir, name), "utf8")
+        (await readUnsealedFile(path.join(this.dir, name))).toString("utf8")
       );
       return parseCancellationMarker(value, mutationId).mutationId;
     }));
@@ -282,7 +283,7 @@ export class MutationOutbox {
     for (const name of names) {
       const mutationId = name.slice(0, -5);
       validateMutationId(mutationId);
-      const value: unknown = JSON.parse(await readFile(path.join(this.archiveDir(), name), "utf8"));
+      const value: unknown = JSON.parse((await readUnsealedFile(path.join(this.archiveDir(), name))).toString("utf8"));
       records.push(parseArchivedMutationOutboxRecord(
         value,
         mutationId,
@@ -345,10 +346,9 @@ export class MutationOutbox {
   ): Promise<ArchivedMutationOutboxRecord | null> {
     try {
       const value: unknown = JSON.parse(
-        await readFile(
+        (await readUnsealedFile(
           path.join(this.archiveDir(), `${mutationId}.json`),
-          "utf8"
-        )
+        )).toString("utf8")
       );
       return parseArchivedMutationOutboxRecord(
         value,

--- a/server/mutation-receipts.ts
+++ b/server/mutation-receipts.ts
@@ -62,6 +62,7 @@ import {
 } from "./mutation-ledger-types.js";
 import { isProviderMutationId } from "../shared/provider-recovery.js";
 import { mkdirDurable, requireDurableCommit, writeDurableAtomic } from "./story-lifecycle.js";
+import { readUnsealedFile } from "./vault-file-read.js";
 import { exactStringPattern } from "./story-wire-patterns.js";
 
 const LEGACY_MUTATION_ID_PATTERN = exactStringPattern("m1-([0-9a-z]+)-([0-9a-f]{32})");
@@ -331,7 +332,7 @@ export class MutationReceiptStore {
   private async load(mutationId: string): Promise<MutationReceipt | null> {
     validateMutationIdSyntax(mutationId);
     try {
-      const value: unknown = JSON.parse(await readFile(this.file(mutationId), "utf8"));
+      const value: unknown = JSON.parse((await readUnsealedFile(this.file(mutationId))).toString("utf8"));
       return parseMutationReceipt(value, mutationId);
     } catch (error) {
       if (error instanceof Error && "code" in error && error.code === "ENOENT") return null;

--- a/server/private-file-publication.ts
+++ b/server/private-file-publication.ts
@@ -21,6 +21,10 @@ import {
   retainedDirectoryOpenFlags
 } from "./retained-directory-authority.js";
 import { withReservedPathOwnership } from "./reserved-path-owner.js";
+import {
+  sealVaultFileForPath,
+  vaultStoredByteLimit
+} from "./vault-key-registry.js";
 
 /**
  * No-replace publication of reserved private files.
@@ -64,8 +68,10 @@ export async function publishPrivateFileNoReplace(
   policy: PrivateFilePolicy
 ): Promise<void> {
   requireBoundedBytes(bytes, policy);
+  const storedBytes = sealVaultFileForPath(file, bytes);
+  const storedPolicy = vaultStoragePolicy(file, policy);
   await withReservedPathOwnership(file, async () =>
-    await publishOwned(file, bytes, policy));
+    await publishOwned(file, storedBytes, storedPolicy));
 }
 
 async function publishOwned(
@@ -143,7 +149,7 @@ export async function recoverPrivatePublication(
   policy: PrivateFilePolicy
 ): Promise<void> {
   await withReservedPathOwnership(file, async () =>
-    await recoverOwned(file, policy));
+    await recoverOwned(file, vaultStoragePolicy(file, policy)));
 }
 
 async function recoverOwned(
@@ -189,20 +195,27 @@ export async function readOptionalPrivateFile(
   policy: PrivateFilePolicy
 ): Promise<Buffer | null> {
   return await withReservedPathOwnership(file, async () =>
-    await readOptionalOwned(file, policy));
+    await readOptionalOwned(file, policy, vaultStoragePolicy(file, policy)));
 }
 
 async function readOptionalOwned(
   file: string,
-  policy: PrivateFilePolicy
+  policy: PrivateFilePolicy,
+  storedPolicy: PrivateFilePolicy
 ): Promise<Buffer | null> {
   if (await optionalPathInfo(privatePublicationScratchPath(file)) !== null) {
-    await recoverOwned(file, policy);
+    await recoverOwned(file, storedPolicy);
   }
   try {
     if (await optionalPathInfo(file) === null) return null;
     await inspectPrivateDirectory(path.dirname(file), policy.label);
-    return await readBoundedRegularFile(file, policy.maxBytes, regularFileOptions(policy, 1));
+    const stored = await readBoundedRegularFile(
+      file,
+      policy.maxBytes,
+      regularFileOptions(policy, 1)
+    );
+    requireBoundedBytes(stored, policy);
+    return stored;
   } catch (error) {
     if (isErrorCode(error, "ENOENT")) return null;
     throw error;
@@ -225,14 +238,16 @@ export async function readOptionalPrivateFiles(
   return await Promise.all(files.map(
     async (file) => await withReservedPathOwnership(file, async () => {
       if (await optionalPathInfo(privatePublicationScratchPath(file)) !== null) {
-        await recoverOwned(file, policy);
+        await recoverOwned(file, vaultStoragePolicy(file, policy));
       }
       try {
-        return await readBoundedRegularFile(
+        const stored = await readBoundedRegularFile(
           file,
           policy.maxBytes,
           regularFileOptions(policy, 1)
         );
+        requireBoundedBytes(stored, policy);
+        return stored;
       } catch (error) {
         if (isErrorCode(error, "ENOENT")) return null;
         throw error;
@@ -245,10 +260,11 @@ export async function removePrivateFile(
   file: string,
   policy: PrivateFilePolicy
 ): Promise<void> {
+  const storedPolicy = vaultStoragePolicy(file, policy);
   await withReservedPathOwnership(file, async () => {
-    await recoverOwned(file, policy);
+    await recoverOwned(file, storedPolicy);
     try {
-      await inspectPrivateRegularFile(file, policy, 1);
+      await inspectPrivateRegularFile(file, storedPolicy, 1);
       await unlink(file);
     } catch (error) {
       if (isErrorCode(error, "ENOENT")) return;
@@ -330,6 +346,11 @@ function strictScratchPolicy(policy: PrivateFilePolicy): PrivateFilePolicy {
   return policy.allowLegacyReadMode
     ? { label: policy.label, maxBytes: policy.maxBytes }
     : policy;
+}
+
+function vaultStoragePolicy(file: string, policy: PrivateFilePolicy): PrivateFilePolicy {
+  const maxBytes = vaultStoredByteLimit(file, policy.maxBytes);
+  return maxBytes === policy.maxBytes ? policy : { ...policy, maxBytes };
 }
 
 function requirePrivateDirectory(info: Stats, directory: string, label: string): void {

--- a/server/runtime-data-directory.ts
+++ b/server/runtime-data-directory.ts
@@ -44,10 +44,13 @@ export class RuntimeDataDirectoryLock {
     return this.lock.initializedNewDirectory;
   }
 
-  async acquire(): Promise<string> {
+  async acquire(
+    options: { readonly beforeMigration?: (lockedDataDirectory: string) => Promise<void> } = {}
+  ): Promise<string> {
     return await this.serializeRunRecord(async () => {
       try {
         const canonicalDir = await this.lock.acquire();
+        await options.beforeMigration?.(canonicalDir);
         await this.lock.migrateSettingsFormat();
         this.acquired = true;
         this.canonicalDir = canonicalDir;

--- a/server/settings.ts
+++ b/server/settings.ts
@@ -53,7 +53,7 @@ const PROVIDERS: readonly Provider[] = ["dry-run", "openai-compatible", "anthrop
  * read. So the store's presence, not one exact number, is the discriminant. */
 type InitializedSettingsStore =
   | { readonly dataFormat: 1 }
-  | { readonly dataFormat: 2 | 3 | 4; readonly store: SettingsV2Store };
+  | { readonly dataFormat: 2 | 3 | 4 | 5; readonly store: SettingsV2Store };
 
 export interface LoadedGenerationSettings {
   readonly settings: GenerationSettings;

--- a/server/story-lifecycle.ts
+++ b/server/story-lifecycle.ts
@@ -1,6 +1,7 @@
 import { mkdir, open, readdir, rename, rm, stat, unlink, type FileHandle } from "node:fs/promises";
 import { createHash, randomUUID } from "node:crypto";
 import path from "node:path";
+import { sealVaultFileForPath } from "./vault-key-registry.js";
 import { isStoryId, STORY_ID_PATTERN_SOURCE } from "./story-v5-strict.js";
 import { exactStringPattern } from "./story-wire-patterns.js";
 
@@ -108,6 +109,16 @@ export async function writeSyncedFile(
   flag: string = "w",
   mode: number = 0o666
 ): Promise<void> {
+  const storedData = sealVaultFileForPath(file, data);
+  await writeSyncedStoredFile(file, storedData, flag, mode);
+}
+
+async function writeSyncedStoredFile(
+  file: string,
+  data: string | Uint8Array,
+  flag: string = "w",
+  mode: number = 0o666
+): Promise<void> {
   const handle = await open(file, flag, mode);
   try {
     await handle.writeFile(data);
@@ -128,8 +139,9 @@ export async function writeDurableFile(
 
 export async function writeDurableAtomic(file: string, data: string | Uint8Array): Promise<CommitResult> {
   const temporary = `${file}.${randomUUID()}.tmp`;
+  const storedData = sealVaultFileForPath(file, data);
   try {
-    await writeSyncedFile(temporary, data, "wx");
+    await writeSyncedStoredFile(temporary, storedData, "wx");
     await rename(temporary, file);
     return await commitBarrier(path.basename(file), path.dirname(file));
   } finally {

--- a/server/story-storage-reader.ts
+++ b/server/story-storage-reader.ts
@@ -1,5 +1,5 @@
 import type { Dirent, Stats } from "node:fs";
-import { lstat, readFile, readdir } from "node:fs/promises";
+import { lstat, readdir } from "node:fs/promises";
 import path from "node:path";
 import type { Story } from "../shared/types.js";
 import { FileSizeLimitError, readBoundedFile } from "./bounded-file.js";
@@ -13,6 +13,7 @@ import {
 import { readOversizeLegacyManifestBytes } from "./json-schema-version.js";
 import { MAX_STORY_MANIFEST_BYTES } from "./story-v5-strict.js";
 import { parseStoryManifestBytes } from "./story-v6-codec.js";
+import { readUnsealedFile } from "./vault-file-read.js";
 import type { DeletedStoryManifestV6, LiveStoryManifestV6 } from "./story-v6-types.js";
 import {
   classifyStoryEntry,
@@ -68,7 +69,7 @@ export function storyMetadataFromSlot(
 
 export async function readOptionalStoryFile(file: string): Promise<Buffer | null> {
   try {
-    return await readFile(file);
+    return await readUnsealedFile(file);
   } catch (error) {
     if (isErrorCode(error, "ENOENT") || isErrorCode(error, "ENAMETOOLONG")) return null;
     throw error;
@@ -131,7 +132,7 @@ export async function readStoredStorySlot(root: string, storyId: string): Promis
   const legacyInfo = await lstatOptionalConstructedPath(legacyPath);
   if (legacyInfo === null) return { kind: "absent" };
   if (!legacyInfo.isFile()) throw new StoryFormatError(`Legacy story path is not a regular file: ${storyId}`);
-  const raw = await readFile(legacyPath);
+  const raw = await readUnsealedFile(legacyPath);
   return { kind: "legacy", story: parseLegacyStory(raw.toString("utf8"), storyId), raw };
 }
 

--- a/server/supervised-serve-child.ts
+++ b/server/supervised-serve-child.ts
@@ -50,6 +50,7 @@ import {
 import { localStartupFailure } from "./local-startup-failure.js";
 import { failureMessageFields } from "../shared/failure-envelope.js";
 import { toPublicServiceError } from "./service-error-policy.js";
+import { refuseSealedVaultForHttp } from "./vault-access-policy.js";
 
 interface IpcProcess extends NodeJS.Process {
   send?: (message: ChildToSupervisorMessage) => boolean;
@@ -57,8 +58,14 @@ interface IpcProcess extends NodeJS.Process {
 
 const ipc = process as IpcProcess;
 
+export interface SupervisedServeChildDependencies {
+  /** @internal Deterministic test seam before the retained vault check. */
+  readonly beforeLockedVaultCheck?: (authorityPath: string) => Promise<void>;
+}
+
 export async function runSupervisedServeChild(
-  argv: readonly string[]
+  argv: readonly string[],
+  dependencies: SupervisedServeChildDependencies = {}
 ): Promise<void> {
   if (ipc.send === undefined) {
     throw new PublicRuntimeError(
@@ -115,7 +122,8 @@ export async function runSupervisedServeChild(
       argv,
       machineDir,
       errorReporterLease,
-      project
+      project,
+      dependencies
     );
   } catch (error) {
     const reported = await errorReporter.report(localStartupFailure(error), {
@@ -165,11 +173,13 @@ async function runSupervisedServeChildCore(
   argv: readonly string[],
   machineDir: string,
   errorReporterLease: InternalErrorReporterLease,
-  project: ResolvedProject
+  project: ResolvedProject,
+  dependencies: SupervisedServeChildDependencies
 ): Promise<void> {
   const dataDir = project.exists
     ? project.directory
     : await createProjectTier(project.directory);
+  await refuseSealedVaultForHttp(dataDir, "serve");
   const port = Number(valueAfter(argv, "--port"));
   const secretFd = Number(valueAfter(argv, "--secret-fd"));
   if (!Number.isSafeInteger(port) || port < 0 || port > 65_535) {
@@ -223,7 +233,13 @@ async function runSupervisedServeChildCore(
           listenerProject.dataDir
         );
         dataLock = acquiredDataLock;
-        displayDataDir = await acquiredDataLock.acquire();
+        displayDataDir = await acquiredDataLock.acquire({
+          beforeMigration: async () => {
+            const authorityPath = acquiredDataLock.authorityPath;
+            await dependencies.beforeLockedVaultCheck?.(authorityPath);
+            await refuseSealedVaultForHttp(authorityPath, "serve");
+          }
+        });
         const lockedDataDir = acquiredDataLock.authorityPath;
         await installRequestedSecrets(
           await credentialNames(lockedDataDir),

--- a/server/vault-access-policy.ts
+++ b/server/vault-access-policy.ts
@@ -1,0 +1,19 @@
+import { readDataDirectoryFormat } from "./data-directory-format.js";
+import { PublicRuntimeError } from "./errors.js";
+
+/** HTTP transports never receive a Vault Key, so they must refuse sealed vaults. */
+export async function refuseSealedVaultForHttp(
+  dataDirectory: string,
+  operation: string
+): Promise<void> {
+  try {
+    if (await readDataDirectoryFormat(dataDirectory) === 5) {
+      throw new PublicRuntimeError(
+        `${operation} cannot open a sealed vault; use the TUI or an offline command with --passphrase-file`
+      );
+    }
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") return;
+    throw error;
+  }
+}

--- a/server/vault-file-read.ts
+++ b/server/vault-file-read.ts
@@ -1,0 +1,7 @@
+import { readFile } from "node:fs/promises";
+import { unsealVaultFileForPath } from "./vault-key-registry.js";
+
+/** Read project bytes and unseal them when their data directory is open. */
+export async function readUnsealedFile(file: string): Promise<Buffer> {
+  return unsealVaultFileForPath(file, await readFile(file));
+}

--- a/server/vault-key-registry.ts
+++ b/server/vault-key-registry.ts
@@ -1,0 +1,149 @@
+import path from "node:path";
+import {
+  VAULT_SEAL_OVERHEAD,
+  isSealed,
+  sealVaultBytes,
+  unsealVaultBytes
+} from "../shared/vault-cipher.js";
+import { isStoryId } from "./story-v5-strict.js";
+import { isVaultUnsealProgressPath } from "./vault-unseal-progress-layout.js";
+
+const keys = new Map<string, VaultKeyRegistrationImpl>();
+const PRIVATE_PUBLICATION_SCRATCH_SUFFIX = ".1667-publish-v1.tmp";
+const PRIVATE_REPLACEMENT_SUFFIX = ".1667-replace-v1.next";
+const ROOT_CONTROL_NAMES = new Set([
+  "lock",
+  "data-id",
+  "owner.json",
+  "owner.json.next",
+  "run.json",
+  ".gitignore",
+  "vault.json",
+  ".1667-data-owner.json",
+  ".1667-data-owner.json.next",
+  ".1667.lock",
+  ".1667.owner-v1",
+  ".1667-data.lock",
+  ".1667-data-v1.json"
+]);
+const CLEANUP_MARKER = ".1667-cleanup-needed";
+const CLEANUP_MARKER_ATOMIC_TEMP = /^\.1667-cleanup-needed\.[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}\.tmp$/;
+
+export interface VaultKeyRegistration {
+  /** Register another lexical path to the same retained vault directory. */
+  addAlias(dataDirectory: string): void;
+  /** Remove every path alias and zero this registration's in-memory key. */
+  clear(): void;
+}
+
+/** Register the in-memory Vault Key for one project directory and return its scope. */
+export function registerVaultKey(dataDirectory: string, key: Uint8Array): VaultKeyRegistration {
+  if (key.byteLength !== 32) throw new Error("Vault Key must be 32 bytes");
+  const registration = new VaultKeyRegistrationImpl(Buffer.from(key));
+  registration.addAlias(dataDirectory);
+  return registration;
+}
+
+export function vaultKeyForPath(file: string): Buffer | null {
+  // The ordinary project path must stay a no-op. Most process starts have no
+  // Vault Key, and avoiding path normalization here preserves the bounded
+  // read/write hot path for an unsealed project.
+  if (keys.size === 0) return null;
+  const resolved = path.resolve(file);
+  for (const [root, registration] of keys) {
+    const relative = path.relative(root, resolved);
+    if (relative === "" || relative === ".." || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) {
+      continue;
+    }
+    if (!isVaultControlPath(root, resolved)) return registration.key;
+  }
+  return null;
+}
+
+class VaultKeyRegistrationImpl implements VaultKeyRegistration {
+  private readonly aliases = new Set<string>();
+  private cleared = false;
+
+  constructor(readonly key: Buffer) {}
+
+  addAlias(dataDirectory: string): void {
+    if (this.cleared) throw new Error("Vault Key registration is already cleared");
+    const alias = path.resolve(dataDirectory);
+    const existing = keys.get(alias);
+    if (existing !== undefined && existing !== this) {
+      throw new Error(`Vault Key path alias is already registered: ${alias}`);
+    }
+    keys.set(alias, this);
+    this.aliases.add(alias);
+  }
+
+  clear(): void {
+    if (this.cleared) return;
+    this.cleared = true;
+    for (const alias of this.aliases) {
+      if (keys.get(alias) === this) keys.delete(alias);
+    }
+    this.aliases.clear();
+    this.key.fill(0);
+  }
+}
+
+export function hasVaultKeyForPath(file: string): boolean {
+  return vaultKeyForPath(file) !== null;
+}
+
+export function sealVaultFileForPath<T extends Uint8Array | string>(
+  file: string,
+  bytes: T
+): T | Buffer {
+  const key = vaultKeyForPath(file);
+  if (key !== null) return sealVaultBytes(key, Buffer.from(bytes));
+  return bytes;
+}
+
+export function unsealVaultFileForPath(file: string, bytes: Uint8Array): Buffer {
+  const key = vaultKeyForPath(file);
+  if (key === null) return Buffer.isBuffer(bytes) ? bytes : Buffer.from(bytes);
+  if (!isSealed(bytes)) throw new Error(`Vault file is not sealed: ${file}`);
+  return unsealVaultBytes(key, bytes, file);
+}
+
+/** The on-disk cap has the same plaintext meaning in sealed and plain vaults. */
+export function vaultStoredByteLimit(file: string, plaintextLimit: number): number {
+  return vaultKeyForPath(file) === null ? plaintextLimit : plaintextLimit + VAULT_SEAL_OVERHEAD;
+}
+
+/** Return true when a path stays plaintext while its containing vault is sealed. */
+export function isVaultControlPath(root: string, fileOrRelative: string): boolean {
+  const relative = path.isAbsolute(fileOrRelative)
+    ? path.relative(path.resolve(root), path.resolve(fileOrRelative))
+    : fileOrRelative;
+  if (relative === "" || relative === ".." || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) {
+    return false;
+  }
+  const parts = relative.split(path.sep);
+  if (isVaultUnsealProgressPath(root, relative)) return true;
+  if (isStoryCleanupControlPath(parts)) return true;
+  if (parts.length !== 1) return false;
+  return isRootControlName(parts[0]!);
+}
+
+function isStoryCleanupControlPath(parts: readonly string[]): boolean {
+  if (parts.length !== 3 || parts[0] !== "stories" || !isStoryId(parts[1]!)) return false;
+  const name = parts[2]!;
+  return name === CLEANUP_MARKER || CLEANUP_MARKER_ATOMIC_TEMP.test(name);
+}
+
+function isRootControlName(name: string): boolean {
+  if (ROOT_CONTROL_NAMES.has(name)) return true;
+  if (name.endsWith(PRIVATE_REPLACEMENT_SUFFIX)) {
+    return ROOT_CONTROL_NAMES.has(name.slice(0, -PRIVATE_REPLACEMENT_SUFFIX.length));
+  }
+  if (!name.endsWith(PRIVATE_PUBLICATION_SCRATCH_SUFFIX)) return false;
+  const publicationTarget = name.slice(0, -PRIVATE_PUBLICATION_SCRATCH_SUFFIX.length);
+  if (ROOT_CONTROL_NAMES.has(publicationTarget)) return true;
+  if (!publicationTarget.endsWith(PRIVATE_REPLACEMENT_SUFFIX)) return false;
+  return ROOT_CONTROL_NAMES.has(
+    publicationTarget.slice(0, -PRIVATE_REPLACEMENT_SUFFIX.length)
+  );
+}

--- a/server/vault-lifecycle.ts
+++ b/server/vault-lifecycle.ts
@@ -1,0 +1,361 @@
+import { constants } from "node:fs";
+import { link, lstat, open, readFile, readdir, rename, unlink } from "node:fs/promises";
+import { randomBytes, randomUUID } from "node:crypto";
+import path from "node:path";
+import {
+  createKeyslot,
+  encodeKeyslot,
+  isSealed,
+  keyslotWithState,
+  parseKeyslot,
+  sealVaultBytes,
+  unsealKeyslot,
+  unsealVaultBytes
+} from "../shared/vault-cipher.js";
+import {
+  VAULT_KEYSLOT_FILE
+} from "./data-directory-layout.js";
+import { publishDataDirectoryOwnerMarker } from "./data-directory-format.js";
+import { DataDirectoryLock } from "./data-directory-lock.js";
+import {
+  publishPrivateFileNoReplace,
+  readOptionalPrivateFile,
+  removePrivateFile,
+  type PrivateFilePolicy
+} from "./private-file-publication.js";
+import { replacePrivateFile } from "./private-file-replacement.js";
+import { syncDirectory } from "./story-lifecycle.js";
+import { isVaultControlPath } from "./vault-key-registry.js";
+import {
+  isVaultUnsealProgressPath,
+  VaultUnsealProgress
+} from "./vault-unseal-progress.js";
+
+export { VAULT_KEYSLOT_FILE } from "./data-directory-layout.js";
+
+const VAULT_KEYSLOT_POLICY: PrivateFilePolicy = Object.freeze({
+  label: "Vault Keyslot",
+  maxBytes: 16 * 1024
+});
+const VAULT_REPLACE_RESIDUE = /^\.1667-vault-replace-[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\.tmp$/;
+const RUN_RECORD_ATOMIC_RESIDUE = /^run\.json\.[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\.tmp$/;
+
+interface VaultFileEntry {
+  readonly file: string;
+  readonly group: string;
+  readonly isControl: boolean;
+}
+
+interface VaultInodeGroup {
+  readonly group: string;
+  readonly representative: string;
+  readonly controls: string[];
+  readonly payloads: string[];
+}
+
+export interface VaultLifecycleOptions {
+  readonly dataDirectory: string;
+  readonly password: VaultPassword;
+}
+
+export interface VaultDecryptLifecycleOptions {
+  readonly dataDirectory: string;
+  readonly password?: VaultPassword;
+  /** @internal Test seam for a crash after one durable unseal replacement. */
+  readonly afterUnsealReplacement?: (files: readonly string[]) => Promise<void>;
+}
+
+export type VaultPassword = string | VaultPasswordProvider;
+
+/** The lifecycle calls this only after it owns the data-directory lock. */
+export type VaultPasswordProvider = (
+  request: VaultPasswordRequest
+) => Promise<string>;
+
+export interface VaultPasswordRequest {
+  readonly command: "encrypt" | "decrypt";
+  readonly resume: boolean;
+}
+
+/** Seal one stopped vault. A second call resumes an interrupted seal pass. */
+export async function encryptVault(options: VaultLifecycleOptions): Promise<void> {
+  const lock = new DataDirectoryLock(options.dataDirectory);
+  await lock.acquire();
+  try {
+    const root = lock.authorityPath;
+    const keyslotPath = path.join(root, VAULT_KEYSLOT_FILE);
+    const bytes = await readOptionalPrivateFile(keyslotPath, VAULT_KEYSLOT_POLICY);
+    if (bytes === null) {
+      if (lock.dataFormat !== 4) throw new Error("encrypt requires data format 4 and no Vault Keyslot");
+      await VaultUnsealProgress.assertAbsent(root);
+      await assertVaultTraversalSafe(root);
+      const password = await resolveVaultPassword(options.password, {
+        command: "encrypt",
+        resume: false
+      });
+      const key = randomBytes(32);
+      const keyslot = await createKeyslot(password, key);
+      await publishPrivateFileNoReplace(
+        keyslotPath,
+        encodeKeyslot(keyslotWithState(keyslot, "sealing")),
+        VAULT_KEYSLOT_POLICY
+      );
+      await publishDataDirectoryOwnerMarker(root, 5);
+      await sealFiles(root, key);
+      await replaceKeyslotState(keyslotPath, keyslot, "sealed");
+      return;
+    }
+    const keyslot = parseKeyslot(bytes);
+    if (keyslot.state !== "sealing") {
+      throw new Error("vault is not ready to encrypt; run 1667 decrypt first if it is sealed");
+    }
+    if (lock.dataFormat !== 4 && lock.dataFormat !== 5) {
+      throw new Error("encrypt resume requires data format 4 or 5");
+    }
+    await VaultUnsealProgress.assertAbsent(root);
+    await assertVaultTraversalSafe(root);
+    const password = await resolveVaultPassword(options.password, {
+      command: "encrypt",
+      resume: true
+    });
+    const key = await unsealKeyslot(password, keyslot);
+    if (lock.dataFormat === 4) await publishDataDirectoryOwnerMarker(root, 5);
+    await sealFiles(root, key);
+    await replaceKeyslotState(keyslotPath, keyslot, "sealed");
+  } finally {
+    await lock.release();
+  }
+}
+
+/** Unseal one stopped vault. A second call resumes an interrupted unseal pass. */
+export async function decryptVault(options: VaultDecryptLifecycleOptions): Promise<void> {
+  const lock = new DataDirectoryLock(options.dataDirectory);
+  await lock.acquire();
+  try {
+    const root = lock.authorityPath;
+    const keyslotPath = path.join(root, VAULT_KEYSLOT_FILE);
+    const bytes = await readOptionalPrivateFile(keyslotPath, VAULT_KEYSLOT_POLICY);
+    if (bytes === null) throw new Error("decrypt requires a Vault Keyslot");
+    const keyslot = parseKeyslot(bytes);
+    if (keyslot.state === "unsealing" && lock.dataFormat === 4) {
+      await (await VaultUnsealProgress.load(root)).clear();
+      await removePrivateFile(keyslotPath, VAULT_KEYSLOT_POLICY);
+      return;
+    }
+    if (keyslot.state !== "sealed" && keyslot.state !== "unsealing") {
+      throw new Error("vault is still sealing; run 1667 encrypt again");
+    }
+    if (lock.dataFormat !== 5) throw new Error("decrypt requires data format 5");
+    await assertVaultTraversalSafe(root);
+    if (options.password === undefined) {
+      throw new Error("Vault Password is required to decrypt this vault");
+    }
+    const password = await resolveVaultPassword(options.password, {
+      command: "decrypt",
+      resume: keyslot.state === "unsealing"
+    });
+    const key = await unsealKeyslot(password, keyslot);
+    if (keyslot.state === "sealed") {
+      await replaceKeyslotState(keyslotPath, keyslot, "unsealing");
+    }
+    const progress = await unsealFiles(root, key, options.afterUnsealReplacement);
+    await publishDataDirectoryOwnerMarker(root, 4);
+    await progress.clear();
+    await removePrivateFile(keyslotPath, VAULT_KEYSLOT_POLICY);
+  } finally {
+    await lock.release();
+  }
+}
+
+async function resolveVaultPassword(
+  password: VaultPassword,
+  request: VaultPasswordRequest
+): Promise<string> {
+  return typeof password === "string" ? password : await password(request);
+}
+
+async function replaceKeyslotState(
+  keyslotPath: string,
+  keyslot: ReturnType<typeof parseKeyslot>,
+  state: "sealing" | "sealed" | "unsealing"
+): Promise<void> {
+  await replacePrivateFile(
+    keyslotPath,
+    encodeKeyslot(keyslotWithState(keyslot, state)),
+    VAULT_KEYSLOT_POLICY
+  );
+}
+
+async function sealFiles(root: string, key: Uint8Array): Promise<void> {
+  await transformFiles(root, async (_files, file, bytes) => {
+    if (!isSealed(bytes)) return sealVaultBytes(key, bytes);
+    try {
+      // A sealed file must authenticate with this vault key before a resumed
+      // pass can classify it as complete. A non-authentic magic prefix is
+      // ordinary plaintext and gets one normal seal.
+      unsealVaultBytes(key, bytes, file);
+      return null;
+    } catch {
+      return sealVaultBytes(key, bytes);
+    }
+  });
+}
+
+async function unsealFiles(
+  root: string,
+  key: Uint8Array,
+  afterReplacement: ((files: readonly string[]) => Promise<void>) | undefined
+): Promise<VaultUnsealProgress> {
+  const progress = await VaultUnsealProgress.load(root, key);
+  await transformFiles(root, async (files, file, bytes) => {
+    const matching = files.map((path) => progress.matches(path, bytes));
+    if (matching.every(Boolean)) return null;
+    if (matching.some(Boolean)) {
+      throw new Error(`Vault unseal progress disagrees with hard-link group: ${file}`);
+    }
+    if (!isSealed(bytes)) {
+      if (files.some((path) => progress.has(path))) {
+        throw new Error(`Vault unseal progress does not match plaintext: ${file}`);
+      }
+      throw new Error(`cannot unseal ${file}: sealed vault file is plaintext without a progress witness`);
+    }
+    let plaintext: Buffer;
+    try {
+      plaintext = unsealVaultBytes(key, bytes, file);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(
+        `cannot unseal ${file}: ${message}. Delete this file if its plaintext is unrecoverable, then run 1667 decrypt again.`,
+        { cause: error }
+      );
+    }
+    await progress.record(files, plaintext);
+    return plaintext;
+  }, afterReplacement);
+  return progress;
+}
+
+async function transformFiles(
+  root: string,
+  transform: (
+    files: readonly string[],
+    file: string,
+    bytes: Buffer
+  ) => Promise<Uint8Array | null>,
+  afterReplacement?: (files: readonly string[]) => Promise<void>
+): Promise<void> {
+  const groups = await collectVaultInodeGroups(root);
+  for (const group of groups.values()) {
+    if (group.payloads.length === 0) continue;
+    if (group.controls.length !== 0) throw mixedVaultInodeGroup(group);
+    const files = group.payloads;
+    const first = files[0]!;
+    const bytes = await readFile(first);
+    const replacement = await transform(files, first, bytes);
+    if (replacement === null) continue;
+    await replaceInodeGroup(files, replacement);
+    await afterReplacement?.(files);
+  }
+}
+
+async function assertVaultTraversalSafe(root: string): Promise<void> {
+  const groups = await collectVaultInodeGroups(root);
+  for (const group of groups.values()) {
+    if (group.controls.length !== 0 && group.payloads.length !== 0) {
+      throw mixedVaultInodeGroup(group);
+    }
+  }
+}
+
+async function collectVaultInodeGroups(root: string): Promise<Map<string, VaultInodeGroup>> {
+  const groups = new Map<string, VaultInodeGroup>();
+  for await (const entry of vaultFiles(root)) {
+    const group = groups.get(entry.group);
+    if (group === undefined) {
+      groups.set(entry.group, {
+        group: entry.group,
+        representative: entry.file,
+        controls: entry.isControl ? [entry.file] : [],
+        payloads: entry.isControl ? [] : [entry.file]
+      });
+    } else if (entry.isControl) {
+      group.controls.push(entry.file);
+    } else {
+      group.payloads.push(entry.file);
+    }
+  }
+  for (const group of groups.values()) {
+    const info = await lstat(group.representative, { bigint: true });
+    if (!info.isFile() || `${info.dev}:${info.ino}` !== group.group) {
+      throw new Error(`Vault hard-link group changed during traversal: ${group.representative}`);
+    }
+    const aliases = BigInt(group.controls.length + group.payloads.length);
+    if (info.nlink !== aliases) {
+      throw new Error(`Vault hard-link group has aliases outside the data directory: ${group.representative}`);
+    }
+  }
+  return groups;
+}
+
+function mixedVaultInodeGroup(group: VaultInodeGroup): Error {
+  return new Error(
+    `Vault hard-link group mixes control and payload paths: ${group.controls[0]!} and ${group.payloads[0]!}`
+  );
+}
+
+async function* vaultFiles(root: string, relative = ""): AsyncGenerator<VaultFileEntry> {
+  const directory = path.join(root, relative);
+  for (const entry of await readdir(directory, { withFileTypes: true })) {
+    const nextRelative = relative === "" ? entry.name : path.join(relative, entry.name);
+    const file = path.join(root, nextRelative);
+    if (isVaultUnsealProgressPath(root, nextRelative)) continue;
+    const info = await lstat(file, { bigint: true });
+    if (info.isDirectory()) {
+      yield* vaultFiles(root, nextRelative);
+      continue;
+    }
+    if (!info.isFile()) {
+      throw new Error(`Vault contains an unsupported filesystem entry: ${file}`);
+    }
+    if (relative === "" && RUN_RECORD_ATOMIC_RESIDUE.test(entry.name)) {
+      await unlink(file);
+      await syncDirectory(directory);
+      continue;
+    }
+    if (VAULT_REPLACE_RESIDUE.test(entry.name)) {
+      await unlink(file);
+      await syncDirectory(directory);
+      continue;
+    }
+    yield {
+      file,
+      group: `${info.dev}:${info.ino}`,
+      isControl: isVaultControlPath(root, nextRelative)
+    };
+  }
+}
+
+async function replaceInodeGroup(files: readonly string[], bytes: Uint8Array): Promise<void> {
+  const first = files[0]!;
+  const info = await lstat(first);
+  const temporary = path.join(path.dirname(first), `.1667-vault-replace-${randomUUID()}.tmp`);
+  const handle = await open(
+    temporary,
+    constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL,
+    info.mode & 0o777
+  );
+  try {
+    await handle.writeFile(bytes);
+    await handle.sync();
+  } finally {
+    await handle.close();
+  }
+  await rename(temporary, first);
+  await syncDirectory(path.dirname(first));
+  for (const alias of files.slice(1)) {
+    const aliasTemporary = path.join(path.dirname(alias), `.1667-vault-replace-${randomUUID()}.tmp`);
+    await link(first, aliasTemporary);
+    await rename(aliasTemporary, alias);
+    await syncDirectory(path.dirname(alias));
+  }
+}

--- a/server/vault-unseal-progress-layout.ts
+++ b/server/vault-unseal-progress-layout.ts
@@ -1,0 +1,41 @@
+import path from "node:path";
+
+export const VAULT_UNSEAL_PROGRESS_DIRECTORY = ".1667-vault-unseal-progress";
+
+const PROGRESS_FILE = /^[a-f0-9]{64}\.json$/;
+const PRIVATE_PUBLICATION_SCRATCH_SUFFIX = ".1667-publish-v1.tmp";
+const PRIVATE_REPLACEMENT_SUFFIX = ".1667-replace-v1.next";
+
+/** True for the exact transient progress directory and its typed file residue. */
+export function isVaultUnsealProgressPath(root: string, fileOrRelative: string): boolean {
+  const relative = path.isAbsolute(fileOrRelative)
+    ? path.relative(path.resolve(root), path.resolve(fileOrRelative))
+    : fileOrRelative;
+  if (relative === VAULT_UNSEAL_PROGRESS_DIRECTORY) return true;
+  if (
+    relative === "" ||
+    relative === ".." ||
+    relative.startsWith(`..${path.sep}`) ||
+    path.isAbsolute(relative)
+  ) return false;
+  return path.dirname(relative) === VAULT_UNSEAL_PROGRESS_DIRECTORY
+    && canonicalProgressName(path.basename(relative)) !== null;
+}
+
+export function canonicalVaultUnsealProgressName(name: string): string | null {
+  return canonicalProgressName(name);
+}
+
+function canonicalProgressName(name: string): string | null {
+  if (PROGRESS_FILE.test(name)) return name;
+  if (name.endsWith(PRIVATE_REPLACEMENT_SUFFIX)) {
+    const replacementTarget = name.slice(0, -PRIVATE_REPLACEMENT_SUFFIX.length);
+    return PROGRESS_FILE.test(replacementTarget) ? replacementTarget : null;
+  }
+  if (!name.endsWith(PRIVATE_PUBLICATION_SCRATCH_SUFFIX)) return null;
+  const publicationTarget = name.slice(0, -PRIVATE_PUBLICATION_SCRATCH_SUFFIX.length);
+  if (PROGRESS_FILE.test(publicationTarget)) return publicationTarget;
+  if (!publicationTarget.endsWith(PRIVATE_REPLACEMENT_SUFFIX)) return null;
+  const replacementTarget = publicationTarget.slice(0, -PRIVATE_REPLACEMENT_SUFFIX.length);
+  return PROGRESS_FILE.test(replacementTarget) ? replacementTarget : null;
+}

--- a/server/vault-unseal-progress.ts
+++ b/server/vault-unseal-progress.ts
@@ -1,0 +1,256 @@
+import { createHash, createHmac } from "node:crypto";
+import type { Dirent } from "node:fs";
+import { chmod, lstat, mkdir, readdir, rmdir } from "node:fs/promises";
+import path from "node:path";
+import {
+  inspectPrivateDirectory,
+  publishPrivateFileNoReplace,
+  readOptionalPrivateFile,
+  removePrivateFile,
+  type PrivateFilePolicy
+} from "./private-file-publication.js";
+import { recoverPrivateFileReplacement } from "./private-file-replacement.js";
+import { syncDirectory } from "./story-lifecycle.js";
+import {
+  canonicalVaultUnsealProgressName,
+  VAULT_UNSEAL_PROGRESS_DIRECTORY
+} from "./vault-unseal-progress-layout.js";
+
+export {
+  isVaultUnsealProgressPath,
+  VAULT_UNSEAL_PROGRESS_DIRECTORY
+} from "./vault-unseal-progress-layout.js";
+
+const PROGRESS_POLICY: PrivateFilePolicy = Object.freeze({
+  label: "Vault unseal progress",
+  maxBytes: 16 * 1024
+});
+
+interface ProgressRecord {
+  readonly format: 1;
+  readonly path: string;
+  readonly plaintextTag: string;
+}
+
+interface ProgressEntry {
+  readonly file: string;
+  readonly plaintextTag: string;
+}
+
+/** @internal Test seam for the root directory durability barrier. */
+export interface VaultUnsealProgressOptions {
+  readonly syncRoot?: (directory: string) => Promise<void>;
+}
+
+/** Durable witnesses for files already unsealed during one in-progress pass. */
+export class VaultUnsealProgress {
+  private readonly entries = new Map<string, ProgressEntry>();
+  private directoryReady = false;
+
+  private constructor(
+    private readonly root: string,
+    private readonly key: Uint8Array | null,
+    private readonly syncRoot: (directory: string) => Promise<void>
+  ) {}
+
+  /** Encryption cannot start while an earlier unseal control path exists. */
+  static async assertAbsent(root: string): Promise<void> {
+    const directory = path.join(root, VAULT_UNSEAL_PROGRESS_DIRECTORY);
+    try {
+      await lstat(directory);
+    } catch (error) {
+      if (isErrorCode(error, "ENOENT")) return;
+      throw error;
+    }
+    throw new Error(`Vault unseal progress already exists: ${directory}`);
+  }
+
+  static async load(
+    root: string,
+    key: Uint8Array | null = null,
+    options: VaultUnsealProgressOptions = {}
+  ): Promise<VaultUnsealProgress> {
+    const progress = new VaultUnsealProgress(root, key, options.syncRoot ?? syncDirectory);
+    const directory = progress.directory;
+    const files = new Set<string>();
+    let entries: Dirent<string>[];
+    try {
+      await inspectPrivateDirectory(directory, PROGRESS_POLICY.label);
+      await progress.syncRoot(root);
+      entries = await readdir(directory, { withFileTypes: true });
+    } catch (error) {
+      if (isErrorCode(error, "ENOENT")) return progress;
+      throw error;
+    }
+    progress.directoryReady = true;
+    for (const entry of entries) {
+      const name = canonicalVaultUnsealProgressName(entry.name);
+      if (!entry.isFile() || name === null) {
+        throw new Error(`Vault unseal progress has an unknown entry: ${path.join(directory, entry.name)}`);
+      }
+      files.add(path.join(directory, name));
+    }
+    for (const file of files) {
+      await recoverPrivateFileReplacement(file, PROGRESS_POLICY);
+      const bytes = await readOptionalPrivateFile(file, PROGRESS_POLICY);
+      if (bytes === null) continue;
+      const record = parseRecord(bytes, file);
+      if (path.basename(file) !== recordFileName(record.path)) {
+        throw new Error(`Vault unseal progress has a non-canonical file name: ${file}`);
+      }
+      if (progress.entries.has(record.path)) {
+        throw new Error(`Vault unseal progress has duplicate path: ${record.path}`);
+      }
+      progress.entries.set(record.path, { file, plaintextTag: record.plaintextTag });
+    }
+    return progress;
+  }
+
+  /** True only when a durable witness names these exact bytes as plaintext. */
+  matches(file: string, bytes: Uint8Array): boolean {
+    const relative = relativePath(this.root, file);
+    const entry = this.entries.get(relative);
+    return entry !== undefined && entry.plaintextTag === plaintextTag(this.requireKey(), relative, bytes);
+  }
+
+  has(file: string): boolean {
+    return this.entries.has(relativePath(this.root, file));
+  }
+
+  /** Publish every alias witness before their shared inode is replaced. */
+  async record(files: readonly string[], plaintext: Uint8Array): Promise<void> {
+    for (const file of files) {
+      const relative = relativePath(this.root, file);
+      const tag = plaintextTag(this.requireKey(), relative, plaintext);
+      const existing = this.entries.get(relative);
+      if (existing !== undefined) {
+        if (existing.plaintextTag !== tag) {
+          throw new Error(`Vault unseal progress disagrees with ${file}`);
+        }
+        continue;
+      }
+      const record: ProgressRecord = { format: 1, path: relative, plaintextTag: tag };
+      await this.ensureDirectory();
+      const progressFile = path.join(this.directory, recordFileName(relative));
+      const encoded = Buffer.from(`${JSON.stringify(record)}\n`, "utf8");
+      const published = await readOptionalPrivateFile(progressFile, PROGRESS_POLICY);
+      if (published === null) {
+        await publishPrivateFileNoReplace(progressFile, encoded, PROGRESS_POLICY);
+      } else {
+        const publishedRecord = parseRecord(published, progressFile);
+        if (publishedRecord.path !== relative || publishedRecord.plaintextTag !== tag) {
+          throw new Error(`Vault unseal progress disagrees with ${file}`);
+        }
+      }
+      this.entries.set(relative, { file: progressFile, plaintextTag: tag });
+    }
+  }
+
+  /** Clear witnesses only after the format-4 fence makes cipher reads impossible. */
+  async clear(): Promise<void> {
+    for (const entry of this.entries.values()) {
+      await removePrivateFile(entry.file, PROGRESS_POLICY);
+    }
+    this.entries.clear();
+    try {
+      await rmdir(this.directory);
+      await syncDirectory(this.root);
+    } catch (error) {
+      if (!isErrorCode(error, "ENOENT")) throw error;
+    }
+    this.directoryReady = false;
+  }
+
+  private get directory(): string {
+    return path.join(this.root, VAULT_UNSEAL_PROGRESS_DIRECTORY);
+  }
+
+  private async ensureDirectory(): Promise<void> {
+    if (this.directoryReady) return;
+    try {
+      await mkdir(this.directory, { mode: 0o700 });
+    } catch (error) {
+      if (!isErrorCode(error, "EEXIST")) throw error;
+    }
+    await this.syncRoot(this.root);
+    if (process.platform !== "win32") {
+      const before = await lstat(this.directory);
+      if (!before.isDirectory() || before.isSymbolicLink()) {
+        throw new Error(`Vault unseal progress is not a private directory: ${this.directory}`);
+      }
+      if ((before.mode & 0o777) !== 0o700) await chmod(this.directory, 0o700);
+      const after = await lstat(this.directory);
+      if (!after.isDirectory() || after.isSymbolicLink() || (after.mode & 0o777) !== 0o700) {
+        throw new Error(`Vault unseal progress is not a private directory: ${this.directory}`);
+      }
+    }
+    await inspectPrivateDirectory(this.directory, PROGRESS_POLICY.label);
+    this.directoryReady = true;
+  }
+
+  private requireKey(): Uint8Array {
+    if (this.key === null) throw new Error("Vault unseal progress needs the Vault Key to verify a record");
+    return this.key;
+  }
+}
+
+function parseRecord(bytes: Uint8Array, file: string): ProgressRecord {
+  let value: unknown;
+  try {
+    value = JSON.parse(Buffer.from(bytes).toString("utf8"));
+  } catch (error) {
+    throw new Error(`Vault unseal progress is invalid: ${file}`, { cause: error });
+  }
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`Vault unseal progress is invalid: ${file}`);
+  }
+  const record = value as Record<string, unknown>;
+  if (!exactKeys(record, ["format", "path", "plaintextTag"])
+    || record.format !== 1 || typeof record.path !== "string"
+    || typeof record.plaintextTag !== "string" || !/^[a-f0-9]{64}$/.test(record.plaintextTag)
+    || !isSafeRelativePath(record.path)) {
+    throw new Error(`Vault unseal progress is invalid: ${file}`);
+  }
+  return { format: 1, path: record.path, plaintextTag: record.plaintextTag };
+}
+
+function relativePath(root: string, file: string): string {
+  const relative = path.relative(root, file);
+  if (!isSafeRelativePath(relative)) throw new Error(`Vault path is outside its data directory: ${file}`);
+  return relative;
+}
+
+function isSafeRelativePath(value: string): boolean {
+  if (value.length === 0 || value.includes("\0") || path.isAbsolute(value)) return false;
+  const normalized = path.normalize(value);
+  return normalized === value
+    && normalized !== "."
+    && normalized !== ".."
+    && !normalized.startsWith(`..${path.sep}`)
+    && !path.isAbsolute(normalized);
+}
+
+function exactKeys(value: Record<string, unknown>, keys: readonly string[]): boolean {
+  return Object.keys(value).length === keys.length && keys.every((key) => key in value);
+}
+
+function digest(bytes: Uint8Array): string {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function recordFileName(relative: string): string {
+  return `${digest(Buffer.from(relative, "utf8"))}.json`;
+}
+
+function plaintextTag(key: Uint8Array, relative: string, plaintext: Uint8Array): string {
+  return createHmac("sha256", key)
+    .update("1667-vault-unseal-progress-v1\0", "utf8")
+    .update(relative, "utf8")
+    .update("\0", "utf8")
+    .update(plaintext)
+    .digest("hex");
+}
+
+function isErrorCode(error: unknown, code: string): boolean {
+  return error instanceof Error && "code" in error && error.code === code;
+}

--- a/server/worker-message.ts
+++ b/server/worker-message.ts
@@ -28,9 +28,19 @@ export function parseWorkerBootstrap(
     ...(message.machineDir === undefined
       ? {}
       : { machineDir: requireString(message.machineDir, "machineDir") }),
+    ...(message.vaultKey === undefined
+      ? {}
+      : { vaultKey: requireVaultKey(message.vaultKey) }),
     ...(message.printLogs === true ? { printLogs: true } as const : {}),
     ...(message.freshDataDirectory === true ? { freshDataDirectory: true } as const : {})
   };
+}
+
+function requireVaultKey(value: unknown): Uint8Array {
+  if (!(value instanceof Uint8Array) || value.byteLength !== 32) {
+    throw new ServiceError(400, "vaultKey must be a 32-byte byte array");
+  }
+  return new Uint8Array(value);
 }
 
 export function parseWorkerRequest(

--- a/server/worker.ts
+++ b/server/worker.ts
@@ -34,6 +34,10 @@ import { resolveDiagnosticMachineTier } from "./diagnostic-machine-tier.js";
 import { executeWorkerRequest } from "./worker-request-executor.js";
 import { localStartupFailure } from "./local-startup-failure.js";
 import { errorFromFailureIncident } from "./reported-service-error.js";
+import {
+  registerVaultKey,
+  type VaultKeyRegistration
+} from "./vault-key-registry.js";
 
 interface WorkerRuntime {
   postMessage(message: WorkerToMainMessage): void;
@@ -55,6 +59,7 @@ let errorReporter = WorkerErrorReporter.disabled();
 let initializing = false;
 const active = new Map<string, ActiveRequest>();
 let stopping = false;
+let vaultRegistration: VaultKeyRegistration | null = null;
 
 runtime.onmessage = (event) => {
   void receive(event.data).catch(async (error: unknown) => {
@@ -262,7 +267,12 @@ async function shutdown(): Promise<void> {
   }
   await Promise.allSettled([...active.values()].map((request) => request.done));
   clearInterval(startupHeartbeat);
-  await service?.dispose();
+  try {
+    await service?.dispose();
+  } finally {
+    vaultRegistration?.clear();
+    vaultRegistration = null;
+  }
   await errorReporter.close().catch(() => undefined);
   errorReporter = WorkerErrorReporter.disabled();
   runtime.postMessage({ type: "stopped" });
@@ -291,6 +301,9 @@ async function bootstrap(message: Extract<MainToWorkerMessage, { type: "bootstra
   errorReporter = candidateReporter;
   let candidate: StoryService | null = null;
   try {
+    if (message.vaultKey !== undefined) {
+      vaultRegistration = registerVaultKey(message.dataDir, message.vaultKey);
+    }
     candidate = new StoryService({
       dataDir: message.dataDir,
       machineDir,
@@ -331,6 +344,8 @@ async function bootstrap(message: Extract<MainToWorkerMessage, { type: "bootstra
       );
       throw errorFromFailureIncident(reported);
     } finally {
+      vaultRegistration?.clear();
+      vaultRegistration = null;
       await candidateReporter.close().catch(() => undefined);
       if (errorReporter === candidateReporter) {
         errorReporter = WorkerErrorReporter.disabled();

--- a/shared/vault-cipher.ts
+++ b/shared/vault-cipher.ts
@@ -1,0 +1,193 @@
+import { createCipheriv, createDecipheriv, randomBytes, scrypt } from "node:crypto";
+
+export const VAULT_SEAL_OVERHEAD = 36;
+const VAULT_FILE_MAGIC = Buffer.from([0x00, 0x31, 0x36, 0x36, 0x37, 0x56, 0x01, 0x01]);
+const VAULT_FILE_NONCE_BYTES = 12;
+const VAULT_KEY_BYTES = 32;
+const VAULT_TAG_BYTES = 16;
+const VAULT_SALT_BYTES = 32;
+const SCRYPT_COST = 131_072;
+const SCRYPT_BLOCK_SIZE = 8;
+const SCRYPT_PARALLELIZATION = 1;
+const SCRYPT_MAX_MEMORY = 256 * 1024 * 1024;
+
+export type VaultKeyslotState = "sealing" | "sealed" | "unsealing";
+
+export interface VaultKeyslot {
+  readonly format: 1;
+  readonly kdf: {
+    readonly name: "scrypt";
+    readonly n: 131072;
+    readonly r: 8;
+    readonly p: 1;
+    readonly salt: string;
+  };
+  readonly sealedKey: {
+    readonly nonce: string;
+    readonly data: string;
+  };
+  readonly state: VaultKeyslotState;
+}
+
+export class VaultCipherError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "VaultCipherError";
+  }
+}
+
+export function isSealed(bytes: Uint8Array): boolean {
+  return bytes.byteLength >= VAULT_SEAL_OVERHEAD
+    && Buffer.from(bytes).subarray(0, VAULT_FILE_MAGIC.byteLength).equals(VAULT_FILE_MAGIC);
+}
+
+export function sealVaultBytes(key: Uint8Array, plaintext: Uint8Array): Buffer {
+  requireVaultKey(key);
+  const nonce = randomBytes(VAULT_FILE_NONCE_BYTES);
+  const cipher = createCipheriv("aes-256-gcm", key, nonce);
+  const encrypted = Buffer.concat([cipher.update(plaintext), cipher.final(), cipher.getAuthTag()]);
+  return Buffer.concat([VAULT_FILE_MAGIC, nonce, encrypted]);
+}
+
+export function unsealVaultBytes(key: Uint8Array, sealed: Uint8Array, label: string): Buffer {
+  requireVaultKey(key);
+  if (!isSealed(sealed)) return Buffer.from(sealed);
+  const bytes = Buffer.from(sealed);
+  const nonceStart = VAULT_FILE_MAGIC.byteLength;
+  const ciphertextStart = nonceStart + VAULT_FILE_NONCE_BYTES;
+  if (bytes.byteLength < ciphertextStart + VAULT_TAG_BYTES) {
+    throw new VaultCipherError(`Sealed file is malformed: ${label}`);
+  }
+  const ciphertextEnd = bytes.byteLength - VAULT_TAG_BYTES;
+  try {
+    const decipher = createDecipheriv("aes-256-gcm", key, bytes.subarray(nonceStart, ciphertextStart));
+    decipher.setAuthTag(bytes.subarray(ciphertextEnd));
+    return Buffer.concat([decipher.update(bytes.subarray(ciphertextStart, ciphertextEnd)), decipher.final()]);
+  } catch (error) {
+    throw new VaultCipherError(`Sealed file authentication failed: ${label}`, { cause: error });
+  }
+}
+
+export async function createKeyslot(
+  password: string,
+  vaultKey: Uint8Array = randomBytes(VAULT_KEY_BYTES)
+): Promise<VaultKeyslot> {
+  requireVaultKey(vaultKey);
+  const salt = randomBytes(VAULT_SALT_BYTES);
+  const kdf = {
+    name: "scrypt" as const,
+    n: SCRYPT_COST as 131072,
+    r: SCRYPT_BLOCK_SIZE as 8,
+    p: SCRYPT_PARALLELIZATION as 1,
+    salt: salt.toString("base64")
+  };
+  const derivedKey = await deriveKey(password, salt);
+  const sealed = sealVaultBytes(derivedKey, vaultKey);
+  return {
+    format: 1,
+    kdf,
+    sealedKey: {
+      nonce: sealed.subarray(VAULT_FILE_MAGIC.byteLength, VAULT_FILE_MAGIC.byteLength + VAULT_FILE_NONCE_BYTES).toString("base64"),
+      data: sealed.subarray(VAULT_FILE_MAGIC.byteLength + VAULT_FILE_NONCE_BYTES).toString("base64")
+    },
+    state: "sealing"
+  };
+}
+
+/** Decode the only supported canonical Keyslot record. */
+export function parseKeyslot(bytes: Uint8Array): VaultKeyslot {
+  let value: unknown;
+  try {
+    value = JSON.parse(Buffer.from(bytes).toString("utf8"));
+  } catch (error) {
+    throw new VaultCipherError("Vault Keyslot is not valid JSON", { cause: error });
+  }
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new VaultCipherError("Vault Keyslot is not an object");
+  }
+  const record = value as Record<string, unknown>;
+  if (record.format !== 1 || !isExactKeys(record, ["format", "kdf", "sealedKey", "state"])) {
+    throw new VaultCipherError("Vault Keyslot has an unsupported format");
+  }
+  const kdf = requireRecord(record.kdf, "Vault Keyslot kdf");
+  const sealedKey = requireRecord(record.sealedKey, "Vault Keyslot sealedKey");
+  if (!isExactKeys(kdf, ["name", "n", "r", "p", "salt"])
+    || kdf.name !== "scrypt" || kdf.n !== SCRYPT_COST || kdf.r !== SCRYPT_BLOCK_SIZE || kdf.p !== SCRYPT_PARALLELIZATION) {
+    throw new VaultCipherError("Vault Keyslot has unsupported derivation parameters");
+  }
+  if (!isExactKeys(sealedKey, ["nonce", "data"])
+    || !isVaultKeyslotState(record.state)
+    || typeof kdf.salt !== "string" || typeof sealedKey.nonce !== "string" || typeof sealedKey.data !== "string") {
+    throw new VaultCipherError("Vault Keyslot has invalid fields");
+  }
+  const salt = parseBase64(kdf.salt, "Vault Keyslot salt");
+  const nonce = parseBase64(sealedKey.nonce, "Vault Keyslot nonce");
+  const data = parseBase64(sealedKey.data, "Vault Keyslot data");
+  if (salt.byteLength !== VAULT_SALT_BYTES || nonce.byteLength !== VAULT_FILE_NONCE_BYTES
+    || data.byteLength !== VAULT_KEY_BYTES + VAULT_TAG_BYTES) {
+    throw new VaultCipherError("Vault Keyslot field length is invalid");
+  }
+  return {
+    format: 1,
+    kdf: { name: "scrypt", n: SCRYPT_COST, r: SCRYPT_BLOCK_SIZE, p: SCRYPT_PARALLELIZATION, salt: kdf.salt },
+    sealedKey: { nonce: sealedKey.nonce, data: sealedKey.data },
+    state: record.state
+  };
+}
+
+export function encodeKeyslot(keyslot: VaultKeyslot): Buffer {
+  return Buffer.from(`${JSON.stringify(keyslot)}\n`, "utf8");
+}
+
+export async function unsealKeyslot(password: string, keyslot: VaultKeyslot): Promise<Buffer> {
+  const salt = parseBase64(keyslot.kdf.salt, "Vault Keyslot salt");
+  const nonce = parseBase64(keyslot.sealedKey.nonce, "Vault Keyslot nonce");
+  const data = parseBase64(keyslot.sealedKey.data, "Vault Keyslot data");
+  const derivedKey = await deriveKey(password, salt);
+  const sealed = Buffer.concat([VAULT_FILE_MAGIC, nonce, data]);
+  const key = unsealVaultBytes(derivedKey, sealed, "Vault Keyslot");
+  requireVaultKey(key);
+  return key;
+}
+
+export function keyslotWithState(keyslot: VaultKeyslot, state: VaultKeyslotState): VaultKeyslot {
+  return { ...keyslot, state };
+}
+
+async function deriveKey(password: string, salt: Uint8Array): Promise<Buffer> {
+  return await new Promise((resolve, reject) => {
+    scrypt(password, salt, VAULT_KEY_BYTES, {
+      N: SCRYPT_COST,
+      r: SCRYPT_BLOCK_SIZE,
+      p: SCRYPT_PARALLELIZATION,
+      maxmem: SCRYPT_MAX_MEMORY
+    }, (error, derived) => error === null ? resolve(derived) : reject(error));
+  });
+}
+
+function requireVaultKey(key: Uint8Array): void {
+  if (key.byteLength !== VAULT_KEY_BYTES) throw new VaultCipherError("Vault Key must be 32 bytes");
+}
+
+function requireRecord(value: unknown, label: string): Record<string, unknown> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new VaultCipherError(`${label} is not an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function isExactKeys(value: Record<string, unknown>, keys: readonly string[]): boolean {
+  return Object.keys(value).length === keys.length && keys.every((key) => key in value);
+}
+
+function isVaultKeyslotState(value: unknown): value is VaultKeyslotState {
+  return value === "sealing" || value === "sealed" || value === "unsealing";
+}
+
+function parseBase64(value: string, label: string): Buffer {
+  const bytes = Buffer.from(value, "base64");
+  if (bytes.byteLength === 0 || bytes.toString("base64") !== value) {
+    throw new VaultCipherError(`${label} is not canonical base64`);
+  }
+  return bytes;
+}

--- a/shared/worker-protocol.ts
+++ b/shared/worker-protocol.ts
@@ -458,6 +458,8 @@ export type MainToWorkerMessage =
        * worker. Absent only for a directly-posted bootstrap in tests.
        */
       machineDir?: string;
+      /** The in-process Vault Key. It never crosses a network boundary. */
+      vaultKey?: Uint8Array;
       /** Echo unexpected embedded errors to stderr as well as the private log. */
       printLogs?: true;
       /** Main created this directory during startup, so the worker fills it

--- a/test/data-directory-format-compatibility.test.ts
+++ b/test/data-directory-format-compatibility.test.ts
@@ -108,6 +108,23 @@ test("a format-3 reader refuses a format-4 directory before opening its state", 
   assert.equal(await readFile(markerPath, "utf8"), marker);
 });
 
+test("a format-4 reader refuses a sealed format-5 directory at the marker", async (t) => {
+  const dataDir = await mkdtemp(path.join(os.tmpdir(), "1667-format-5-compat-"));
+  t.after(async () => {
+    await rm(dataDir, { recursive: true, force: true });
+  });
+  const markerPath = path.join(dataDir, DATA_DIRECTORY_OWNER_MARKER);
+  const marker = dataDirectoryOwnerMarkerText(5);
+  await writeFile(markerPath, marker, { mode: 0o600 });
+
+  await assert.rejects(
+    readDataDirectoryFormat(dataDir, { supportedFormats: [1, 2, 3, 4] }),
+    (error: unknown) => error instanceof ServiceError
+      && error.code === "data_directory_version_unsupported"
+  );
+  assert.equal(await readFile(markerPath, "utf8"), marker);
+});
+
 test("opening a format-2 project upgrades it to the fence its writes need", async (t) => {
   const dataDir = await mkdtemp(path.join(os.tmpdir(), "1667-format-3-upgrade-"));
   t.after(async () => {

--- a/test/data-directory-marker-adoption.test.ts
+++ b/test/data-directory-marker-adoption.test.ts
@@ -199,7 +199,7 @@ test("malformed typed marker residue is preserved for diagnosis", async (t) => {
     const nextPath = path.join(dataDir, DATA_DIRECTORY_OWNER_MARKER_NEXT);
     const malformed = dataDirectoryOwnerMarkerText(2).replace(
       '"dataFormat":2',
-      '"dataFormat":5'
+      '"dataFormat":6'
     );
     await writeFile(nextPath, malformed, { mode: 0o600 });
 

--- a/test/legacy-serve.test.ts
+++ b/test/legacy-serve.test.ts
@@ -21,6 +21,7 @@ import {
 } from "../shared/http-listener-authority.js";
 import { startHttpListener } from "../server/http-listener.js";
 import { startLegacyServe } from "../tui/src/http-commands.js";
+import { publishDataDirectoryOwnerMarker } from "../server/data-directory-format.js";
 import {
   acquireLegacyDataDirectoryLease
 } from "../server/legacy-data-directory.js";
@@ -94,6 +95,31 @@ test("legacy serve refuses a platform without retained-directory authority", {
     /requires Linux retained-directory authority/
   );
   await assert.rejects(access(stateRoot), /ENOENT/);
+});
+
+test("legacy serve refuses a sealed vault before it opens HTTP state", async (t) => {
+  const dataDir = await privateTemporaryDirectory(t, "1667-legacy-sealed-");
+  await publishDataDirectoryOwnerMarker(dataDir, 5);
+  await assert.rejects(startLegacyServe(dataDir), /cannot open a sealed vault/);
+});
+
+test("legacy serve rechecks the sealed-vault fence through its retained authority", {
+  skip: process.platform !== "linux"
+}, async (t) => {
+  const dataDir = await legacyDataDirectory(t);
+  let lockedAuthority: string | null = null;
+
+  await assert.rejects(
+    startLegacyServe(dataDir, {
+      beforeLockedVaultCheck: async (authorityPath) => {
+        lockedAuthority = authorityPath;
+        await publishDataDirectoryOwnerMarker(authorityPath, 5);
+      }
+    }),
+    /legacy HTTP serve cannot open a sealed vault/
+  );
+
+  assert.match(lockedAuthority ?? "", /^\/proc\/self\/fd\/\d+$/);
 });
 
 test("legacy serve binds a free port and opens unmarked v1 data", {

--- a/test/legacy-serve.test.ts
+++ b/test/legacy-serve.test.ts
@@ -97,7 +97,9 @@ test("legacy serve refuses a platform without retained-directory authority", {
   await assert.rejects(access(stateRoot), /ENOENT/);
 });
 
-test("legacy serve refuses a sealed vault before it opens HTTP state", async (t) => {
+test("legacy serve refuses a sealed vault before it opens HTTP state", {
+  skip: process.platform !== "linux"
+}, async (t) => {
   const dataDir = await privateTemporaryDirectory(t, "1667-legacy-sealed-");
   await publishDataDirectoryOwnerMarker(dataDir, 5);
   await assert.rejects(startLegacyServe(dataDir), /cannot open a sealed vault/);

--- a/test/runtime-data-directory-boundary.test.ts
+++ b/test/runtime-data-directory-boundary.test.ts
@@ -8,7 +8,9 @@ const PRODUCTION_ROOTS = ["server", "tui/src"] as const;
 const RAW_LOCK_IMPORT = /from\s+["'][^"']*data-directory-lock\.js["']/;
 const ALLOWED_RAW_IMPORTS = [
   "server/data-directory-migration.ts",
-  "server/runtime-data-directory.ts"
+  "server/runtime-data-directory.ts",
+  // Vault lifecycle commands must lock format 5 before a Vault Key exists.
+  "server/vault-lifecycle.ts"
 ];
 
 test("production runtime code cannot bypass prepared data-directory acquisition", async () => {

--- a/test/story-markdown-import.test.ts
+++ b/test/story-markdown-import.test.ts
@@ -374,12 +374,14 @@ test("CLI parseImportCommand parses files and flags correctly", () => {
   assert.deepEqual(parseImportCommand(["file1.md", "file2.jsonl"]), {
     files: ["file1.md", "file2.jsonl"],
     data: null,
-    global: false
+    global: false,
+    passphraseFile: null
   });
   assert.deepEqual(parseImportCommand(["--data", "myproject", "story.md"]), {
     files: ["story.md"],
     data: "myproject",
-    global: false
+    global: false,
+    passphraseFile: null
   });
   assert.throws(
     () => parseImportCommand([]),

--- a/test/supervised-serve-boundary.test.ts
+++ b/test/supervised-serve-boundary.test.ts
@@ -26,8 +26,11 @@ import {
 import {
   assertSupervisedMachineTierOutsideProject,
   resolveSupervisedProject,
-  recoverDescriptors
+  recoverDescriptors,
+  runSupervisedServeChild
 } from "../server/supervised-serve-child.js";
+import { DataDirectoryLock } from "../server/data-directory-lock.js";
+import { publishDataDirectoryOwnerMarker } from "../server/data-directory-format.js";
 import { PlatformStateRootError } from "../server/platform-state-root.js";
 import { toPublicServiceError } from "../server/service-error-policy.js";
 import { localStartupFailure } from "../server/local-startup-failure.js";
@@ -114,6 +117,61 @@ test("supervised serve keeps machine state outside the project", async (t) => {
     ),
     /machine tier outside the project/
   );
+});
+
+test("supervised serve rechecks the sealed-vault fence through its retained authority", async (t) => {
+  const root = await mkdtemp(path.join(tmpdir(), "1667-supervised-vault-race-"));
+  const machineDir = await mkdtemp(path.join(tmpdir(), "1667-supervised-machine-"));
+  t.after(async () => await Promise.all([
+    rm(root, { recursive: true, force: true }),
+    rm(machineDir, { recursive: true, force: true })
+  ]));
+  const dataDirectory = path.join(root, ".1667");
+  const initializer = new DataDirectoryLock(dataDirectory);
+  await initializer.acquire();
+  await initializer.release();
+
+  const previousMachineDirectory = process.env[MACHINE_TIER_OVERRIDE_VARIABLE];
+  const processWithIpc = process as NodeJS.Process & {
+    send?: (message: unknown) => boolean;
+  };
+  const previousSend = processWithIpc.send;
+  const previousExitCode = process.exitCode;
+  const messages: unknown[] = [];
+  process.env[MACHINE_TIER_OVERRIDE_VARIABLE] = machineDir;
+  processWithIpc.send = (message) => {
+    messages.push(message);
+    return true;
+  };
+  t.after(() => {
+    if (previousMachineDirectory === undefined) {
+      delete process.env[MACHINE_TIER_OVERRIDE_VARIABLE];
+    } else {
+      process.env[MACHINE_TIER_OVERRIDE_VARIABLE] = previousMachineDirectory;
+    }
+    if (previousSend === undefined) delete processWithIpc.send;
+    else processWithIpc.send = previousSend;
+    process.exitCode = previousExitCode;
+  });
+
+  let lockedAuthority: string | null = null;
+  await runSupervisedServeChild([
+    "--data", root,
+    "--port", "0",
+    "--secret-fd", "4"
+  ], {
+    beforeLockedVaultCheck: async (authorityPath) => {
+      lockedAuthority = authorityPath;
+      await publishDataDirectoryOwnerMarker(authorityPath, 5);
+    }
+  });
+
+  assert.match(lockedAuthority ?? "", /^\/proc\/self\/fd\/\d+$/);
+  assert.equal(process.exitCode, 1);
+  assert.deepEqual(messages, [{
+    type: "fatal",
+    message: "serve cannot open a sealed vault; use the TUI or an offline command with --passphrase-file"
+  }]);
 });
 
 test("machine-tier boundary rejects a bind-mounted project descendant", () => {

--- a/test/supervised-serve-boundary.test.ts
+++ b/test/supervised-serve-boundary.test.ts
@@ -119,7 +119,9 @@ test("supervised serve keeps machine state outside the project", async (t) => {
   );
 });
 
-test("supervised serve rechecks the sealed-vault fence through its retained authority", async (t) => {
+test("supervised serve rechecks the sealed-vault fence through its retained authority", {
+  skip: process.platform !== "linux"
+}, async (t) => {
   const root = await mkdtemp(path.join(tmpdir(), "1667-supervised-vault-race-"));
   const machineDir = await mkdtemp(path.join(tmpdir(), "1667-supervised-machine-"));
   t.after(async () => await Promise.all([

--- a/test/vault-lifecycle-safety.integration.test.ts
+++ b/test/vault-lifecycle-safety.integration.test.ts
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { link, mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test, { type TestContext } from "node:test";
+import { readDataDirectoryFormat } from "../server/data-directory-format.js";
+import { DataDirectoryLock } from "../server/data-directory-lock.js";
+import {
+  decryptVault,
+  encryptVault,
+  VAULT_KEYSLOT_FILE
+} from "../server/vault-lifecycle.js";
+import { VAULT_UNSEAL_PROGRESS_DIRECTORY } from "../server/vault-unseal-progress.js";
+
+test("encrypt rejects a payload hard link outside the data directory", async (t) => {
+  const dataDirectory = await newVault(t, "1667-vault-external-hard-link-");
+  const externalDirectory = await mkdtemp(path.join(tmpdir(), "1667-vault-external-alias-"));
+  t.after(async () => await rm(externalDirectory, { recursive: true, force: true }));
+  const external = path.join(externalDirectory, "external.json");
+  const payload = path.join(dataDirectory, "story.json");
+  const plaintext = "external hard-link sentinel";
+  await writeFile(external, plaintext);
+  await link(external, payload);
+
+  await assert.rejects(
+    encryptVault({ dataDirectory, password: "correct horse battery staple" }),
+    /Vault hard-link group has aliases outside the data directory/
+  );
+
+  assert.equal(await readDataDirectoryFormat(dataDirectory), 4);
+  assert.equal(await readFile(external, "utf8"), plaintext);
+  await assert.rejects(readFile(path.join(dataDirectory, VAULT_KEYSLOT_FILE)), { code: "ENOENT" });
+});
+
+test("decrypt reports a progress-record failure without delete advice", async (t) => {
+  const dataDirectory = await newVault(t, "1667-vault-progress-record-error-");
+  const story = path.join(dataDirectory, "story.json");
+  const progressDirectory = path.join(dataDirectory, VAULT_UNSEAL_PROGRESS_DIRECTORY);
+  await writeFile(story, "progress record error sentinel");
+  await encryptVault({ dataDirectory, password: "correct horse battery staple" });
+  await mkdir(progressDirectory, { mode: 0o700 });
+  const recordName = `${createHash("sha256").update("story.json", "utf8").digest("hex")}.json`;
+  await writeFile(
+    path.join(progressDirectory, recordName),
+    `${JSON.stringify({ format: 1, path: "story.json", plaintextTag: "0".repeat(64) })}\n`,
+    { mode: 0o600 }
+  );
+
+  await assert.rejects(
+    decryptVault({ dataDirectory, password: "correct horse battery staple" }),
+    (error: unknown) => {
+      if (!(error instanceof Error)) return false;
+      assert.match(error.message, /Vault unseal progress disagrees with/);
+      assert.equal(error.message.includes("Delete this file"), false);
+      return true;
+    }
+  );
+});
+
+test("decrypt records a POSIX backslash and dot-dot filename", async (t) => {
+  if (process.platform === "win32") return;
+  const dataDirectory = await newVault(t, "1667-vault-backslash-dot-dot-");
+  const file = path.join(dataDirectory, "payload\\..");
+  const plaintext = "backslash dot-dot filename sentinel";
+  await writeFile(file, plaintext);
+
+  await encryptVault({ dataDirectory, password: "correct horse battery staple" });
+  await decryptVault({ dataDirectory, password: "correct horse battery staple" });
+
+  assert.equal(await readFile(file, "utf8"), plaintext);
+});
+
+async function newVault(t: TestContext, prefix: string): Promise<string> {
+  const dataDirectory = await mkdtemp(path.join(tmpdir(), prefix));
+  t.after(async () => await rm(dataDirectory, { recursive: true, force: true }));
+  const initializer = new DataDirectoryLock(dataDirectory);
+  await initializer.acquire();
+  await initializer.release();
+  return dataDirectory;
+}

--- a/test/vault-lifecycle.integration.test.ts
+++ b/test/vault-lifecycle.integration.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { link, mkdtemp, mkdir, readFile, rm, stat, symlink, writeFile } from "node:fs/promises";
-import { randomBytes } from "node:crypto";
+import { randomBytes, randomUUID } from "node:crypto";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test, { type TestContext } from "node:test";
@@ -153,15 +153,15 @@ test("encrypt refuses a pre-existing unseal progress directory before format 5",
   await assert.rejects(readFile(path.join(dataDirectory, VAULT_KEYSLOT_FILE)), { code: "ENOENT" });
 });
 
-test("encrypt preserves deceptive replace residue and removes valid residue", async (t) => {
+test("encrypt preserves deceptive replace residue and removes emitted valid residue", async (t) => {
   const dataDirectory = await newVault(t, "1667-vault-replace-residue-");
   const deceptive = [
     path.join(dataDirectory, ".1667-vault-replace-123e4567-e89b-12d3-a456-426614174000.tmp"),
-    path.join(dataDirectory, ".1667-vault-replace-123E4567-E89B-42D3-A456-426614174000.tmp")
+    path.join(dataDirectory, ".1667-vault-replace-223E4567-E89B-42D3-A456-426614174000.tmp")
   ];
   const validResidue = path.join(
     dataDirectory,
-    ".1667-vault-replace-123e4567-e89b-42d3-a456-426614174000.tmp"
+    `.1667-vault-replace-${randomUUID()}.tmp`
   );
   const plaintext = "deceptive replace residue sentinel";
   await Promise.all(deceptive.map(async (file) => await writeFile(file, plaintext)));

--- a/test/vault-lifecycle.integration.test.ts
+++ b/test/vault-lifecycle.integration.test.ts
@@ -1,0 +1,429 @@
+import assert from "node:assert/strict";
+import { link, mkdtemp, mkdir, readFile, rm, stat, symlink, writeFile } from "node:fs/promises";
+import { randomBytes } from "node:crypto";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test, { type TestContext } from "node:test";
+import {
+  createKeyslot,
+  encodeKeyslot,
+  isSealed,
+  keyslotWithState,
+  parseKeyslot
+} from "../shared/vault-cipher.js";
+import { publishDataDirectoryOwnerMarker } from "../server/data-directory-format.js";
+import { DataDirectoryLock } from "../server/data-directory-lock.js";
+import {
+  decryptVault,
+  encryptVault,
+  VAULT_KEYSLOT_FILE
+} from "../server/vault-lifecycle.js";
+import { readDataDirectoryFormat } from "../server/data-directory-format.js";
+import { VAULT_UNSEAL_PROGRESS_DIRECTORY } from "../server/vault-unseal-progress.js";
+
+interface VaultCipherCorpus {
+  readonly sealedFile: {
+    readonly magicHex: string;
+    readonly overheadBytes: number;
+    readonly nonceBytes: number;
+    readonly tagBytes: number;
+  };
+  readonly keyslot: {
+    readonly format: number;
+    readonly kdf: { readonly name: string; readonly n: number; readonly r: number; readonly p: number; readonly saltBytes: number };
+    readonly sealedKey: { readonly nonceBytes: number; readonly dataBytes: number };
+  };
+}
+
+test("vault lifecycle seals a project, preserves hard links, and restores plaintext", async (t) => {
+  const dataDirectory = await mkdtemp(path.join(tmpdir(), "1667-vault-lifecycle-"));
+  t.after(async () => await rm(dataDirectory, { recursive: true, force: true }));
+  const initializer = new DataDirectoryLock(dataDirectory);
+  await initializer.acquire();
+  await initializer.release();
+
+  await mkdir(path.join(dataDirectory, "stories"));
+  await writeFile(path.join(dataDirectory, ".gitignore"), "run.json\n");
+  const first = path.join(dataDirectory, "stories", "first.json");
+  const second = path.join(dataDirectory, "stories", "second.json");
+  const plaintext = "vault integration sentinel: small green comet";
+  await writeFile(first, plaintext);
+  await link(first, second);
+
+  await encryptVault({ dataDirectory, password: "correct horse battery staple" });
+
+  const sealed = await readFile(first);
+  const corpus = JSON.parse(await readFile(new URL("../schema/vault-cipher.corpus.json", import.meta.url), "utf8")) as VaultCipherCorpus;
+  const keyslot = JSON.parse(await readFile(path.join(dataDirectory, VAULT_KEYSLOT_FILE), "utf8")) as {
+    format: number;
+    kdf: { name: string; n: number; r: number; p: number; salt: string };
+    sealedKey: { nonce: string; data: string };
+    state: string;
+  };
+  assert.equal(isSealed(sealed), true);
+  assert.equal(sealed.subarray(0, 8).toString("hex"), corpus.sealedFile.magicHex);
+  assert.equal(sealed.byteLength - Buffer.byteLength(plaintext), corpus.sealedFile.overheadBytes);
+  assert.equal(await readFile(path.join(dataDirectory, ".gitignore"), "utf8"), "run.json\n");
+  assert.equal(keyslot.state, "sealed");
+  assert.equal(keyslot.format, corpus.keyslot.format);
+  assert.deepEqual(
+    { name: keyslot.kdf.name, n: keyslot.kdf.n, r: keyslot.kdf.r, p: keyslot.kdf.p },
+    { name: corpus.keyslot.kdf.name, n: corpus.keyslot.kdf.n, r: corpus.keyslot.kdf.r, p: corpus.keyslot.kdf.p }
+  );
+  assert.equal(Buffer.from(keyslot.kdf.salt, "base64").byteLength, corpus.keyslot.kdf.saltBytes);
+  assert.equal(Buffer.from(keyslot.sealedKey.nonce, "base64").byteLength, corpus.keyslot.sealedKey.nonceBytes);
+  assert.equal(Buffer.from(keyslot.sealedKey.data, "base64").byteLength, corpus.keyslot.sealedKey.dataBytes);
+  assert.equal((await stat(first)).ino, (await stat(second)).ino);
+  await assert.rejects(
+    decryptVault({ dataDirectory, password: "wrong password" }),
+    /authentication failed/
+  );
+
+  await decryptVault({ dataDirectory, password: "correct horse battery staple" });
+
+  assert.equal(await readFile(first, "utf8"), plaintext);
+  assert.equal((await stat(first)).ino, (await stat(second)).ino);
+  await assert.rejects(readFile(path.join(dataDirectory, VAULT_KEYSLOT_FILE)), { code: "ENOENT" });
+});
+
+test("encrypt resumes from a durable sealing Keyslot", async (t) => {
+  const dataDirectory = await newVault(t, "1667-vault-sealing-resume-");
+  const story = path.join(dataDirectory, "story.json");
+  const password = "correct horse battery staple";
+  await writeFile(story, "sealing resume sentinel");
+  const keyslot = await createKeyslot(password, randomBytes(32));
+  await writeFile(
+    path.join(dataDirectory, VAULT_KEYSLOT_FILE),
+    encodeKeyslot(keyslotWithState(keyslot, "sealing")),
+    { mode: 0o600 }
+  );
+  await publishDataDirectoryOwnerMarker(dataDirectory, 5);
+
+  await encryptVault({ dataDirectory, password });
+
+  assert.equal(isSealed(await readFile(story)), true);
+  assert.equal(JSON.parse(await readFile(path.join(dataDirectory, VAULT_KEYSLOT_FILE), "utf8")).state, "sealed");
+});
+
+test("encrypt seals a plaintext file that carries the public seal magic", async (t) => {
+  const dataDirectory = await newVault(t, "1667-vault-magic-prefix-");
+  const file = path.join(dataDirectory, "crafted.json");
+  const plaintext = Buffer.concat([
+    Buffer.from([0x00, 0x31, 0x36, 0x36, 0x37, 0x56, 0x01, 0x01]),
+    Buffer.alloc(48, 0x61)
+  ]);
+  await writeFile(file, plaintext);
+
+  await encryptVault({ dataDirectory, password: "correct horse battery staple" });
+
+  assert.equal(isSealed(await readFile(file)), true);
+  await decryptVault({ dataDirectory, password: "correct horse battery staple" });
+  assert.deepEqual(await readFile(file), plaintext);
+});
+
+test("encrypt seals a POSIX backslash progress look-alike", async (t) => {
+  if (process.platform === "win32") return;
+  const dataDirectory = await newVault(t, "1667-vault-progress-look-alike-");
+  const filename = `.1667-vault-unseal-progress\\${"a".repeat(64)}.json`;
+  const file = path.join(dataDirectory, filename);
+  const plaintext = "backslash progress look-alike sentinel";
+  await writeFile(file, plaintext);
+
+  await encryptVault({ dataDirectory, password: "correct horse battery staple" });
+
+  assert.equal(isSealed(await readFile(file)), true);
+  await decryptVault({ dataDirectory, password: "correct horse battery staple" });
+  assert.equal(await readFile(file, "utf8"), plaintext);
+});
+
+test("encrypt refuses a pre-existing unseal progress directory before format 5", async (t) => {
+  const dataDirectory = await newVault(t, "1667-vault-preexisting-progress-");
+  const progressDirectory = path.join(dataDirectory, VAULT_UNSEAL_PROGRESS_DIRECTORY);
+  const child = path.join(progressDirectory, "unexpected.txt");
+  await mkdir(progressDirectory, { mode: 0o700 });
+  await writeFile(child, "unexpected plaintext progress child");
+
+  await assert.rejects(
+    encryptVault({ dataDirectory, password: "correct horse battery staple" }),
+    /Vault unseal progress already exists/
+  );
+
+  assert.equal(await readDataDirectoryFormat(dataDirectory), 4);
+  assert.equal(await readFile(child, "utf8"), "unexpected plaintext progress child");
+  await assert.rejects(readFile(path.join(dataDirectory, VAULT_KEYSLOT_FILE)), { code: "ENOENT" });
+});
+
+test("encrypt preserves deceptive replace residue and removes valid residue", async (t) => {
+  const dataDirectory = await newVault(t, "1667-vault-replace-residue-");
+  const deceptive = [
+    path.join(dataDirectory, ".1667-vault-replace-123e4567-e89b-12d3-a456-426614174000.tmp"),
+    path.join(dataDirectory, ".1667-vault-replace-123E4567-E89B-42D3-A456-426614174000.tmp")
+  ];
+  const validResidue = path.join(
+    dataDirectory,
+    ".1667-vault-replace-123e4567-e89b-42d3-a456-426614174000.tmp"
+  );
+  const plaintext = "deceptive replace residue sentinel";
+  await Promise.all(deceptive.map(async (file) => await writeFile(file, plaintext)));
+  await writeFile(validResidue, "abandoned replacement bytes");
+
+  await encryptVault({ dataDirectory, password: "correct horse battery staple" });
+
+  for (const file of deceptive) assert.equal(isSealed(await readFile(file)), true);
+  await assert.rejects(readFile(validResidue), { code: "ENOENT" });
+  await decryptVault({ dataDirectory, password: "correct horse battery staple" });
+  for (const file of deceptive) assert.equal(await readFile(file, "utf8"), plaintext);
+});
+
+test("encrypt seals malformed root control residue chains", async (t) => {
+  const dataDirectory = await newVault(t, "1667-vault-control-residue-chain-");
+  const valid = path.join(dataDirectory, ".gitignore.1667-replace-v1.next.1667-publish-v1.tmp");
+  const malformed = [
+    path.join(dataDirectory, ".gitignore.1667-publish-v1.tmp.1667-publish-v1.tmp"),
+    path.join(dataDirectory, ".gitignore.1667-publish-v1.tmp.1667-replace-v1.next"),
+    path.join(dataDirectory, ".gitignore.1667-replace-v1.next.1667-replace-v1.next")
+  ];
+  await writeFile(valid, "valid control residue sentinel");
+  await Promise.all(malformed.map(async (file) => await writeFile(file, "malformed control residue sentinel")));
+
+  await encryptVault({ dataDirectory, password: "correct horse battery staple" });
+
+  assert.equal(isSealed(await readFile(valid)), false);
+  for (const file of malformed) assert.equal(isSealed(await readFile(file)), true);
+  await decryptVault({ dataDirectory, password: "correct horse battery staple" });
+  assert.equal(await readFile(valid, "utf8"), "valid control residue sentinel");
+  for (const file of malformed) {
+    assert.equal(await readFile(file, "utf8"), "malformed control residue sentinel");
+  }
+});
+
+test("encrypt refuses a symbolic-link payload before format 5", async (t) => {
+  if (process.platform === "win32") return;
+  const dataDirectory = await newVault(t, "1667-vault-symbolic-link-");
+  const linkPath = path.join(dataDirectory, "payload-link");
+  await symlink("missing-payload", linkPath);
+
+  await assert.rejects(
+    encryptVault({ dataDirectory, password: "correct horse battery staple" }),
+    /Vault contains an unsupported filesystem entry/
+  );
+
+  assert.equal(await readDataDirectoryFormat(dataDirectory), 4);
+  await assert.rejects(readFile(path.join(dataDirectory, VAULT_KEYSLOT_FILE)), { code: "ENOENT" });
+});
+
+test("encrypt refuses a hard link from a control file to payload", async (t) => {
+  const dataDirectory = await newVault(t, "1667-vault-control-hard-link-");
+  const control = path.join(dataDirectory, ".gitignore");
+  const payload = path.join(dataDirectory, "story.json");
+  await writeFile(control, "control and payload hard-link sentinel");
+  await link(control, payload);
+
+  await assert.rejects(
+    encryptVault({ dataDirectory, password: "correct horse battery staple" }),
+    /Vault hard-link group mixes control and payload paths/
+  );
+
+  assert.equal(await readDataDirectoryFormat(dataDirectory), 4);
+  assert.equal((await stat(control)).ino, (await stat(payload)).ino);
+  assert.equal(await readFile(payload, "utf8"), "control and payload hard-link sentinel");
+  await assert.rejects(readFile(path.join(dataDirectory, VAULT_KEYSLOT_FILE)), { code: "ENOENT" });
+});
+
+test("decrypt resume removes an exact stale run record atomic residue", async (t) => {
+  const dataDirectory = await newVault(t, "1667-vault-run-record-residue-");
+  const story = path.join(dataDirectory, "story.json");
+  const residue = path.join(
+    dataDirectory,
+    "run.json.123e4567-e89b-42d3-a456-426614174000.tmp"
+  );
+  const plaintext = "run record residue resume sentinel";
+  await writeFile(story, plaintext);
+  await encryptVault({ dataDirectory, password: "correct horse battery staple" });
+  await assert.rejects(
+    decryptVault({
+      dataDirectory,
+      password: "correct horse battery staple",
+      afterUnsealReplacement: async () => {
+        throw new Error("simulated crash before run record cleanup");
+      }
+    }),
+    /simulated crash before run record cleanup/
+  );
+  await writeFile(residue, "plaintext stale run record");
+
+  await decryptVault({ dataDirectory, password: "correct horse battery staple" });
+
+  assert.equal(await readFile(story, "utf8"), plaintext);
+  await assert.rejects(readFile(residue), { code: "ENOENT" });
+});
+
+test("encrypt seals a malformed run record atomic name", async (t) => {
+  const dataDirectory = await newVault(t, "1667-vault-run-record-look-alike-");
+  const file = path.join(
+    dataDirectory,
+    "run.json.123e4567-e89b-12d3-a456-426614174000.tmp"
+  );
+  const plaintext = "malformed run record atomic sentinel";
+  await writeFile(file, plaintext);
+
+  await encryptVault({ dataDirectory, password: "correct horse battery staple" });
+
+  assert.equal(isSealed(await readFile(file)), true);
+  await decryptVault({ dataDirectory, password: "correct horse battery staple" });
+  assert.equal(await readFile(file, "utf8"), plaintext);
+});
+
+test("decrypt resume accepts a witnessed magic-prefix plaintext replacement", async (t) => {
+  const dataDirectory = await newVault(t, "1667-vault-magic-resume-");
+  const file = path.join(dataDirectory, "crafted.json");
+  const plaintext = Buffer.concat([
+    Buffer.from([0x00, 0x31, 0x36, 0x36, 0x37, 0x56, 0x01, 0x01]),
+    Buffer.alloc(48, 0x62)
+  ]);
+  await writeFile(file, plaintext);
+  await encryptVault({ dataDirectory, password: "correct horse battery staple" });
+
+  await assert.rejects(
+    decryptVault({
+      dataDirectory,
+      password: "correct horse battery staple",
+      afterUnsealReplacement: async () => {
+        throw new Error("simulated crash after magic replacement");
+      }
+    }),
+    /simulated crash after magic replacement/
+  );
+  if (process.platform !== "win32") {
+    assert.equal(
+      (await stat(path.join(dataDirectory, VAULT_UNSEAL_PROGRESS_DIRECTORY))).mode & 0o777,
+      0o700
+    );
+  }
+  await decryptVault({ dataDirectory, password: "correct horse battery staple" });
+
+  assert.deepEqual(await readFile(file), plaintext);
+});
+
+test("decrypt refuses an unseal progress directory with an unknown child", async (t) => {
+  const dataDirectory = await newVault(t, "1667-vault-unknown-progress-child-");
+  const story = path.join(dataDirectory, "story.json");
+  const progressDirectory = path.join(dataDirectory, VAULT_UNSEAL_PROGRESS_DIRECTORY);
+  await writeFile(story, "unknown progress child sentinel");
+  await encryptVault({ dataDirectory, password: "correct horse battery staple" });
+  await mkdir(progressDirectory, { mode: 0o700 });
+  await writeFile(path.join(progressDirectory, "unexpected.txt"), "unexpected plaintext child");
+
+  await assert.rejects(
+    decryptVault({ dataDirectory, password: "correct horse battery staple" }),
+    /Vault unseal progress has an unknown entry/
+  );
+
+  assert.equal(await readDataDirectoryFormat(dataDirectory), 5);
+  assert.equal(isSealed(await readFile(story)), true);
+});
+
+test("decrypt refuses a repeated unseal progress residue before format 4", async (t) => {
+  const dataDirectory = await newVault(t, "1667-vault-progress-residue-chain-");
+  const story = path.join(dataDirectory, "story.json");
+  const progressDirectory = path.join(dataDirectory, VAULT_UNSEAL_PROGRESS_DIRECTORY);
+  const malformed = path.join(
+    progressDirectory,
+    `${"a".repeat(64)}.json.1667-publish-v1.tmp.1667-publish-v1.tmp`
+  );
+  await writeFile(story, "repeated progress residue sentinel");
+  await encryptVault({ dataDirectory, password: "correct horse battery staple" });
+  await mkdir(progressDirectory, { mode: 0o700 });
+  await writeFile(malformed, "malformed progress residue");
+
+  await assert.rejects(
+    decryptVault({ dataDirectory, password: "correct horse battery staple" }),
+    /Vault unseal progress has an unknown entry/
+  );
+
+  assert.equal(await readDataDirectoryFormat(dataDirectory), 5);
+  assert.equal(isSealed(await readFile(story)), true);
+});
+
+test("decrypt accepts an empty unseal progress directory", async (t) => {
+  const dataDirectory = await newVault(t, "1667-vault-empty-progress-");
+  const story = path.join(dataDirectory, "story.json");
+  const progressDirectory = path.join(dataDirectory, VAULT_UNSEAL_PROGRESS_DIRECTORY);
+  await writeFile(story, "empty progress directory sentinel");
+  await encryptVault({ dataDirectory, password: "correct horse battery staple" });
+  await mkdir(progressDirectory, { mode: 0o700 });
+
+  await decryptVault({ dataDirectory, password: "correct horse battery staple" });
+
+  assert.equal(await readFile(story, "utf8"), "empty progress directory sentinel");
+  await assert.rejects(readFile(progressDirectory), { code: "ENOENT" });
+});
+
+test("decrypt refuses an unwitnessed sealed file that fails authentication", async (t) => {
+  const dataDirectory = await newVault(t, "1667-vault-corrupt-ciphertext-");
+  const file = path.join(dataDirectory, "story.json");
+  await writeFile(file, "ciphertext corruption sentinel");
+  await encryptVault({ dataDirectory, password: "correct horse battery staple" });
+  const corrupted = await readFile(file);
+  const lastIndex = corrupted.byteLength - 1;
+  const lastByte = corrupted[lastIndex];
+  if (lastByte === undefined) throw new Error("sealed test file is empty");
+  corrupted[lastIndex] = lastByte ^ 0x01;
+  await writeFile(file, corrupted);
+
+  await assert.rejects(
+    decryptVault({ dataDirectory, password: "correct horse battery staple" }),
+    /authentication failed/
+  );
+  assert.equal(isSealed(await readFile(file)), true);
+});
+
+test("decrypt tail removes an unsealing Keyslot without a password", async (t) => {
+  const dataDirectory = await newVault(t, "1667-vault-decrypt-tail-");
+  const story = path.join(dataDirectory, "story.json");
+  const password = "correct horse battery staple";
+  await writeFile(story, "decrypt tail sentinel");
+  await encryptVault({ dataDirectory, password });
+  const sealedKeyslot = parseKeyslot(await readFile(path.join(dataDirectory, VAULT_KEYSLOT_FILE)));
+  await decryptVault({ dataDirectory, password });
+  await writeFile(
+    path.join(dataDirectory, VAULT_KEYSLOT_FILE),
+    encodeKeyslot(keyslotWithState(sealedKeyslot, "unsealing")),
+    { mode: 0o600 }
+  );
+
+  await decryptVault({ dataDirectory });
+
+  assert.equal(await readFile(story, "utf8"), "decrypt tail sentinel");
+  await assert.rejects(readFile(path.join(dataDirectory, VAULT_KEYSLOT_FILE)), { code: "ENOENT" });
+});
+
+test("a held vault lock refuses before the password provider runs", async (t) => {
+  const dataDirectory = await newVault(t, "1667-vault-password-lock-");
+  const holder = new DataDirectoryLock(dataDirectory);
+  await holder.acquire();
+  t.after(async () => await holder.release());
+  let passwordRequests = 0;
+
+  await assert.rejects(
+    encryptVault({
+      dataDirectory,
+      password: async () => {
+        passwordRequests += 1;
+        return "correct horse battery staple";
+      }
+    }),
+    /already open/
+  );
+
+  assert.equal(passwordRequests, 0);
+});
+
+async function newVault(t: TestContext, prefix: string): Promise<string> {
+  const dataDirectory = await mkdtemp(path.join(tmpdir(), prefix));
+  t.after(async () => await rm(dataDirectory, { recursive: true, force: true }));
+  const initializer = new DataDirectoryLock(dataDirectory);
+  await initializer.acquire();
+  await initializer.release();
+  return dataDirectory;
+}

--- a/test/vault-storage-hooks.integration.test.ts
+++ b/test/vault-storage-hooks.integration.test.ts
@@ -1,0 +1,117 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, readFile, rm } from "node:fs/promises";
+import { randomBytes } from "node:crypto";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { isSealed } from "../shared/vault-cipher.js";
+import { MutationOutbox } from "../server/mutation-outbox.js";
+import { publishProjectRunRecord, readProjectRunRecord } from "../server/project-run-record.js";
+import { RuntimeDataDirectoryLock } from "../server/runtime-data-directory.js";
+import { writeDurableAtomic } from "../server/story-lifecycle.js";
+import {
+  isVaultControlPath,
+  registerVaultKey,
+  vaultKeyForPath
+} from "../server/vault-key-registry.js";
+
+test("sealed storage hooks keep mutation records encrypted on disk and readable in process", async (t) => {
+  const dataDirectory = await mkdtemp(path.join(tmpdir(), "1667-vault-storage-hooks-"));
+  t.after(async () => await rm(dataDirectory, { recursive: true, force: true }));
+  const registration = registerVaultKey(dataDirectory, randomBytes(32));
+  t.after(() => registration.clear());
+
+  const mutationId = "m1.1767225600000.0123456789abcdef0123456789abcdef";
+  const sentinel = "vault storage hook sentinel: amber lighthouse";
+  const outbox = new MutationOutbox(path.join(dataDirectory, "mutation-outbox"));
+  await outbox.init();
+  await outbox.enqueue(mutationId, "createStory", { title: sentinel });
+
+  const stored = await readFile(path.join(dataDirectory, "mutation-outbox", `${mutationId}.json`));
+  assert.equal(isSealed(stored), true);
+  assert.equal(stored.includes(Buffer.from(sentinel)), false);
+  const [record] = await new MutationOutbox(path.join(dataDirectory, "mutation-outbox")).list();
+  assert.equal((record?.input as { title?: unknown } | undefined)?.title, sentinel);
+});
+
+test("a scoped key registration covers retained authority writes and leaves atomic control files plain", async (t) => {
+  const dataDirectory = await mkdtemp(path.join(tmpdir(), "1667-vault-authority-hooks-"));
+  t.after(async () => await rm(dataDirectory, { recursive: true, force: true }));
+  const lock = new RuntimeDataDirectoryLock(dataDirectory);
+  const canonical = await lock.acquire();
+  t.after(async () => await lock.release());
+  const authority = lock.authorityPath;
+  const registration = registerVaultKey(canonical, randomBytes(32));
+  registration.addAlias(authority);
+  t.after(() => registration.clear());
+  const registeredKey = vaultKeyForPath(path.join(authority, "mutation-outbox", "probe.json"));
+  assert.notEqual(registeredKey, null);
+
+  const mutationId = "m1.1767225600000.1123456789abcdef0123456789abcdef";
+  const sentinel = "retained authority vault sentinel";
+  const outbox = new MutationOutbox(path.join(authority, "mutation-outbox"));
+  await outbox.init();
+  await outbox.enqueue(mutationId, "createStory", { title: sentinel });
+  const stored = await readFile(path.join(authority, "mutation-outbox", `${mutationId}.json`));
+  assert.equal(isSealed(stored), true);
+  const [record] = await outbox.list();
+  assert.equal((record?.input as { title?: unknown } | undefined)?.title, sentinel);
+
+  const runRecord = { pid: process.pid, port: null, url: null, startedAt: "2026-08-09T00:00:00.000Z" };
+  await publishProjectRunRecord(authority, runRecord);
+  const storedRunRecord = await readFile(path.join(authority, "run.json"));
+  assert.equal(isSealed(storedRunRecord), false);
+  registration.clear();
+  assert.deepEqual(await readProjectRunRecord(authority), runRecord);
+  assert.equal(vaultKeyForPath(path.join(authority, "mutation-outbox", "probe.json")), null);
+  assert.equal(registeredKey!.every((byte) => byte === 0), true);
+});
+
+test("an alias collision can clear a failed scoped registration without leaving its key active", async (t) => {
+  const root = await mkdtemp(path.join(tmpdir(), "1667-vault-alias-collision-"));
+  t.after(async () => await rm(root, { recursive: true, force: true }));
+  const alias = path.join(root, "retained-authority");
+  await mkdir(alias);
+  const registration = registerVaultKey(root, randomBytes(32));
+  const registeredKey = vaultKeyForPath(path.join(root, "story.json"));
+  assert.notEqual(registeredKey, null);
+  const conflicting = registerVaultKey(alias, randomBytes(32));
+  try {
+    assert.throws(() => registration.addAlias(alias), /already registered/);
+  } finally {
+    registration.clear();
+    conflicting.clear();
+  }
+  assert.equal(vaultKeyForPath(path.join(alias, "child.json")), null);
+  assert.equal(registeredKey!.every((byte) => byte === 0), true);
+});
+
+test("only the documented story cleanup marker remains plaintext", async (t) => {
+  const root = await mkdtemp(path.join(tmpdir(), "1667-vault-cleanup-control-"));
+  t.after(async () => await rm(root, { recursive: true, force: true }));
+  const registration = registerVaultKey(root, randomBytes(32));
+  t.after(() => registration.clear());
+  const storyMarker = path.join(root, "stories", "story-1", ".1667-cleanup-needed");
+  const unrelatedMarker = path.join(root, "other", ".1667-cleanup-needed");
+  await mkdir(path.dirname(storyMarker), { recursive: true });
+  await mkdir(path.dirname(unrelatedMarker), { recursive: true });
+
+  await writeDurableAtomic(storyMarker, "cleanup pending\n");
+  await writeDurableAtomic(unrelatedMarker, "must be sealed\n");
+
+  assert.equal(isSealed(await readFile(storyMarker)), false);
+  assert.equal(isSealed(await readFile(unrelatedMarker)), true);
+  assert.equal(isVaultControlPath(root, path.relative(root, storyMarker)), true);
+  assert.equal(
+    isVaultControlPath(root, path.join(
+      "stories",
+      "story-1",
+      ".1667-cleanup-needed.12345678-1234-4123-8123-123456789abc.tmp"
+    )),
+    true
+  );
+  assert.equal(isVaultControlPath(root, path.join(
+    "other",
+    ".1667-cleanup-needed.12345678-1234-4123-8123-123456789abc.tmp"
+  )), false);
+});

--- a/test/vault-unseal-progress.test.ts
+++ b/test/vault-unseal-progress.test.ts
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import { randomBytes } from "node:crypto";
+import { mkdir, mkdtemp, readdir, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test, { type TestContext } from "node:test";
+import {
+  VAULT_UNSEAL_PROGRESS_DIRECTORY,
+  VaultUnsealProgress
+} from "../server/vault-unseal-progress.js";
+
+test("unseal progress syncs an existing directory before it can publish witnesses", async (t) => {
+  const root = await newRoot(t);
+  const directory = path.join(root, VAULT_UNSEAL_PROGRESS_DIRECTORY);
+  await mkdir(directory, { mode: 0o700 });
+  const calls: string[] = [];
+  const syncRoot = async (value: string): Promise<void> => {
+    calls.push(value);
+    assert.deepEqual(await readdir(directory), []);
+  };
+
+  const loaded = await VaultUnsealProgress.load(root, randomBytes(32), { syncRoot });
+  await loaded.record([path.join(root, "story.json")], Buffer.from("first witness"));
+
+  assert.deepEqual(calls, [root]);
+});
+
+test("unseal progress syncs an EEXIST directory before it publishes a witness", async (t) => {
+  const root = await newRoot(t);
+  const directory = path.join(root, VAULT_UNSEAL_PROGRESS_DIRECTORY);
+  const calls: string[] = [];
+  const syncRoot = async (value: string): Promise<void> => {
+    calls.push(value);
+    assert.deepEqual(await readdir(directory), []);
+  };
+  const progress = await VaultUnsealProgress.load(root, randomBytes(32), { syncRoot });
+  await mkdir(directory, { mode: 0o700 });
+
+  await progress.record([path.join(root, "story.json")], Buffer.from("EEXIST witness"));
+
+  assert.deepEqual(calls, [root]);
+});
+
+async function newRoot(t: TestContext): Promise<string> {
+  const root = await mkdtemp(path.join(tmpdir(), "1667-vault-progress-sync-"));
+  t.after(async () => await rm(root, { recursive: true, force: true }));
+  return root;
+}

--- a/tui/src/card-import-cli.ts
+++ b/tui/src/card-import-cli.ts
@@ -3,7 +3,7 @@ import type { StorySummary } from "../../shared/types.js";
 import { readImportBytes } from "../../server/import-file.js";
 import { selectStory } from "./story-selector.js";
 import { terminalLineText as plain } from "../../shared/terminal-text.js";
-import { createWorkerStoryApi } from "./worker-api.js";
+import { openProjectBackend } from "./vault-project-backend.js";
 import { fidelityReport } from "../../shared/fidelity.js";
 
 export interface CardImportCommand {
@@ -11,6 +11,7 @@ export interface CardImportCommand {
   readonly files: readonly string[];
   readonly data: string | null;
   readonly global: boolean;
+  readonly passphraseFile: string | null;
 }
 
 export function parseCardImportCommand(argv: readonly string[]): CardImportCommand {
@@ -18,15 +19,20 @@ export function parseCardImportCommand(argv: readonly string[]): CardImportComma
   let story: string | null = null;
   let data: string | null = null;
   let global = false;
+  let passphraseFile: string | null = null;
   for (let index = 0; index < argv.length; index += 1) {
     const argument = argv[index]!;
     if (argument === "--global") global = true;
+    else if (argument.startsWith("--passphrase-file=")) {
+      passphraseFile = inlineValue(argument, "--passphrase-file");
+    }
     else if (argument.startsWith("--story=")) story = inlineValue(argument, "--story");
     else if (argument.startsWith("--data=")) data = inlineValue(argument, "--data");
-    else if (argument === "--story" || argument === "--data") {
+    else if (argument === "--story" || argument === "--data" || argument === "--passphrase-file") {
       const value = separatedValue(argv, ++index, argument);
       if (argument === "--story") story = value;
-      else data = value;
+      else if (argument === "--data") data = value;
+      else passphraseFile = value;
     } else if (argument.startsWith("-")) {
       throw new Error(`unknown import-card option: ${plain(argument)}`);
     } else {
@@ -44,7 +50,7 @@ export function parseCardImportCommand(argv: readonly string[]): CardImportComma
   if (global && data !== null) {
     throw new Error("--global and --data select different projects");
   }
-  return { story, files, data, global };
+  return { story, files, data, global, passphraseFile };
 }
 
 export async function runCardImport(
@@ -54,7 +60,7 @@ export async function runCardImport(
 ): Promise<void> {
   const command = parseCardImportCommand(argv);
   const project = await resolveExistingProject(command, "import");
-  const backend = await createWorkerStoryApi({ dataDir: project.directory });
+  const backend = await openProjectBackend(project, command.passphraseFile);
   let failed = false;
   try {
     const story = selectStory(await backend.api.listStories(), command.story);
@@ -87,6 +93,3 @@ export async function runCardImport(
   }
   if (failed) process.exitCode = 1;
 }
-
-
-

--- a/tui/src/cli-help.ts
+++ b/tui/src/cli-help.ts
@@ -5,12 +5,13 @@
  * command it belongs to and the front page stays a map. */
 
 export const HELP = `1667 — a full-screen terminal environment for writing fiction
-
 Usage: 1667 [options]
        1667 <command> [options]
 
 Commands:
   init             Make a project in this directory
+  encrypt          Seal this project with a Vault Password
+  decrypt          Unseal this project
   export           Write a story to Markdown or a NovelAI archive
   import           Make a new story from a file
   import-card      Add Facts from a character card to a story that exists
@@ -19,7 +20,6 @@ Commands:
   serve            Run the HTTP server
   auth             Show an access record
   upgrade          Update this program
-
 Options:
   --story <id>       Open this story instead of the most recently updated
   --data <path>      Open this project root instead of discovering one
@@ -32,7 +32,7 @@ Run '1667 <command> --help' for one command, or read docs/development.md.`;
 export const EXPORT_HELP = `1667 export — write a story to a file
 
 Usage: 1667 export [--story <id>|--all] [--format story|scenario|lorebook]
-                   [--force] [--data <path>|--global]
+                   [--force] [--passphrase-file <path>] [--data <path>|--global]
 
 Writes Markdown by default. It contains one story's selected line — the take
 chosen at each part, as you last left it. Prose only: chapters become '##'
@@ -51,12 +51,13 @@ Options:
                      for equal file names
   --format <format>  Write a NovelAI story, scenario, or lorebook archive
   --force            Replace the selected output file
+  --passphrase-file <path>  Read the Vault Password from this file
   --data <path>      Open this project root instead of discovering one
   --global           Open the machine-wide project instead of a folder`;
 
 export const IMPORT_HELP = `1667 import — make a new story from a file
 
-Usage: 1667 import [--data <path>|--global] <file...>
+Usage: 1667 import [--passphrase-file <path>] [--data <path>|--global] <file...>
 
 Makes one new story from each Markdown, SillyTavern (.jsonl), NovelAI .story,
 or NovelAI .scenario file.
@@ -79,12 +80,14 @@ To add Facts to a story that already exists, use 1667 import-card or
 1667 import-lorebook.
 
 Options:
+  --passphrase-file <path>  Read the Vault Password from this file
   --data <path>      Open this project root instead of discovering one
   --global           Open the machine-wide project instead of a folder`;
 
 export const IMPORT_CARD_HELP = `1667 import-card — add character card Facts to a story
 
-Usage: 1667 import-card --story <id-or-title> [--data <path>|--global] <file...>
+Usage: 1667 import-card --story <id-or-title> [--passphrase-file <path>]
+                       [--data <path>|--global] <file...>
 
 Adds Facts from one or more V1, V2, or V3 JSON or PNG character cards to a
 story that already exists. It does not make a new story, so --story is
@@ -103,12 +106,14 @@ and exits non-zero at the end.
 
 Options:
   --story <id-or-title>  The story that receives the Facts; required
+  --passphrase-file <path>  Read the Vault Password from this file
   --data <path>          Open this project root instead of discovering one
   --global               Open the machine-wide project instead of a folder`;
 
 export const IMPORT_LOREBOOK_HELP = `1667 import-lorebook — add lorebook Facts to a story
 
-Usage: 1667 import-lorebook --story <id-or-title> [--data <path>|--global] <file...>
+Usage: 1667 import-lorebook --story <id-or-title> [--passphrase-file <path>]
+                           [--data <path>|--global] <file...>
 
 Adds one Fact for each entry of a lorebook to a story that already exists. It
 does not make a new story, so --story is required.
@@ -128,13 +133,16 @@ and also reads .scenario and .story files.
 
 Options:
   --story <id-or-title>  The story that receives the Facts; required
+  --passphrase-file <path>  Read the Vault Password from this file
   --data <path>          Open this project root instead of discovering one
   --global               Open the machine-wide project instead of a folder`;
 
 export const PROFILE_HELP = `1667 profile — import or export a Generation Profile
 
-Usage: 1667 profile import [--profile <name>] [--data <path>|--global] <file...>
-       1667 profile export [--profile <name>] [--force] [--data <path>|--global]
+Usage: 1667 profile import [--profile <name>] [--passphrase-file <path>]
+                            [--data <path>|--global] <file...>
+       1667 profile export [--profile <name>] [--force] [--passphrase-file <path>]
+                            [--data <path>|--global]
 
 Import reads a NovelAI Sampler Preset or a Profile Export. It creates a new
 Generation Profile and does not change the selected profile. 1667 reports
@@ -146,6 +154,7 @@ does not include a connection, credentials, headers, or private endpoint data.
 Options:
   --profile <name>  Select a profile ID or unique profile name
   --force           Replace the export file
+  --passphrase-file <path>  Read the Vault Password from this file
   --data <path>     Open this project root instead of discovering one
   --global          Open the machine-wide project instead of a folder`;
 
@@ -162,6 +171,40 @@ Use separate project roots for separate story libraries.
 Options:
   --adopt            Adopt an existing legacy data directory
   --from <path>      The legacy data directory to adopt; requires --adopt`;
+
+export const ENCRYPT_HELP = `1667 encrypt — seal this project
+
+Usage: 1667 encrypt [--passphrase-file <path>] [--data <path>|--global]
+
+Seals every project file except control files. The command changes the project
+to format 5. A stopped seal resumes when you run this command again.
+
+With a terminal, enter the Vault Password two times. Without a terminal, use
+--passphrase-file. The file must be outside the data directory. An empty Vault
+Password is refused.
+
+If you lose the Vault Password, 1667 cannot recover the vault.
+
+Options:
+  --passphrase-file <path>  Read the Vault Password from this file
+  --data <path>             Open this project root instead of discovering one
+  --global                  Open the machine-wide project instead of a folder`;
+
+export const DECRYPT_HELP = `1667 decrypt — unseal this project
+
+Usage: 1667 decrypt [--passphrase-file <path>] [--data <path>|--global]
+
+Unseals every project file and changes the project to format 4. A stopped
+unseal resumes when you run this command again.
+
+With a terminal, enter the Vault Password. Without a terminal, use
+--passphrase-file. The file must be outside the data directory. An empty Vault
+Password is refused.
+
+Options:
+  --passphrase-file <path>  Read the Vault Password from this file
+  --data <path>             Open this project root instead of discovering one
+  --global                  Open the machine-wide project instead of a folder`;
 
 export const AUTH_HELP = `1667 auth — show an access record
 
@@ -181,6 +224,8 @@ Options:
 
 const COMMAND_HELP: ReadonlyMap<string, string> = new Map([
   ["init", INIT_HELP],
+  ["encrypt", ENCRYPT_HELP],
+  ["decrypt", DECRYPT_HELP],
   ["auth", AUTH_HELP],
   ["export", EXPORT_HELP],
   ["import", IMPORT_HELP],

--- a/tui/src/export-cli.ts
+++ b/tui/src/export-cli.ts
@@ -7,9 +7,9 @@ import {
   writeExportFile,
   writeStoryExport
 } from "./export-file.js";
-import { createWorkerStoryApi } from "./worker-api.js";
 import { fidelityReport } from "../../shared/fidelity.js";
 import { inlineValue, resolveExistingProject, separatedValue } from "./project-command.js";
+import { openProjectBackend } from "./vault-project-backend.js";
 
 export type ExportFormat = "markdown" | NovelAiExportFormat;
 
@@ -20,6 +20,7 @@ export interface ExportCommand {
   readonly force: boolean;
   readonly data: string | null;
   readonly global: boolean;
+  readonly passphraseFile: string | null;
 }
 
 export function parseExportCommand(argv: readonly string[]): ExportCommand {
@@ -29,18 +30,24 @@ export function parseExportCommand(argv: readonly string[]): ExportCommand {
   let force = false;
   let data: string | null = null;
   let global = false;
+  let passphraseFile: string | null = null;
   for (let index = 0; index < argv.length; index += 1) {
     const argument = argv[index]!;
     if (argument === "--force") force = true;
     else if (argument === "--all") all = true;
     else if (argument === "--global") global = true;
+    else if (argument.startsWith("--passphrase-file=")) {
+      passphraseFile = inlineValue(argument, "--passphrase-file");
+    }
     else if (argument.startsWith("--story=")) storyId = inlineValue(argument, "--story");
     else if (argument.startsWith("--data=")) data = inlineValue(argument, "--data");
     else if (argument.startsWith("--format=")) format = archiveFormat(inlineValue(argument, "--format"));
-    else if (argument === "--story" || argument === "--data" || argument === "--format") {
+    else if (argument === "--story" || argument === "--data" || argument === "--format"
+      || argument === "--passphrase-file") {
       const value = separatedValue(argv, ++index, argument);
       if (argument === "--story") storyId = value;
       else if (argument === "--data") data = value;
+      else if (argument === "--passphrase-file") passphraseFile = value;
       else format = archiveFormat(value);
     } else throw new Error(`unknown export option: ${argument}`);
   }
@@ -50,7 +57,7 @@ export function parseExportCommand(argv: readonly string[]): ExportCommand {
   if (all && storyId !== null) {
     throw new Error("--story and --all select different stories");
   }
-  return { storyId, all, format, force, data, global };
+  return { storyId, all, format, force, data, global, passphraseFile };
 }
 
 /**
@@ -65,7 +72,7 @@ export async function runStoryExport(
 ): Promise<void> {
   const command = parseExportCommand(argv);
   const project = await resolveExistingProject(command, "export");
-  const backend = await createWorkerStoryApi({ dataDir: project.directory });
+  const backend = await openProjectBackend(project, command.passphraseFile);
   try {
     const stories = [...await backend.api.listStories()].sort(
       (left, right) => compareStoriesForExport(left, right)

--- a/tui/src/http-commands.ts
+++ b/tui/src/http-commands.ts
@@ -27,6 +27,7 @@ import {
 } from "../../server/service-error-policy.js";
 import type { HttpCapabilityScope } from "../../shared/http-auth.js";
 import { attachHttpServer } from "./http-attach.js";
+import { refuseSealedVaultForHttp } from "../../server/vault-access-policy.js";
 
 export async function runHttpCommand(argv: string[]): Promise<boolean> {
   if (argv[0] === "auth") {
@@ -98,10 +99,13 @@ export async function startLegacyServe(
   options: {
     readonly port?: number;
     readonly printLogs?: boolean;
+    /** @internal Deterministic test seam before the retained vault check. */
+    readonly beforeLockedVaultCheck?: (authorityPath: string) => Promise<void>;
   } = {}
 ): Promise<HttpListener> {
   assertLegacyDataDirectoryPlatform();
   const dataDir = resolve(dataDirInput);
+  await refuseSealedVaultForHttp(dataDir, "legacy HTTP serve");
   const machineTierContext = {
     service: "http-server-startup",
     operation: "machine-tier-resolution"
@@ -137,9 +141,22 @@ export async function startLegacyServe(
     machineDir,
     project: { root: dataDir, dataDir },
     serviceFactory: async (errorReporter, machineDir, project) => {
+      let legacyValidationCount = 0;
       const legacyDataLease = await acquireLegacyDataDirectoryLease(
         project.dataDir,
-        machineDir
+        machineDir,
+        {
+          validateAuthority: async (authorityPath) => {
+            // The lease calls this once before its layout validation and once
+            // after every data lock is retained. Only the second callback is
+            // useful to a race test.
+            if (legacyValidationCount > 0) {
+              await options.beforeLockedVaultCheck?.(authorityPath);
+            }
+            legacyValidationCount += 1;
+            await refuseSealedVaultForHttp(authorityPath, "legacy HTTP serve");
+          }
+        }
       );
       try {
         return new StoryService({

--- a/tui/src/import-cli.ts
+++ b/tui/src/import-cli.ts
@@ -2,24 +2,33 @@ import path from "node:path";
 import { inlineValue, resolveExistingProject, separatedValue } from "./project-command.js";
 import { readImportBytes } from "../../server/import-file.js";
 import { terminalLineText as plain } from "../../shared/terminal-text.js";
-import { createWorkerStoryApi } from "./worker-api.js";
+import { openProjectBackend } from "./vault-project-backend.js";
 import { fidelityReport } from "../../shared/fidelity.js";
 
 export interface ImportCommand {
   readonly files: readonly string[];
   readonly data: string | null;
   readonly global: boolean;
+  readonly passphraseFile: string | null;
 }
 
 export function parseImportCommand(argv: readonly string[]): ImportCommand {
   const files: string[] = [];
   let data: string | null = null;
   let global = false;
+  let passphraseFile: string | null = null;
   for (let index = 0; index < argv.length; index += 1) {
     const argument = argv[index]!;
     if (argument === "--global") global = true;
+    else if (argument.startsWith("--passphrase-file=")) {
+      passphraseFile = inlineValue(argument, "--passphrase-file");
+    }
     else if (argument.startsWith("--data=")) data = inlineValue(argument, "--data");
-    else if (argument === "--data") data = separatedValue(argv, ++index, argument); else if (argument.startsWith("-")) {
+    else if (argument === "--data" || argument === "--passphrase-file") {
+      const value = separatedValue(argv, ++index, argument);
+      if (argument === "--data") data = value;
+      else passphraseFile = value;
+    } else if (argument.startsWith("-")) {
       throw new Error(`unknown import option: ${plain(argument)}`);
     } else {
       files.push(argument);
@@ -36,8 +45,7 @@ export function parseImportCommand(argv: readonly string[]): ImportCommand {
       throw new Error("1667 import creates stories, not Lorebooks (.lorebook); use 1667 import-lorebook");
     }
   }
-  return { files, data, global };
-
+  return { files, data, global, passphraseFile };
 }
 
 
@@ -48,7 +56,7 @@ export async function runStoryImport(
 ): Promise<void> {
   const command = parseImportCommand(argv);
   const project = await resolveExistingProject(command, "import");
-  const backend = await createWorkerStoryApi({ dataDir: project.directory });
+  const backend = await openProjectBackend(project, command.passphraseFile);
   let failed = false;
   try {
     for (const file of command.files) {

--- a/tui/src/lorebook-import-cli.ts
+++ b/tui/src/lorebook-import-cli.ts
@@ -3,7 +3,7 @@ import type { StorySummary } from "../../shared/types.js";
 import { readImportBytes } from "../../server/import-file.js";
 import { selectStory } from "./story-selector.js";
 import { terminalLineText as plain } from "../../shared/terminal-text.js";
-import { createWorkerStoryApi } from "./worker-api.js";
+import { openProjectBackend } from "./vault-project-backend.js";
 import { countNoun, fidelityReport } from "../../shared/fidelity.js";
 
 export interface LorebookImportCommand {
@@ -11,6 +11,7 @@ export interface LorebookImportCommand {
   readonly files: readonly string[];
   readonly data: string | null;
   readonly global: boolean;
+  readonly passphraseFile: string | null;
 }
 
 export function parseLorebookImportCommand(argv: readonly string[]): LorebookImportCommand {
@@ -18,16 +19,21 @@ export function parseLorebookImportCommand(argv: readonly string[]): LorebookImp
   let story: string | null = null;
   let data: string | null = null;
   let global = false;
+  let passphraseFile: string | null = null;
 
   for (let index = 0; index < argv.length; index += 1) {
     const argument = argv[index]!;
     if (argument === "--global") global = true;
+    else if (argument.startsWith("--passphrase-file=")) {
+      passphraseFile = inlineValue(argument, "--passphrase-file");
+    }
     else if (argument.startsWith("--story=")) story = inlineValue(argument, "--story");
     else if (argument.startsWith("--data=")) data = inlineValue(argument, "--data");
-    else if (argument === "--story" || argument === "--data") {
+    else if (argument === "--story" || argument === "--data" || argument === "--passphrase-file") {
       const value = separatedValue(argv, ++index, argument);
       if (argument === "--story") story = value;
-      else data = value;
+      else if (argument === "--data") data = value;
+      else passphraseFile = value;
     } else if (argument.startsWith("-")) {
       throw new Error(`unknown import-lorebook option: ${plain(argument)}`);
     } else {
@@ -57,7 +63,7 @@ export function parseLorebookImportCommand(argv: readonly string[]): LorebookImp
     }
   }
 
-  return { story, files, data, global };
+  return { story, files, data, global, passphraseFile };
 }
 
 export async function runLorebookImport(
@@ -67,7 +73,7 @@ export async function runLorebookImport(
 ): Promise<void> {
   const command = parseLorebookImportCommand(argv);
   const project = await resolveExistingProject(command, "import");
-  const backend = await createWorkerStoryApi({ dataDir: project.directory });
+  const backend = await openProjectBackend(project, command.passphraseFile);
   let failed = false;
 
   try {

--- a/tui/src/main.ts
+++ b/tui/src/main.ts
@@ -34,6 +34,7 @@ import { runCardImport } from "./card-import-cli.js";
 import { runLorebookImport } from "./lorebook-import-cli.js";
 import { runProfileCommand } from "./profile-cli.js";
 import { runHttpCommand } from "./http-commands.js";
+import { runVaultDecrypt, runVaultEncrypt } from "./vault-cli.js";
 
 import { parseCanonicalLoopbackOrigin } from "../../shared/http-loopback-origin.js";
 import {
@@ -58,6 +59,11 @@ import {
   canPromptForProject,
   confirmProjectCreation
 } from "./project-prompt.js";
+import {
+  openSealedVault,
+  revalidateSealedVault,
+  revalidateUnsealedVault
+} from "./vault-open.js";
 
 interface Arguments {
   url: string | null;
@@ -92,6 +98,14 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
   }
   if (argv[0] === "init") {
     await runProjectInit(argv.slice(1));
+    return;
+  }
+  if (argv[0] === "encrypt") {
+    await runVaultEncrypt(argv.slice(1));
+    return;
+  }
+  if (argv[0] === "decrypt") {
+    await runVaultDecrypt(argv.slice(1));
     return;
   }
   if (argv[0] === "export") {
@@ -355,16 +369,24 @@ async function attachOrigin(args: Arguments): Promise<string> {
  * Open the project this invocation names, asking once when none exists.
  * Returns null when the person declines, which is not an error.
  */
-async function openProject(args: Arguments): Promise<ResolvedProject | null> {
+interface OpenedProject {
+  readonly project: ResolvedProject;
+  readonly vault: Awaited<ReturnType<typeof openSealedVault>>;
+}
+
+async function openProject(args: Arguments): Promise<OpenedProject | null> {
   const outcome = await resolveProject(projectRequest(args));
   if (outcome.kind === "project") {
     // An explicitly named project — `--data` or `--global` — is explicit intent
     // to have one, so it is created. Discovery only ever finds existing ones.
     if (!outcome.project.exists) {
       await createProjectTier(outcome.project.directory);
-      return { ...outcome.project, exists: true };
+      return { project: { ...outcome.project, exists: true }, vault: null };
     }
-    return outcome.project;
+    return {
+      project: outcome.project,
+      vault: await openSealedVault(outcome.project.directory)
+    };
   }
   const streams = { input: process.stdin, output: process.stdout };
   if (!canPromptForProject(streams)) {
@@ -380,7 +402,7 @@ async function openProject(args: Arguments): Promise<ResolvedProject | null> {
     );
     return null;
   }
-  return await initializeProject(outcome.cwd);
+  return { project: await initializeProject(outcome.cwd), vault: null };
 }
 
 function serviceErrorCode(error: unknown): string {
@@ -434,14 +456,27 @@ interface LoadedSource {
 async function loadSource(args: Arguments): Promise<LoadedSource | null> {
   if (args.demo) return { source: demoAppSource(args.dense), dispose: async () => {} };
   let dataDir: string | null = null;
+  let vaultOptions: {
+    readonly vaultKey: Buffer;
+    readonly beforeVaultMigration: (lockedDataDirectory: string) => Promise<void>;
+  } | undefined;
   // Exports land in the project root, beside the writing. A client
   // attached to a server has no project of its own and writes where it started.
   let exportDirectory = process.cwd();
   if (args.embedded) {
-    const project = await openProject(args);
-    if (project === null) return null;
-    dataDir = project.directory;
-    exportDirectory = project.root;
+    const opened = await openProject(args);
+    if (opened === null) return null;
+    dataDir = opened.project.directory;
+    exportDirectory = opened.project.root;
+    const vault = opened.vault;
+    if (vault !== null) {
+      vaultOptions = {
+        vaultKey: vault.key,
+        beforeVaultMigration: async (lockedDataDirectory: string) => {
+          await revalidateSealedVault(lockedDataDirectory, vault.keyslotBytes);
+        }
+      };
+    }
   }
   const storyFolder = dataDir === null
     ? ""
@@ -450,7 +485,8 @@ async function loadSource(args: Arguments): Promise<LoadedSource | null> {
   const worker = dataDir === null ? null : await createWorkerStoryApi({
     dataDir,
     printLogs: args.printLogs,
-    onRecoveryWarnings: (warnings) => backendRecovery.publish(warnings)
+    onRecoveryWarnings: (warnings) => backendRecovery.publish(warnings),
+    ...(vaultOptions ?? { beforeVaultMigration: revalidateUnsealedVault })
   });
   let httpAttach = worker === null
     ? await attachHttpServer(await attachOrigin(args), {

--- a/tui/src/profile-cli.ts
+++ b/tui/src/profile-cli.ts
@@ -11,7 +11,7 @@ import type { SettingsDocumentV2, SettingsMutationResult } from "../../shared/se
 import { applyProfileTransfer } from "./profile-transfer-apply.js";
 import { writeExportFile } from "./export-file.js";
 import { inlineValue, resolveExistingProject, separatedValue } from "./project-command.js";
-import { createWorkerStoryApi } from "./worker-api.js";
+import { openProjectBackend } from "./vault-project-backend.js";
 import { settingsActivationFailureText } from "./settings-overlay-model.js";
 import type { StoryApi } from "./api.js";
 import { selectSettingsRoute } from "../../shared/settings-route.js";
@@ -32,6 +32,7 @@ export interface ProfileCommand {
   readonly data: string | null;
   readonly global: boolean;
   readonly force: boolean;
+  readonly passphraseFile: string | null;
 }
 
 export function parseProfileCommand(argv: readonly string[]): ProfileCommand {
@@ -41,16 +42,22 @@ export function parseProfileCommand(argv: readonly string[]): ProfileCommand {
   let data: string | null = null;
   let global = false;
   let force = false;
+  let passphraseFile: string | null = null;
   const files: string[] = [];
   for (let index = 1; index < argv.length; index += 1) {
     const argument = argv[index]!;
     if (argument === "--global") global = true;
     else if (argument === "--force") force = true;
+    else if (argument.startsWith("--passphrase-file=")) {
+      passphraseFile = inlineValue(argument, "--passphrase-file");
+    }
     else if (argument.startsWith("--profile=")) profile = inlineValue(argument, "--profile");
     else if (argument.startsWith("--data=")) data = inlineValue(argument, "--data");
-    else if (argument === "--profile" || argument === "--data") {
+    else if (argument === "--profile" || argument === "--data" || argument === "--passphrase-file") {
       const value = separatedValue(argv, ++index, argument);
-      if (argument === "--profile") profile = value; else data = value;
+      if (argument === "--profile") profile = value;
+      else if (argument === "--data") data = value;
+      else passphraseFile = value;
     } else if (argument.startsWith("-")) throw new Error(`unknown profile option: ${plain(argument)}`);
     else files.push(argument);
   }
@@ -58,7 +65,7 @@ export function parseProfileCommand(argv: readonly string[]): ProfileCommand {
   if (action === "import" && files.length === 0) throw new Error("profile import requires at least one file argument");
   if (action === "export" && files.length > 0) throw new Error("profile export does not accept a file argument");
   if (action === "import" && force) throw new Error("--force applies only to profile export");
-  return { action, profile, files, data, global, force };
+  return { action, profile, files, data, global, force, passphraseFile };
 }
 
 export async function runProfileCommand(
@@ -70,7 +77,7 @@ export async function runProfileCommand(
   const command = parseProfileCommand(argv);
   const project = await resolveExistingProject(command, command.action);
   const backend = dependencies.createBackend === undefined
-    ? await createWorkerStoryApi({ dataDir: project.directory })
+    ? await openProjectBackend(project, command.passphraseFile)
     : await dependencies.createBackend({ dataDir: project.directory });
   let failed = false;
   try {

--- a/tui/src/project-command.ts
+++ b/tui/src/project-command.ts
@@ -13,7 +13,7 @@ export interface ProjectSelection {
   readonly global: boolean;
 }
 
-export type ExistingProjectOperation = "import" | "export";
+export type ExistingProjectOperation = "import" | "export" | "encrypt" | "decrypt";
 
 export interface ExistingProjectRequirement {
   /** Text after "so there is" for an absent or uninitialized project. */
@@ -29,9 +29,18 @@ export async function resolveExistingProject(
 ): Promise<ResolvedProject> {
   const outcome = await resolveProject(projectRequest(selection));
   return requireExistingProject(outcome, {
-    unavailable: operation === "import" ? "nowhere to import" : "nothing to export",
+    unavailable: unavailableProjectOperationText(operation),
     displayPath: plain
   });
+}
+
+function unavailableProjectOperationText(operation: ExistingProjectOperation): string {
+  switch (operation) {
+    case "import": return "nowhere to import";
+    case "export": return "nothing to export";
+    case "encrypt": return "nothing to encrypt";
+    case "decrypt": return "nothing to decrypt";
+  }
 }
 
 /** Reject absent and uninitialized projects without creating either one. */

--- a/tui/src/project-prompt.ts
+++ b/tui/src/project-prompt.ts
@@ -29,3 +29,73 @@ export async function confirmProjectCreation(
     readline.close();
   }
 }
+
+/** Read one Vault Password without echoing its characters to the terminal. */
+export async function promptVaultPassword(
+  streams: ProjectPromptStreams,
+  prompt = "Vault Password: "
+): Promise<string> {
+  if (!canPromptForProject(streams) || streams.input.setRawMode === undefined) {
+    throw new Error("Vault Password requires a TTY");
+  }
+  streams.output.write(prompt);
+  streams.input.setRawMode(true);
+  // A CLI can receive a paused stdin from its caller. We need flowing input
+  // for the hidden prompt, but must return that stream to its prior state.
+  const resumedPausedStream = streams.input.readableFlowing !== true;
+  return await new Promise<string>((resolve, reject) => {
+    let value = "";
+    let settled = false;
+    const decoder = new TextDecoder("utf-8", { fatal: false });
+    let pending: number[] = [];
+    const appendPending = () => {
+      if (pending.length === 0) return;
+      value += decoder.decode(Uint8Array.from(pending), { stream: true });
+      pending = [];
+    };
+    const finish = (error?: Error) => {
+      if (settled) return;
+      settled = true;
+      streams.input.off("data", onData);
+      streams.input.off("error", onError);
+      streams.input.off("end", onEnd);
+      streams.input.off("close", onClose);
+      streams.input.setRawMode?.(false);
+      if (resumedPausedStream) streams.input.pause();
+      streams.output.write("\n");
+      if (error === undefined) resolve(value);
+      else reject(error);
+    };
+    const onData = (chunk: Buffer) => {
+      for (const byte of chunk) {
+        if (byte === 3) {
+          appendPending();
+          return finish(new Error("Vault Password prompt cancelled"));
+        }
+        if (byte === 4) {
+          appendPending();
+          return finish(new Error("Vault Password prompt input ended"));
+        }
+        if (byte === 13 || byte === 10) {
+          appendPending();
+          return finish();
+        }
+        if (byte === 127 || byte === 8) {
+          appendPending();
+          value = Array.from(value).slice(0, -1).join("");
+          continue;
+        }
+        if (byte >= 32) pending.push(byte);
+      }
+      appendPending();
+    };
+    const onError = (error: Error) => finish(error);
+    const onEnd = () => finish(new Error("Vault Password prompt input ended"));
+    const onClose = () => finish(new Error("Vault Password prompt input closed"));
+    streams.input.on("data", onData);
+    streams.input.once("error", onError);
+    streams.input.once("end", onEnd);
+    streams.input.once("close", onClose);
+    if (resumedPausedStream) streams.input.resume();
+  });
+}

--- a/tui/src/vault-cli.ts
+++ b/tui/src/vault-cli.ts
@@ -1,0 +1,69 @@
+import {
+  decryptVault,
+  encryptVault
+} from "../../server/vault-lifecycle.js";
+import { inlineValue, resolveExistingProject, separatedValue } from "./project-command.js";
+import { readVaultPassphrase } from "./vault-passphrase.js";
+
+export interface VaultCommand {
+  readonly passphraseFile: string | null;
+  readonly data: string | null;
+  readonly global: boolean;
+}
+
+export function parseVaultCommand(argv: readonly string[]): VaultCommand {
+  let passphraseFile: string | null = null;
+  let data: string | null = null;
+  let global = false;
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index]!;
+    if (argument === "--global") global = true;
+    else if (argument.startsWith("--data=")) data = inlineValue(argument, "--data");
+    else if (argument.startsWith("--passphrase-file=")) {
+      passphraseFile = inlineValue(argument, "--passphrase-file");
+    } else if (argument === "--data" || argument === "--passphrase-file") {
+      const value = separatedValue(argv, ++index, argument);
+      if (argument === "--data") data = value;
+      else passphraseFile = value;
+    } else throw new Error(`unknown vault option: ${argument}`);
+  }
+  if (global && data !== null) throw new Error("--global and --data select different projects");
+  return { passphraseFile, data, global };
+}
+
+export async function runVaultEncrypt(
+  argv: readonly string[],
+  errorOutput: Pick<NodeJS.WriteStream, "write"> = process.stderr
+): Promise<void> {
+  const command = parseVaultCommand(argv);
+  const project = await resolveExistingProject(command, "encrypt");
+  await encryptVault({
+    dataDirectory: project.directory,
+    password: async ({ resume }) => {
+      if (!resume) {
+        errorOutput.write(
+          "Warning: a lost Vault Password cannot be recovered. Copies from before this run, "
+          + "including snapshots, sync history, backups, and freed blocks, can stay plaintext.\n"
+        );
+      }
+      return await readVaultPassphrase({
+        passphraseFile: command.passphraseFile,
+        dataDirectory: project.directory,
+        confirm: !resume
+      });
+    }
+  });
+}
+
+export async function runVaultDecrypt(argv: readonly string[]): Promise<void> {
+  const command = parseVaultCommand(argv);
+  const project = await resolveExistingProject(command, "decrypt");
+  await decryptVault({
+    dataDirectory: project.directory,
+    password: async () => await readVaultPassphrase({
+      passphraseFile: command.passphraseFile,
+      dataDirectory: project.directory,
+      confirm: false
+    })
+  });
+}

--- a/tui/src/vault-open.ts
+++ b/tui/src/vault-open.ts
@@ -1,0 +1,165 @@
+import path from "node:path";
+import { readBoundedRegularFile } from "../../server/data-directory-file-read.js";
+import {
+  MAX_DATA_DIRECTORY_OWNER_MARKER_BYTES,
+  parseDataDirectoryOwnerMarkerBytes
+} from "../../server/data-directory-format.js";
+import { parseKeyslot, unsealKeyslot } from "../../shared/vault-cipher.js";
+import {
+  canPromptForProject,
+  promptVaultPassword,
+  type ProjectPromptStreams
+} from "./project-prompt.js";
+
+const KEYSLOT_FILE = "vault.json";
+const MAX_KEYSLOT_BYTES = 16 * 1024;
+
+export interface OpenedVault {
+  readonly key: Buffer;
+  readonly keyslotBytes: Buffer;
+}
+
+/** The owner marker is the authority on whether this project is sealed. */
+export async function isSealedVault(dataDirectory: string): Promise<boolean> {
+  return (await inspectVault(dataDirectory))?.dataFormat === 5;
+}
+
+/**
+ * Open a sealed vault before its process lock is acquired. The caller must
+ * revalidate the returned Keyslot after it owns the lock.
+ */
+export async function openSealedVault(
+  dataDirectory: string,
+  streams: ProjectPromptStreams = { input: process.stdin, output: process.stdout }
+): Promise<OpenedVault | null> {
+  const sealed = await inspectVault(dataDirectory);
+  if (sealed === null) return null;
+  const { keyslotBytes, keyslot } = sealed;
+  if (!canPromptForProject(streams)) {
+    throw new Error("a sealed vault requires a TTY Vault Password prompt");
+  }
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    const password = await promptVaultPassword(streams);
+    try {
+      return { key: await unsealKeyslot(password, keyslot), keyslotBytes };
+    } catch {
+      if (attempt < 2) streams.output.write("Incorrect Vault Password. Try again.\n");
+    }
+  }
+  throw new Error("Vault Password failed three times");
+}
+
+/** Open a sealed vault with a password supplied by a non-interactive command. */
+export async function openSealedVaultWithPassword(
+  dataDirectory: string,
+  password: string
+): Promise<OpenedVault | null> {
+  const sealed = await inspectVault(dataDirectory);
+  if (sealed === null) return null;
+  try {
+    return {
+      key: await unsealKeyslot(password, sealed.keyslot),
+      keyslotBytes: sealed.keyslotBytes
+    };
+  } catch {
+    throw new Error("Vault Password is incorrect");
+  }
+}
+
+/** Recheck the sealing fence and Keyslot while the caller owns the lock. */
+export async function revalidateSealedVault(
+  dataDirectory: string,
+  expectedKeyslotBytes: Uint8Array
+): Promise<void> {
+  if (await readOwnerFormat(dataDirectory) !== 5) {
+    throw new Error("vault changed during the Vault Password prompt; start again");
+  }
+  const actual = await readKeyslotBytes(dataDirectory);
+  if (!Buffer.from(actual).equals(Buffer.from(expectedKeyslotBytes))) {
+    throw new Error("vault changed during the Vault Password prompt; start again");
+  }
+  const keyslot = parseKeyslot(actual);
+  if (keyslot.state === "sealing") {
+    throw new Error("vault sealing is incomplete; run '1667 encrypt' again");
+  }
+  if (keyslot.state === "unsealing") {
+    throw new Error("vault unsealing is incomplete; run '1667 decrypt' again");
+  }
+  if (keyslot.state !== "sealed") {
+    throw new Error("vault changed during the Vault Password prompt; start again");
+  }
+}
+
+/** Refuse a plain open when another process sealed the vault before its lock. */
+export async function revalidateUnsealedVault(dataDirectory: string): Promise<void> {
+  if (await inspectVault(dataDirectory) !== null) {
+    throw new Error("vault became sealed while it was opening; start again with its Vault Password");
+  }
+}
+
+async function readOwnerFormat(dataDirectory: string): Promise<number> {
+  const marker = path.join(dataDirectory, "owner.json");
+  const bytes = await readBoundedRegularFile(marker, MAX_DATA_DIRECTORY_OWNER_MARKER_BYTES, {
+    requirePrivate: true
+  });
+  return parseDataDirectoryOwnerMarkerBytes(bytes, marker).dataFormat;
+}
+
+async function inspectVault(dataDirectory: string): Promise<{
+  readonly dataFormat: number;
+  readonly keyslotBytes: Buffer;
+  readonly keyslot: ReturnType<typeof parseKeyslot>;
+} | null> {
+  let dataFormat: number;
+  try {
+    dataFormat = await readOwnerFormat(dataDirectory);
+  } catch (error) {
+    // Unmarked and legacy-preview projects take the normal initialization
+    // path. Only the format-5 owner marker is sealing authority.
+    if (isMissing(error)) return null;
+    throw error;
+  }
+  let keyslotBytes: Buffer | null;
+  try {
+    keyslotBytes = await readBoundedRegularFile(
+      path.join(dataDirectory, KEYSLOT_FILE),
+      MAX_KEYSLOT_BYTES,
+      { requirePrivate: true }
+    );
+  } catch (error) {
+    if (dataFormat !== 5 && isMissing(error)) return null;
+    throw new Error("sealed vault Keyslot is unavailable; restore .1667/vault.json from a backup");
+  }
+  let keyslot: ReturnType<typeof parseKeyslot>;
+  try {
+    keyslot = parseKeyslot(keyslotBytes);
+  } catch (error) {
+    if (dataFormat === 5) {
+      throw new Error("sealed vault Keyslot is unavailable; restore .1667/vault.json from a backup");
+    }
+    throw error;
+  }
+  if (keyslot.state === "sealing") {
+    throw new Error("vault sealing is incomplete; run '1667 encrypt' again");
+  }
+  if (keyslot.state === "unsealing") {
+    throw new Error("vault unsealing is incomplete; run '1667 decrypt' again");
+  }
+  if (dataFormat !== 5) {
+    throw new Error("Vault Keyslot does not match the owner marker; run '1667 decrypt' again");
+  }
+  return { dataFormat, keyslotBytes, keyslot };
+}
+
+async function readKeyslotBytes(dataDirectory: string): Promise<Buffer> {
+  const keyslot = path.join(dataDirectory, KEYSLOT_FILE);
+  try {
+    return await readBoundedRegularFile(keyslot, MAX_KEYSLOT_BYTES, { requirePrivate: true });
+  } catch {
+    throw new Error("sealed vault Keyslot is unavailable; restore .1667/vault.json from a backup");
+  }
+}
+
+function isMissing(error: unknown): boolean {
+  return error instanceof Error && "code" in error && error.code === "ENOENT";
+}

--- a/tui/src/vault-passphrase.ts
+++ b/tui/src/vault-passphrase.ts
@@ -1,0 +1,48 @@
+import { readFile, realpath } from "node:fs/promises";
+import path from "node:path";
+import { promptVaultPassword } from "./project-prompt.js";
+
+export interface VaultPassphraseOptions {
+  readonly passphraseFile: string | null;
+  readonly dataDirectory: string;
+  readonly confirm: boolean;
+  readonly input?: NodeJS.ReadStream;
+  readonly output?: NodeJS.WriteStream;
+}
+
+/** Read one non-empty Vault Password without putting it in argv or output. */
+export async function readVaultPassphrase(options: VaultPassphraseOptions): Promise<string> {
+  if (options.passphraseFile !== null) {
+    const passphrase = await readPassphraseFile(options.passphraseFile, options.dataDirectory);
+    requirePassphrase(passphrase);
+    return passphrase;
+  }
+  const input = options.input ?? process.stdin;
+  const output = options.output ?? process.stdout;
+  if (input.isTTY !== true || output.isTTY !== true) {
+    throw new Error("a non-interactive vault command requires --passphrase-file <path>");
+  }
+  const streams = { input, output };
+  const first = await promptVaultPassword(streams, "Vault Password: ");
+  requirePassphrase(first);
+  if (!options.confirm) return first;
+  const second = await promptVaultPassword(streams, "Confirm Vault Password: ");
+  if (first !== second) throw new Error("Vault Password entries do not match");
+  return first;
+}
+
+async function readPassphraseFile(file: string, dataDirectory: string): Promise<string> {
+  const resolvedFile = await realpath(file);
+  const resolvedDataDirectory = await realpath(dataDirectory);
+  if (resolvedFile === resolvedDataDirectory
+    || resolvedFile.startsWith(`${resolvedDataDirectory}${path.sep}`)) {
+    throw new Error("--passphrase-file must be outside the data directory");
+  }
+  const bytes = await readFile(resolvedFile);
+  const text = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  return text.endsWith("\r\n") ? text.slice(0, -2) : text.endsWith("\n") ? text.slice(0, -1) : text;
+}
+
+function requirePassphrase(value: string): void {
+  if (value.length === 0) throw new Error("Vault Password must not be empty");
+}

--- a/tui/src/vault-project-backend.ts
+++ b/tui/src/vault-project-backend.ts
@@ -1,0 +1,46 @@
+import type { ResolvedProject } from "../../server/project-discovery.js";
+import {
+  createWorkerStoryApi,
+  type WorkerStoryApi,
+  type WorkerStoryApiOptions
+} from "./worker-api.js";
+import { readVaultPassphrase } from "./vault-passphrase.js";
+import {
+  isSealedVault,
+  openSealedVaultWithPassword,
+  revalidateSealedVault,
+  revalidateUnsealedVault
+} from "./vault-open.js";
+
+export interface ProjectBackendDependencies {
+  readonly createWorker?: (options: WorkerStoryApiOptions) => Promise<WorkerStoryApi>;
+}
+
+/** Open one command backend, prompting for a Vault Password only when needed. */
+export async function openProjectBackend(
+  project: ResolvedProject,
+  passphraseFile: string | null,
+  dependencies: ProjectBackendDependencies = {}
+): Promise<WorkerStoryApi> {
+  const createWorker = dependencies.createWorker ?? createWorkerStoryApi;
+  if (!await isSealedVault(project.directory)) {
+    return await createWorker({
+      dataDir: project.directory,
+      beforeVaultMigration: revalidateUnsealedVault
+    });
+  }
+  const password = await readVaultPassphrase({
+    passphraseFile,
+    dataDirectory: project.directory,
+    confirm: false
+  });
+  const vault = await openSealedVaultWithPassword(project.directory, password);
+  if (vault === null) throw new Error("vault changed while reading the Vault Password; start again");
+  return await createWorker({
+    dataDir: project.directory,
+    vaultKey: vault.key,
+    beforeVaultMigration: async (lockedDataDirectory) => {
+      await revalidateSealedVault(lockedDataDirectory, vault.keyslotBytes);
+    }
+  });
+}

--- a/tui/src/worker-api-contract.ts
+++ b/tui/src/worker-api-contract.ts
@@ -27,6 +27,10 @@ export interface WorkerStoryApiOptions {
   machineDir?: string;
   /** Set by the lock owner when startup created the data directory. */
   freshDataDirectory?: boolean;
+  /** Vault Key held only by the opening process and its worker. */
+  vaultKey?: Uint8Array;
+  /** Revalidates a sealed vault after this process owns its lock. */
+  beforeVaultMigration?: (lockedDataDirectory: string) => Promise<void>;
   /** Echo unexpected embedded errors to stderr as well as the private log. */
   printLogs?: boolean;
   readyTimeoutMs?: number;

--- a/tui/src/worker-api.ts
+++ b/tui/src/worker-api.ts
@@ -9,6 +9,10 @@ import { WorkerTransport } from "./worker-transport.js";
 import type { WorkerStoryApi, WorkerStoryApiOptions } from "./worker-api-contract.js";
 import { reportEmbeddedWorkerHostFailure } from "./worker-host-diagnostics.js";
 import { BackendRestartRequiredError } from "./worker-error.js";
+import {
+  registerVaultKey,
+  type VaultKeyRegistration
+} from "../../server/vault-key-registry.js";
 
 export { WorkerExitUnconfirmedError } from "./worker-data-lock.js";
 export {
@@ -25,6 +29,12 @@ export type {
 } from "./worker-api-contract.js";
 
 export async function createWorkerStoryApi(options: WorkerStoryApiOptions = {}): Promise<WorkerStoryApi> {
+  const vault = { registration: null as VaultKeyRegistration | null };
+  const clearVaultRegistration = (): void => {
+    const registration = vault.registration;
+    vault.registration = null;
+    registration?.clear();
+  };
   if (options.worker === undefined && options.machineDir === undefined) {
     // Resolving here, not in the worker, is what turns "this platform has no
     // private state root yet" into one line on stderr instead of a dead backend.
@@ -43,15 +53,23 @@ export async function createWorkerStoryApi(options: WorkerStoryApiOptions = {}):
   const dataLock = options.worker === undefined
     ? new RuntimeDataDirectoryLock(resolveDataDirectory(options.dataDir))
     : null;
-  if (dataLock !== null) await dataLock.acquire();
-  const lockedDataDir = dataLock?.authorityPath ?? null;
-  const transportOptions = dataLock === null
-    ? options
-    : {
-        ...options,
-        dataDir: dataLock.authorityPath,
-        freshDataDirectory: dataLock.initializedNewDirectory
-      };
+  if (dataLock !== null) {
+    try {
+      await dataLock.acquire({
+        beforeMigration: async (lockedDataDirectory) => {
+          await options.beforeVaultMigration?.(lockedDataDirectory);
+          if (options.vaultKey !== undefined) {
+            vault.registration = registerVaultKey(lockedDataDirectory, options.vaultKey);
+          }
+        }
+      });
+    } catch (error) {
+      clearVaultRegistration();
+      throw error;
+    }
+  }
+  let lockedDataDir: string | null = null;
+  let transportOptions: WorkerStoryApiOptions = options;
   let transport: WorkerTransport;
   let failureReport: Promise<Error> | null = null;
   const reportFailure = (error: Error): Promise<Error> => {
@@ -67,6 +85,18 @@ export async function createWorkerStoryApi(options: WorkerStoryApiOptions = {}):
     return failureReport;
   };
   try {
+    lockedDataDir = dataLock?.authorityPath ?? null;
+    if (lockedDataDir !== null) vault.registration?.addAlias(lockedDataDir);
+    if (dataLock === null) {
+      transportOptions = options;
+    } else {
+      if (lockedDataDir === null) throw new Error("Data-directory authority is unavailable after acquisition");
+      transportOptions = {
+        ...options,
+        dataDir: lockedDataDir,
+        freshDataDirectory: dataLock.initializedNewDirectory
+      };
+    }
     const outbox = options.outbox ?? (lockedDataDir === null
       ? null
       : new MutationOutbox(path.join(lockedDataDir, "mutation-outbox")));
@@ -74,8 +104,18 @@ export async function createWorkerStoryApi(options: WorkerStoryApiOptions = {}):
     transport = new WorkerTransport(transportOptions, outbox);
     await transport.start();
   } catch (error) {
-    await releaseOrRetainDataLock(dataLock, error);
-    throw error instanceof Error ? await reportFailure(error) : error;
+    let terminal: unknown = error;
+    try {
+      if (error instanceof Error) terminal = await reportFailure(error);
+    } catch (reportError) {
+      terminal = reportError;
+    }
+    try {
+      await releaseOrRetainDataLock(dataLock, terminal);
+    } finally {
+      clearVaultRegistration();
+    }
+    throw terminal;
   }
   const api = storyApiFromWorkerTransport(transport);
   const failure = transport.failure.then(reportFailure);
@@ -85,13 +125,24 @@ export async function createWorkerStoryApi(options: WorkerStoryApiOptions = {}):
       try {
         await transport.dispose();
       } catch (error) {
-        const reported = error instanceof Error
-          ? await reportFailure(error)
-          : error;
-        await releaseOrRetainDataLock(dataLock, reported);
-        throw reported;
+        let terminal: unknown = error;
+        try {
+          if (error instanceof Error) terminal = await reportFailure(error);
+        } catch (reportError) {
+          terminal = reportError;
+        }
+        try {
+          await releaseOrRetainDataLock(dataLock, terminal);
+        } finally {
+          clearVaultRegistration();
+        }
+        throw terminal;
       }
-      await dataLock?.release();
+      try {
+        await dataLock?.release();
+      } finally {
+        clearVaultRegistration();
+      }
     })();
     return disposal;
   };

--- a/tui/src/worker-transport.ts
+++ b/tui/src/worker-transport.ts
@@ -109,6 +109,7 @@ export class WorkerTransport {
         dataDir: resolveDataDirectory(options.dataDir),
         externalDataLock: true,
         ...(options.machineDir === undefined ? {} : { machineDir: options.machineDir }),
+        ...(options.vaultKey === undefined ? {} : { vaultKey: options.vaultKey }),
         ...(options.printLogs === true ? { printLogs: true } as const : {}),
         ...(options.freshDataDirectory === true ? { freshDataDirectory: true } as const : {})
       });

--- a/tui/test/cli-help.test.ts
+++ b/tui/test/cli-help.test.ts
@@ -1,6 +1,8 @@
 import { expect, test } from "bun:test";
 import {
   AUTH_HELP,
+  DECRYPT_HELP,
+  ENCRYPT_HELP,
   EXPORT_HELP,
   HELP,
   INIT_HELP,
@@ -27,7 +29,7 @@ test("the front page fits a short terminal and keeps usage above the fold", () =
 });
 
 test("the front page names every command that has its own page", () => {
-  for (const command of ["init", "auth", "export", "import", "import-card", "import-lorebook"]) {
+  for (const command of ["init", "encrypt", "decrypt", "auth", "export", "import", "import-card", "import-lorebook"]) {
     expect(`${command}:${HELP.includes(command)}`).toBe(`${command}:true`);
     expect(commandHelp(command)).not.toBe(null);
   }
@@ -50,6 +52,8 @@ test("the front page keeps every root option that the root parser accepts", () =
 test("each command page opens with its own usage line", () => {
   const pages: ReadonlyArray<readonly [string, string]> = [
     ["1667 init", INIT_HELP],
+    ["1667 encrypt", ENCRYPT_HELP],
+    ["1667 decrypt", DECRYPT_HELP],
     ["1667 auth", AUTH_HELP],
     ["1667 export", EXPORT_HELP],
     ["1667 import", IMPORT_HELP],
@@ -86,7 +90,7 @@ test("the front page does not send the reader to a page that does not exist", ()
   // sends a confused reader into an unknown-option error. `serve` and `upgrade`
   // answer it themselves, so they are excluded here and covered by their own
   // commands.
-  for (const command of ["init", "export", "import", "import-card", "import-lorebook", "auth"]) {
+  for (const command of ["init", "encrypt", "decrypt", "export", "import", "import-card", "import-lorebook", "auth"]) {
     expect(`${command}:${commandHelp(command) !== null}`).toBe(`${command}:true`);
   }
 });

--- a/tui/test/export-file.test.ts
+++ b/tui/test/export-file.test.ts
@@ -147,7 +147,8 @@ describe("export command line", () => {
       format: "markdown",
       force: false,
       data: null,
-      global: false
+      global: false,
+      passphraseFile: null
     });
     expect(parseExportCommand(["--story", "st1_abc", "--force"])).toMatchObject({
       storyId: "st1_abc",
@@ -308,7 +309,7 @@ describe("export help", () => {
     // No flag picks a branch, so the help has to say where that choice lives.
     expect(block).toContain("choose it in the app first");
     // Usage must list every selector the parser honours, and only those.
-    for (const flag of ["--story", "--all", "--format", "--force", "--data", "--global"]) {
+    for (const flag of ["--story", "--all", "--format", "--force", "--passphrase-file", "--data", "--global"]) {
       expect(`${flag}:${EXPORT_HELP.includes(flag)}`).toBe(`${flag}:true`);
     }
     // The front page must still name the command, or nobody reaches this page.
@@ -320,7 +321,8 @@ describe("export help", () => {
       format: "markdown",
       force: true,
       data: "book",
-      global: false
+      global: false,
+      passphraseFile: null
     });
   });
 });

--- a/tui/test/project-prompt.test.ts
+++ b/tui/test/project-prompt.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, test } from "bun:test";
+import assert from "node:assert/strict";
 import { PassThrough } from "node:stream";
 import {
   canPromptForProject,
-  confirmProjectCreation
+  confirmProjectCreation,
+  promptVaultPassword
 } from "../src/project-prompt.js";
+import { readVaultPassphrase } from "../src/vault-passphrase.js";
 
 describe("absent project prompt", () => {
   test("asks only where a person can answer", () => {
@@ -28,6 +31,99 @@ describe("absent project prompt", () => {
       expect(await asked).toBe(expected);
       expect(written(output)).toContain("Create story project in /writing/book? [Y/n]");
     }
+  });
+
+  test("reads a hidden Vault Password and restores a paused terminal stream", async () => {
+    const { input, output, rawModes, paused } = rawPipes();
+    const asked = promptVaultPassword({ input, output });
+    input.write(Buffer.from("passé\bword\n", "utf8"));
+    expect(await asked).toBe("password");
+    expect(rawModes).toEqual([true, false]);
+    expect(paused()).toBe(1);
+    expect(input.readableFlowing).toBeFalse();
+    expect(written(output)).toBe("Vault Password: \n");
+  });
+
+  test("cancelling a Vault Password restores raw mode and a paused stream", async () => {
+    const { input, output, rawModes, paused } = rawPipes();
+    const asked = promptVaultPassword({ input, output });
+    input.write(Buffer.from([3]));
+    await assert.rejects(asked, /prompt cancelled/);
+    expect(rawModes).toEqual([true, false]);
+    expect(paused()).toBe(1);
+    expect(input.readableFlowing).toBeFalse();
+  });
+
+  test("an input error restores raw mode and a paused stream", async () => {
+    const { input, output, rawModes, paused } = rawPipes();
+    const asked = promptVaultPassword({ input, output });
+    input.emit("error", new Error("terminal input failed"));
+    await assert.rejects(asked, /terminal input failed/);
+    expect(rawModes).toEqual([true, false]);
+    expect(paused()).toBe(1);
+    expect(input.readableFlowing).toBeFalse();
+  });
+
+  test("an input end restores raw mode and a paused stream once", async () => {
+    const { input, output, rawModes, paused } = rawPipes();
+    const asked = promptVaultPassword({ input, output });
+    input.end();
+    await assert.rejects(asked, /prompt input ended/);
+    expect(rawModes).toEqual([true, false]);
+    expect(paused()).toBe(1);
+    expect(input.readableFlowing).toBeFalse();
+    expect(written(output)).toBe("Vault Password: \n");
+  });
+
+  test("an input close restores raw mode and a paused stream", async () => {
+    const { input, output, rawModes, paused } = rawPipes();
+    const asked = promptVaultPassword({ input, output });
+    input.emit("close");
+    await assert.rejects(asked, /prompt input closed/);
+    expect(rawModes).toEqual([true, false]);
+    expect(paused()).toBe(1);
+    expect(input.readableFlowing).toBeFalse();
+    expect(written(output)).toBe("Vault Password: \n");
+  });
+
+  test("Ctrl-D stops a Vault Password prompt without double cleanup", async () => {
+    const { input, output, rawModes, paused } = rawPipes();
+    const asked = promptVaultPassword({ input, output });
+    input.write(Buffer.from([4]));
+    input.emit("close");
+    await assert.rejects(asked, /prompt input ended/);
+    expect(rawModes).toEqual([true, false]);
+    expect(paused()).toBe(1);
+    expect(input.readableFlowing).toBeFalse();
+    expect(written(output)).toBe("Vault Password: \n");
+  });
+
+  test("leaves an already flowing terminal stream flowing", async () => {
+    const { input, rawModes, paused, output } = rawPipes({ flowing: true });
+    const asked = promptVaultPassword({ input, output });
+    input.write("password\n");
+    expect(await asked).toBe("password");
+    expect(rawModes).toEqual([true, false]);
+    expect(paused()).toBe(0);
+    expect(input.readableFlowing).toBeTrue();
+  });
+
+  test("confirmation mismatch restores both prompt stream lifecycles", async () => {
+    const { input, output, rawModes, paused } = rawPipes();
+    const asked = readVaultPassphrase({
+      passphraseFile: null,
+      dataDirectory: "/writing/.1667",
+      confirm: true,
+      input,
+      output
+    });
+    input.write("first\n");
+    await waitFor(() => rawModes.length === 3);
+    input.write("second\n");
+    await assert.rejects(asked, /entries do not match/);
+    expect(rawModes).toEqual([true, false, true, false]);
+    expect(paused()).toBe(2);
+    expect(input.readableFlowing).toBeFalse();
   });
 });
 
@@ -55,4 +151,35 @@ function pipes(): {
 
 function written(output: NodeJS.WriteStream & { chunks: string[] }): string {
   return output.chunks.join("");
+}
+
+function rawPipes(options: { flowing?: boolean } = {}): {
+  input: NodeJS.ReadStream;
+  output: NodeJS.WriteStream & { chunks: string[] };
+  rawModes: boolean[];
+  paused(): number;
+} {
+  const { input, output } = pipes();
+  const rawModes: boolean[] = [];
+  let pauseCalls = 0;
+  const pause = input.pause.bind(input);
+  const resume = input.resume.bind(input);
+  Object.assign(input, {
+    isTTY: true,
+    setRawMode: (value: boolean) => { rawModes.push(value); },
+    pause: () => { pauseCalls += 1; return pause(); },
+    resume: () => resume()
+  });
+  Object.assign(output, { isTTY: true });
+  if (options.flowing === true) input.resume();
+  return {
+    input,
+    output,
+    rawModes,
+    paused: () => pauseCalls,
+  };
+}
+
+async function waitFor(condition: () => boolean): Promise<void> {
+  while (!condition()) await new Promise((resolve) => setTimeout(resolve, 0));
 }

--- a/tui/test/vault-cli.test.ts
+++ b/tui/test/vault-cli.test.ts
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { DataDirectoryLock } from "../../server/data-directory-lock.js";
+import { isSealed } from "../../shared/vault-cipher.js";
+import { parseVaultCommand, runVaultDecrypt, runVaultEncrypt } from "../src/vault-cli.js";
+
+test("vault command parser accepts only project and password options", () => {
+  assert.deepEqual(parseVaultCommand([
+    "--data", "book", "--passphrase-file=secret"
+  ]), { data: "book", global: false, passphraseFile: "secret" });
+  assert.throws(() => parseVaultCommand(["--global", "--data", "book"]), /select different projects/);
+  assert.throws(() => parseVaultCommand(["--unknown"]), /unknown vault option/);
+});
+
+test("vault commands name their unavailable operation", async (t) => {
+  const root = await mkdtemp(path.join(tmpdir(), "1667-vault-cli-absent-"));
+  t.after(async () => await rm(root, { recursive: true, force: true }));
+  const missing = path.join(root, "missing-project");
+
+  await assert.rejects(runVaultEncrypt(["--data", missing]), /nothing to encrypt/);
+  await assert.rejects(runVaultDecrypt(["--data", missing]), /nothing to decrypt/);
+});
+
+test("vault commands use a passphrase file for a non-interactive round trip", async (t) => {
+  const root = await mkdtemp(path.join(tmpdir(), "1667-vault-cli-"));
+  t.after(async () => await rm(root, { recursive: true, force: true }));
+  const dataDirectory = path.join(root, ".1667");
+  const initializer = new DataDirectoryLock(dataDirectory);
+  await initializer.acquire();
+  await initializer.release();
+  const story = path.join(dataDirectory, "story.json");
+  const passphraseFile = path.join(root, "vault-password");
+  await writeFile(story, "command vault sentinel");
+  await writeFile(passphraseFile, "correct horse battery staple\n");
+
+  await runVaultEncrypt(["--data", root, "--passphrase-file", passphraseFile], {
+    write: () => true
+  });
+  assert.equal(isSealed(await readFile(story)), true);
+  await runVaultDecrypt(["--data", root, "--passphrase-file", passphraseFile]);
+  assert.equal(await readFile(story, "utf8"), "command vault sentinel");
+});

--- a/tui/test/vault-project-backend.test.ts
+++ b/tui/test/vault-project-backend.test.ts
@@ -1,0 +1,179 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm, symlink, unlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { DataDirectoryLock } from "../../server/data-directory-lock.js";
+import { VAULT_KEYSLOT_FILE } from "../../server/data-directory-layout.js";
+import { publishDataDirectoryOwnerMarker } from "../../server/data-directory-format.js";
+import { publishPrivateFileNoReplace } from "../../server/private-file-publication.js";
+import {
+  createKeyslot,
+  encodeKeyslot,
+  keyslotWithState
+} from "../../shared/vault-cipher.js";
+import { runStoryExport } from "../src/export-cli.js";
+import { parseImportCommand, runStoryImport } from "../src/import-cli.js";
+import { parseCardImportCommand } from "../src/card-import-cli.js";
+import { parseLorebookImportCommand } from "../src/lorebook-import-cli.js";
+import { parseProfileCommand } from "../src/profile-cli.js";
+import { runVaultEncrypt } from "../src/vault-cli.js";
+import { openProjectBackend } from "../src/vault-project-backend.js";
+import { openSealedVault, openSealedVaultWithPassword } from "../src/vault-open.js";
+
+test("sealed import and export open from a passphrase file", async (t) => {
+  const root = await mkdtemp(path.join(tmpdir(), "1667-vault-project-backend-"));
+  t.after(async () => await rm(root, { recursive: true, force: true }));
+  const dataDirectory = path.join(root, ".1667");
+  const initializer = new DataDirectoryLock(dataDirectory);
+  await initializer.acquire();
+  await initializer.release();
+  const passwordFile = path.join(root, "vault-password");
+  const importFile = path.join(root, "chapter.md");
+  const selectedRoot = process.platform === "win32" ? root : `${root}-alias`;
+  if (selectedRoot !== root) {
+    await symlink(root, selectedRoot, "dir");
+    t.after(async () => await rm(selectedRoot, { force: true }));
+  }
+  await writeFile(passwordFile, "correct horse battery staple\n");
+  await writeFile(importFile, "The door opens.\n");
+  await runVaultEncrypt(["--data", selectedRoot, "--passphrase-file", passwordFile], { write: () => true });
+
+  await assert.rejects(
+    openSealedVault(dataDirectory, nonTtyStreams()),
+    /requires a TTY/
+  );
+  await assert.rejects(openSealedVaultWithPassword(dataDirectory, "wrong password"), /incorrect/);
+
+  const imported = collector();
+  await runStoryImport([
+    "--data", selectedRoot, "--passphrase-file", passwordFile, importFile
+  ], imported.stream, sink());
+  assert.match(imported.text(), /imported/);
+
+  const exported = collector();
+  await runStoryExport([
+    "--data", selectedRoot, "--passphrase-file", passwordFile
+  ], exported.stream, sink());
+  assert.match(exported.text(), /\.md/);
+
+  await writeFile(path.join(dataDirectory, "vault.json"), "{}");
+  await assert.rejects(
+    openSealedVault(dataDirectory, nonTtyStreams()),
+    /restore .1667\/vault.json from a backup/
+  );
+  await unlink(path.join(dataDirectory, "vault.json"));
+  await assert.rejects(
+    openSealedVaultWithPassword(dataDirectory, "correct horse battery staple"),
+    /restore .1667\/vault.json from a backup/
+  );
+});
+
+test("every offline project command accepts --passphrase-file", () => {
+  assert.equal(parseImportCommand(["--passphrase-file", "secret", "story.md"]).passphraseFile, "secret");
+  assert.equal(parseCardImportCommand([
+    "--story", "story", "--passphrase-file=secret", "card.json"
+  ]).passphraseFile, "secret");
+  assert.equal(parseLorebookImportCommand([
+    "--story", "story", "--passphrase-file=secret", "book.json"
+  ]).passphraseFile, "secret");
+  assert.equal(parseProfileCommand([
+    "export", "--passphrase-file=secret"
+  ]).passphraseFile, "secret");
+});
+
+test("a plain offline open rechecks a format-5 fence under its lock", async (t) => {
+  const root = await mkdtemp(path.join(tmpdir(), "1667-vault-project-race-"));
+  t.after(async () => await rm(root, { recursive: true, force: true }));
+  const dataDirectory = path.join(root, ".1667");
+  const initializer = new DataDirectoryLock(dataDirectory);
+  await initializer.acquire();
+  await initializer.release();
+  const project = { root, directory: dataDirectory, source: "explicit", exists: true } as const;
+
+  const error = await plainBackendFailure(project, async (authorityPath) => {
+    await publishKeyslot(authorityPath, "sealed");
+    await publishDataDirectoryOwnerMarker(authorityPath, 5);
+  });
+  assert.match(
+    error.message,
+    /vault became sealed while it was opening; start again with its Vault Password/
+  );
+});
+
+test("a plain offline open rejects a sealing Keyslot before the format fence rises", async (t) => {
+  const root = await mkdtemp(path.join(tmpdir(), "1667-vault-project-race-"));
+  t.after(async () => await rm(root, { recursive: true, force: true }));
+  const dataDirectory = path.join(root, ".1667");
+  const initializer = new DataDirectoryLock(dataDirectory);
+  await initializer.acquire();
+  await initializer.release();
+  const project = { root, directory: dataDirectory, source: "explicit", exists: true } as const;
+
+  const error = await plainBackendFailure(project, async (authorityPath) => {
+    await publishKeyslot(authorityPath, "sealing");
+  });
+  assert.match(
+    error.message,
+    /vault sealing is incomplete; run '1667 encrypt' again/
+  );
+});
+
+async function plainBackendFailure(
+  project: { readonly root: string; readonly directory: string; readonly source: "explicit"; readonly exists: true },
+  changeVault: (authorityPath: string) => Promise<void>
+): Promise<Error> {
+  try {
+    await openProjectBackend(project, null, {
+      createWorker: async (options) => {
+        const lock = new DataDirectoryLock(project.directory);
+        await lock.acquire();
+        try {
+          await changeVault(lock.authorityPath);
+          await options.beforeVaultMigration!(lock.authorityPath);
+        } finally {
+          await lock.release();
+        }
+        throw new Error("plain open continued after the vault changed");
+      }
+    });
+  } catch (error) {
+    if (error instanceof Error) return error;
+    throw error;
+  }
+  throw new Error("plain open continued after the vault changed");
+}
+
+async function publishKeyslot(
+  authorityPath: string,
+  state: "sealing" | "sealed"
+): Promise<void> {
+  const keyslot = await createKeyslot("correct horse battery staple");
+  await publishPrivateFileNoReplace(
+    path.join(authorityPath, VAULT_KEYSLOT_FILE),
+    encodeKeyslot(keyslotWithState(keyslot, state)),
+    { label: "Vault Keyslot", maxBytes: 16 * 1024 }
+  );
+}
+
+function nonTtyStreams(): { input: NodeJS.ReadStream; output: NodeJS.WriteStream } {
+  return {
+    input: { isTTY: false } as NodeJS.ReadStream,
+    output: { isTTY: false, write: () => true } as unknown as NodeJS.WriteStream
+  };
+}
+
+function collector(): {
+  readonly stream: Pick<NodeJS.WriteStream, "write">;
+  text(): string;
+} {
+  const chunks: string[] = [];
+  return {
+    stream: { write: (chunk: string) => { chunks.push(String(chunk)); return true; } },
+    text: () => chunks.join("")
+  };
+}
+
+function sink(): Pick<NodeJS.WriteStream, "write"> {
+  return { write: () => true };
+}


### PR DESCRIPTION
## Summary

- add password-sealed project vaults with resumable encrypt and decrypt lifecycle commands
- keep Vault Keys scoped to locked runtime authorities and seal persisted project content
- refuse sealed vaults from HTTP modes while supporting interactive and offline vault access
- document the storage format and add lifecycle, crash-recovery, storage-hook, CLI, and open-boundary coverage

## Verification

- `npm run build`
- `npm test`
- `cd tui && bun run typecheck`
- `cd tui && bun test --timeout 30000`
- `cd tui && bun run build:standalone`
- autoreview: clean
- thermonuclear code-quality review: GREEN

Closes #89