### PR TITLE
chore(release): prepare 0.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "1667-workspace",
-  "version": "0.6.0-rc.1",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "1667-workspace",
-      "version": "0.6.0-rc.1",
+      "version": "0.6.0",
       "license": "Apache-2.0",
       "dependencies": {
         "fs-ext-extra-prebuilt": "2.2.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667-workspace",
-  "version": "0.6.0-rc.1",
+  "version": "0.6.0",
   "private": true,
   "description": "Source workspace for the 1667 terminal writing environment",
   "license": "Apache-2.0",

--- a/tui/package.json
+++ b/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667",
-  "version": "0.6.0-rc.1",
+  "version": "0.6.0",
   "private": true,
   "description": "A terminal environment for writing fiction with language models",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary

- Set the root package version to `0.6.0`.
- Set the TUI package version to `0.6.0`.
- Keep the root lockfile version fields synchronized.

Same contents as `0.6.0-rc.1`, which published to the `beta` dist-tag: the reasoning tokens set from #102, which adds features and moves the HTTP API protocol.

A version that is not a prerelease publishes to `latest`, which is the dist-tag the stable channel reads.

## Verification

- `npm run typecheck`
- `node --test test/release-identity.test.ts test/release-content.test.ts test/release-preflight.test.ts test/build-identity.test.ts`: 16 pass, 0 fail
- `v0.6.0-rc.1` release run: success, GitHub prerelease with 27 assets, `beta` now names it

Closes #105

https://claude.ai/code/session_01MfCTszz1WFpnUh7He5B9Mb