### PR TITLE
fix(facts): raise the Fact text limit and stop the save-error race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,15 @@ This file records notable changes to 1667. Product terms use the definitions in
   ceiling still ends the generation, the same as any other oversized response
   from the model. Thanks @10fra for the report.
 
+- **A Fact can now hold up to 100,000 characters, and an over-long Fact says
+  so.** The old limit was 4,000 characters, well under what a NovelAI
+  Lorebook entry or a SillyTavern World Info entry allows. The token budget
+  already governs what a request sends, so the character limit no longer
+  needs to be so tight. The Fact editor shows a character count as a Fact
+  nears the new limit. It also refuses an over-limit Fact right away, with a
+  message that names the limit. Before this fix, the refusal could arrive
+  after the writer's next keystroke had already cleared it from view.
+
 - **1667 shows what a model thinks before it writes.** Some models write
   reasoning text before prose. 1667 calls this text a thought and keeps it
   apart from your story. The margin shows `⟳ thinking` while the model works,

--- a/docs/character-card-import.md
+++ b/docs/character-card-import.md
@@ -194,7 +194,7 @@ line, word, and Unicode-safe boundaries. It does not truncate selected text.
 - Maximum character card file size: 20 MB
 - Maximum decoded card JSON size: 1 MB
 - Maximum character name length: 200 UTF-16 code units
-- Maximum Fact input length: 4,000 Unicode scalar values
+- Maximum Fact input length: 100,000 Unicode scalar values
 - Maximum result: 128 Fact inputs
 - Maximum card import request size: 1 MB
 

--- a/docs/design/importers-253-256-257.md
+++ b/docs/design/importers-253-256-257.md
@@ -294,7 +294,7 @@ This is the exact inversion of `server/novelai-export.ts:223` `lorebookEntry`.
 | Lorebook Entry field | Fact field | Rule |
 | --- | --- | --- |
 | `enabled: false` | — | Skip the entry. A disabled entry is switched off in the source; importing it live would change what the model reads. Counted. |
-| `text` | `text` | Trim. Normalise CR, CRLF, U+2028, and U+2029 to LF. Refuse an unpaired surrogate. Over 4,000 UTF-16 code units, cut at the last paragraph break, then line break, then word break at or before the cap, and never between surrogates. Counted. Empty after the trim: drop the entry, counted. |
+| `text` | `text` | Trim. Normalise CR, CRLF, U+2028, and U+2029 to LF. Refuse an unpaired surrogate. Over 100,000 UTF-16 code units, cut at the last paragraph break, then line break, then word break at or before the cap, and never between surrogates. Counted. Empty after the trim: drop the entry, counted. |
 | `displayName` | `tag` | Trim. Empty or absent: fall back to the category name. Still empty: `null`. Over 48 Unicode scalars: cut with `sliceUnicodeScalarPrefix`. Counted. |
 | `category` | `tag` fallback | Resolve the id against `categories[].name`. The exporter writes `id = "category:" + tag` (`server/novelai-export.ts:206`), so a 1667 export round-trips. |
 | `keys` | `keys` | Keep strings only. Trim. Drop an empty key. Drop a key that holds a comma or a line break, because `parseFactKeys` refuses both. Cut a key over 64 scalars. Drop a duplicate after normalisation. Keep the first 32. Every drop counted. |
@@ -324,7 +324,7 @@ order there is. The report names the remainder:
 ```
 
 **The request body limit can bite first.** `MAX_JSON_BODY_BYTES` is 1,000,000
-bytes, and 128 Facts of 4,000 characters can exceed it. Reuse
+bytes, and 128 Facts of 100,000 characters can exceed it. Reuse
 `shared/character-card.ts:89` `factImportRequestBytes`. If the body is too
 large, drop Facts from the end until it fits, and name the drop in the report.
 This differs from `planCardImport`, which throws. A card is small enough for a
@@ -383,7 +383,7 @@ introduced.
 | JSON values | `MAX_NOVELAI_JSON_VALUES` | `server/import-nai.ts:24`, via `parseJsonRejectingDuplicateKeys` |
 | MessagePack | records, tokens, depth, scalar bytes | `server/import-nai-msgpack-preflight.ts:25` |
 | Facts | 128 | `MAX_FACTS` |
-| Fact text | 4,000 UTF-16 code units | `MAX_FACT_TEXT_CHARS` |
+| Fact text | 100,000 Unicode scalar values | `MAX_FACT_TEXT_CHARS` |
 | Fact tag | 48 Unicode scalars | `MAX_FACT_TAG_CHARS` |
 | Fact keys | 32 keys, 64 scalars each | `MAX_FACT_KEYS`, `MAX_FACT_KEY_SCALARS` |
 | Author's Note | 4,000 | `MAX_AUTHORS_NOTE_CHARS` |
@@ -484,7 +484,7 @@ pinned near the top of every request. A 1667 Fact with `always` activation is
 that same surface. Splitting the block into paragraphs would invent structure
 the source never had, and it would spend several of the 128 Facts on one idea.
 
-Over 4,000 UTF-16 code units: cut at the last paragraph break at or before the
+Over 100,000 UTF-16 code units: cut at the last paragraph break at or before the
 cap, and report it.
 
 Order matters against the ceiling. Import the Memory Fact first, then the
@@ -561,7 +561,7 @@ $ 1667 import-lorebook --story "the lantern keeper" ~/nai/lantern.lorebook
 ```
 $ 1667 import-lorebook --story "the lantern keeper" ~/nai/lantern.lorebook 2>&1 1>/dev/null
 ~/nai/lantern.lorebook: 41 entries read; 34 facts imported; 3 disabled entries
-skipped; 2 entries truncated to 4,000 characters; 1 tag cut to 48 characters;
+skipped; 2 entries truncated to 100,000 characters; 1 tag cut to 48 characters;
 2 keyed entries have no keys and will not activate; 7 entries did not fit the
 128-fact limit; unsupported search ranges, bias groups, and advanced conditions omitted.
 ```
@@ -721,7 +721,7 @@ Full-bleed at 120 columns. Opened with `!` from anywhere.
 
 ▸ 21:04:12  ⚑ lantern-keeper.lorebook · 34 Facts imported
               41 entries read. 34 facts imported. 3 disabled entries skipped.
-              2 entries truncated to 4,000 characters. 1 tag cut to 48 characters.
+              2 entries truncated to 100,000 characters. 1 tag cut to 48 characters.
               2 keyed entries have no keys and will not activate.
               7 entries did not fit the 128-fact limit.
               14 control characters kept in the file; they draw as ▪.

--- a/docs/design/importers-253-256-257.md
+++ b/docs/design/importers-253-256-257.md
@@ -294,7 +294,7 @@ This is the exact inversion of `server/novelai-export.ts:223` `lorebookEntry`.
 | Lorebook Entry field | Fact field | Rule |
 | --- | --- | --- |
 | `enabled: false` | — | Skip the entry. A disabled entry is switched off in the source; importing it live would change what the model reads. Counted. |
-| `text` | `text` | Trim. Normalise CR, CRLF, U+2028, and U+2029 to LF. Refuse an unpaired surrogate. Over 100,000 UTF-16 code units, cut at the last paragraph break, then line break, then word break at or before the cap, and never between surrogates. Counted. Empty after the trim: drop the entry, counted. |
+| `text` | `text` | Trim. Normalise CR, CRLF, U+2028, and U+2029 to LF. Refuse an unpaired surrogate. Over 100,000 Unicode scalar values, cut at the last paragraph break, then line break, then word break at or before the cap, and never between surrogates. Counted. Empty after the trim: drop the entry, counted. |
 | `displayName` | `tag` | Trim. Empty or absent: fall back to the category name. Still empty: `null`. Over 48 Unicode scalars: cut with `sliceUnicodeScalarPrefix`. Counted. |
 | `category` | `tag` fallback | Resolve the id against `categories[].name`. The exporter writes `id = "category:" + tag` (`server/novelai-export.ts:206`), so a 1667 export round-trips. |
 | `keys` | `keys` | Keep strings only. Trim. Drop an empty key. Drop a key that holds a comma or a line break, because `parseFactKeys` refuses both. Cut a key over 64 scalars. Drop a duplicate after normalisation. Keep the first 32. Every drop counted. |
@@ -484,7 +484,7 @@ pinned near the top of every request. A 1667 Fact with `always` activation is
 that same surface. Splitting the block into paragraphs would invent structure
 the source never had, and it would spend several of the 128 Facts on one idea.
 
-Over 100,000 UTF-16 code units: cut at the last paragraph break at or before the
+Over 100,000 Unicode scalar values: cut at the last paragraph break at or before the
 cap, and report it.
 
 Order matters against the ceiling. Import the Memory Fact first, then the

--- a/docs/move-from-novelai.md
+++ b/docs/move-from-novelai.md
@@ -161,9 +161,9 @@ occurred:
 
 | Item | Meaning |
 | --- | --- |
-| `memory truncated to 4,000 characters` | A Fact holds a maximum of 4,000 characters |
+| `memory truncated to 100,000 characters` | A Fact holds a maximum of 100,000 characters |
 | `2 disabled entries skipped` | A disabled Lorebook Entry does not import |
-| `3 entries truncated to 4,000 characters` | The entry text was longer than one Fact holds |
+| `3 entries truncated to 100,000 characters` | The entry text was longer than one Fact holds |
 | `1 entry could not be read` | The entry was not a readable record |
 
 ## Where your data lives

--- a/server/import-nai.ts
+++ b/server/import-nai.ts
@@ -16,6 +16,7 @@ import { splitLegacyStoryLines } from "./import-nai-legacy-lines.js";
 import { parseJsonRejectingDuplicateKeys } from "./strict-json.js";
 import {
   MAX_FACTS,
+  MAX_FACT_TEXT_CHARS,
   MAX_STORED_TITLE_CHARS,
   type FactInput
 } from "../shared/types.js";
@@ -144,7 +145,7 @@ export function extractFacts(
       let text = normalized;
       if (!factTextWithinLimit(text)) {
         text = truncateFactText(text);
-        fidelity.push("memory truncated to 4,000 characters");
+        fidelity.push(`memory truncated to ${MAX_FACT_TEXT_CHARS.toLocaleString()} characters`);
       }
       memoryFact = { tag: "memory", text, activation: "always", keys: [] };
     }
@@ -190,7 +191,7 @@ export function extractAuthorsNote(
   const norm = normalizeAuthorsNote(anEntry.text);
   if (norm === null) return null;
   if (unicodeScalarLength(norm, MAX_AUTHORS_NOTE_CHARS + 1) > MAX_AUTHORS_NOTE_CHARS) {
-    fidelity.push("author's note truncated to 4,000 characters");
+    fidelity.push(`author's note truncated to ${MAX_AUTHORS_NOTE_CHARS.toLocaleString()} characters`);
     return sliceUnicodeScalarPrefix(norm, MAX_AUTHORS_NOTE_CHARS);
   }
   return norm;

--- a/shared/fact-scan.ts
+++ b/shared/fact-scan.ts
@@ -65,7 +65,74 @@ export function boundedSegment(parts: readonly string[], max = MAX_FACT_SCAN_UTF
   return segment(source.slice(start), scalarBefore(source, start));
 }
 export function recursionScanSegment(texts: readonly string[]): FactScanSegment | null {
-  return boundedSegment(texts, MAX_FACT_RECURSION_UTF16);
+  return boundedSegment(fairShareRecursionTexts(texts, MAX_FACT_RECURSION_UTF16), MAX_FACT_RECURSION_UTF16);
+}
+
+/** Give every active recursion-enabled Fact a bounded, max-min-fair share of
+ * the recursion window, so one oversized Fact cannot crowd the rest out of
+ * chain matching. `boundedSegment` alone keeps only the *tail* of the joined
+ * text — fine when the join already fits, but when it does not, a single
+ * Fact placed early can lose its entire contribution to a huge Fact that
+ * follows it, even though every other Fact is tiny.
+ *
+ * When the join already fits in `max` (the common case), this returns
+ * `texts` untouched and `boundedSegment` takes its normal, unmodified path —
+ * the fair-share pass changes nothing unless the window is actually tight.
+ * Only reached over budget: each text keeps at most its water-filling share,
+ * taken from its own tail (the same "keep what's most recent" rule
+ * `boundedSegment` already applies to the join as a whole). A share of zero
+ * drops that Fact from the window entirely, same as today when there are
+ * simply too many Facts for the space available. */
+function fairShareRecursionTexts(texts: readonly string[], max: number): readonly string[] {
+  const nonEmpty = texts.filter(hasFactScanText);
+  if (nonEmpty.length === 0) return texts;
+  const separators = 2 * (nonEmpty.length - 1);
+  const joinedLength = nonEmpty.reduce((sum, text) => sum + text.length, 0) + separators;
+  if (joinedLength <= max) return texts;
+  const budget = Math.max(0, max - separators);
+  const shares = maxMinShares(nonEmpty.map((text) => text.length), budget);
+  return nonEmpty.map((text, index) => tailSlice(text, shares[index]!));
+}
+
+/** Classic max-min fair-share (water-filling): a text shorter than an equal
+ * split keeps its whole length and returns its unused share to the pool,
+ * which grows every other text's share in turn. Converges in at most
+ * `lengths.length` passes, each of which finalizes at least one text or
+ * exits. */
+function maxMinShares(lengths: readonly number[], budget: number): number[] {
+  const shares = new Array<number>(lengths.length).fill(0);
+  const remaining = new Set(lengths.map((_, index) => index));
+  let remainingBudget = budget;
+  let progressed = true;
+  while (progressed && remaining.size > 0) {
+    progressed = false;
+    const equalShare = Math.floor(remainingBudget / remaining.size);
+    for (const index of remaining) {
+      if (lengths[index]! <= equalShare) {
+        shares[index] = lengths[index]!;
+        remainingBudget -= lengths[index]!;
+        remaining.delete(index);
+        progressed = true;
+      }
+    }
+  }
+  if (remaining.size > 0) {
+    const equalShare = Math.floor(remainingBudget / remaining.size);
+    let extra = remainingBudget - equalShare * remaining.size;
+    for (const index of remaining) {
+      shares[index] = equalShare + (extra > 0 ? 1 : 0);
+      if (extra > 0) extra -= 1;
+    }
+  }
+  return shares;
+}
+
+/** The last `limit` UTF-16 units of `text`, never split between a surrogate
+ * pair — the same boundary rule `boundedSegment`'s own suffix trim uses. */
+function tailSlice(text: string, limit: number): string {
+  if (limit <= 0) return "";
+  if (text.length <= limit) return text;
+  return text.slice(suffixStart(text, text.length - limit));
 }
 function segment(text: string, before: string | null): FactScanSegment {
   return { text: text.normalize("NFC"), folded: normalizeFactText(text), before };

--- a/shared/fact-scan.ts
+++ b/shared/fact-scan.ts
@@ -127,12 +127,40 @@ function maxMinShares(lengths: readonly number[], budget: number): number[] {
   return shares;
 }
 
-/** The last `limit` UTF-16 units of `text`, never split between a surrogate
- * pair — the same boundary rule `boundedSegment`'s own suffix trim uses. */
+/** The last `limit` UTF-16 units of `text`, aligned so the retained text
+ * never starts mid-word — never split between a surrogate pair either, the
+ * same rule `boundedSegment`'s own suffix trim uses.
+ *
+ * A raw tail cut can land inside a word: "xtrigger" cut between "x" and
+ * "trigger" hands the matcher a fragment that reads as the whole word
+ * "trigger" starting fresh — preceded by nothing (or by another Fact's
+ * "\n\n" join separator), both of which pass the boundary check — even
+ * though the real text has "x" right there and a real scan would refuse
+ * the match. Dropping the partial leading word removes that fabricated
+ * boundary along with the rest of the excess. Text that already fits `limit`
+ * returns unchanged: only a cut this function actually makes can create an
+ * artificial boundary to fix. */
 function tailSlice(text: string, limit: number): string {
   if (limit <= 0) return "";
   if (text.length <= limit) return text;
-  return text.slice(suffixStart(text, text.length - limit));
+  const start = suffixStart(text, text.length - limit);
+  return text.slice(skipPartialWord(text, start));
+}
+
+/** `start` cuts `text` mid-word when the scalar just before it is a word
+ * scalar; advance past the rest of that word (surrogate-safe) so the
+ * retained text begins at a real word boundary, same as the text would
+ * naturally start after any other non-word character. */
+function skipPartialWord(text: string, start: number): number {
+  const before = scalarBefore(text, start);
+  if (before === null || !isWord(before)) return start;
+  let index = start;
+  while (index < text.length) {
+    const scalar = scalarAt(text, index);
+    if (scalar === null || !isWord(scalar)) break;
+    index += scalar.length;
+  }
+  return index;
 }
 function segment(text: string, before: string | null): FactScanSegment {
   return { text: text.normalize("NFC"), folded: normalizeFactText(text), before };

--- a/shared/lorebook-entry.ts
+++ b/shared/lorebook-entry.ts
@@ -1,5 +1,6 @@
 import {
   MAX_FACTS,
+  MAX_FACT_TEXT_CHARS,
   factImportRequestBytes,
   type FactInput
 } from "./types.js";
@@ -73,7 +74,8 @@ type EntryLoss =
 
 const ENTRY_LOSS_PHRASES: LossPhrases<EntryLoss> = {
   disabled: (count) => `${count} disabled ${countNoun(count, "entry", "entries")} skipped`,
-  textTruncated: (count) => `${count} ${countNoun(count, "entry", "entries")} truncated to 4,000 characters`,
+  textTruncated: (count) =>
+    `${count} ${countNoun(count, "entry", "entries")} truncated to ${MAX_FACT_TEXT_CHARS.toLocaleString()} characters`,
   textEmpty: (count) => `${count} empty ${countNoun(count, "entry", "entries")} dropped`,
   textInvalid: (count) => `${count} ${countNoun(count, "entry", "entries")} dropped for invalid Unicode`,
   textRelined: (count) => `${count} fact ${countNoun(count, "body", "bodies")} changed to line feeds`,

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -36,7 +36,16 @@ export const MAX_HUMAN_EDIT_RANGES = 256;
 export const MAX_REWRITTEN_SPANS = 256;
 
 export const MAX_FACTS = 128;
-export const MAX_FACT_TEXT_CHARS = 4_000;
+// Raised from 4,000 (issue-driven): the character ceiling is no longer meant
+// to be the writer-visible constraint on Fact size. NovelAI and SillyTavern
+// World Info both govern entry size by token budget, not a character cap, and
+// `selectFactsWithinBudget` (shared/fact-budget.ts) already drops an
+// over-budget Fact whole rather than truncating it — so the token budget does
+// the real governing here too. Fact text is content-addressed and carried by
+// `revisionId` in the hash-pinned schema (scripts/story-schema-definition.ts
+// `StoredFactV5`), so this constant is free to move without a schema bump or
+// a data migration.
+export const MAX_FACT_TEXT_CHARS = 100_000;
 export const MAX_FACT_TAG_CHARS = 48;
 
 export type { FactActivation, FactPriority, FactRecursion, FactSecondaryMode };

--- a/test/character-card.test.ts
+++ b/test/character-card.test.ts
@@ -5,11 +5,15 @@ import {
   factsFromCharacterCard,
   parseCharacterCard
 } from "../shared/character-card.js";
-import { MAX_FACT_TEXT_CHARS, factImportRequestBytes } from "../shared/types.js";
+import { MAX_FACTS, MAX_FACT_TEXT_CHARS, factImportRequestBytes } from "../shared/types.js";
 import { unicodeScalarLength } from "../shared/unicode.js";
 
 const encoder = new TextEncoder();
 const PNG_SIGNATURE = Uint8Array.from([137, 80, 78, 71, 13, 10, 26, 10]);
+// The fixtures below were sized against the old 4,000-character Fact cap;
+// this keeps them proportionally oversized against whatever the cap is now,
+// instead of a fresh literal that would go stale exactly the same way.
+const FACT_TEXT_SCALE = Math.ceil(MAX_FACT_TEXT_CHARS / 4_000);
 
 test("a V3 spec version must be digits and dots, not merely start with a 3", () => {
   for (const version of ["3.0", "3.1", "3"]) {
@@ -300,15 +304,18 @@ test("character card mapping imports only selected prose and expands macros once
   }
   assert.throws(() => factsFromCharacterCard({ name: "Mira" }), /Select at least one/);
   assert.throws(() => factsFromCharacterCard({ name: "Mira\nSystem", description: "x" }), /one line/);
+  const nameLength = 200;
+  const combinedLimit = MAX_FACTS * MAX_FACT_TEXT_CHARS;
+  const macroRepeats = Math.ceil(combinedLimit / nameLength) + 1;
   assert.throws(
-    () => factsFromCharacterCard({ name: "M".repeat(200), description: "{{char}}".repeat(2_600) }),
+    () => factsFromCharacterCard({ name: "M".repeat(nameLength), description: "{{char}}".repeat(macroRepeats) }),
     /needs more than 128 facts/
   );
 });
 
 test("character card mapping packs fields and splits long prose without loss", () => {
-  const description = `${"North wind. ".repeat(390)}\n\n${"🌙".repeat(1_200)}`;
-  const personality = "Careful ".repeat(540).trimEnd();
+  const description = `${"North wind. ".repeat(390 * FACT_TEXT_SCALE)}\n\n${"🌙".repeat(1_200 * FACT_TEXT_SCALE)}`;
+  const personality = "Careful ".repeat(540 * FACT_TEXT_SCALE).trimEnd();
   const facts = factsFromCharacterCard({ name: "Mira", description, personality });
   assert.ok(facts.length >= 3);
   assert.ok(facts.every((fact) => fact.tag === "Character"));

--- a/test/fact-activation.test.ts
+++ b/test/fact-activation.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { selectActiveFactsWithTrace } from "../shared/fact-activation.js";
-import { MAX_FACT_SCAN_UTF16 } from "../shared/fact-metadata.js";
+import { MAX_FACT_RECURSION_UTF16, MAX_FACT_SCAN_UTF16 } from "../shared/fact-metadata.js";
 import { parseFactKeys, splitFactKeyLine } from "../shared/fact-keys.js";
 import { compileFactPattern, factPatternMatches } from "../shared/fact-pattern.js";
 import type { StoryFact, StoryNode } from "../shared/types.js";
@@ -185,6 +185,47 @@ test("secondary gates, scan depth, and recursion select Facts in stored order", 
   assert.deepEqual(selected.facts.map(({ id }) => id), ["and", "not", "deep", "seed", "chain", "leaf"]);
   assert.equal(selected.traces.get("chain")?.round, 1);
   assert.equal(selected.traces.get("leaf")?.round, 2);
+});
+
+// A per-fact fair share of the recursion window (shared/fact-scan.ts
+// `recursionScanSegment`) only ever changes anything once the joined
+// recursion text is over MAX_FACT_RECURSION_UTF16. Below that, this pins the
+// unchanged case: several small always-active Facts all keep seeding the
+// chain exactly as before.
+test("recursion chain activation is unchanged when active Facts' text already fits the window", () => {
+  const facts: StoryFact[] = [
+    { ...alwaysFact("first"), id: "first", text: "The lantern keeper lit the wick." },
+    { ...alwaysFact("second"), id: "second", text: "A storm gathered over the bay." },
+    { ...fact("wick"), id: "chain-wick" },
+    { ...fact("storm"), id: "chain-storm" }
+  ];
+  const selected = selectActiveFactsWithTrace(facts);
+  assert.deepEqual(selected.facts.map(({ id }) => id), [
+    "first", "second", "chain-wick", "chain-storm"
+  ]);
+  assert.equal(selected.traces.get("chain-wick")?.round, 1);
+  assert.equal(selected.traces.get("chain-storm")?.round, 1);
+});
+
+// Before the fair-share fix, `recursionScanSegment` joined every active
+// recursion-enabled Fact's *full* text and kept only the tail of the join.
+// A single Fact bigger than the whole window — legal once MAX_FACT_TEXT_CHARS
+// was raised — could then occupy the entire window by itself and silently
+// erase every other active Fact's contribution to chain matching, even one
+// listed ahead of it. This pins the fix: the small Fact's "teapot" survives
+// and the chain Fact it feeds still activates.
+test("a huge recursion-enabled Fact no longer crowds a small one out of the chain-activation window", () => {
+  const small: StoryFact = { ...alwaysFact("small"), id: "small", text: "the small porcelain teapot sits here" };
+  const big: StoryFact = { ...alwaysFact("big"), id: "big", text: "b".repeat(MAX_FACT_RECURSION_UTF16 * 2) };
+  const chain: StoryFact = { ...fact("teapot"), id: "chain" };
+
+  const selected = selectActiveFactsWithTrace([small, big, chain]);
+
+  assert.deepEqual(
+    new Set(selected.facts.map(({ id }) => id)),
+    new Set(["small", "big", "chain"])
+  );
+  assert.equal(selected.traces.get("chain")?.round, 1);
 });
 
 function fact(key: string): StoryFact {

--- a/test/fact-activation.test.ts
+++ b/test/fact-activation.test.ts
@@ -228,6 +228,36 @@ test("a huge recursion-enabled Fact no longer crowds a small one out of the chai
   assert.equal(selected.traces.get("chain")?.round, 1);
 });
 
+// A fair share cuts a Fact's own text, and that cut must not fabricate a word
+// boundary the real text does not have. Before this test's fix, a Fact's
+// share was taken as a raw tail slice: if the cut landed mid-word, the kept
+// fragment read as a fresh word at the front of the recursion segment (or
+// right after the "\n\n" join separator — both non-word, so the boundary
+// check passes) even though the real text has a word character right there.
+test("a fair-share cut never fabricates a word boundary the real text does not have", () => {
+  // Exactly one recursion-enabled Fact feeds the window, so its fair share is
+  // the whole MAX_FACT_RECURSION_UTF16 budget — arithmetic this test controls
+  // completely. Built so the tail-slice cut lands exactly between "x" and
+  // "trigger": 100 filler characters, then "x", then "trigger " (embedded,
+  // preceded by a word character), then enough filler that "trigger " plus
+  // the filler is exactly the window size.
+  const embedded = "trigger";
+  const afterCut = `${embedded} ${"z".repeat(MAX_FACT_RECURSION_UTF16 - embedded.length - 1)}`;
+  assert.equal(afterCut.length, MAX_FACT_RECURSION_UTF16, "fixture must sit exactly at the share");
+  const bigText = `${"z".repeat(100)}x${afterCut}`;
+
+  const big: StoryFact = { ...alwaysFact("big"), id: "big", text: bigText };
+  const chain: StoryFact = { ...fact(embedded), id: "chain" };
+
+  const selected = selectActiveFactsWithTrace([big, chain]);
+
+  assert.equal(
+    selected.facts.some(({ id }) => id === "chain"),
+    false,
+    "\"trigger\" is embedded inside \"xtrigger\" in the real text and must not activate a Fact keyed on it"
+  );
+});
+
 function fact(key: string): StoryFact {
   return {
     id: `fact-${key}`,

--- a/test/fact-text-http.test.ts
+++ b/test/fact-text-http.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import type { StoryPayload } from "../shared/types.js";
+import { MAX_FACT_TAG_CHARS, MAX_FACT_TEXT_CHARS, type StoryPayload } from "../shared/types.js";
 import { API_PROTOCOL_HEADERS, fetchWithApiProtocol } from "./http-test-client.js";
 import { json, testApp } from "./story-server-fixture.js";
 
@@ -14,9 +14,10 @@ linuxTest("Fact text and Fact tag admission counts Unicode scalars at the HTTP b
   const base = await testApp(t, "1667-fact-scalars-");
   const created = await json<StoryPayload>(`${base}/api/stories`, post({ title: "Scalar limits" }));
 
-  // 4,000 astral scalars are 8,000 UTF-16 code units. The old code-unit
-  // measure refused this text; the scalar contract admits it whole.
-  const fullText = ASTRAL.repeat(4_000);
+  // MAX_FACT_TEXT_CHARS astral scalars are twice as many UTF-16 code units.
+  // The old code-unit measure refused this text; the scalar contract admits
+  // it whole.
+  const fullText = ASTRAL.repeat(MAX_FACT_TEXT_CHARS);
   const admitted = await json<StoryPayload>(
     `${base}/api/stories/${created.id}/facts`,
     post({ tag: "astral", text: fullText })
@@ -26,11 +27,11 @@ linuxTest("Fact text and Fact tag admission counts Unicode scalars at the HTTP b
 
   const overText = await fetchWithApiProtocol(
     `${base}/api/stories/${created.id}/facts`,
-    post({ text: ASTRAL.repeat(4_001) })
+    post({ text: ASTRAL.repeat(MAX_FACT_TEXT_CHARS + 1) })
   );
   assert.equal(overText.status, 400);
 
-  const fullTag = ASTRAL.repeat(48);
+  const fullTag = ASTRAL.repeat(MAX_FACT_TAG_CHARS);
   const tagged = await json<StoryPayload>(
     `${base}/api/stories/${created.id}/facts`,
     post({ tag: fullTag, text: "the keeper trims the wick" })
@@ -39,13 +40,13 @@ linuxTest("Fact text and Fact tag admission counts Unicode scalars at the HTTP b
 
   const overTag = await fetchWithApiProtocol(
     `${base}/api/stories/${created.id}/facts`,
-    post({ tag: ASTRAL.repeat(49), text: "the keeper trims the wick" })
+    post({ tag: ASTRAL.repeat(MAX_FACT_TAG_CHARS + 1), text: "the keeper trims the wick" })
   );
   assert.equal(overTag.status, 400);
 
   // A patch admits by the same contract as a create.
   const factId = admitted.facts[0]!.id;
-  const patchedText = `${ASTRAL.repeat(3_999)}!`;
+  const patchedText = `${ASTRAL.repeat(MAX_FACT_TEXT_CHARS - 1)}!`;
   const patched = await json<StoryPayload>(
     `${base}/api/stories/${created.id}/facts/${factId}`,
     patchRequest({ text: patchedText })
@@ -54,7 +55,7 @@ linuxTest("Fact text and Fact tag admission counts Unicode scalars at the HTTP b
 
   const overPatch = await fetchWithApiProtocol(
     `${base}/api/stories/${created.id}/facts/${factId}`,
-    patchRequest({ text: ASTRAL.repeat(4_001) })
+    patchRequest({ text: ASTRAL.repeat(MAX_FACT_TEXT_CHARS + 1) })
   );
   assert.equal(overPatch.status, 400);
 });

--- a/test/fact-text-limit.integration.test.ts
+++ b/test/fact-text-limit.integration.test.ts
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { StoryService } from "../server/story-service.js";
+import { MAX_FACT_TEXT_CHARS } from "../shared/types.js";
+
+// Fact text is content-addressed (scripts/story-schema-definition.ts
+// `StoredFactV5` carries only `revisionId`, not the text itself), so raising
+// MAX_FACT_TEXT_CHARS changes no on-disk schema. This is the test that proves
+// that in practice: a Fact at the new ceiling actually survives a real
+// create -> dispose -> reload cycle through the production storage path,
+// rather than only passing the admission check that lets it in.
+test("a Fact at the new character ceiling round-trips through create, save, and reload intact", async (t) => {
+  const dataDir = await mkdtemp(path.join(tmpdir(), "1667-fact-text-limit-"));
+  t.after(() => rm(dataDir, { recursive: true, force: true }));
+  let service = StoryService.withoutDiagnostics({ dataDir });
+  await service.init();
+
+  const story = await service.createStory("Near the ceiling");
+  // Multi-byte and astral content on top of plain ASCII, so the round trip
+  // also proves the content-addressed store keeps the text exactly — no
+  // re-encoding drift at this size. "\n\n" and "!" cost 3 scalars, so the
+  // banner repeat count is derived rather than picked to land exactly on
+  // the ceiling regardless of where it sits.
+  const astralCount = 1_000;
+  const bannerCount = MAX_FACT_TEXT_CHARS - astralCount - 3;
+  const nearLimitText = `${"銀".repeat(bannerCount)}\n\n${"𐐀".repeat(astralCount)}!`;
+  assert.equal([...nearLimitText].length, MAX_FACT_TEXT_CHARS, "fixture must sit exactly at the ceiling");
+
+  const created = await service.createFact(story.id, { text: nearLimitText, tag: "ceiling" });
+  const factId = created.facts[0]!.id;
+  assert.equal(created.facts[0]!.text, nearLimitText);
+
+  await service.dispose();
+  service = StoryService.withoutDiagnostics({ dataDir });
+  await service.init();
+  try {
+    const reloaded = await service.loadStory(story.id);
+    const fact = reloaded.facts.find(({ id }) => id === factId);
+    assert.equal(fact?.text, nearLimitText);
+    assert.equal(fact?.text.length, nearLimitText.length);
+  } finally {
+    await service.dispose();
+  }
+});
+
+test("one Unicode scalar over the ceiling is still refused", async (t) => {
+  const dataDir = await mkdtemp(path.join(tmpdir(), "1667-fact-text-limit-over-"));
+  t.after(() => rm(dataDir, { recursive: true, force: true }));
+  const service = StoryService.withoutDiagnostics({ dataDir });
+  await service.init();
+  try {
+    const story = await service.createStory("Over the ceiling");
+    await assert.rejects(
+      service.createFact(story.id, { text: "x".repeat(MAX_FACT_TEXT_CHARS + 1) }),
+      new RegExp(`${MAX_FACT_TEXT_CHARS}-character limit`)
+    );
+    assert.equal((await service.loadStory(story.id)).facts.length, 0);
+  } finally {
+    await service.dispose();
+  }
+});

--- a/test/novelai-lorebook.test.ts
+++ b/test/novelai-lorebook.test.ts
@@ -7,7 +7,7 @@ import {
 } from "../shared/novelai-lorebook.js";
 import { createFacts } from "../server/story-facts.js";
 import { fidelityReport } from "../shared/fidelity.js";
-import { MAX_JSON_BODY_BYTES, type Story } from "../shared/types.js";
+import { MAX_FACT_TEXT_CHARS, MAX_JSON_BODY_BYTES, type Story } from "../shared/types.js";
 
 test("factsFromLorebook maps every row of the §2.2 table", () => {
   const lorebook = {
@@ -81,9 +81,10 @@ test("fidelity report text for a Lorebook that fires every counter at once asser
   allEntries.push({ enabled: false, text: "d2" });
   allEntries.push({ enabled: false, text: "d3" });
 
-  // 2 truncated
-  allEntries.push({ enabled: true, forceActivation: true, text: ("Paragraph 1\n\n".repeat(400)) });
-  allEntries.push({ enabled: true, forceActivation: true, text: ("Paragraph 2\n\n".repeat(400)) });
+  // 2 truncated — each comfortably over MAX_FACT_TEXT_CHARS, so this keeps
+  // exercising truncation regardless of where that ceiling sits.
+  allEntries.push({ enabled: true, forceActivation: true, text: oversizedParagraphs("Paragraph 1") });
+  allEntries.push({ enabled: true, forceActivation: true, text: oversizedParagraphs("Paragraph 2") });
 
   // 1 tag cut
   allEntries.push({ enabled: true, forceActivation: true, text: "tag test", displayName: "T".repeat(60) });
@@ -111,16 +112,20 @@ test("fidelity report text for a Lorebook that fires every counter at once asser
   const importResult = factsFromLorebook(lorebook, 34);
   const formattedReport = fidelityReport(importResult.fidelity);
 
-  const expected = "41 entries read; 34 facts imported; 3 disabled entries skipped; 2 entries truncated to 4,000 characters; 2 fact bodies trimmed of surrounding whitespace; 1 tag cut to 48 characters; 2 keys dropped; 2 keyed entries have no keys and will not activate; 4 entries did not fit the 128-fact limit; unsupported search ranges, bias groups, and advanced conditions omitted";
+  const expected = `41 entries read; 34 facts imported; 3 disabled entries skipped; 2 entries truncated to ${MAX_FACT_TEXT_CHARS.toLocaleString()} characters; 2 fact bodies trimmed of surrounding whitespace; 1 tag cut to 48 characters; 2 keys dropped; 2 keyed entries have no keys and will not activate; 4 entries did not fit the 128-fact limit; unsupported search ranges, bias groups, and advanced conditions omitted`;
   assert.equal(formattedReport, expected);
 
 });
 
 test("oversized entry is cut on a paragraph boundary, never between surrogates, and createFacts accepts it", () => {
-  const paragraph1 = "A".repeat(2_000);
-  const paragraph2 = "B".repeat(1_500);
-  const paragraph3 = "C".repeat(1_000);
-  // Total length = 2000 + 2 + 1500 + 2 + 1000 = 4504 UTF-16 code units
+  // Scaled off MAX_FACT_TEXT_CHARS rather than a fresh literal, so this stays
+  // correct if the ceiling ever moves again: paragraph1 sits at the cap's
+  // floor (half the cap), paragraph1 + paragraph2 lands past the floor but
+  // before the cap (where the cut must land), and paragraph3 alone pushes
+  // the whole entry over the cap.
+  const paragraph1 = "A".repeat(Math.floor(MAX_FACT_TEXT_CHARS / 2));
+  const paragraph2 = "B".repeat(Math.floor(MAX_FACT_TEXT_CHARS * 0.375));
+  const paragraph3 = "C".repeat(Math.floor(MAX_FACT_TEXT_CHARS * 0.25));
   const oversizedText = `${paragraph1}\n\n${paragraph2}\n\n${paragraph3}`;
 
   const lorebook = {
@@ -132,9 +137,9 @@ test("oversized entry is cut on a paragraph boundary, never between surrogates, 
   assert.equal(importResult.facts.length, 1);
   const fact = importResult.facts[0]!;
 
-  // Must be cut at paragraph break before 4,000 code units (which is paragraph1 + \n\n + paragraph2 = 3502 code units)
+  // Must be cut at the paragraph break before the cap (paragraph1 + \n\n + paragraph2).
   assert.equal(fact.text, `${paragraph1}\n\n${paragraph2}`);
-  assert.ok(fact.text.length <= 4000);
+  assert.ok(fact.text.length <= MAX_FACT_TEXT_CHARS);
 
   // Assert createFacts accepts it without throwing
   const mockStory: Story = {
@@ -159,15 +164,17 @@ test("astral entry text measures in Unicode scalars, cuts on a paragraph boundar
   // One scalar, two UTF-16 code units — a scalar count and a code-unit count
   // disagree on every measurement below.
   const astral = "\u{1D54F}";
-  // 3,000 scalars are 6,000 code units. The old code-unit measure cut this
-  // text; the scalar contract keeps it whole.
-  const wholeText = astral.repeat(3_000);
-  // 4,804 scalars pass the 4,000-scalar limit, so the cut lands on the last
-  // paragraph break at or before the cap: after paragraph two, at 3,802
-  // scalars — which is 7,602 code units, past the old code-unit limit.
-  const paragraph1 = astral.repeat(2_400);
-  const paragraph2 = astral.repeat(1_400);
-  const paragraph3 = astral.repeat(1_000);
+  // Comfortably under MAX_FACT_TEXT_CHARS scalars, which is twice as many
+  // UTF-16 code units. The old code-unit measure cut this text; the scalar
+  // contract keeps it whole.
+  const wholeText = astral.repeat(Math.floor(MAX_FACT_TEXT_CHARS * 0.75));
+  // These three paragraphs together pass the scalar limit, so the cut lands
+  // on the last paragraph break at or before the cap: after paragraph two,
+  // at paragraph1 + paragraph2 scalars — twice as many code units, past
+  // where the old code-unit measure would have cut.
+  const paragraph1 = astral.repeat(Math.floor(MAX_FACT_TEXT_CHARS * 0.6));
+  const paragraph2 = astral.repeat(Math.floor(MAX_FACT_TEXT_CHARS * 0.35));
+  const paragraph3 = astral.repeat(Math.floor(MAX_FACT_TEXT_CHARS * 0.25));
   const oversizedText = `${paragraph1}\n\n${paragraph2}\n\n${paragraph3}`;
 
   const result = factsFromLorebook({
@@ -182,7 +189,7 @@ test("astral entry text measures in Unicode scalars, cuts on a paragraph boundar
   assert.equal(result.facts[0]?.text, wholeText);
   assert.equal(result.facts[1]?.text, `${paragraph1}\n\n${paragraph2}`);
   const report = fidelityReport(result.fidelity);
-  assert.ok(report.includes("1 entry truncated to 4,000 characters"), report);
+  assert.ok(report.includes(`1 entry truncated to ${MAX_FACT_TEXT_CHARS.toLocaleString()} characters`), report);
 
   const story: Story = {
     id: "astral-story",
@@ -428,3 +435,13 @@ test("a key that grows past the ceiling when folded is dropped, not left to abor
   };
   assert.equal(createFacts(story, { facts: [...result.facts] }), true);
 });
+
+/** `label` repeated, with a paragraph break after each repeat, until the
+ * result comfortably exceeds MAX_FACT_TEXT_CHARS — enough to force
+ * truncation regardless of where that ceiling sits, without hardcoding a
+ * repeat count that would go stale if it moves again. */
+function oversizedParagraphs(label: string): string {
+  const unit = `${label}\n\n`;
+  const repeats = Math.ceil((MAX_FACT_TEXT_CHARS + unit.length) / unit.length);
+  return unit.repeat(repeats);
+}

--- a/test/story-novelai-container.test.ts
+++ b/test/story-novelai-container.test.ts
@@ -17,15 +17,23 @@ import {
 
 test("A long Memory is cut on a paragraph boundary and reported", async (t) => {
   const service = await temporaryService(t);
-  const firstParagraph = "m".repeat(3_000);
-  const secondParagraph = "n".repeat(1_500);
+  // Sized off MAX_FACT_TEXT_CHARS rather than a fresh literal, so this stays
+  // correct if the cap moves again: firstParagraph alone sits past the cap's
+  // floor (half the cap), and firstParagraph + secondParagraph together pass
+  // the cap, so the cut must land on the paragraph break and drop the second
+  // paragraph whole.
+  const firstParagraph = "m".repeat(Math.floor(MAX_FACT_TEXT_CHARS * 0.75));
+  const secondParagraph = "n".repeat(Math.floor(MAX_FACT_TEXT_CHARS * 0.5));
   const result = await service.importNovelAIWithReport(novelAiStoryContainer({
     context: { memory: `${firstParagraph}\n\n${secondParagraph}` }
   }));
 
   assert.equal(result.payload.facts[0]?.text, firstParagraph);
   assert.ok(result.payload.facts[0]!.text.length <= MAX_FACT_TEXT_CHARS);
-  assert.match(fidelityReport(result.fidelity), /memory truncated to 4,000 characters/u);
+  assert.match(
+    fidelityReport(result.fidelity),
+    new RegExp(`memory truncated to ${MAX_FACT_TEXT_CHARS.toLocaleString()} characters`, "u")
+  );
 });
 
 test("A long Author's Note is cut to 4,000 Unicode scalars and reported", async (t) => {

--- a/tui/src/fact-editor-draft.ts
+++ b/tui/src/fact-editor-draft.ts
@@ -3,6 +3,8 @@ import { FactActivationError, parseFactScanDepth } from "../../shared/fact-metad
 import { parseFactKeys } from "../../shared/fact-keys.js";
 import { splitFactKeyLine } from "../../shared/fact-keys.js";
 import { MAX_FACT_BUDGET_TOKENS } from "../../shared/fact-budget.js";
+import { factTextWithinLimit } from "../../shared/fact-limits.js";
+import { MAX_FACT_TEXT_CHARS } from "../../shared/types.js";
 import { FACT_DRAFT_FIELDS, type FactDraft } from "../../shared/fact-draft.js";
 import type { FactEditorSession } from "./state.js";
 
@@ -52,6 +54,12 @@ export function factEditorSavePayload(
 ): { ok: true; draft: FactDraft } | { ok: false; toast: string } {
   if (editor.composer.text.trim().length === 0) {
     return { ok: false, toast: "fact text cannot be empty" };
+  }
+  if (!factTextWithinLimit(editor.composer.text)) {
+    return {
+      ok: false,
+      toast: `fact text exceeds the ${MAX_FACT_TEXT_CHARS.toLocaleString()}-character limit · shorten it before saving`
+    };
   }
   const parsedKeys = factEditorKeys(editor);
   if (!parsedKeys.ok) return parsedKeys;

--- a/tui/src/screens/story/fact-editor-layout.ts
+++ b/tui/src/screens/story/fact-editor-layout.ts
@@ -1,3 +1,5 @@
+import { MAX_FACT_TEXT_CHARS } from "../../../../shared/types.js";
+import { unicodeScalarLength } from "../../../../shared/unicode.js";
 import { composerPosition } from "../../composer-model.js";
 import { factEditorTagLabel } from "../../fact-editor-draft.js";
 import {
@@ -22,7 +24,8 @@ import {
   type ComposerLayout
 } from "./composer.js";
 import {
-  composerFieldLine
+  composerFieldLine,
+  type ComposerStatus
 } from "./composer-chrome.js";
 import { renderComposerChoiceRow } from "./composer-choice.js";
 import { segment, visibleWidth, type FrameLine } from "./frame.js";
@@ -55,7 +58,8 @@ export function renderFactEditorLayout(
     scrollTop: options.scrollTop,
     narrow: options.narrow,
     softWrap: options.softWrap,
-    caret: editor.focus === "body" ? "focused" : "none"
+    caret: editor.focus === "body" ? "focused" : "none",
+    status: factTextCounterStatus(editor.composer.text)
   });
   const tagLabel = factEditorTagLabel(editor);
   const tag = editor.focus === "tag"
@@ -136,6 +140,25 @@ export function renderFactEditorLayout(
     cursorViewportRow: editor.focus === "body"
       ? body.cursorViewportRow + headerRows
       : FACT_EDITOR_ROWS.indexOf(editor.focus)
+  };
+}
+
+/** Only the "context warning" (≥80%) and "danger text" (at/over the limit)
+ *  bands of `contextSeverity` (rail.ts) apply here — below that a Fact is
+ *  nowhere near its own ceiling, and the top rule stays quiet the same way a
+ *  fullscreen composer already shows no status by default. The `.length`
+ *  check first is a cheap lower bound (UTF-16 length never undercounts
+ *  Unicode scalars), so an ordinary small Fact never pays for the exact scan. */
+const FACT_TEXT_COUNTER_WARNING_FILL = 0.8;
+
+function factTextCounterStatus(text: string): ComposerStatus | undefined {
+  const warningFloor = Math.ceil(MAX_FACT_TEXT_CHARS * FACT_TEXT_COUNTER_WARNING_FILL);
+  if (text.length < warningFloor) return undefined;
+  const count = unicodeScalarLength(text);
+  if (count < warningFloor) return undefined;
+  return {
+    text: `${count.toLocaleString()} / ${MAX_FACT_TEXT_CHARS.toLocaleString()} chars`,
+    role: count >= MAX_FACT_TEXT_CHARS ? "danger text" : "context warning"
   };
 }
 

--- a/tui/test/fact-text-limit.test.ts
+++ b/tui/test/fact-text-limit.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, test } from "bun:test";
+import { ActionRuntime } from "../src/action-runtime.js";
+import { handleKey, initialState } from "../src/app.js";
+import { setComposerText } from "../src/composer-model.js";
+import { demoAppSource } from "../src/demo.js";
+import { openFactEditor } from "../src/editor-action.js";
+import { recordSessionNotices } from "../src/notice-log.js";
+import { renderStoryScreen } from "../src/screens/story.js";
+import { frameText } from "../src/screens/story/frame.js";
+import type { FactEditorSession, RuntimeState } from "../src/state.js";
+import { createWrapCache, type ProseStyle } from "../src/wrap.js";
+import { MAX_FACT_TEXT_CHARS } from "../../shared/types.js";
+import { editorHarness, key } from "./editor-harness.js";
+
+/** Ctrl+S's raw terminal sequence (0x13), built at runtime so the literal
+ *  control byte never has to live in this file's source text — matches
+ *  fact-editor.test.ts's own convention. */
+const SAVE_SEQUENCE = String.fromCharCode(0x13);
+const SAVE = key("s", { sequence: SAVE_SEQUENCE, ctrl: true });
+
+function activeFactEditor(state: RuntimeState): FactEditorSession {
+  const editor = state.editor;
+  if (editor?.kind !== "fact") throw new Error("expected an active Fact editor");
+  return editor;
+}
+
+function frame(state: RuntimeState, width = 100, height = 30): string {
+  return frameText(renderStoryScreen(state, { width, height }).lines);
+}
+
+describe("Fact text limit — synchronous rejection (issue: a fact over the limit silently failed to save)", () => {
+  test("an over-limit Fact never reaches the network, and the editor names the limit and what to do", async () => {
+    const { source, state, press } = editorHarness();
+    let createCalls = 0;
+    const createFact = source.api.createFact;
+    source.api.createFact = async (...args) => {
+      createCalls += 1;
+      return createFact(...args);
+    };
+
+    await press(key("f"));
+    await press(key("n"));
+    setComposerText(activeFactEditor(state).composer, "x".repeat(MAX_FACT_TEXT_CHARS + 1));
+
+    await press(SAVE);
+
+    expect(createCalls).toBe(0);
+    expect(state.mode).toBe("EDITOR");
+    expect(state.toast).toContain(`${MAX_FACT_TEXT_CHARS.toLocaleString()}-character limit`);
+    expect(state.toast).toContain("shorten it before saving");
+  });
+
+  test("a Fact exactly at the limit is not refused", async () => {
+    const { state, press } = editorHarness();
+    await press(key("f"));
+    await press(key("n"));
+    setComposerText(activeFactEditor(state).composer, "x".repeat(MAX_FACT_TEXT_CHARS));
+
+    await press(SAVE);
+
+    expect(state.mode).toBe("FACTS");
+    expect(state.payload.facts.some((fact) => fact.text.length === MAX_FACT_TEXT_CHARS)).toBeTrue();
+  });
+});
+
+describe("Fact text limit — the size counter (item 3: warn before the writer hits the wall)", () => {
+  test("stays quiet for an ordinary Fact", async () => {
+    const { state, press } = editorHarness();
+    await press(key("f"));
+    await press(key("n"));
+    setComposerText(activeFactEditor(state).composer, "A short fact about the lighthouse keeper.");
+
+    expect(frame(state)).not.toContain(`/ ${MAX_FACT_TEXT_CHARS.toLocaleString()} chars`);
+  });
+
+  test("appears once a Fact nears the limit, and reports the exact count", async () => {
+    const { state, press } = editorHarness();
+    await press(key("f"));
+    await press(key("n"));
+    const nearLimit = MAX_FACT_TEXT_CHARS - 1;
+    setComposerText(activeFactEditor(state).composer, "x".repeat(nearLimit));
+
+    expect(frame(state)).toContain(`${nearLimit.toLocaleString()} / ${MAX_FACT_TEXT_CHARS.toLocaleString()} chars`);
+  });
+});
+
+describe("Fact text limit — a lost async error is recoverable (item 4: the notice log makes every transient channel honest)", () => {
+  test("an async save failure lands in the notice log immediately, and outlives the next keystroke's toast", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const cache = createWrapCache<ProseStyle>();
+    // The production repaint (app.ts) records every notice as it repaints —
+    // "a backend task can raise a notice long after the key that started it,
+    // so the log is filled here as well as at the end of dispatch." Rebuilding
+    // that one line is what makes this a fair test of the real wiring instead
+    // of a stub that begs the question.
+    const repaint = () => recordSessionNotices(state);
+    const backend = new ActionRuntime(state, repaint);
+    const dispatchKey = (event: Parameters<typeof handleKey>[0]) => {
+      const work = handleKey(
+        event, state, source, cache, repaint,
+        async () => undefined, () => undefined, null,
+        () => undefined, () => undefined, backend
+      );
+      // The real dispatcher hands the whole key's promise to
+      // `backend.observe()` (see presented-input-queue.ts
+      // `observeInputAdmission`); this reproduces exactly that handoff.
+      backend.observe(work);
+      return work.catch(() => undefined);
+    };
+
+    const fact = state.payload.facts[0]!;
+    openFactEditor(state, fact);
+    const editor = activeFactEditor(state);
+    setComposerText(editor.composer, `${editor.composer.text} — a real, in-limit edit`);
+    source.api.patchFact = async () => { throw new Error("mock backend outage"); };
+
+    await dispatchKey(SAVE);
+
+    expect(state.toast).toBe("mock backend outage");
+    expect(state.notices.entries.some((entry) => entry.text === "mock backend outage")).toBeTrue();
+
+    // The next keystroke's dispatch wipes the live toast (app.ts's dispatch
+    // clears it unconditionally at the top of every call) — that is the half
+    // of the race this fix does not touch. The log must still remember it.
+    await dispatchKey(key("down"));
+
+    expect(state.toast).not.toBe("mock backend outage");
+    expect(state.notices.entries.some((entry) => entry.text === "mock backend outage")).toBeTrue();
+  });
+});


### PR DESCRIPTION
Closes #113

## Summary

- Raise `MAX_FACT_TEXT_CHARS` from 4,000 to 100,000 Unicode scalars. The token budget (`selectFactsWithinBudget`) already governs request size and drops an over-budget Fact whole, so the character ceiling no longer needs to be the writer-visible constraint. NovelAI and SillyTavern World Info both govern by token budget too, with no hard character limit.
- Derive every truncation message and doc citation from the constant instead of a hardcoded `4,000`, so this can't go stale the same way again. Left `MAX_AUTHORS_NOTE_CHARS` (also 4,000) and `MAX_TOTAL_CHARS` (4,000,000, chat import) alone — different constants, not part of this change.
- Give the chain-activation recursion scan window (`shared/fact-scan.ts`) a max-min fair share per active recursion-enabled Fact. Before, `boundedSegment` kept only the *tail* of every active Fact's text joined together — at a 100,000 ceiling, a single large Fact could fill the whole 20,000-character window and silently erase every other Fact's contribution to chain matching. When the total already fits the window, behavior is byte-for-byte identical to before; only the over-budget case changes.
- The Fact editor now refuses an over-limit Fact synchronously, before the network reaches the server, using `factTextWithinLimit` — with a toast naming the limit and what to do.
- The Fact editor shows a character count once a Fact nears the limit (≥80%), reusing the same "context warning" / "danger text" severity roles the context meter already uses — quiet below that, so an ordinary Fact draws no extra chrome.
- Root cause of the "no error shown" report: `ActionRuntime.run()` reopens input admission before a save settles (deliberate, for responsiveness), and `dispatch()` clears the toast unconditionally on the very next keystroke — a slow rejection could be wiped before it painted. Verified the systemic fix already exists: `observe()`'s catch handler sets the toast and calls `repaint()`, and `repaint()` already calls `recordSessionNotices()` in the same tick — so the message reaches the C-37 notice log before any later keystroke can clear it, recoverable with `!`. Added a test pinning that; no code change needed there.

## Test plan

- [x] `npm run typecheck` (root) — clean
- [x] `npm test` (root) — 2113 pass / 0 fail / 200 skip (skips are the usual Windows- and Linux-only gates)
- [x] `cd tui && bun test` — 1667 pass / 0 fail
- [x] `cd tui && bun run typecheck` — clean
- [x] `test/settings-activation-in-process.test.ts` re-run in isolation — passed cleanly, no flake this run
- [x] `test/story-catalog-performance.test.ts` and `test/story-wire-performance.test.ts` — both stayed inside budget; neither exercises Fact text so neither was expected to move
- [x] New tests: over-limit Fact refused before the network (editor-driven, real save path), a Fact exactly at the limit still saves, the size counter appears/stays quiet correctly, an async save failure is recoverable from the notice log after the next keystroke, the recursion fair-share fix (unchanged small-facts case + the crowding-out case it fixes), and a Fact at the new ceiling round-trips through create → dispose → reload intact

https://claude.ai/code/session_01Sr685JMg4PnFJvaUoMVHkJ