### PR TITLE
fix(release): compare beta channel precedence

### DIFF
--- a/scripts/release-install-upgrade-e2e-lib.ts
+++ b/scripts/release-install-upgrade-e2e-lib.ts
@@ -3,6 +3,7 @@ import { chmod, copyFile, mkdir, readFile, realpath, writeFile } from "node:fs/p
 import path from "node:path";
 import packageJson from "../package.json" with { type: "json" };
 import { releaseTargetForRuntime } from "../shared/release-targets.js";
+import { isSemVerUpgradeAvailable } from "../shared/semver.js";
 import { isPrereleaseVersion } from "./release-publication-assets.js";
 import { INSTALL_PREVIOUS_FILE } from "../shared/install-layout.js";
 import { INSTALL_ACTIVE_EXECUTABLE } from "../shared/install-ownership-record.js";
@@ -355,7 +356,7 @@ export async function runInstallUpgradeE2e(
       `Beta channel check reported latest ${JSON.stringify(betaHead)}, expected a version.`
     );
   }
-  const betaIsNewer = betaHead !== currentVersion;
+  const betaIsNewer = isSemVerUpgradeAvailable(betaHead, currentVersion);
   const betaExpectation = {
     method: "shell",
     current: currentVersion,

--- a/shared/semver.ts
+++ b/shared/semver.ts
@@ -59,6 +59,11 @@ export function compareSemVer(left: string, right: string): number {
   return 0;
 }
 
+/** True when a channel head is an applicable upgrade from an exact version identity. */
+export function isSemVerUpgradeAvailable(channelHead: string, currentVersion: string): boolean {
+  return channelHead !== currentVersion && compareSemVer(channelHead, currentVersion) >= 0;
+}
+
 function requireSemVer(value: string): SemVer {
   const parsed = parseSemVer(value);
   if (parsed === null) throw new TypeError(`Invalid semantic version: ${value}`);

--- a/test/semver.test.ts
+++ b/test/semver.test.ts
@@ -1,6 +1,11 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { compareSemVer, isSemVer, parseSemVer } from "../shared/semver.js";
+import {
+  compareSemVer,
+  isSemVer,
+  isSemVerUpgradeAvailable,
+  parseSemVer
+} from "../shared/semver.js";
 
 test("strict SemVer parsing accepts canonical versions without integer-size limits", () => {
   const parsed = parseSemVer("999999999999999999999.2.3-alpha.1+build.7");
@@ -34,4 +39,11 @@ test("SemVer precedence follows the normative prerelease ordering", () => {
   }
   assert.equal(compareSemVer("1.2.3+first", "1.2.3+second"), 0);
   assert.throws(() => compareSemVer("latest", "1.2.3"), TypeError);
+});
+
+test("upgrade availability follows precedence and exact version identity", () => {
+  assert.equal(isSemVerUpgradeAvailable("0.5.6-rc.1", "0.5.5"), true);
+  assert.equal(isSemVerUpgradeAvailable("0.5.5", "0.5.5"), false);
+  assert.equal(isSemVerUpgradeAvailable("0.5.5+build.2", "0.5.5+build.1"), true);
+  assert.equal(isSemVerUpgradeAvailable("0.5.5-rc.1", "0.5.5"), false);
 });

--- a/tui/src/background-update-check.ts
+++ b/tui/src/background-update-check.ts
@@ -1,4 +1,4 @@
-import { compareSemVer } from "../../shared/semver.js";
+import { isSemVerUpgradeAvailable } from "../../shared/semver.js";
 import { RELEASE_LAUNCHER_PACKAGE } from "../../shared/release-targets.js";
 import {
   UPDATE_CHECK_INITIAL_DELAY_MS,
@@ -109,13 +109,7 @@ export function updateNotice(
   latest: string,
   observation: UpgradeObservation
 ): string | null {
-  // Exact version string equality is the only current identity. SemVer
-  // precedence ignores build metadata, so equal precedence with different
-  // build metadata is still a notifyable target (same rule as planUpgrade).
-  if (latest === observation.currentVersion) return null;
-  const comparison = compareSemVer(latest, observation.currentVersion);
-  if (comparison < 0) return null;
-  // comparison > 0: newer precedence. comparison === 0: build-metadata-only change.
+  if (!isSemVerUpgradeAvailable(latest, observation.currentVersion)) return null;
   return `1667 ${latest} available · see npmjs.com/package/${RELEASE_LAUNCHER_PACKAGE}`;
 }
 

--- a/tui/src/upgrade-plan.ts
+++ b/tui/src/upgrade-plan.ts
@@ -1,4 +1,4 @@
-import { compareSemVer, isSemVer } from "../../shared/semver.js";
+import { isSemVer, isSemVerUpgradeAvailable } from "../../shared/semver.js";
 import {
   NpmUpgradeRegistry,
   type NpmVersionMetadata,
@@ -100,14 +100,8 @@ export async function planUpgrade(
       "The requested version is no longer the selected channel head."
     );
   }
-  // Exact SemVer string equality is the only up-to-date identity. Same precedence
-  // with different build metadata stays an available, applicable target.
-  if (latest === observation.currentVersion) {
-    return upToDatePlan(observation.currentVersion, latest, command.channel);
-  }
-  const comparison = compareSemVer(latest, observation.currentVersion);
-  if (comparison < 0) {
-    if (version !== null) {
+  if (!isSemVerUpgradeAvailable(latest, observation.currentVersion)) {
+    if (version !== null && latest !== observation.currentVersion) {
       throw new UpgradeFailure("unsupported_target", "Downgrades are not supported.");
     }
     return upToDatePlan(observation.currentVersion, latest, command.channel);


### PR DESCRIPTION
## Summary

- centralize upgrade availability in the shared SemVer policy
- treat an older beta channel head as up to date after stable promotion
- preserve equal-precedence build-metadata upgrades
- reuse the policy in upgrade planning, background notices, and the live release gate

## Verification

- root and TUI typechecks
- 13 root SemVer/release-gate regression tests
- 19 TUI upgrade-plan/background-update integration tests
- all 10 live install/upgrade release-gate steps from 0.5.4 to 0.5.5
- `$autoreview`: clean
- `$thermo-nuclear-code-quality-review`: clean

Closes #96