### PR TITLE
chore(release): prepare 0.6.0-rc.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "1667-workspace",
-  "version": "0.5.6",
+  "version": "0.6.0-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "1667-workspace",
-      "version": "0.5.6",
+      "version": "0.6.0-rc.1",
       "license": "Apache-2.0",
       "dependencies": {
         "fs-ext-extra-prebuilt": "2.2.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667-workspace",
-  "version": "0.5.6",
+  "version": "0.6.0-rc.1",
   "private": true,
   "description": "Source workspace for the 1667 terminal writing environment",
   "license": "Apache-2.0",

--- a/tui/package.json
+++ b/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667",
-  "version": "0.5.6",
+  "version": "0.6.0-rc.1",
   "private": true,
   "description": "A terminal environment for writing fiction with language models",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary

- Set the root package version to `0.6.0-rc.1`.
- Set the TUI package version to `0.6.0-rc.1`.
- Keep the root lockfile version fields synchronized.

The reasoning tokens set from #102 adds features and moves the HTTP API protocol, so this is a minor prerelease: a provider streams model reasoning as its own channel, a take keeps its thought and the TUI shows it beside the prose, Settings gains the Reasoning and keep-thought rows, a thought that passes the storage bound keeps its prefix, and a thought that would complete a credential with its prose is dropped.

A prerelease publishes to the `beta` dist-tag. The homepage keeps serving the stable Installers, which name 0.5.6.

## Verification

- `npm run typecheck`
- `node --test test/release-identity.test.ts test/release-content.test.ts test/release-preflight.test.ts test/build-identity.test.ts`: 16 pass, 0 fail

Closes #104

https://claude.ai/code/session_01MfCTszz1WFpnUh7He5B9Mb