### PR TITLE
chore(release): prepare 0.5.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "1667-workspace",
-  "version": "0.5.5-rc.1",
+  "version": "0.5.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "1667-workspace",
-      "version": "0.5.5-rc.1",
+      "version": "0.5.5",
       "license": "Apache-2.0",
       "dependencies": {
         "fs-ext-extra-prebuilt": "2.2.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667-workspace",
-  "version": "0.5.5-rc.1",
+  "version": "0.5.5",
   "private": true,
   "description": "Source workspace for the 1667 terminal writing environment",
   "license": "Apache-2.0",

--- a/tui/package.json
+++ b/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667",
-  "version": "0.5.5-rc.1",
+  "version": "0.5.5",
   "private": true,
   "description": "A terminal environment for writing fiction with language models",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary

- promote the verified `0.5.5-rc.1` release to stable `0.5.5`
- keep the root package, lockfile, and TUI package versions aligned

## Verification

- `npm run typecheck`
- `cd tui && bun run typecheck`
- 16 release identity, content, preflight, and build identity tests
- `v0.5.5-rc.1`: immutable GitHub prerelease with 27 assets
- npm `beta`: `0.5.5-rc.1`

Closes #94