### PR TITLE
fix(settings): load the only unsaved model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ This file records notable changes to 1667. Product terms use the definitions in
 
 ## Unreleased
 
+- **Settings loads a provider's only model before Save.** A provider or base
+  URL change could return one model while the model row stayed blank. The
+  writer then had to save or select the model. Settings now selects the model
+  when the current model is blank. It does not replace a model name that the
+  writer typed. Thanks to @10fra.
+
 - Show live download progress for managed upgrades and the Windows Installer.
   Thanks to @10fra.
 

--- a/docs/model-providers.md
+++ b/docs/model-providers.md
@@ -279,7 +279,9 @@ Dry-run mode tests the interface without a provider request.
 Settings reads the model list from the selected provider. Use `Left Arrow` or
 `Right Arrow` to select a model. Press `Enter` to type a custom model name.
 Settings reads the list again after you change the provider or the base URL.
-Save a new credential target before you use it to read a model list.
+Settings selects the model when the list contains one model and the model row
+is blank. An unsaved stored API key can read the model list. Settings uses the
+key for this request only. Save the settings to store the key.
 
 ## Use Generation Profiles and Generation Routes
 

--- a/shared/settings-basic-draft.ts
+++ b/shared/settings-basic-draft.ts
@@ -24,9 +24,16 @@ import { resolveSettingsProfile } from "./settings-route.js";
 export function applyBasicSettingsDraft(
   document: SettingsDocumentV2,
   draft: GenerationSettings,
-  profileId: string = document.routing.default
+  profileId: string = document.routing.default,
+  retainContextWindowOverride = false
 ): SettingsDocumentV2 {
-  return applyBasicSettingsDocumentDraft(document, draft, savedModelIdentity, profileId);
+  return applyBasicSettingsDocumentDraft(
+    document,
+    draft,
+    savedModelIdentity,
+    profileId,
+    retainContextWindowOverride
+  );
 }
 
 /**
@@ -36,9 +43,16 @@ export function applyBasicSettingsDraft(
 export function applyBasicSettingsProbeDraft(
   document: SettingsDocumentV2,
   draft: GenerationSettings,
-  profileId: string = document.routing.default
+  profileId: string = document.routing.default,
+  retainContextWindowOverride = false
 ): SettingsDocumentV2 {
-  return applyBasicSettingsDocumentDraft(document, draft, probeModelIdentity, profileId);
+  return applyBasicSettingsDocumentDraft(
+    document,
+    draft,
+    probeModelIdentity,
+    profileId,
+    retainContextWindowOverride
+  );
 }
 
 type ModelIdentity = {
@@ -50,7 +64,8 @@ function applyBasicSettingsDocumentDraft(
   document: SettingsDocumentV2,
   draft: GenerationSettings,
   modelIdentityFor: (settings: GenerationSettings) => ModelIdentity,
-  profileId: string
+  profileId: string,
+  retainContextWindowOverride: boolean
 ): SettingsDocumentV2 {
   const route = resolveSettingsProfile(document, profileId);
   const projected = basicSettingsFromDocument(document, profileId);
@@ -61,7 +76,11 @@ function applyBasicSettingsDocumentDraft(
   // already contains the same incomplete value. The probe reducer deliberately
   // accepts a blank model so discovery can complete that draft.
   const requestedModelIdentity = modelIdentityFor(normalizedDraft);
-  if (sameBasicSettings(normalizedProjection, normalizedDraft)) return document;
+  if (sameBasicSettings(normalizedProjection, normalizedDraft)
+    && (!retainContextWindowOverride
+      || route.model.overrides.contextWindow === normalizedDraft.contextWindow)) {
+    return document;
+  }
 
   const protocol = protocolFor(normalizedDraft.provider);
   const protocolChanged = route.connection.protocol !== protocol;
@@ -93,7 +112,8 @@ function applyBasicSettingsDocumentDraft(
         ...route.model,
         ...modelIdentity,
         discovered: {},
-        overrides: contextWindowChanged && normalizedDraft.contextWindow !== null
+        overrides: (contextWindowChanged || retainContextWindowOverride)
+          && normalizedDraft.contextWindow !== null
           ? { contextWindow: normalizedDraft.contextWindow }
           : {},
         capabilities: defaultModelCapabilities(normalizedDraft.provider)
@@ -103,7 +123,7 @@ function applyBasicSettingsDocumentDraft(
         discovered: contextWindowChanged && normalizedDraft.contextWindow === null
           ? metadataWithoutContextWindow(route.model.discovered)
           : route.model.discovered,
-        overrides: contextWindowChanged
+        overrides: contextWindowChanged || retainContextWindowOverride
           ? overridesWithContextWindow(route.model.overrides, normalizedDraft.contextWindow)
           : route.model.overrides
       };
@@ -138,7 +158,8 @@ export function applyBasicModelDiscovery(
   document: SettingsDocumentV2,
   discovery: ModelDiscoveryResultV2 | null,
   visibleContextWindow: number | null,
-  profileId: string = document.routing.default
+  profileId: string = document.routing.default,
+  retainVisibleContextWindowOverride = false
 ): SettingsDocumentV2 {
   if (discovery === null) return document;
   const route = resolveSettingsProfile(document, profileId);
@@ -157,7 +178,8 @@ export function applyBasicModelDiscovery(
   const overrides = { ...route.model.overrides };
   if (
     visibleContextWindow === null
-    || visibleContextWindow === found.contextWindow
+    || (!retainVisibleContextWindowOverride
+      && visibleContextWindow === found.contextWindow)
   ) {
     delete overrides.contextWindow;
   } else {

--- a/tui/src/profile-transfer-actions.ts
+++ b/tui/src/profile-transfer-actions.ts
@@ -5,6 +5,7 @@ import { STARTER_PROFILES } from "../../shared/generation-profile-starters.js";
 import { completeFilePath, errorMessage, expandLeadingTilde } from "./path-completion.js";
 import { recordNotice } from "./notice-log.js";
 import { applyProfileTransfer } from "./profile-transfer-apply.js";
+import { cloneSettingsProfileDraft } from "./settings-draft-transition.js";
 import { settingsTextDraftForDocument } from "./settings-text.js";
 import { readFromClipboard } from "./clipboard.js";
 import { pasteInto, type ResolvedKey } from "./keys.js";
@@ -157,7 +158,14 @@ function applyCandidate(
   const sourceId = overlay.draft.selectedProfileId!;
   const fitted = applyProfileTransfer(document, sourceId, candidate);
   if ("error" in fitted) { prompt.error = fitted.error; return; }
-  overlay.draft = settingsTextDraftForDocument(fitted.document, fitted.profileId);
+  cloneSettingsProfileDraft(
+    overlay,
+    settingsTextDraftForDocument(
+      fitted.document,
+      fitted.profileId
+    ),
+    sourceId
+  );
   overlay.deleteArmedProfileId = null;
   overlay.result = null;
   if (overlay.conflict !== null) overlay.conflict.armed = false;

--- a/tui/src/sampling-panel-spec.ts
+++ b/tui/src/sampling-panel-spec.ts
@@ -15,6 +15,7 @@ import type {
   SamplingPhraseBiasEntryV2,
   SamplingSettingsV2
 } from "../../shared/settings-v2-types.js";
+import { replaceSettingsDraft } from "./settings-draft-transition.js";
 import type { SamplingListPanel, SettingsOverlayState } from "./state.js";
 
 /**
@@ -320,7 +321,7 @@ export function updateSamplingDraft(
         sampling,
         overlay.draft.selectedProfileId
       );
-  overlay.draft = { ...overlay.draft, document, sampling };
+  replaceSettingsDraft(overlay, { ...overlay.draft, document, sampling });
   if (overlay.conflict !== null) overlay.conflict.armed = false;
   overlay.result = null;
   if (overlay.sampling !== null) overlay.sampling.result = "draft updated · save in Settings";

--- a/tui/src/settings-allow-insecure.ts
+++ b/tui/src/settings-allow-insecure.ts
@@ -1,0 +1,19 @@
+import { replaceSettingsDraft } from "./settings-draft-transition.js";
+import { settingsDraftChanged } from "./settings-overlay-reconciliation.js";
+import { settingsTextDraftWithGeneration } from "./settings-text.js";
+import type { SettingsOverlayState } from "./state.js";
+
+export function cycleAllowInsecureHttp(overlay: SettingsOverlayState): boolean {
+  const allowInsecureHttp = overlay.draft.generation.allowInsecureHttp !== true;
+  const generation = { ...overlay.draft.generation };
+  if (allowInsecureHttp) generation.allowInsecureHttp = true;
+  else delete generation.allowInsecureHttp;
+  replaceSettingsDraft(
+    overlay,
+    settingsTextDraftWithGeneration(overlay.draft, generation)
+  );
+  overlay.result = null;
+  if (!settingsDraftChanged(overlay)) overlay.conflict = null;
+  else if (overlay.conflict !== null) overlay.conflict.armed = false;
+  return allowInsecureHttp;
+}

--- a/tui/src/settings-context-detection.ts
+++ b/tui/src/settings-context-detection.ts
@@ -9,6 +9,7 @@ import { settingsTextDraftWithDetectedContext } from "./settings-text.js";
 import { settingsProviderProbeTarget } from "./settings-provider-probe.js";
 import { sameConnectionSecrets } from "./settings-secret-sidecar.js";
 import { activeSettingsEdit } from "./settings-edit-state.js";
+import { replaceSettingsDraft } from "./settings-draft-transition.js";
 import type { RuntimeState, SettingsOverlayState } from "./state.js";
 
 /** Probe the selected draft without letting a late response overwrite newer
@@ -69,9 +70,9 @@ export async function detectSettingsContext(
         return;
       }
       if (editable) {
-        overlay.draft = settingsTextDraftWithDetectedContext(
-          overlay.draft,
-          contextWindow
+        replaceSettingsDraft(
+          overlay,
+          settingsTextDraftWithDetectedContext(overlay.draft, contextWindow)
         );
         if (sameSettingsDraft(overlay.draft, overlay.base)) overlay.conflict = null;
         else if (overlay.conflict !== null) overlay.conflict.armed = false;

--- a/tui/src/settings-draft-transition.ts
+++ b/tui/src/settings-draft-transition.ts
@@ -1,0 +1,341 @@
+import { resolveSettingsProfile } from "../../shared/settings-route.js";
+import type { DiscoveredModelV2 } from "../../shared/settings-v2-types.js";
+import { isolateSettingsProfileModel } from "./settings-profile-draft.js";
+import { settingsModelTargetFingerprint } from "./settings-provider-probe.js";
+import {
+  settingsTextDraftWithDetectedContext,
+  settingsTextDraftWithGeneration,
+  type SettingsTextDraft
+} from "./settings-text.js";
+import type {
+  SettingsModelSelectionByProfile,
+  SettingsOverlayState,
+  SettingsProfileModelSelection
+} from "./state.js";
+
+export type SettingsModelChoiceOrigin =
+  | { kind: "automatic"; targetIdentity: string }
+  | { kind: "manual" }
+  | { kind: "typed" };
+
+/** Replace an unrelated draft value without bypassing selection ownership. */
+export function replaceSettingsDraft(
+  overlay: SettingsOverlayState,
+  next: SettingsTextDraft
+): void {
+  updateDraft(overlay, next);
+}
+
+/** Apply a provider preset. Its model default is an explicit candidate. */
+export function replaceSettingsProviderDraft(
+  overlay: SettingsOverlayState,
+  next: SettingsTextDraft
+): void {
+  updateDraft(overlay, next, true);
+}
+
+/** Apply manual context ownership and isolate a shared model first. */
+export function applySettingsManualContextDraft(
+  overlay: SettingsOverlayState,
+  generation: SettingsTextDraft["generation"]
+): void {
+  const document = overlay.draft.document;
+  const profileId = overlay.draft.selectedProfileId;
+  const isolated = document === null || profileId === null
+    ? overlay.draft
+    : {
+        ...overlay.draft,
+        document: isolateSettingsProfileModel(document, profileId)
+      };
+  const next = generation.contextWindow === null
+    ? settingsTextDraftWithGeneration(overlay.draft, generation)
+    : settingsTextDraftWithGeneration(isolated, generation, true);
+  updateDraft(overlay, next);
+}
+
+/** Atomically update the draft and automatic-selection ownership. */
+export function applySettingsModelChoiceDraft(
+  overlay: SettingsOverlayState,
+  model: Pick<DiscoveredModelV2, "remoteId" | "contextWindow">,
+  contextWindow: number | null = model.contextWindow,
+  origin: SettingsModelChoiceOrigin = { kind: "manual" }
+): void {
+  const manualContext = (origin.kind === "automatic"
+      || model.remoteId === overlay.draft.generation.model)
+    && settingsContextWindowIsManual(overlay);
+  const selectedContext = manualContext
+    ? overlay.draft.generation.contextWindow
+    : contextWindow;
+  let next = overlay.draft;
+  if (model.remoteId !== overlay.draft.generation.model
+    || selectedContext !== overlay.draft.generation.contextWindow) {
+    next = settingsTextDraftWithGeneration(overlay.draft, {
+      ...overlay.draft.generation,
+      model: model.remoteId,
+      contextWindow: manualContext ? overlay.draft.generation.contextWindow : null
+    }, manualContext);
+    if (!manualContext && contextWindow !== null) {
+      next = settingsTextDraftWithDetectedContext(next, contextWindow);
+    }
+  }
+  const key = settingsModelSelectionKey(next.selectedProfileId);
+  let provenance = pruneRemovedProfiles(overlay.modelSelectionByProfile, next);
+  if (settingsDraftTargetChanged(overlay, next)) {
+    ({ next, provenance } = withoutStaleAutomaticSelection(
+      overlay,
+      next,
+      provenance
+    ));
+  }
+  const selected = { ...provenance[key] };
+  if (origin.kind === "automatic") {
+    selected.automaticModel = {
+      remoteId: next.generation.model,
+      targetIdentity: origin.targetIdentity
+    };
+  } else {
+    delete selected.automaticModel;
+  }
+  commitSettingsDraft(
+    overlay,
+    next,
+    withProfileProvenance(provenance, key, selected)
+  );
+}
+
+export function clearSettingsModelChoiceDraft(
+  overlay: SettingsOverlayState
+): void {
+  const manualContext = settingsContextWindowIsManual(overlay);
+  applySettingsModelChoiceDraft(overlay, {
+    remoteId: "",
+    contextWindow: manualContext ? overlay.draft.generation.contextWindow : null
+  });
+}
+
+export function replaceAuthoritativeSettingsDraft(
+  overlay: SettingsOverlayState,
+  next: SettingsTextDraft,
+  modelSelectionByProfile: SettingsModelSelectionByProfile
+): void {
+  commitSettingsDraft(overlay, next, modelSelectionByProfile);
+}
+
+export function cloneSettingsProfileDraft(
+  overlay: SettingsOverlayState,
+  next: SettingsTextDraft,
+  sourceProfileId: string
+): void {
+  cloneProfileDraft(overlay, next, sourceProfileId);
+}
+
+function updateDraft(
+  overlay: SettingsOverlayState,
+  candidate: SettingsTextDraft,
+  candidateModelIsExplicit = false
+): void {
+  let next = candidate;
+  let provenance = pruneRemovedProfiles(overlay.modelSelectionByProfile, next);
+  if (next.selectedProfileId === overlay.draft.selectedProfileId) {
+    if (settingsDraftTargetChanged(overlay, next)) {
+      ({ next, provenance } = withoutStaleAutomaticSelection(
+        overlay,
+        next,
+        provenance,
+        candidateModelIsExplicit
+      ));
+    } else if (next.generation.model !== overlay.draft.generation.model) {
+      provenance = withoutAutomaticSelection(
+        provenance,
+        next.selectedProfileId
+      );
+    }
+  }
+  commitSettingsDraft(overlay, next, provenance);
+}
+
+function cloneProfileDraft(
+  overlay: SettingsOverlayState,
+  next: SettingsTextDraft,
+  sourceProfileId: string
+): void {
+  let provenance = pruneRemovedProfiles(overlay.modelSelectionByProfile, next);
+  const source = profileProvenance(provenance, sourceProfileId);
+  if (source?.automaticModel?.remoteId === next.generation.model) {
+    provenance = withProfileProvenance(
+      provenance,
+      settingsModelSelectionKey(next.selectedProfileId),
+      { automaticModel: source.automaticModel }
+    );
+  }
+  commitSettingsDraft(overlay, next, provenance);
+}
+
+export function settingsAutomaticModelSelection(
+  overlay: SettingsOverlayState
+): NonNullable<SettingsProfileModelSelection["automaticModel"]> | null {
+  const selection = settingsAutomaticModelSelectionForProfile(
+    overlay,
+    overlay.draft.selectedProfileId
+  );
+  return selection?.remoteId === overlay.draft.generation.model
+    ? selection
+    : null;
+}
+
+export function settingsAutomaticModelSelectionForProfile(
+  overlay: SettingsOverlayState,
+  profileId: string | null
+): NonNullable<SettingsProfileModelSelection["automaticModel"]> | null {
+  return profileProvenance(overlay.modelSelectionByProfile, profileId)?.automaticModel ?? null;
+}
+
+export function settingsContextWindowIsManual(
+  overlay: SettingsOverlayState
+): boolean {
+  const document = overlay.draft.document;
+  const profileId = overlay.draft.selectedProfileId;
+  if (document === null || profileId === null
+    || overlay.draft.generation.contextWindow === null) return false;
+  return resolveSettingsProfile(document, profileId).model.overrides.contextWindow
+    === overlay.draft.generation.contextWindow;
+}
+
+export function settingsHasAutomaticModelSelections(
+  overlay: SettingsOverlayState
+): boolean {
+  return Object.values(overlay.modelSelectionByProfile).some(
+    ({ automaticModel }) => automaticModel !== undefined
+  );
+}
+
+export function acknowledgeSettingsModelSelection(
+  overlay: SettingsOverlayState,
+  profileId: string | null,
+  model: string
+): void {
+  const key = settingsModelSelectionKey(profileId);
+  const selected = overlay.modelSelectionByProfile[key];
+  if (selected?.automaticModel?.remoteId !== model) return;
+  overlay.modelSelectionByProfile = withoutAutomaticSelection(
+    overlay.modelSelectionByProfile,
+    profileId
+  );
+}
+
+export function acknowledgeAllSettingsModelSelections(
+  overlay: SettingsOverlayState
+): void {
+  overlay.modelSelectionByProfile = {};
+}
+
+function withoutStaleAutomaticSelection(
+  overlay: SettingsOverlayState,
+  candidate: SettingsTextDraft,
+  provenance: SettingsModelSelectionByProfile,
+  candidateModelIsExplicit = false
+): { next: SettingsTextDraft; provenance: SettingsModelSelectionByProfile } {
+  const key = settingsModelSelectionKey(candidate.selectedProfileId);
+  const automatic = provenance[key]?.automaticModel;
+  const withoutAutomatic = withoutAutomaticSelection(
+    provenance,
+    candidate.selectedProfileId
+  );
+  if (automatic?.remoteId !== overlay.draft.generation.model
+    || candidateModelIsExplicit
+    || candidate.generation.model !== overlay.draft.generation.model) {
+    return { next: candidate, provenance: withoutAutomatic };
+  }
+  const manualContext = settingsContextWindowIsManual(overlay);
+  return {
+    next: settingsTextDraftWithGeneration(candidate, {
+      ...candidate.generation,
+      model: "",
+      contextWindow: manualContext
+        ? overlay.draft.generation.contextWindow
+        : null
+    }, manualContext),
+    provenance: withoutAutomatic
+  };
+}
+
+function withoutAutomaticSelection(
+  current: SettingsModelSelectionByProfile,
+  profileId: string | null
+): SettingsModelSelectionByProfile {
+  const key = settingsModelSelectionKey(profileId);
+  const next = { ...current };
+  delete next[key];
+  return next;
+}
+
+function settingsModelSelectionKey(profileId: string | null): string {
+  return profileId ?? "legacy";
+}
+
+function profileProvenance(
+  provenance: SettingsModelSelectionByProfile,
+  profileId: string | null
+): SettingsProfileModelSelection | undefined {
+  return provenance[settingsModelSelectionKey(profileId)];
+}
+
+function withProfileProvenance(
+  current: SettingsModelSelectionByProfile,
+  key: string,
+  provenance: SettingsProfileModelSelection
+): SettingsModelSelectionByProfile {
+  return { ...current, [key]: provenance };
+}
+
+function pruneRemovedProfiles(
+  current: SettingsModelSelectionByProfile,
+  next: SettingsTextDraft
+): SettingsModelSelectionByProfile {
+  if (next.document === null) return current;
+  const keep = new Set(Object.keys(next.document.profiles));
+  return Object.fromEntries(
+    Object.entries(current).filter(([key]) => keep.has(key))
+  );
+}
+
+function commitSettingsDraft(
+  overlay: SettingsOverlayState,
+  next: SettingsTextDraft,
+  provenance: SettingsModelSelectionByProfile
+): void {
+  overlay.modelSelectionByProfile = provenance;
+  overlay.draft = next;
+}
+
+function settingsDraftTargetChanged(
+  overlay: SettingsOverlayState,
+  next: SettingsTextDraft
+): boolean {
+  return settingsDraftTargetIdentity(overlay, overlay.draft)
+    !== settingsDraftTargetIdentity(overlay, next);
+}
+
+function settingsDraftTargetIdentity(
+  overlay: SettingsOverlayState,
+  draft: SettingsTextDraft
+): string {
+  try {
+    return settingsModelTargetFingerprint(
+      overlay.view,
+      draft.generation,
+      overlay.connectionSecrets,
+      draft.document,
+      draft.selectedProfileId
+    );
+  } catch {
+    return JSON.stringify([
+      draft.selectedProfileId,
+      draft.generation.provider,
+      draft.generation.baseUrl,
+      draft.generation.apiKeyEnv,
+      draft.generation.allowInsecureHttp === true,
+      draft.document
+    ]);
+  }
+}

--- a/tui/src/settings-field-actions.ts
+++ b/tui/src/settings-field-actions.ts
@@ -9,11 +9,13 @@ import {
   modelPickerRows
 } from "./settings-model-picker.js";
 import {
+  applySettingsModelChoice
+} from "./settings-model-selection.js";
+import {
   applySettingsRowEdit,
   disarmSettingsConflict,
   settingsDraftChanged
 } from "./settings-overlay-model.js";
-import { settingsTextDraftWithGeneration } from "./settings-text.js";
 import {
   applySettingsLocalToggle,
   applySettingsTheme
@@ -89,13 +91,10 @@ export function settingsModelPickerAction(
   const model = chosen?.remoteId ?? picker.query.trim();
   overlay.modelPicker = null;
   if (model.length === 0) return;
-  overlay.draft = settingsTextDraftWithGeneration(overlay.draft, {
-    ...overlay.draft.generation,
-    model,
+  applySettingsModelChoice(overlay, {
+    remoteId: model,
     contextWindow: chosen?.contextWindow ?? null
-  });
-  overlay.result = null;
-  disarmSettingsConflict(overlay);
+  }, undefined, chosen === undefined ? { kind: "typed" } : { kind: "manual" });
   state.toast = `model · ${model} · s saves settings`;
 }
 

--- a/tui/src/settings-model-discovery.ts
+++ b/tui/src/settings-model-discovery.ts
@@ -5,10 +5,20 @@ import type {
   SettingsView
 } from "../../shared/settings-v2-types.js";
 import type { GenerationSettings } from "../../shared/types.js";
-import { selectSettingsRoute } from "../../shared/settings-route.js";
 import type { ActionContext } from "./action-context.js";
 import type { AppSource } from "./app.js";
-import { settingsProviderProbeTarget } from "./settings-provider-probe.js";
+import {
+  settingsAutomaticModelSelection,
+  settingsContextWindowIsManual,
+} from "./settings-draft-transition.js";
+import {
+  applySettingsModelChoice,
+  clearAutomaticSettingsModel
+} from "./settings-model-selection.js";
+import {
+  settingsModelTargetFingerprint,
+  settingsProviderProbeTarget
+} from "./settings-provider-probe.js";
 import type { RuntimeState, SettingsOverlayState } from "./state.js";
 
 const synchronizedOverlays = new WeakMap<RuntimeState, SettingsOverlayState>();
@@ -29,8 +39,22 @@ export function settingsModelChoices(
 ): readonly DiscoveredModelV2[] {
   return overlay.modelDiscoveryIdentity
       === settingsModelDiscoveryIdentity(overlay.draft.generation)
+      && overlay.modelDiscoveryResultTargetIdentity
+        === settingsModelSelectionScopeIdentity(overlay)
     ? overlay.modelDiscovery?.models ?? []
     : [];
+}
+
+export function publishCurrentSettingsModelDiscovery(
+  overlay: SettingsOverlayState,
+  discovery: ModelDiscoveryResultV2
+): void {
+  publishSettingsModelDiscoveryResult(
+    overlay,
+    discovery,
+    settingsModelDiscoveryIdentity(overlay.draft.generation),
+    settingsModelSelectionScopeIdentity(overlay)
+  );
 }
 
 export function clearSettingsModelDiscovery(
@@ -42,6 +66,7 @@ export function clearSettingsModelDiscovery(
   overlay.discoveringModels = false;
   overlay.modelDiscovery = null;
   overlay.modelDiscoveryIdentity = null;
+  overlay.modelDiscoveryResultTargetIdentity = null;
 }
 
 export async function synchronizeSettingsModelDiscovery(
@@ -74,6 +99,9 @@ export async function synchronizeSettingsModelDiscovery(
 interface ModelDiscoveryRequest {
   generation: number;
   identity: string;
+  targetIdentity: string;
+  selectionTargetIdentity: string;
+  selectionScopeIdentity: string;
   settings: GenerationSettings;
   view: SettingsView;
   document: SettingsDocumentV2 | null;
@@ -87,6 +115,7 @@ export async function discoverSettingsModels(
   context: Pick<ActionContext, "backend" | "repaint">,
   overlay: SettingsOverlayState
 ): Promise<void> {
+  clearStaleAutomaticModel(overlay);
   const settings = overlay.view.editable
     ? overlay.draft.generation
     : overlay.view.effective;
@@ -98,6 +127,9 @@ export async function discoverSettingsModels(
   const request: ModelDiscoveryRequest = {
     generation: overlay.modelDiscoveryGeneration,
     identity,
+    targetIdentity: settingsModelDiscoveryTargetIdentity(overlay),
+    selectionTargetIdentity: settingsModelSelectionTargetIdentity(overlay),
+    selectionScopeIdentity: settingsModelSelectionScopeIdentity(overlay),
     settings,
     view: overlay.view,
     document: overlay.draft.document,
@@ -147,8 +179,17 @@ async function runModelDiscoveryRequest(
         request.signal
       );
       if (!task.owns() || !ownsCurrentRequest(state, overlay, request)) return;
-      publishModelDiscovery(overlay, request.identity, discovery);
-      if (discovery.models.length === 0) {
+      const selectionError = publishModelDiscovery(overlay, request, discovery);
+      if (selectionError !== null) {
+        overlay.result = {
+          state: "warning",
+          message: "model list loaded · choose the model manually"
+        };
+        overlay.resultRow = "model";
+        state.toast = selectionError instanceof Error
+          ? selectionError.message
+          : String(selectionError);
+      } else if (discovery.models.length === 0) {
         overlay.result = {
           state: "warning",
           message: `model list is empty · ${namedModelSuffix(overlay)}`
@@ -203,40 +244,52 @@ function canDiscoverModels(settings: GenerationSettings): boolean {
   }
 }
 
-function settingsModelDiscoveryTargetIdentity(
+export function settingsModelSelectionTargetIdentity(
   overlay: SettingsOverlayState
 ): string {
   const settings = overlay.view.editable
     ? overlay.draft.generation
     : overlay.view.effective;
-  let connection: unknown = null;
   try {
-    const target = settingsProviderProbeTarget(
+    return settingsModelTargetFingerprint(
       overlay.view,
       settings,
       overlay.connectionSecrets,
       overlay.draft.document,
       overlay.draft.selectedProfileId
     );
-    if ("kind" in target) {
-      connection = selectSettingsRoute(
-        target.document,
-        target.purpose
-      ).connection;
-    }
   } catch {
-    connection = "invalid";
+    return JSON.stringify([
+      "invalid",
+      settingsModelDiscoveryIdentity(settings)
+    ]);
   }
-  const secretIntent = Object.entries(overlay.connectionSecrets)
-    .sort(([left], [right]) => left.localeCompare(right))
-    .map(([id, value]) => [id, value === null ? "delete" : "replace"]);
+}
+
+function settingsModelSelectionScopeIdentity(
+  overlay: SettingsOverlayState
+): string {
   return JSON.stringify([
-    settingsModelDiscoveryIdentity(settings),
     overlay.draft.selectedProfileId,
-    overlay.view.stateGeneration,
-    connection,
-    secretIntent
+    settingsModelSelectionTargetIdentity(overlay)
   ]);
+}
+
+function settingsModelDiscoveryTargetIdentity(
+  overlay: SettingsOverlayState
+): string {
+  return JSON.stringify([
+    overlay.view.stateGeneration,
+    settingsModelSelectionScopeIdentity(overlay)
+  ]);
+}
+
+function clearStaleAutomaticModel(overlay: SettingsOverlayState): void {
+  const automatic = settingsAutomaticModelSelection(overlay);
+  if (automatic !== null
+    && automatic.targetIdentity !== settingsModelSelectionTargetIdentity(overlay)) {
+    clearAutomaticSettingsModel(overlay);
+  }
 }
 
 function ownsCurrentRequest(
@@ -250,16 +303,67 @@ function ownsCurrentRequest(
   return state.settings === overlay
     && overlay.modelDiscoveryGeneration === request.generation
     && overlay.draft.selectedProfileId === request.profileId
+    && settingsModelDiscoveryTargetIdentity(overlay) === request.targetIdentity
     && settingsModelDiscoveryIdentity(current) === request.identity;
 }
 
 function publishModelDiscovery(
   overlay: SettingsOverlayState,
-  identity: string,
+  request: ModelDiscoveryRequest,
   discovery: ModelDiscoveryResultV2
+): unknown | null {
+  publishSettingsModelDiscoveryResult(
+    overlay,
+    discovery,
+    request.identity,
+    request.selectionScopeIdentity
+  );
+  const onlyModel = discovery.models.length === 1
+    ? discovery.models[0]
+    : undefined;
+  const currentModel = overlay.draft.generation.model;
+  const automatic = settingsAutomaticModelSelection(overlay);
+  if (!overlay.view.editable
+    || (currentModel.trim().length > 0 && automatic === null)) {
+    return null;
+  }
+  const listedModel = automatic === null
+      || automatic.targetIdentity !== request.selectionTargetIdentity
+    ? undefined
+    : discovery.models.find((model) => model.remoteId === automatic.remoteId);
+  const selected = listedModel ?? onlyModel;
+  if (selected === undefined) {
+    if (automatic !== null) clearAutomaticSettingsModel(overlay);
+    return null;
+  }
+  const contextWindow = settingsContextWindowIsManual(overlay)
+    ? overlay.draft.generation.contextWindow
+    : selected.contextWindow;
+  try {
+    applySettingsModelChoice(
+      overlay,
+      selected,
+      contextWindow,
+      {
+        kind: "automatic",
+        targetIdentity: request.selectionTargetIdentity
+      }
+    );
+    return null;
+  } catch (error) {
+    return error;
+  }
+}
+
+function publishSettingsModelDiscoveryResult(
+  overlay: SettingsOverlayState,
+  discovery: ModelDiscoveryResultV2,
+  identity: string,
+  targetIdentity: string
 ): void {
   overlay.modelDiscovery = discovery;
   overlay.modelDiscoveryIdentity = identity;
+  overlay.modelDiscoveryResultTargetIdentity = targetIdentity;
 }
 
 /** What to say after a discovery failure. Telling a writer to "enter a custom

--- a/tui/src/settings-model-selection.ts
+++ b/tui/src/settings-model-selection.ts
@@ -1,0 +1,48 @@
+import {
+  applySettingsModelChoiceDraft,
+  clearSettingsModelChoiceDraft,
+  type SettingsModelChoiceOrigin
+} from "./settings-draft-transition.js";
+import { settingsDraftChanged } from "./settings-overlay-reconciliation.js";
+import type { DiscoveredModelV2 } from "../../shared/settings-v2-types.js";
+import type { SettingsOverlayState } from "./state.js";
+
+export function applySettingsModelChoice(
+  overlay: SettingsOverlayState,
+  model: Pick<DiscoveredModelV2, "remoteId" | "contextWindow">,
+  contextWindow: number | null = model.contextWindow,
+  origin: SettingsModelChoiceOrigin = { kind: "manual" }
+): void {
+  applySettingsModelChoiceDraft(overlay, model, contextWindow, origin);
+  overlay.result = null;
+  if (!settingsDraftChanged(overlay)) overlay.conflict = null;
+  else if (overlay.conflict !== null) overlay.conflict.armed = false;
+}
+
+export function applyCachedSettingsModelChoice(
+  overlay: SettingsOverlayState,
+  choices: readonly DiscoveredModelV2[],
+  targetIdentity: string
+): string | null {
+  if (overlay.draft.generation.model.trim().length > 0 || choices.length !== 1) {
+    return null;
+  }
+  try {
+    applySettingsModelChoice(
+      overlay,
+      choices[0]!,
+      choices[0]!.contextWindow,
+      { kind: "automatic", targetIdentity }
+    );
+    return null;
+  } catch (error) {
+    return error instanceof Error ? error.message : String(error);
+  }
+}
+
+export function clearAutomaticSettingsModel(
+  overlay: SettingsOverlayState
+): void {
+  clearSettingsModelChoiceDraft(overlay);
+  overlay.result = null;
+}

--- a/tui/src/settings-overlay-actions.ts
+++ b/tui/src/settings-overlay-actions.ts
@@ -45,6 +45,13 @@ import {
 } from "./settings-prompt-editor.js";
 import { activeSettingsEdit } from "./settings-edit-state.js";
 import {
+  acknowledgeAllSettingsModelSelections,
+  cloneSettingsProfileDraft,
+  replaceSettingsDraft,
+  settingsContextWindowIsManual,
+  settingsHasAutomaticModelSelections
+} from "./settings-draft-transition.js";
+import {
   applySettingsRowEdit,
   beginSettingsRowEdit,
   boundedSettingsCursor,
@@ -68,7 +75,11 @@ import {
   isolateSettingsProfileModel
 } from "./settings-profile-draft.js";
 import { discardUnreferencedConnectionSecretWrites } from "./settings-secret-sidecar.js";
-import { settingsTextDraftForDocument, settingsTextDraftWithGeneration } from "./settings-text.js";
+import {
+  settingsTextDraftForDocument,
+  settingsTextDraftForView,
+  settingsTextDraftWithGeneration
+} from "./settings-text.js";
 import { modelPickerRequired } from "./settings-model-picker.js";
 import { openProfileTransfer, profileTransferAction } from "./profile-transfer-actions.js";
 import {
@@ -291,7 +302,14 @@ function manageSettingsProfile(
       state.toast = `profile kept · ${created.error}`;
       return;
     }
-    overlay.draft = settingsTextDraftForDocument(created.document, created.profileId);
+    cloneSettingsProfileDraft(
+      overlay,
+      settingsTextDraftForDocument(
+        created.document,
+        created.profileId
+      ),
+      profileId
+    );
     overlay.deleteArmedProfileId = null;
     overlay.result = null;
     overlay.conflict = overlay.conflict === null ? null : { ...overlay.conflict, armed: false };
@@ -313,7 +331,13 @@ function manageSettingsProfile(
     state.toast = `profile kept · ${deleted.error}`;
     return;
   }
-  overlay.draft = settingsTextDraftForDocument(deleted.document, deleted.profileId);
+  replaceSettingsDraft(
+    overlay,
+    settingsTextDraftForDocument(
+      deleted.document,
+      deleted.profileId
+    )
+  );
   discardUnreferencedConnectionSecretWrites(overlay);
   overlay.deleteArmedProfileId = null;
   overlay.result = null;
@@ -334,7 +358,12 @@ async function saveSettingsDraft(
   // A staged view means the last activation attempt did not commit; saving
   // the unmodified candidate is the retry, so the no-op guards step aside.
   const stagedRetry = overlay.view.pendingRevision !== null;
-  if (overlay.saveIntent === undefined && !settingsDraftChanged(overlay) && !stagedRetry) {
+  if (overlay.saveIntent === undefined
+    && !settingsDraftChanged(overlay)
+    && !stagedRetry) {
+    if (settingsHasAutomaticModelSelections(overlay)) {
+      acknowledgeAllSettingsModelSelections(overlay);
+    }
     overlay.conflict = null;
     return;
   }
@@ -358,9 +387,10 @@ async function saveSettingsDraft(
         ? overlay.modelDiscovery
         : null;
       const savedDocument = applyBasicSettingsDraft(
-        draft.document,
-        draft.generation,
-        draft.selectedProfileId
+          draft.document,
+          draft.generation,
+          draft.selectedProfileId,
+          settingsContextWindowIsManual(overlay)
       );
       const selectedRemoteId = resolveSettingsProfile(
         savedDocument,
@@ -375,7 +405,8 @@ async function saveSettingsDraft(
           : savedDocument,
         discovery,
         draft.generation.contextWindow,
-        draft.selectedProfileId
+        draft.selectedProfileId,
+        settingsContextWindowIsManual(overlay)
       );
       document = applySamplingSettings(
         document,
@@ -396,10 +427,20 @@ async function saveSettingsDraft(
     }
     if (
       !stagedRetry
-      && document === overlay.view.document
+      && sameSettingsDraft(
+        settingsTextDraftForDocument(document, draft.selectedProfileId),
+        settingsTextDraftForView(overlay.view, draft.selectedProfileId)
+      )
       && Object.keys(connectionSecrets).length === 0
     ) {
-      overlay.draft = overlay.base;
+      acknowledgeAllSettingsModelSelections(overlay);
+      replaceSettingsDraft(
+        overlay,
+        settingsTextDraftForView(
+          overlay.view,
+          overlay.draft.selectedProfileId
+        )
+      );
       overlay.conflict = null;
       return;
     }

--- a/tui/src/settings-overlay-model.ts
+++ b/tui/src/settings-overlay-model.ts
@@ -8,7 +8,6 @@ import {
   settingsRowIsLocal,
   type LocalConfigRow
 } from "./settings-local-rows.js";
-
 export { LOCAL_CONFIG_ROWS, settingsRowIsLocal, type LocalConfigRow };
 import { resolveSettingsProfile } from "../../shared/settings-route.js";
 import type { UserConfig } from "./config.js";
@@ -22,7 +21,19 @@ import {
   nextSettingsProviderChoice,
   type SettingsProviderChoice
 } from "./settings-provider-choices.js";
-import { settingsModelChoices } from "./settings-model-discovery.js";
+import {
+  applySettingsManualContextDraft,
+  replaceSettingsDraft,
+  replaceSettingsProviderDraft
+} from "./settings-draft-transition.js";
+import {
+  applyCachedSettingsModelChoice,
+  applySettingsModelChoice
+} from "./settings-model-selection.js";
+import {
+  settingsModelChoices,
+  settingsModelSelectionTargetIdentity
+} from "./settings-model-discovery.js";
 import { isSettingsScalarRow } from "./settings-scalar.js";
 import { modelPickerRequired } from "./settings-model-picker.js";
 import {
@@ -51,7 +62,6 @@ import {
   settingsDraftChanged,
   settingsFieldKey
 } from "./settings-overlay-reconciliation.js";
-
 export {
   promptCacheRowValue,
   settingsModelDisplayText,
@@ -117,6 +127,7 @@ export function initialSettingsOverlay(
     view,
     base: draft,
     draft,
+    modelSelectionByProfile: {},
     connectionSecrets: {},
     cursor: 0,
     edit: null,
@@ -128,6 +139,7 @@ export function initialSettingsOverlay(
     discoveringModels: false,
     modelDiscovery: null,
     modelDiscoveryIdentity: null,
+    modelDiscoveryResultTargetIdentity: null,
     modelDiscoveryGeneration: 0,
     modelDiscoveryAbortController: null,
     modelDiscoveryTargetIdentity: null,
@@ -260,7 +272,10 @@ export function applySettingsRowEdit(
       rawValue
     );
     if ("error" in renamed) return { kind: "error", message: renamed.error };
-    overlay.draft = settingsTextDraftForDocument(renamed, overlay.draft.selectedProfileId);
+    replaceSettingsDraft(
+      overlay,
+      settingsTextDraftForDocument(renamed, overlay.draft.selectedProfileId)
+    );
     overlay.edit = null;
     overlay.result = null;
     return { kind: "draft" };
@@ -272,13 +287,12 @@ export function applySettingsRowEdit(
     overlay.draft
   );
   if ("error" in parsed) return { kind: "error", message: parsed.error };
+  const modelChanged = edit.row === "model"
+    && parsed.generation.model !== overlay.draft.generation.model;
   const identityChanged = (
     edit.row === "base-url"
       && parsed.generation.baseUrl !== overlay.draft.generation.baseUrl
-  ) || (
-    edit.row === "model"
-      && parsed.generation.model !== overlay.draft.generation.model
-  );
+  ) || modelChanged;
   const next = identityChanged
     ? {
         ...parsed,
@@ -286,9 +300,32 @@ export function applySettingsRowEdit(
       }
     : parsed;
   try {
-    overlay.draft = settingsTextDraftWithGeneration(overlay.draft, next.generation);
+    if (edit.row === "model") {
+      applySettingsModelChoice(overlay, {
+        remoteId: next.generation.model,
+        contextWindow: modelChanged ? null : next.generation.contextWindow
+      }, undefined, { kind: "typed" });
+    } else {
+      if (edit.row === "context-window"
+        && next.generation.contextWindow !== null) {
+        applySettingsManualContextDraft(overlay, next.generation);
+      } else {
+        replaceSettingsDraft(
+          overlay,
+          settingsTextDraftWithGeneration(overlay.draft, next.generation)
+        );
+      }
+    }
   } catch (error) {
     return { kind: "error", message: error instanceof Error ? error.message : String(error) };
+  }
+  if (edit.row === "model") {
+    const error = applyCachedSettingsModelChoice(
+      overlay,
+      settingsModelChoices(overlay),
+      settingsModelSelectionTargetIdentity(overlay)
+    );
+    if (error !== null) return { kind: "error", message: error };
   }
   if (edit.row === "api-key-env") discardUnreferencedConnectionSecretWrites(overlay);
   if (!settingsDraftChanged(overlay)) overlay.conflict = null;
@@ -302,10 +339,13 @@ export function applySystemPromptDraft(
   systemPrompt: string
 ): void {
   disarmSettingsConflict(overlay);
-  overlay.draft = settingsTextDraftWithGeneration(overlay.draft, {
-    ...overlay.draft.generation,
-    systemPrompt
-  });
+  replaceSettingsDraft(
+    overlay,
+    settingsTextDraftWithGeneration(overlay.draft, {
+      ...overlay.draft.generation,
+      systemPrompt
+    })
+  );
   if (sameSettingsDraft(overlay.draft, overlay.base)) overlay.conflict = null;
   overlay.result = null;
 }
@@ -384,15 +424,21 @@ export function cycleSettingsProvider(
     selectedConnectionPreset(overlay)
   );
   const preserveStoredApiKey = hasStoredApiKey(overlay);
-  overlay.draft = settingsTextDraftWithGeneration(overlay.draft, {
-    ...overlay.draft.generation,
-    provider: choice.provider,
-    ...choice.defaults,
-    ...(preserveStoredApiKey ? { apiKeyEnv: null } : {})
-  });
+  replaceSettingsProviderDraft(
+    overlay,
+    settingsTextDraftWithGeneration(overlay.draft, {
+      ...overlay.draft.generation,
+      provider: choice.provider,
+      ...choice.defaults,
+      ...(preserveStoredApiKey ? { apiKeyEnv: null } : {})
+    })
+  );
   const textPreset = textPresetForChoice(choice);
   if (textPreset !== null) {
-    overlay.draft = settingsTextDraftWithTextPreset(overlay.draft, textPreset);
+    replaceSettingsDraft(
+      overlay,
+      settingsTextDraftWithTextPreset(overlay.draft, textPreset)
+    );
   }
   rekeyPendingStoredSecret(overlay);
   discardUnreferencedConnectionSecretWrites(overlay);
@@ -432,30 +478,8 @@ export function cycleSettingsModel(
     ? step === 1 ? 0 : choices.length - 1
     : (current + step + choices.length) % choices.length;
   const choice = choices[index]!;
-  if (choice.remoteId === overlay.draft.generation.model) {
-    return choice.remoteId;
-  }
-  overlay.draft = settingsTextDraftWithGeneration(overlay.draft, {
-    ...overlay.draft.generation,
-    model: choice.remoteId,
-    contextWindow: choice.contextWindow
-  });
-  overlay.result = null;
-  if (!settingsDraftChanged(overlay)) overlay.conflict = null;
-  else disarmSettingsConflict(overlay);
+  applySettingsModelChoice(overlay, choice);
   return choice.remoteId;
-}
-
-export function cycleAllowInsecureHttp(overlay: SettingsOverlayState): boolean {
-  const allowInsecureHttp = overlay.draft.generation.allowInsecureHttp !== true;
-  const generation = { ...overlay.draft.generation };
-  if (allowInsecureHttp) generation.allowInsecureHttp = true;
-  else delete generation.allowInsecureHttp;
-  overlay.draft = settingsTextDraftWithGeneration(overlay.draft, generation);
-  overlay.result = null;
-  if (!settingsDraftChanged(overlay)) overlay.conflict = null;
-  else disarmSettingsConflict(overlay);
-  return allowInsecureHttp;
 }
 
 function maskSecretText(value: string): string {

--- a/tui/src/settings-overlay-reconciliation.ts
+++ b/tui/src/settings-overlay-reconciliation.ts
@@ -18,6 +18,13 @@ import {
   type SettingsTextDraft
 } from "./settings-text.js";
 import type { SettingsOverlayState, SettingsRowId } from "./state.js";
+import {
+  acknowledgeSettingsModelSelection,
+  replaceAuthoritativeSettingsDraft,
+  replaceSettingsDraft,
+  settingsAutomaticModelSelectionForProfile
+} from "./settings-draft-transition.js";
+import { settingsModelTargetFingerprint } from "./settings-provider-probe.js";
 
 type EditableSettingsFieldRow =
   | "provider"
@@ -75,7 +82,6 @@ export function reconcileSettingsOverlay(
     overlay.base = nextBase;
     return null;
   }
-
   const samplingWasOpen = overlay.sampling !== null;
   const draftWasClean = !settingsDraftChanged(overlay);
   const editAffectsServer = edit !== null && (
@@ -89,7 +95,13 @@ export function reconcileSettingsOverlay(
     ? draftWithActiveEdit(activeEditBase, edit)
     : overlay.draft;
   const converged = activeDraft !== null && sameSettingsDraft(activeDraft, nextBase);
-  if (draftWasClean || converged) overlay.draft = nextBase;
+  if (draftWasClean || converged) {
+    replaceAuthoritativeSettingsDraft(
+      overlay,
+      nextBase,
+      reconciledModelProvenance(overlay, nextBase, view)
+    );
+  }
   overlay.base = nextBase;
 
   if (edit !== null && (draftWasClean || converged) && editWasClean) {
@@ -134,6 +146,7 @@ export function settleSettingsOverlaySave(
 ): boolean {
   const newerDraft = !sameSettingsDraft(overlay.draft, acknowledged)
     || !sameConnectionSecrets(overlay.connectionSecrets, acknowledgedSecrets);
+  acknowledgeSavedAutomaticModels(overlay, acknowledged, acknowledgedSecrets);
   if (sameConnectionSecrets(overlay.connectionSecrets, acknowledgedSecrets)) {
     overlay.connectionSecrets = {};
   }
@@ -142,11 +155,110 @@ export function settleSettingsOverlaySave(
     overlay.draft.selectedProfileId
   );
   overlay.base = nextBase;
-  if (!newerDraft) overlay.draft = nextBase;
+  if (!newerDraft) {
+    replaceSettingsDraft(overlay, nextBase);
+  }
   overlay.conflict = null;
   return newerDraft || (
     edit !== null && edit.composer.text !== edit.initialText()
   );
+}
+
+function reconciledModelProvenance(
+  overlay: SettingsOverlayState,
+  next: SettingsTextDraft,
+  view: SettingsView
+): SettingsOverlayState["modelSelectionByProfile"] {
+  return Object.fromEntries(
+    Object.keys(overlay.modelSelectionByProfile).flatMap((key) => {
+      const current = overlay.modelSelectionByProfile[key] ?? {};
+      const profileId = overlay.draft.document === null ? null : key;
+      const previousDraft = draftForProfile(overlay.draft, profileId);
+      const nextDraft = draftForProfile(next, profileId);
+      if (previousDraft === null || nextDraft === null) return [];
+      const reconciled = {
+        ...(current.automaticModel !== undefined
+          && nextDraft.generation.model === current.automaticModel.remoteId
+          && modelTargetIdentityForView(
+            view,
+            nextDraft,
+            overlay.connectionSecrets
+          ) === current.automaticModel.targetIdentity
+          ? { automaticModel: current.automaticModel }
+          : {}),
+      };
+      return Object.keys(reconciled).length === 0
+        ? []
+        : [[key, reconciled]];
+    })
+  );
+}
+
+function acknowledgeSavedAutomaticModels(
+  overlay: SettingsOverlayState,
+  acknowledged: SettingsTextDraft,
+  acknowledgedSecrets: Readonly<Record<string, string | null>>
+): void {
+  const profileIds: readonly (string | null)[] = acknowledged.document === null
+    ? [null]
+    : Object.keys(acknowledged.document.profiles);
+  for (const profileId of profileIds) {
+    const automatic = settingsAutomaticModelSelectionForProfile(
+      overlay,
+      profileId
+    );
+    if (automatic === null) continue;
+    const saved = draftForProfile(acknowledged, profileId);
+    const current = draftForProfile(overlay.draft, profileId);
+    if (saved === null || current === null
+      || saved.generation.model !== automatic.remoteId
+      || current.generation.model !== automatic.remoteId) continue;
+    const currentTarget = modelTargetIdentityForView(
+      overlay.view,
+      current,
+      overlay.connectionSecrets
+    );
+    if (currentTarget !== null
+      && currentTarget === modelTargetIdentityForView(
+        overlay.view,
+        saved,
+        acknowledgedSecrets
+      )) {
+      acknowledgeSettingsModelSelection(overlay, profileId, automatic.remoteId);
+    }
+  }
+}
+
+function draftForProfile(
+  draft: SettingsTextDraft,
+  profileId: string | null
+): SettingsTextDraft | null {
+  if (profileId === null) {
+    return draft.selectedProfileId === null ? draft : null;
+  }
+  if (draft.document?.profiles[profileId] === undefined) return null;
+  return settingsTextDraftForDocument(
+    draft.document,
+    profileId
+  );
+}
+
+function modelTargetIdentityForView(
+  view: SettingsView,
+  draft: SettingsTextDraft,
+  connectionSecrets: Readonly<Record<string, string | null>>
+): string | null {
+  try {
+    return settingsModelTargetFingerprint(
+      view,
+      draft.generation,
+      connectionSecrets,
+      draft.document,
+      draft.selectedProfileId
+    );
+  } catch {
+    return null;
+  }
 }
 
 export function sameGenerationSettings(

--- a/tui/src/settings-profile-controls.ts
+++ b/tui/src/settings-profile-controls.ts
@@ -30,6 +30,10 @@ import {
   settingsProviderChoice
 } from "./settings-provider-choices.js";
 import { settingsModelChoices } from "./settings-model-discovery.js";
+import {
+  applySettingsManualContextDraft,
+  replaceSettingsDraft
+} from "./settings-draft-transition.js";
 import { promptCacheSummaryParts } from "./settings-cache-summary.js";
 import { samplingRowValue } from "./sampling-model.js";
 import { cycleProfileField, markControlMutation } from "./settings-profile-cycle.js";
@@ -259,7 +263,14 @@ export function stepSettingsScalar(
   else if (row === "context-window") generation.contextWindow = next;
   else if (next === null) throw new Error("max tokens has no sentinel to step to");
   else generation.maxTokens = next;
-  overlay.draft = settingsTextDraftWithGeneration(overlay.draft, generation);
+  if (row === "context-window" && next !== null) {
+    applySettingsManualContextDraft(overlay, generation);
+  } else {
+    replaceSettingsDraft(
+      overlay,
+      settingsTextDraftWithGeneration(overlay.draft, generation)
+    );
+  }
   markControlMutation(overlay);
 }
 
@@ -280,7 +291,7 @@ export function cycleProfileControl(
   const selected = overlay.draft.selectedProfileId;
   if (document === null || selected === null) return null;
   const profileId = cycleProfile(document, selected, step);
-  overlay.draft = settingsTextDraftForDocument(document, profileId);
+  replaceSettingsDraft(overlay, settingsTextDraftForDocument(document, profileId));
   markControlMutation(overlay);
   return document.profiles[profileId]!.name;
 }
@@ -294,7 +305,7 @@ export function cycleRouteControl(
   const selected = overlay.draft.selectedProfileId;
   if (document === null || selected === null) return null;
   const next = cycleRoute(document, purpose, step);
-  overlay.draft = settingsTextDraftForDocument(next, selected);
+  replaceSettingsDraft(overlay, settingsTextDraftForDocument(next, selected));
   markControlMutation(overlay);
   return routeRowValue(overlay, purpose);
 }
@@ -323,7 +334,10 @@ export function cycleCachePolicyControl(
   const policy = PROMPT_CACHE_POLICY_V2_VALUES[
     (index + step + PROMPT_CACHE_POLICY_V2_VALUES.length) % PROMPT_CACHE_POLICY_V2_VALUES.length
   ]!;
-  overlay.draft = settingsTextDraftWithCachePolicy(overlay.draft, policy);
+  replaceSettingsDraft(
+    overlay,
+    settingsTextDraftWithCachePolicy(overlay.draft, policy)
+  );
   markControlMutation(overlay);
   return policy;
 }
@@ -344,16 +358,19 @@ export function cycleTextPromptFormatControl(
   const current = route.connection.textPromptFormat ?? "raw";
   const index = Math.max(0, choices.indexOf(current));
   const format = choices[(index + step + choices.length) % choices.length]!;
-  overlay.draft = settingsTextDraftForDocument({
-    ...document,
-    connections: {
-      ...document.connections,
-      [route.model.connectionId]: {
-        ...route.connection,
-        textPromptFormat: format
+  replaceSettingsDraft(
+    overlay,
+    settingsTextDraftForDocument({
+      ...document,
+      connections: {
+        ...document.connections,
+        [route.model.connectionId]: {
+          ...route.connection,
+          textPromptFormat: format
+        }
       }
-    }
-  }, profileId);
+    }, profileId)
+  );
   markControlMutation(overlay);
   return format;
 }

--- a/tui/src/settings-profile-cycle.ts
+++ b/tui/src/settings-profile-cycle.ts
@@ -1,4 +1,5 @@
 import type { GenerationProfileV2 } from "../../shared/settings-v2-types.js";
+import { replaceSettingsDraft } from "./settings-draft-transition.js";
 import { settingsTextDraftForDocument } from "./settings-text.js";
 import type { SettingsOverlayState } from "./state.js";
 
@@ -26,10 +27,13 @@ export function cycleProfileField<T>(
   const next = choices[index < 0
     ? 0
     : (index + step + choices.length) % choices.length]!;
-  overlay.draft = settingsTextDraftForDocument({
-    ...document,
-    profiles: { ...document.profiles, [profileId]: write(profile, next) }
-  }, profileId);
+  replaceSettingsDraft(
+    overlay,
+    settingsTextDraftForDocument({
+      ...document,
+      profiles: { ...document.profiles, [profileId]: write(profile, next) }
+    }, profileId)
+  );
   markControlMutation(overlay);
   return next;
 }

--- a/tui/src/settings-provider-probe.ts
+++ b/tui/src/settings-provider-probe.ts
@@ -1,11 +1,15 @@
 import { applyBasicSettingsProbeDraft } from "../../shared/settings-basic-draft.js";
 import type {
+  ModelConnectionV2,
   ProviderProbeTarget,
   SettingsDocumentV2,
   SettingsView
 } from "../../shared/settings-v2-types.js";
 import type { GenerationSettings } from "../../shared/types.js";
-import { resolveSettingsProfile } from "../../shared/settings-route.js";
+import {
+  resolveSettingsProfile,
+  selectSettingsRoute
+} from "../../shared/settings-route.js";
 import { storedCredentialSecretId } from "../../shared/settings-stored-credential.js";
 
 /** Editable format-2 drafts must retain document-only connection policy across
@@ -49,5 +53,55 @@ export function settingsProviderProbeTarget(
     ...(typeof pendingSecret !== "string" || secretId === null
       ? {}
       : { secrets: { [secretId]: pendingSecret } })
+  };
+}
+
+export function settingsModelTargetFingerprint(
+  view: SettingsView,
+  settings: GenerationSettings,
+  connectionSecrets: Readonly<Record<string, string | null>>,
+  draftDocument?: SettingsDocumentV2 | null,
+  selectedProfileId?: string | null
+): string {
+  const target = settingsProviderProbeTarget(
+    view,
+    settings,
+    connectionSecrets,
+    draftDocument,
+    selectedProfileId
+  );
+  const connection = "kind" in target
+    ? modelDiscoveryConnectionTarget(
+        selectSettingsRoute(target.document, target.purpose).connection
+      )
+    : null;
+  const secretIntent = "kind" in target
+    ? Object.keys(target.secrets ?? {})
+      .sort((left, right) => left.localeCompare(right))
+      .map((id) => [id, "replace"] as const)
+    : [];
+  return JSON.stringify([
+    settings.provider,
+    settings.baseUrl,
+    settings.apiKeyEnv,
+    settings.allowInsecureHttp === true,
+    connection,
+    secretIntent
+  ]);
+}
+
+function modelDiscoveryConnectionTarget(
+  connection: ModelConnectionV2
+) {
+  return {
+    preset: connection.preset,
+    protocol: connection.protocol,
+    baseUrl: connection.baseUrl,
+    auth: connection.auth,
+    headers: connection.headers,
+    timeoutMs: connection.timeouts.totalMs,
+    ...(connection.allowInsecureHttp === true
+      ? { allowInsecureHttp: true as const }
+      : {})
   };
 }

--- a/tui/src/settings-secret-sidecar.ts
+++ b/tui/src/settings-secret-sidecar.ts
@@ -8,6 +8,7 @@ import { storedCredentialSecretId } from "../../shared/settings-stored-credentia
 import { MAX_SETTINGS_ID_SCALARS } from "../../server/settings-v2-scalars.js";
 import type { SettingsOverlayState } from "./state.js";
 import { isolateSettingsProfileConnection } from "./settings-profile-draft.js";
+import { replaceSettingsDraft } from "./settings-draft-transition.js";
 import {
   settingsTextDraftForDocument,
   settingsTextDraftWithGeneration
@@ -38,11 +39,18 @@ export function applyStoredApiKeyEdit(
       overlay.draft.document,
       overlay.draft.selectedProfileId
     );
-    overlay.draft = settingsTextDraftForDocument(document, overlay.draft.selectedProfileId);
-    overlay.draft = settingsTextDraftWithGeneration(overlay.draft, {
-      ...overlay.draft.generation,
-      apiKeyEnv: null
-    });
+    const generation = overlay.draft.generation;
+    replaceSettingsDraft(
+      overlay,
+      settingsTextDraftForDocument(document, overlay.draft.selectedProfileId)
+    );
+    replaceSettingsDraft(
+      overlay,
+      settingsTextDraftWithGeneration(overlay.draft, {
+        ...generation,
+        apiKeyEnv: null
+      })
+    );
     const selected = selectedConnection(overlay);
     const existingSecretId = storedCredentialSecretId(selected.connection.auth);
     if (value.length === 0) {
@@ -148,13 +156,16 @@ function replaceSelectedConnectionAuth(
     throw new Error("Stored API keys require editable format-2 settings");
   }
   const selected = profileConnectionInDocument(document, profileId);
-  overlay.draft = settingsTextDraftForDocument({
-    ...document,
-    connections: {
-      ...document.connections,
-      [selected.connectionId]: { ...selected.connection, auth }
-    }
-  }, profileId);
+  replaceSettingsDraft(
+    overlay,
+    settingsTextDraftForDocument({
+      ...document,
+      connections: {
+        ...document.connections,
+        [selected.connectionId]: { ...selected.connection, auth }
+      }
+    }, profileId)
+  );
 }
 
 function storedAuthFor(

--- a/tui/src/settings-selector-actions.ts
+++ b/tui/src/settings-selector-actions.ts
@@ -1,8 +1,8 @@
 import type { ActionContext } from "./action-context.js";
 import type { AppSource } from "./app.js";
 import { saveConfig, THEME_NAMES, type ThemeName } from "./config.js";
+import { cycleAllowInsecureHttp } from "./settings-allow-insecure.js";
 import {
-  cycleAllowInsecureHttp,
   cycleSettingsModel,
   cycleSettingsProvider,
   settingsModelDisplayText,

--- a/tui/src/settings-text.ts
+++ b/tui/src/settings-text.ts
@@ -25,6 +25,7 @@ import {
   promptCacheContextForProfile
 } from "../../shared/prompt-cache-capabilities.js";
 import {
+  isolateSettingsProfileModel,
   prepareSettingsProfileGenerationEdit,
   selectedSettingsProfileId
 } from "./settings-profile-draft.js";
@@ -86,7 +87,7 @@ export function settingsTextDraftForView(
 
 export function settingsTextDraftForDocument(
   document: SettingsDocumentV2,
-  preferredProfileId?: string | null
+  preferredProfileId: string | null | undefined
 ): SettingsTextDraft {
   const selectedProfileId = selectedSettingsProfileId(document, preferredProfileId);
   const route = resolveSettingsProfile(document, selectedProfileId);
@@ -101,7 +102,8 @@ export function settingsTextDraftForDocument(
 
 export function settingsTextDraftWithGeneration(
   draft: SettingsTextDraft,
-  generation: GenerationSettings
+  generation: GenerationSettings,
+  retainContextWindowOverride = false
 ): SettingsTextDraft {
   if (draft.document === null || draft.selectedProfileId === null) {
     return { ...draft, generation };
@@ -113,7 +115,12 @@ export function settingsTextDraftWithGeneration(
     generation
   );
   const projected = settingsTextDraftForDocument(
-    applySettingsGenerationDraft(document, generation, draft.selectedProfileId),
+    applySettingsGenerationDraft(
+      document,
+      generation,
+      draft.selectedProfileId,
+      retainContextWindowOverride
+    ),
     draft.selectedProfileId
   );
   if (generation.provider !== "dry-run") return projected;
@@ -175,14 +182,29 @@ export function settingsTextDraftWithDetectedContext(
   draft: SettingsTextDraft,
   contextWindow: number
 ): SettingsTextDraft {
-  const synchronized = settingsTextDraftWithGeneration(draft, {
-    ...draft.generation,
-    contextWindow: null
-  });
-  return settingsTextDraftWithGeneration(synchronized, {
-    ...synchronized.generation,
-    contextWindow
-  });
+  const document = draft.document;
+  const profileId = draft.selectedProfileId;
+  if (document === null || profileId === null) {
+    return {
+      ...draft,
+      generation: { ...draft.generation, contextWindow }
+    };
+  }
+  const isolated = isolateSettingsProfileModel(document, profileId);
+  const route = resolveSettingsProfile(isolated, profileId);
+  const overrides = { ...route.model.overrides };
+  delete overrides.contextWindow;
+  return settingsTextDraftForDocument({
+    ...isolated,
+    models: {
+      ...isolated.models,
+      [route.profile.modelId]: {
+        ...route.model,
+        discovered: { ...route.model.discovered, contextWindow },
+        overrides
+      }
+    }
+  }, profileId);
 }
 
 /** Identify only form values that the selected document cannot project. This
@@ -373,10 +395,16 @@ export function parseSettings(value: string, base: SettingsTextDraft): SettingsT
 function applySettingsGenerationDraft(
   document: SettingsDocumentV2,
   generation: GenerationSettings,
-  profileId: string
+  profileId: string,
+  retainContextWindowOverride = false
 ): SettingsDocumentV2 {
   try {
-    return applyBasicSettingsProbeDraft(document, generation, profileId);
+    return applyBasicSettingsProbeDraft(
+      document,
+      generation,
+      profileId,
+      retainContextWindowOverride
+    );
   } catch {
     return applyIncompleteGenerationDraft(document, generation, profileId);
   }

--- a/tui/src/state.ts
+++ b/tui/src/state.ts
@@ -252,12 +252,24 @@ export interface SettingsOverlaySaveIntent {
   readonly draft: SettingsTextDraft;
   readonly connectionSecrets: Readonly<Record<string, string | null>>;
 }
+export interface SettingsProfileModelSelection {
+  automaticModel?: {
+    remoteId: string;
+    targetIdentity: string;
+  };
+}
+export type SettingsModelSelectionByProfile = Record<
+  string,
+  SettingsProfileModelSelection
+>;
 export interface SettingsOverlayState {
   view: SettingsView;
   /** Last authoritative projection used to detect/rebase external refreshes. */
   base: SettingsTextDraft;
   /** Atomic unsaved form state. Runtime generation remains pinned to view.effective. */
   draft: SettingsTextDraft;
+  /** One per-profile owner for model values inferred while this overlay is open. */
+  modelSelectionByProfile: SettingsModelSelectionByProfile;
   /** Write-only key material; never projected into GenerationSettings/document. */
   connectionSecrets: Record<string, string | null>;
   cursor: number;
@@ -274,6 +286,7 @@ export interface SettingsOverlayState {
   discoveringModels: boolean;
   modelDiscovery: ModelDiscoveryResultV2 | null;
   modelDiscoveryIdentity: string | null;
+  modelDiscoveryResultTargetIdentity: string | null;
   modelDiscoveryGeneration: number;
   modelDiscoveryAbortController: AbortController | null;
   modelDiscoveryTargetIdentity: string | null;

--- a/tui/test/hit-map-chrome.test.ts
+++ b/tui/test/hit-map-chrome.test.ts
@@ -20,7 +20,7 @@ import {
   initialSettingsOverlay,
   SETTINGS_ROW_IDS
 } from "../src/settings-overlay-model.js";
-import { settingsModelDiscoveryIdentity } from "../src/settings-model-discovery.js";
+import { publishCurrentSettingsModelDiscovery } from "../src/settings-model-discovery.js";
 import { currentPartActions, openActions } from "../src/story-actions.js";
 import {
   ACTIONS_FOOTER_ACTIONS, TAGS_FOOTER_ACTIONS, CHAPTERS_FOOTER_ACTIONS,
@@ -125,7 +125,7 @@ function installModelChoices(state: State, remoteIds: readonly string[]): void {
       model: remoteIds[0] ?? ""
     }
   };
-  overlay.modelDiscovery = {
+  publishCurrentSettingsModelDiscovery(overlay, {
     observedAt: "2026-01-01T00:00:00.000Z",
     models: remoteIds.map((remoteId) => ({
       remoteId,
@@ -134,10 +134,7 @@ function installModelChoices(state: State, remoteIds: readonly string[]): void {
       maxOutputTokens: null,
       source: "openai-models" as const
     }))
-  };
-  overlay.modelDiscoveryIdentity = settingsModelDiscoveryIdentity(
-    overlay.draft.generation
-  );
+  });
 }
 
 function clickText(frame: ReturnType<typeof render>, state: ReturnType<typeof initialState>, text: string) {

--- a/tui/test/settings-form.test.ts
+++ b/tui/test/settings-form.test.ts
@@ -7,7 +7,7 @@ import {
   DEFAULT_PROFILE_TEMPERATURE
 } from "../../shared/settings-v2-types.js";
 import { INITIAL_SETTINGS_DOCUMENT_V2_TEXT } from "../../server/settings-v2-initial-vectors.js";
-import { settingsModelDiscoveryIdentity } from "../src/settings-model-discovery.js";
+import { publishCurrentSettingsModelDiscovery } from "../src/settings-model-discovery.js";
 import {
   initialSettingsOverlay,
   settingsRows,
@@ -178,7 +178,7 @@ describe("C-15 · the model option column", () => {
       ...overlay.draft,
       generation: { ...overlay.draft.generation, model: "model-01" }
     };
-    overlay.modelDiscovery = {
+    publishCurrentSettingsModelDiscovery(overlay, {
       observedAt: "2026-01-01T00:00:00.000Z",
       models: Array.from({ length: count }, (_, index) => ({
         remoteId: `model-${String(index + 1).padStart(2, "0")}`,
@@ -187,9 +187,7 @@ describe("C-15 · the model option column", () => {
         maxOutputTokens: null,
         source: "openai-models" as const
       }))
-    };
-    overlay.modelDiscoveryIdentity =
-      settingsModelDiscoveryIdentity(overlay.draft.generation);
+    });
   }
 
   test("a long list opens as a column that owns the arrows", async () => {

--- a/tui/test/settings-model-picker.test.ts
+++ b/tui/test/settings-model-picker.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { applyBasicSettingsDraft } from "../../shared/settings-basic-draft.js";
+import {
+  applyBasicModelDiscovery,
+  applyBasicSettingsDraft
+} from "../../shared/settings-basic-draft.js";
+import { createFailureEnvelope } from "../../shared/failure-envelope.js";
 import type {
   ModelDiscoveryResultV2,
   SettingsView
@@ -7,6 +11,8 @@ import type {
 import { setComposerText } from "../src/composer-model.js";
 import { renderStoryScreen } from "../src/screens/story.js";
 import { frameText } from "../src/screens/story/frame.js";
+import { WorkerApiError } from "../src/worker-api.js";
+import { settingsModelSelectionTargetIdentity } from "../src/settings-model-discovery.js";
 import {
   deferred,
   draftRow,
@@ -16,13 +22,24 @@ import {
   selectRow,
   settingsHarness
 } from "./settings-test-harness.js";
+import { configureNetworkSource } from "./settings-model-provenance-test-helpers.js";
 
 describe("Settings model picker", () => {
+  test("invalid provider drafts keep distinct discovery identities", async () => {
+    const { source, state, press } = settingsHarness();
+    configureNetworkSource(source);
+
+    await openSettings(press);
+    await draftRow(press, state, "base-url", "not-a-url");
+    const first = settingsModelSelectionTargetIdentity(state.settings!);
+    await draftRow(press, state, "base-url", "still-not-a-url");
+
+    expect(settingsModelSelectionTargetIdentity(state.settings!)).not.toBe(first);
+  });
+
   test("reads provider models, cycles them, and accepts a custom name", async () => {
     const { source, state, cache, press } = settingsHarness();
-    if (!source.settingsView.editable) {
-      throw new Error("demo settings must be editable");
-    }
+    if (!source.settingsView.editable) throw new Error("demo settings must be editable");
     const document = applyBasicSettingsDraft(source.settingsView.document, {
       ...source.settings,
       provider: "openai-compatible",
@@ -164,6 +181,202 @@ describe("Settings model picker", () => {
       .toBe("current-model");
   });
 
+  test("selects the only model returned for an unsaved connection draft", async () => {
+    const { source, state, backend, press } = settingsHarness();
+    configureNetworkSource(source);
+    const targets: string[] = [];
+    source.api.discoverModels = async (target) => {
+      const baseUrl = generationFromProbeTarget(target).baseUrl;
+      targets.push(baseUrl);
+      return discovery(baseUrl === "https://models.example.test/v1"
+        ? "loaded-local-model"
+        : "novelist-a");
+    };
+
+    await openSettings(press);
+    await draftRow(press, state, "model", "");
+    expect(state.settings?.draft.generation.model).toBe("novelist-a");
+    await draftRow(
+      press,
+      state,
+      "base-url",
+      "https://models.example.test/v1"
+    );
+    await backend.whenIdle();
+
+    expect(targets.at(-1)).toBe("https://models.example.test/v1");
+    expect(state.settings?.draft.generation.model).toBe("loaded-local-model");
+    expect(state.settings?.view.effective.model).toBe("novelist-a");
+  });
+
+  test("refreshes an automatic model but preserves a typed model", async () => {
+    const { source, state, backend, press } = settingsHarness();
+    configureNetworkSource(source);
+    source.api.discoverModels = async (target) => {
+      const host = new URL(generationFromProbeTarget(target).baseUrl).hostname;
+      return discovery(`model-${host.split(".")[0]}`);
+    };
+
+    await openSettings(press);
+    await draftRow(press, state, "model", "");
+    await draftRow(press, state, "base-url", "https://alpha.example.test/v1");
+    await backend.whenIdle();
+    expect(state.settings?.draft.generation.model).toBe("model-alpha");
+    await selectRow(press, state, "profile");
+    await press(key("e"));
+    setComposerText(state.settings!.edit!.composer, "Renamed Profile");
+    await press(key("return"));
+    const alphaProfileId = state.settings?.draft.selectedProfileId;
+    await press(key("N"));
+    await press(key("left"));
+    expect(state.settings?.draft.selectedProfileId).toBe(alphaProfileId);
+
+    const original = source.settingsView;
+    if (!original.editable) throw new Error("demo settings must be editable");
+    const refreshedSettings = { ...original.effective, maxTokens: 4_096 };
+    const refreshed: SettingsView = {
+      ...original,
+      stateGeneration: original.stateGeneration + 1,
+      activeRevision: original.activeRevision + 1,
+      document: applyBasicSettingsDraft(original.document, refreshedSettings),
+      effective: refreshedSettings,
+      effectiveProse: refreshedSettings
+    };
+    source.api.saveSettings = async () => {
+      source.settingsView = refreshed;
+      throw new WorkerApiError(createFailureEnvelope({
+        code: "revision_conflict",
+        message: "Settings changed since this edit began.",
+        status: 409
+      }));
+    };
+    source.api.getSettings = async () => source.settingsView;
+    await press(key("s"));
+    expect(state.settings?.draft.generation.model).toBe("model-alpha");
+
+    await draftRow(press, state, "base-url", "https://beta.example.test/v1");
+    await backend.whenIdle();
+    expect(state.settings?.draft.generation.model).toBe("model-beta");
+
+    await draftRow(press, state, "model", "writer-model");
+    await draftRow(press, state, "base-url", "https://gamma.example.test/v1");
+    await backend.whenIdle();
+    expect(state.settings?.draft.generation.model).toBe("writer-model");
+  });
+
+  test("does not select a model in read-only legacy settings", async () => {
+    const { source, state, press } = settingsHarness();
+    configureNetworkSource(source);
+    source.settings = { ...source.settings, model: "" };
+    const view: SettingsView = {
+      dataFormat: 1,
+      editable: false,
+      stateGeneration: null,
+      activeRevision: null,
+      pendingRevision: null,
+      document: null,
+      effective: source.settings,
+      effectiveProse: source.settings,
+      lastActivationOutcome: null
+    };
+    source.settingsView = view;
+    source.api.getSettings = async () => view;
+    source.api.discoverModels = async () => discovery("loaded-local-model");
+
+    await openSettings(press);
+
+    expect(state.settings?.modelDiscovery?.models[0]?.remoteId)
+      .toBe("loaded-local-model");
+    expect(state.settings?.draft.generation.model).toBe("");
+  });
+
+  test("preserves a context edit while selecting a late model", async () => {
+    const { source, state, press } = settingsHarness();
+    configureNetworkSource(source);
+    if (!source.settingsView.editable) throw new Error("demo settings must be editable");
+    source.settings = {
+      ...source.settings,
+      contextWindow: null
+    };
+    source.settingsView = {
+      ...source.settingsView,
+      document: applyBasicSettingsDraft(
+        source.settingsView.document,
+        source.settings
+      ),
+      effective: source.settings,
+      effectiveProse: source.settings
+    };
+    source.api.getSettings = async () => source.settingsView;
+    const entered = deferred<void>();
+    const gate = deferred<ModelDiscoveryResultV2>();
+    let calls = 0;
+    source.api.discoverModels = async () => {
+      calls += 1;
+      if (calls === 1) {
+        return {
+          ...discovery("first-model"),
+          models: ["first-model", "second-model"].map((id) => discovery(id).models[0]!)
+        };
+      }
+      entered.resolve();
+      return gate.promise;
+    };
+
+    await openSettings(press);
+    await draftRow(press, state, "model", "");
+    await draftRow(press, state, "context-window", "12345");
+    expect(state.settings?.draft.generation.contextWindow).toBe(12_345);
+    const changingTarget = draftRow(press, state, "api-key", "replacement-secret");
+    await entered.promise;
+    state.settings!.conflict = { message: "Settings changed", armed: true };
+    gate.resolve(discoveryWithContext("loaded-local-model", 65_536));
+    await changingTarget;
+
+    expect(state.settings?.draft.generation).toMatchObject({
+      model: "loaded-local-model",
+      contextWindow: 12_345
+    });
+    expect(state.settings?.conflict?.armed).toBeFalse();
+  });
+
+  test("uses discovered context after clearing a model in flight", async () => {
+    const { source, state, press } = settingsHarness();
+    configureNetworkSource(source);
+    if (!source.settingsView.editable) throw new Error("demo settings must be editable");
+    source.settings = { ...source.settings, contextWindow: 32_768 };
+    const view: SettingsView = {
+      ...source.settingsView,
+      document: applyBasicModelDiscovery(
+        source.settingsView.document,
+        discoveryWithContext("novelist-a", 32_768),
+        32_768
+      ),
+      effective: source.settings,
+      effectiveProse: source.settings
+    };
+    source.settingsView = view;
+    source.api.getSettings = async () => view;
+    const entered = deferred<void>();
+    const gate = deferred<ModelDiscoveryResultV2>();
+    source.api.discoverModels = async () => {
+      entered.resolve();
+      return gate.promise;
+    };
+
+    const opening = openSettings(press);
+    await entered.promise;
+    await draftRow(press, state, "model", "");
+    expect(state.settings?.draft.generation.contextWindow).toBe(null);
+    gate.resolve(discoveryWithContext("loaded-local-model", 65_536));
+    await opening;
+
+    expect(state.settings?.draft.generation).toMatchObject({
+      model: "loaded-local-model",
+      contextWindow: 65_536
+    });
+  });
+
   test("an API key edit invalidates an in-flight model list", async () => {
     const { source, state, press } = settingsHarness();
     configureNetworkSource(source);
@@ -181,11 +394,13 @@ describe("Settings model picker", () => {
 
     const opening = openSettings(press);
     await entered.promise;
+    await draftRow(press, state, "model", "");
     await draftRow(press, state, "api-key", "replacement-secret");
     gate.resolve(discovery("stale-model"));
     await opening;
 
     expect(calls).toBe(2);
+    expect(state.settings?.draft.generation.model).toBe("");
     expect(state.settings?.modelDiscovery).toBe(null);
     expect(state.settings?.discoveringModels).toBeFalse();
   });
@@ -218,9 +433,7 @@ describe("Settings model picker", () => {
   test("one discovered model preserves a manual context window", async () => {
     const { source, state, press } = settingsHarness();
     configureNetworkSource(source);
-    if (!source.settingsView.editable) {
-      throw new Error("demo settings must be editable");
-    }
+    if (!source.settingsView.editable) throw new Error("demo settings must be editable");
     source.settings = { ...source.settings, contextWindow: 32_768 };
     source.settingsView = {
       ...source.settingsView,
@@ -271,30 +484,7 @@ function discovery(remoteId: string): ModelDiscoveryResultV2 {
   };
 }
 
-function configureNetworkSource(
-  source: ReturnType<typeof settingsHarness>["source"]
-): void {
-  if (!source.settingsView.editable) {
-    throw new Error("demo settings must be editable");
-  }
-  const settings = {
-    ...source.settings,
-    provider: "openai-compatible" as const,
-    baseUrl: "https://api.openai.com/v1",
-    model: "novelist-a",
-    apiKeyEnv: "OPENAI_API_KEY"
-  };
-  const document = applyBasicSettingsDraft(
-    source.settingsView.document,
-    settings
-  );
-  const view: SettingsView = {
-    ...source.settingsView,
-    document,
-    effective: settings,
-    effectiveProse: settings
-  };
-  source.settingsView = view;
-  source.settings = settings;
-  source.api.getSettings = async () => view;
+function discoveryWithContext(remoteId: string, contextWindow: number): ModelDiscoveryResultV2 {
+  const result = discovery(remoteId);
+  return { ...result, models: [{ ...result.models[0]!, contextWindow }] };
 }

--- a/tui/test/settings-model-provenance-test-helpers.ts
+++ b/tui/test/settings-model-provenance-test-helpers.ts
@@ -1,0 +1,106 @@
+import {
+  applyBasicSettingsDraft,
+  basicSettingsFromDocument
+} from "../../shared/settings-basic-draft.js";
+import type {
+  SaveSettingsCommand,
+  SettingsView
+} from "../../shared/settings-v2-types.js";
+import {
+  deferred,
+  generationFromProbeTarget,
+  settingsHarness
+} from "./settings-test-harness.js";
+
+export function installHostModelDiscovery(
+  source: ReturnType<typeof settingsHarness>["source"]
+): void {
+  source.api.discoverModels = async (target) => {
+    const host = new URL(generationFromProbeTarget(target).baseUrl).hostname;
+    const remoteId = `model-${host.split(".")[0]}`;
+    return {
+      observedAt: "2026-01-01T00:00:00.000Z",
+      models: [{
+        remoteId,
+        name: remoteId,
+        contextWindow: null,
+        maxOutputTokens: null,
+        source: "openai-models"
+      }]
+    };
+  };
+}
+
+export function installSettingsSave(
+  source: ReturnType<typeof settingsHarness>["source"],
+  blocked = false
+): {
+  saveEntered: ReturnType<typeof deferred<void>>;
+  saveGate: ReturnType<typeof deferred<void>>;
+} {
+  const saveEntered = deferred<void>();
+  const saveGate = deferred<void>();
+  if (!blocked) saveGate.resolve();
+  source.api.saveSettings = async (command: SaveSettingsCommand) => {
+    saveEntered.resolve();
+    await saveGate.promise;
+    const current = source.settingsView;
+    if (!current.editable) throw new Error("demo settings must be editable");
+    const effective = basicSettingsFromDocument(command.document);
+    source.settingsView = {
+      ...current,
+      stateGeneration: current.stateGeneration + 1,
+      activeRevision: current.activeRevision + 1,
+      document: command.document,
+      effective,
+      effectiveProse: effective
+    };
+    return {
+      kind: "settings",
+      settingsStateGeneration: source.settingsView.stateGeneration,
+      activeSettingsRevision: source.settingsView.activeRevision,
+      pendingSettingsRevision: null,
+      activationOutcome: null
+    };
+  };
+  return { saveEntered, saveGate };
+}
+
+export function installContextDiscovery(
+  source: ReturnType<typeof settingsHarness>["source"],
+  remoteId = "loaded-model"
+): void {
+  source.api.discoverModels = async () => ({
+    observedAt: "2026-01-01T00:00:00.000Z",
+    models: [{
+      remoteId,
+      name: remoteId,
+      contextWindow: 65_536,
+      maxOutputTokens: null,
+      source: "openai-models"
+    }]
+  });
+}
+
+export function configureNetworkSource(
+  source: ReturnType<typeof settingsHarness>["source"]
+): void {
+  if (!source.settingsView.editable) throw new Error("demo settings must be editable");
+  const settings = {
+    ...source.settings,
+    provider: "openai-compatible" as const,
+    baseUrl: "https://api.openai.com/v1",
+    model: "novelist-a",
+    apiKeyEnv: "OPENAI_API_KEY"
+  };
+  const document = applyBasicSettingsDraft(source.settingsView.document, settings);
+  const view: SettingsView = {
+    ...source.settingsView,
+    document,
+    effective: settings,
+    effectiveProse: settings
+  };
+  source.settingsView = view;
+  source.settings = settings;
+  source.api.getSettings = async () => view;
+}

--- a/tui/test/settings-model-provenance.test.ts
+++ b/tui/test/settings-model-provenance.test.ts
@@ -1,0 +1,498 @@
+import { expect, test } from "bun:test";
+import {
+  applyBasicSettingsDraft,
+  basicSettingsFromDocument
+} from "../../shared/settings-basic-draft.js";
+import {
+  createSettingsProfile,
+  isolateSettingsProfileModel
+} from "../src/settings-profile-draft.js";
+import { publishSettingsView } from "../src/overlay-publication.js";
+import { settingsDraftChanged } from "../src/settings-overlay-model.js";
+import {
+  draftRow,
+  generationFromProbeTarget,
+  key,
+  openSettings,
+  selectRow,
+  settingsHarness
+} from "./settings-test-harness.js";
+import {
+  configureNetworkSource,
+  installContextDiscovery,
+  installHostModelDiscovery,
+  installSettingsSave
+} from "./settings-model-provenance-test-helpers.js";
+
+test("deleted profile model provenance does not reach a reused profile ID", async () => {
+  const { source, state, backend, press } = settingsHarness();
+  configureNetworkSource(source);
+  source.api.getSettings = async () => source.settingsView;
+  source.api.discoverModels = async (target) => {
+    const host = new URL(generationFromProbeTarget(target).baseUrl).hostname;
+    const remoteId = `model-${host.split(".")[0]}`;
+    return {
+      observedAt: "2026-01-01T00:00:00.000Z",
+      models: [{
+        remoteId,
+        name: remoteId,
+        contextWindow: null,
+        maxOutputTokens: null,
+        source: "openai-models"
+      }]
+    };
+  };
+
+  await openSettings(press);
+  await draftRow(press, state, "model", "");
+  await draftRow(press, state, "base-url", "https://alpha.example.test/v1");
+  await backend.whenIdle();
+  await selectRow(press, state, "profile");
+  await press(key("N"));
+  await selectRow(press, state, "model");
+  await draftRow(press, state, "model", "");
+  await selectRow(press, state, "profile");
+  await press(key("d"));
+  await press(key("d"));
+  await press(key("n"));
+  await draftRow(press, state, "model", "model-alpha");
+
+  await draftRow(press, state, "base-url", "https://beta.example.test/v1");
+  await backend.whenIdle();
+
+  expect(state.settings?.draft.generation.model).toBe("model-alpha");
+});
+
+for (const cloneKey of ["n", "N"] as const) {
+test(`${cloneKey} profile clone keeps model and context ownership`, async () => {
+  const { source, state, backend, press } = settingsHarness();
+  configureNetworkSource(source);
+  source.api.discoverModels = async (target) => {
+    const host = new URL(generationFromProbeTarget(target).baseUrl).hostname;
+    const remoteId = `model-${host.split(".")[0]}`;
+    return {
+      observedAt: "2026-01-01T00:00:00.000Z",
+      models: [{
+        remoteId,
+        name: remoteId,
+        contextWindow: 65_536,
+        maxOutputTokens: null,
+        source: "openai-models"
+      }]
+    };
+  };
+
+  await openSettings(press);
+  await draftRow(press, state, "model", "");
+  await draftRow(press, state, "base-url", "https://alpha.example.test/v1");
+  await draftRow(press, state, "context-window", "12345");
+  await selectRow(press, state, "profile");
+  await press(key(cloneKey));
+  installContextDiscovery(source, "model-beta");
+  await draftRow(press, state, "api-key", "replacement-secret");
+  await backend.whenIdle();
+
+  expect(state.settings?.draft.generation).toMatchObject({
+    model: "model-beta",
+    contextWindow: 12_345
+  });
+});
+}
+
+test("blank context sentinel accepts cached model metadata", async () => {
+  const { source, state, press } = settingsHarness();
+  configureNetworkSource(source);
+  installContextDiscovery(source);
+
+  await openSettings(press);
+  await draftRow(press, state, "context-window", "12345");
+  await draftRow(press, state, "context-window", "");
+  await draftRow(press, state, "model", "");
+
+  expect(state.settings?.draft.generation.contextWindow).toBe(65_536);
+});
+
+test("context stepper auto sentinel accepts cached model metadata", async () => {
+  const { source, state, press } = settingsHarness();
+  configureNetworkSource(source);
+  installContextDiscovery(source);
+
+  await openSettings(press);
+  await draftRow(press, state, "context-window", "1");
+  await selectRow(press, state, "context-window");
+  await press(key("left"));
+  await draftRow(press, state, "model", "");
+
+  expect(state.settings?.draft.generation.contextWindow).toBe(65_536);
+});
+
+test("equal discovered context remains a manual limit", async () => {
+  const { source, state, press } = settingsHarness();
+  configureNetworkSource(source);
+  if (!source.settingsView.editable) throw new Error("demo settings must be editable");
+  const originalModelId = source.settingsView.document.profiles[
+    source.settingsView.document.routing.default
+  ]!.modelId;
+  const created = createSettingsProfile(
+    source.settingsView.document,
+    source.settingsView.document.routing.default
+  );
+  if ("error" in created) throw new Error(created.error);
+  source.settingsView = {
+    ...source.settingsView,
+    document: created.document
+  };
+  source.api.getSettings = async () => source.settingsView;
+  installSettingsSave(source);
+  let calls = 0;
+  source.api.discoverModels = async () => {
+    calls += 1;
+    const first = {
+      remoteId: "loaded-model",
+      name: "Loaded Model",
+      contextWindow: 65_536,
+      maxOutputTokens: null,
+      source: "openai-models" as const
+    };
+    return {
+      observedAt: "2026-01-01T00:00:00.000Z",
+      models: [{ ...first, contextWindow: calls === 1 ? 65_536 : 32_768 }]
+    };
+  };
+
+  await openSettings(press);
+  await draftRow(press, state, "model", "");
+  await draftRow(press, state, "context-window", "65536");
+  await press(key("s"));
+  if (!source.settingsView.editable) throw new Error("saved settings must be editable");
+  const selectedModelId = source.settingsView.document.profiles[
+    source.settingsView.document.routing.default
+  ]!.modelId;
+  expect(selectedModelId).not.toBe(originalModelId);
+  expect(source.settingsView.document.models[originalModelId]!.overrides.contextWindow)
+    .toBe(undefined);
+  expect(source.settingsView.document.models[selectedModelId]!.overrides.contextWindow)
+    .toBe(65_536);
+  await press(key("escape"));
+  await openSettings(press);
+  await draftRow(press, state, "api-key", "first-secret");
+
+  expect(state.settings?.draft.generation.contextWindow).toBe(65_536);
+});
+
+test("a target change preserves a manual context from an automatic model", async () => {
+  const { source, state, backend, press } = settingsHarness();
+  configureNetworkSource(source);
+  installHostModelDiscovery(source);
+
+  await openSettings(press);
+  await draftRow(press, state, "model", "");
+  await draftRow(press, state, "base-url", "https://alpha.example.test/v1");
+  await draftRow(press, state, "context-window", "12345");
+  await draftRow(press, state, "base-url", "https://beta.example.test/v1");
+  await backend.whenIdle();
+
+  expect(state.settings?.draft.generation).toMatchObject({
+    model: "model-beta",
+    contextWindow: 12_345
+  });
+});
+
+test("a target change replaces context metadata from an automatic model", async () => {
+  const { source, state, backend, press } = settingsHarness();
+  configureNetworkSource(source);
+  source.api.discoverModels = async (target) => {
+    const host = new URL(generationFromProbeTarget(target).baseUrl).hostname;
+    const beta = host === "beta.example.test";
+    return {
+      observedAt: "2026-01-01T00:00:00.000Z",
+      models: [{
+        remoteId: beta ? "model-beta" : "model-api",
+        name: beta ? "Model Beta" : "Model API",
+        contextWindow: beta ? 32_768 : 65_536,
+        maxOutputTokens: null,
+        source: "openai-models"
+      }]
+    };
+  };
+
+  await openSettings(press);
+  await draftRow(press, state, "model", "");
+  expect(state.settings?.draft.generation.contextWindow).toBe(65_536);
+  await draftRow(press, state, "base-url", "https://beta.example.test/v1");
+  await backend.whenIdle();
+
+  expect(state.settings?.draft.generation).toMatchObject({
+    model: "model-beta",
+    contextWindow: 32_768
+  });
+});
+
+test("saved automatic model becomes an explicit model", async () => {
+  const { source, state, backend, press } = settingsHarness();
+  configureNetworkSource(source);
+  source.api.getSettings = async () => source.settingsView;
+  installHostModelDiscovery(source);
+  installSettingsSave(source);
+
+  await openSettings(press);
+  await draftRow(press, state, "model", "");
+  await draftRow(press, state, "base-url", "https://alpha.example.test/v1");
+  await press(key("s"));
+  await draftRow(press, state, "base-url", "https://beta.example.test/v1");
+  await backend.whenIdle();
+
+  expect(state.settings?.draft.generation.model).toBe("model-alpha");
+});
+
+test("save acknowledges an automatic model that equals the saved value", async () => {
+  const { source, state, backend, press } = settingsHarness();
+  configureNetworkSource(source);
+  if (!source.settingsView.editable) throw new Error("demo settings must be editable");
+  const created = createSettingsProfile(
+    source.settingsView.document,
+    source.settingsView.document.routing.default
+  );
+  if ("error" in created) throw new Error(created.error);
+  source.settingsView = {
+    ...source.settingsView,
+    document: isolateSettingsProfileModel(
+      created.document,
+      created.document.routing.default
+    )
+  };
+  source.api.getSettings = async () => source.settingsView;
+  source.api.discoverModels = async (target) => {
+    const host = new URL(generationFromProbeTarget(target).baseUrl).hostname;
+    const remoteId = host === "api.openai.com" ? "novelist-a" : "model-alpha";
+    return {
+      observedAt: "2026-01-01T00:00:00.000Z",
+      models: [{
+        remoteId,
+        name: remoteId,
+        contextWindow: null,
+        maxOutputTokens: null,
+        source: "openai-models"
+      }]
+    };
+  };
+  let saves = 0;
+  source.api.saveSettings = async () => {
+    saves += 1;
+    throw new Error("an equal draft must not reach the server");
+  };
+
+  await openSettings(press);
+  await draftRow(press, state, "model", "");
+  await selectRow(press, state, "profile");
+  await press(key("right"));
+  await press(key("s"));
+  expect(saves).toBe(0);
+  expect(state.settings?.draft.selectedProfileId).toBe(created.profileId);
+  await draftRow(press, state, "base-url", "https://alpha.example.test/v1");
+  await backend.whenIdle();
+
+  expect(state.settings?.draft.generation.model).toBe("novelist-a");
+});
+
+test("an unrelated authoritative refresh preserves automatic ownership", async () => {
+  const { source, state, backend, press } = settingsHarness();
+  configureNetworkSource(source);
+  source.api.discoverModels = async (target) => {
+    const host = new URL(generationFromProbeTarget(target).baseUrl).hostname;
+    const remoteId = host === "api.openai.com" ? "novelist-a" : "model-alpha";
+    return {
+      observedAt: "2026-01-01T00:00:00.000Z",
+      models: [{
+        remoteId,
+        name: remoteId,
+        contextWindow: null,
+        maxOutputTokens: null,
+        source: "openai-models"
+      }]
+    };
+  };
+
+  await openSettings(press);
+  await draftRow(press, state, "model", "");
+  const current = source.settingsView;
+  if (!current.editable) throw new Error("demo settings must be editable");
+  const effective = { ...current.effective, maxTokens: 4_096 };
+  const document = applyBasicSettingsDraft(current.document, effective);
+  publishSettingsView(state, source, {
+    ...current,
+    stateGeneration: current.stateGeneration + 1,
+    activeRevision: current.activeRevision + 1,
+    document,
+    effective,
+    effectiveProse: effective
+  });
+
+  await draftRow(press, state, "base-url", "https://alpha.example.test/v1");
+  await backend.whenIdle();
+
+  expect(state.settings?.draft.generation.model).toBe("model-alpha");
+});
+
+test("an authoritative model change drops old manual context ownership", async () => {
+  const { source, state, press } = settingsHarness();
+  configureNetworkSource(source);
+  source.api.getSettings = async () => source.settingsView;
+  installSettingsSave(source);
+
+  await openSettings(press);
+  await draftRow(press, state, "context-window", "12345");
+  await press(key("s"));
+  const current = source.settingsView;
+  if (!current.editable) throw new Error("demo settings must be editable");
+  const profileId = current.document.routing.default;
+  const modelId = current.document.profiles[profileId]!.modelId;
+  const document = {
+    ...current.document,
+    models: {
+      ...current.document.models,
+      [modelId]: {
+        ...current.document.models[modelId]!,
+        remoteId: "replacement-model",
+        name: "Replacement Model",
+        discovered: { contextWindow: 12_345 },
+        overrides: {}
+      }
+    }
+  };
+  const effective = basicSettingsFromDocument(document);
+
+  publishSettingsView(state, source, {
+    ...current,
+    stateGeneration: current.stateGeneration + 1,
+    activeRevision: current.activeRevision + 1,
+    document,
+    effective,
+    effectiveProse: effective
+  });
+
+  expect(state.settings?.draft.generation.model).toBe("replacement-model");
+  expect(settingsDraftChanged(state.settings!)).toBeFalse();
+});
+
+test("save acknowledges an automatic model while a newer row edit remains", async () => {
+  const { source, state, backend, press } = settingsHarness();
+  configureNetworkSource(source);
+  source.api.getSettings = async () => source.settingsView;
+  installHostModelDiscovery(source);
+  const { saveEntered, saveGate } = installSettingsSave(source, true);
+
+  await openSettings(press);
+  await draftRow(press, state, "model", "");
+  await draftRow(press, state, "base-url", "https://alpha.example.test/v1");
+  const saving = press(key("s"));
+  await saveEntered.promise;
+  await draftRow(press, state, "temperature", "0.7");
+  saveGate.resolve();
+  await saving;
+  await draftRow(press, state, "base-url", "https://beta.example.test/v1");
+  await backend.whenIdle();
+
+  expect(state.settings?.draft.generation).toMatchObject({
+    model: "model-alpha",
+    temperature: 0.7
+  });
+});
+
+test("save acknowledges an automatic model after a concurrent profile switch", async () => {
+  const { source, state, backend, press } = settingsHarness();
+  configureNetworkSource(source);
+  source.api.getSettings = async () => source.settingsView;
+  installHostModelDiscovery(source);
+  const { saveEntered, saveGate } = installSettingsSave(source, true);
+
+  await openSettings(press);
+  await draftRow(press, state, "model", "");
+  await draftRow(press, state, "base-url", "https://alpha.example.test/v1");
+  await selectRow(press, state, "profile");
+  await press(key("N"));
+  await press(key("left"));
+  const saving = press(key("s"));
+  await saveEntered.promise;
+  await selectRow(press, state, "profile");
+  await press(key("right"));
+  await draftRow(press, state, "temperature", "0.7");
+  saveGate.resolve();
+  await saving;
+  await draftRow(press, state, "base-url", "https://beta.example.test/v1");
+  await backend.whenIdle();
+  expect(state.settings?.draft.generation.model).toBe("model-alpha");
+  await selectRow(press, state, "profile");
+  await press(key("left"));
+  await draftRow(press, state, "base-url", "https://beta.example.test/v1");
+  await backend.whenIdle();
+
+  expect(state.settings?.draft.generation.model).toBe("model-alpha");
+});
+
+test("save preserves automatic ownership when its target changes in flight", async () => {
+  const { source, state, backend, press } = settingsHarness();
+  configureNetworkSource(source);
+  source.api.getSettings = async () => source.settingsView;
+  source.api.discoverModels = async (target) => {
+    const host = new URL(generationFromProbeTarget(target).baseUrl).hostname;
+    const remoteId = host.startsWith("gamma") ? "model-gamma" : "shared-model";
+    return {
+      observedAt: "2026-01-01T00:00:00.000Z",
+      models: [{
+        remoteId,
+        name: remoteId,
+        contextWindow: null,
+        maxOutputTokens: null,
+        source: "openai-models"
+      }]
+    };
+  };
+  const { saveEntered, saveGate } = installSettingsSave(source, true);
+
+  await openSettings(press);
+  await draftRow(press, state, "model", "");
+  await draftRow(press, state, "base-url", "https://alpha.example.test/v1");
+  const saving = press(key("s"));
+  await saveEntered.promise;
+  await draftRow(press, state, "base-url", "https://beta.example.test/v1");
+  saveGate.resolve();
+  await saving;
+  await backend.whenIdle();
+  await draftRow(press, state, "base-url", "https://gamma.example.test/v1");
+  await backend.whenIdle();
+
+  expect(state.settings?.draft.generation.model).toBe("model-gamma");
+});
+
+test("a failed target refresh clears the previous automatic model", async () => {
+  const { source, state, backend, press } = settingsHarness();
+  configureNetworkSource(source);
+  source.api.discoverModels = async (target) => {
+    const host = new URL(generationFromProbeTarget(target).baseUrl).hostname;
+    if (host === "beta.example.test") throw new Error("beta is unavailable");
+    const remoteId = `model-${host.split(".")[0]}`;
+    return {
+      observedAt: "2026-01-01T00:00:00.000Z",
+      models: [{
+        remoteId,
+        name: remoteId,
+        contextWindow: null,
+        maxOutputTokens: null,
+        source: "openai-models"
+      }]
+    };
+  };
+
+  await openSettings(press);
+  await draftRow(press, state, "model", "");
+  await draftRow(press, state, "base-url", "https://alpha.example.test/v1");
+  await backend.whenIdle();
+  expect(state.settings?.draft.generation.model).toBe("model-alpha");
+
+  await draftRow(press, state, "base-url", "https://beta.example.test/v1");
+  await backend.whenIdle();
+
+  expect(state.settings?.draft.generation.model).toBe("");
+  expect(state.settings?.result?.message).toContain("type a model name");
+});

--- a/tui/test/settings-model-refresh-provenance.test.ts
+++ b/tui/test/settings-model-refresh-provenance.test.ts
@@ -1,0 +1,182 @@
+import { expect, test } from "bun:test";
+import { applyBasicSettingsDraft } from "../../shared/settings-basic-draft.js";
+import { resolveSettingsProfile } from "../../shared/settings-route.js";
+import type { SettingsView } from "../../shared/settings-v2-types.js";
+import { createSettingsProfile } from "../src/settings-profile-draft.js";
+import { settingsDraftChanged } from "../src/settings-overlay-model.js";
+import {
+  deferred,
+  draftRow,
+  key,
+  openSettings,
+  selectRow,
+  settingsHarness
+} from "./settings-test-harness.js";
+import {
+  configureNetworkSource,
+  installHostModelDiscovery
+} from "./settings-model-provenance-test-helpers.js";
+
+test("an arrow affirms the only automatic model", async () => {
+  const { source, state, backend, press } = settingsHarness();
+  configureNetworkSource(source);
+  installHostModelDiscovery(source);
+
+  await openSettings(press);
+  await draftRow(press, state, "model", "");
+  await selectRow(press, state, "model");
+  await press(key("right"));
+  await draftRow(press, state, "base-url", "https://alpha.example.test/v1");
+  await backend.whenIdle();
+
+  expect(state.settings?.draft.generation.model).toBe("model-api");
+});
+
+test("an unchanged model choice does not fork a shared model", async () => {
+  const { source, state, press } = settingsHarness();
+  configureNetworkSource(source);
+  if (!source.settingsView.editable) throw new Error("demo settings must be editable");
+  const profileId = source.settingsView.document.routing.default;
+  const modelId = source.settingsView.document.profiles[profileId]!.modelId;
+  const documentWithContext = {
+    ...source.settingsView.document,
+    models: {
+      ...source.settingsView.document.models,
+      [modelId]: {
+        ...source.settingsView.document.models[modelId]!,
+        discovered: { contextWindow: 32_768 }
+      }
+    }
+  };
+  const created = createSettingsProfile(
+    documentWithContext,
+    profileId
+  );
+  if ("error" in created) throw new Error(created.error);
+  source.settingsView = { ...source.settingsView, document: created.document };
+  source.api.getSettings = async () => source.settingsView;
+  source.api.discoverModels = async () => ({
+    observedAt: "2026-01-01T00:00:00.000Z",
+    models: [{
+      remoteId: "novelist-a",
+      name: "Novelist A",
+      contextWindow: 32_768,
+      maxOutputTokens: null,
+      source: "openai-models"
+    }]
+  });
+
+  await openSettings(press);
+  const document = state.settings!.draft.document;
+  await selectRow(press, state, "model");
+  await press(key("right"));
+
+  expect(state.settings!.draft.document).toBe(document);
+  expect(settingsDraftChanged(state.settings!)).toBeFalse();
+});
+
+test("a prompt format edit keeps its automatic model target", async () => {
+  const { source, state, press } = settingsHarness();
+  if (!source.settingsView.editable) throw new Error("demo settings must be editable");
+  const settings = {
+    ...source.settings,
+    provider: "text-completion" as const,
+    baseUrl: "http://127.0.0.1:8080/v1",
+    model: "text-model",
+    apiKeyEnv: null
+  };
+  const document = applyBasicSettingsDraft(source.settingsView.document, settings);
+  const view: SettingsView = {
+    ...source.settingsView,
+    document,
+    effective: settings,
+    effectiveProse: settings
+  };
+  source.settingsView = view;
+  source.settings = settings;
+  source.api.getSettings = async () => view;
+  let calls = 0;
+  source.api.discoverModels = async () => {
+    calls += 1;
+    if (calls > 1) throw new Error("prompt format must not refresh models");
+    return {
+      observedAt: "2026-01-01T00:00:00.000Z",
+      models: [{
+        remoteId: "text-model",
+        name: "text-model",
+        contextWindow: null,
+        maxOutputTokens: null,
+        source: "openai-models"
+      }]
+    };
+  };
+
+  await openSettings(press);
+  await draftRow(press, state, "model", "");
+  await selectRow(press, state, "text-prompt-format");
+  await press(key("right"));
+
+  expect(calls).toBe(1);
+  expect(state.settings?.draft.generation.model).toBe("text-model");
+});
+
+test("unchanged inline model keeps its context window", async () => {
+  const { source, state, press } = settingsHarness();
+  configureNetworkSource(source);
+
+  await openSettings(press);
+  await draftRow(press, state, "context-window", "32768");
+  await draftRow(press, state, "model", "novelist-a");
+
+  expect(state.settings?.draft.generation.contextWindow).toBe(32_768);
+  expect(resolveSettingsProfile(
+    state.settings!.draft.document!,
+    state.settings!.draft.selectedProfileId!
+  ).model.overrides.contextWindow).toBe(32_768);
+});
+
+for (const [catalog, nextIds] of [
+  ["empty", []],
+  ["multiple", ["model-beta-a", "model-beta-b"]]
+] as const) {
+test(`${catalog} next catalog clears an unavailable automatic model`, async () => {
+  const { source, state, backend, press } = settingsHarness();
+  configureNetworkSource(source);
+  let calls = 0;
+  const refreshEntered = deferred<void>();
+  const refreshGate = deferred<void>();
+  source.api.discoverModels = async () => {
+    calls += 1;
+    if (calls > 1) {
+      refreshEntered.resolve();
+      await refreshGate.promise;
+    }
+    const ids = calls === 1 ? ["model-api"] : nextIds;
+    return {
+      observedAt: "2026-01-01T00:00:00.000Z",
+      models: ids.map((remoteId) => ({
+        remoteId,
+        name: remoteId,
+        contextWindow: null,
+        maxOutputTokens: null,
+        source: "openai-models" as const
+      }))
+    };
+  };
+
+  await openSettings(press);
+  await draftRow(press, state, "model", "");
+  await draftRow(press, state, "context-window", "12345");
+  const editingKey = draftRow(press, state, "api-key", "replacement-secret");
+  await refreshEntered.promise;
+  expect(state.settings?.draft.generation.contextWindow).toBe(12_345);
+  refreshGate.resolve();
+  await editingKey;
+  await backend.whenIdle();
+
+  expect(state.settings?.draft.generation).toMatchObject({
+    model: "",
+    contextWindow: 12_345
+  });
+});
+}

--- a/tui/test/settings-profiles.test.ts
+++ b/tui/test/settings-profiles.test.ts
@@ -9,7 +9,7 @@ import { setComposerText } from "../src/composer-model.js";
 import { renderStoryScreen } from "../src/screens/story.js";
 import { frameText } from "../src/screens/story/frame.js";
 import { settingsTextDraftForDocument } from "../src/settings-text.js";
-import { settingsModelDiscoveryIdentity } from "../src/settings-model-discovery.js";
+import { publishCurrentSettingsModelDiscovery } from "../src/settings-model-discovery.js";
 import {
   draftRow,
   key,
@@ -292,7 +292,10 @@ describe("Generation Profile settings", () => {
         }
       }
     };
-    state.settings!.draft = settingsTextDraftForDocument(unsupported);
+    state.settings!.draft = settingsTextDraftForDocument(
+      unsupported,
+      undefined
+    );
     await selectRow(press, state, "effort");
     expect(frameText(renderStoryScreen(state, { width: 80, height: 24, wrapCache: cache }).lines))
       .toContain("‹ high ›");
@@ -301,7 +304,10 @@ describe("Generation Profile settings", () => {
     await press(key("left"));
     expect(state.settings?.draft.document?.profiles.default?.effort).toBe("default");
 
-    state.settings!.draft = settingsTextDraftForDocument(unsupported);
+    state.settings!.draft = settingsTextDraftForDocument(
+      unsupported,
+      undefined
+    );
     await press(key("right"));
     expect(state.settings?.draft.document?.profiles.default?.effort).toBe("default");
   });
@@ -379,7 +385,10 @@ describe("Generation Profile settings", () => {
         [connectionId]: { ...document.connections[connectionId]!, preset: "ollama" as const }
       }
     };
-    state.settings!.draft = settingsTextDraftForDocument(unavailable);
+    state.settings!.draft = settingsTextDraftForDocument(
+      unavailable,
+      undefined
+    );
     await selectRow(press, state, "token-probabilities");
     const frame = frameText(renderStoryScreen(state, { width: 80, height: 24, wrapCache: cache }).lines);
     expect(frame).toContain("‹ — ›");
@@ -427,7 +436,7 @@ describe("Generation Profile settings", () => {
       ...draft.document,
       models
     }, draft.selectedProfileId);
-    state.settings!.modelDiscovery = {
+    publishCurrentSettingsModelDiscovery(state.settings!, {
       observedAt: "2026-08-01T00:00:00.000Z",
       models: [{
         remoteId: "some-other-model",
@@ -436,10 +445,7 @@ describe("Generation Profile settings", () => {
         maxOutputTokens: null,
         source: "openai-models"
       }]
-    };
-    state.settings!.modelDiscoveryIdentity = settingsModelDiscoveryIdentity(
-      state.settings!.draft.generation
-    );
+    });
 
     await press(key("s"));
 

--- a/tui/test/settings-save.test.ts
+++ b/tui/test/settings-save.test.ts
@@ -22,6 +22,54 @@ import {
 } from "./settings-test-harness.js";
 
 describe("Settings save lifecycle", () => {
+  test("a normalized no-op save restores the canonical draft", async () => {
+    const { source, state, press } = settingsHarness();
+    if (!source.settingsView.editable) throw new Error("demo settings must be editable");
+    const document = {
+      ...source.settingsView.document,
+      models: {
+        ...source.settingsView.document.models,
+        demo: {
+          ...source.settingsView.document.models.demo!,
+          discovered: {}
+        }
+      }
+    };
+    const effective = basicSettingsFromDocument(document);
+    const view = {
+      ...source.settingsView,
+      document,
+      effective,
+      effectiveProse: effective
+    };
+    publishSettingsView(state, source, view);
+    let saves = 0;
+    source.api.saveSettings = async () => {
+      saves += 1;
+      throw new Error("a normalized no-op must not reach the server");
+    };
+    source.api.discoverModels = async () => ({
+      observedAt: "2026-01-01T00:00:00.000Z",
+      models: []
+    });
+    source.api.getSettings = async () => source.settingsView;
+
+    await openSettings(press);
+    await draftRow(
+      press,
+      state,
+      "base-url",
+      "https://inactive.example.test/v1"
+    );
+    expect(settingsDraftChanged(state.settings!)).toBeTrue();
+
+    await press(key("s"));
+
+    expect(saves).toBe(0);
+    expect(state.settings?.draft.generation.baseUrl).toBe("");
+    expect(settingsDraftChanged(state.settings!)).toBeFalse();
+  });
+
   test("discard refreshes the model list for the restored provider", async () => {
     const { source, state, press } = settingsHarness();
     if (!source.settingsView.editable) {


### PR DESCRIPTION
## Summary
- discover models from the unsaved Settings provider target
- select a singleton catalog without overwriting typed model or context choices
- centralize per-profile automatic selection ownership and reject stale results

## Validation
- thermo-nuclear review: clean
- autoreview: clean
- TUI: 1,621 tests pass
- server: 2,054 tests pass, 196 skip
- root and TUI typechecks pass

Closes #88