### PR TITLE
fix(log): render release-note markdown structure in the log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ This file records notable changes to 1667. Product terms use the definitions in
   stores a credential, a custom header value, or a base URL. Thanks @10fra for
   the request.
 
+- **The log now shows a release note with its paragraphs and list kept.**
+  Before this fix, the log joined a release note into one line, and it
+  showed the raw `**` and backtick marks. The log now keeps each paragraph
+  and each list item on its own line. It also shows bold text and code text
+  in their own style, with the marks removed.
+
 - **1667 shows what a model thinks before it writes.** Some models write
   reasoning text before prose. 1667 calls this text a thought and keeps it
   apart from your story. The margin shows `⟳ thinking` while the model works,

--- a/tui/src/notice-markup.ts
+++ b/tui/src/notice-markup.ts
@@ -1,0 +1,175 @@
+import type { StyleRun } from "./wrap.js";
+
+/** The two inline spans CHANGELOG.md entries actually use. Nothing else in
+ *  markdown gets a style here — an unmatched or unsupported marker survives
+ *  as literal text instead (see `scanInline`). */
+export type NoticeMarkupStyle = "bold" | "code";
+
+export interface NoticeMarkup {
+  readonly text: string;
+  readonly runs: readonly StyleRun<NoticeMarkupStyle>[];
+}
+
+/**
+ * Parse the markdown subset CHANGELOG.md entries use — `**bold**`,
+ * `` `code` ``, `- ` list items, and a blank line as a paragraph break —
+ * into text `wrapText` (wrap.ts) can wrap and style runs a renderer can turn
+ * into segments. Everything else in markdown is left alone: an unmatched
+ * marker (a lone `*`, an unclosed backtick) renders as the literal
+ * character rather than disappearing.
+ *
+ * Pure: markdown text in, `{text, runs}` out. `text` still carries `\n`
+ * structure — a block boundary is `\n` where the source ran two lines
+ * together with no blank line between them, `\n\n` where the source had
+ * one. `noticeMarkupBlocks` reads that same structure back, so a caller
+ * that already has `text` never needs to re-parse the original markdown to
+ * find it.
+ *
+ * A list item's `- ` marker survives into `text` as two literal characters
+ * (not a run) — it costs nothing to wrap alongside the rest of the item,
+ * and it is what lets `noticeMarkupBlocks` tell a list item from a plain
+ * paragraph without extra state passed alongside `text`.
+ */
+export function parseNoticeMarkup(source: string): NoticeMarkup {
+  const blocks = splitBlocks(source);
+  let text = "";
+  const runs: StyleRun<NoticeMarkupStyle>[] = [];
+  blocks.forEach((block, index) => {
+    if (index > 0) text += block.blankBefore ? "\n\n" : "\n";
+    const prefix = block.list ? "- " : "";
+    const scanned = scanInline(block.source);
+    const offset = text.length + prefix.length;
+    for (const run of scanned.runs) {
+      runs.push({ start: run.start + offset, end: run.end + offset, style: run.style });
+    }
+    text += prefix + scanned.text;
+  });
+  return { text, runs };
+}
+
+/** One paragraph or list item in text `parseNoticeMarkup` produced, as an
+ *  offset range into that text — the same paragraph boundaries `wrapText`
+ *  finds on the same text, so a `WrappedLine`'s `start` always falls inside
+ *  exactly one of these. A block never holds an internal newline. */
+export interface NoticeMarkupBlock {
+  readonly start: number;
+  readonly end: number;
+  readonly list: boolean;
+}
+
+/** Read the block structure back out of `parseNoticeMarkup`'s own output,
+ *  rather than threading it through as extra return state: the cleaned text
+ *  already carries it, a `\n` split away. Mirrors `wrapText`'s own
+ *  paragraph-boundary loop exactly, so the two never disagree about where a
+ *  paragraph starts or ends. */
+export function noticeMarkupBlocks(text: string): readonly NoticeMarkupBlock[] {
+  const blocks: NoticeMarkupBlock[] = [];
+  let paragraphStart = 0;
+  while (paragraphStart <= text.length) {
+    const newline = text.indexOf("\n", paragraphStart);
+    const paragraphEnd = newline === -1 ? text.length : newline;
+    blocks.push({
+      start: paragraphStart,
+      end: paragraphEnd,
+      list: text.slice(paragraphStart, paragraphEnd).startsWith("- ")
+    });
+    if (newline === -1) break;
+    paragraphStart = newline + 1;
+  }
+  return blocks;
+}
+
+interface RawBlock {
+  /** Already joined to one line and whitespace-collapsed; markers intact. */
+  readonly source: string;
+  readonly list: boolean;
+  /** Whether a blank source line preceded this block — `parseNoticeMarkup`
+   *  turns that into a `\n\n` paragraph break, and its absence into a tight
+   *  `\n`, so two list items the source ran together stay run together. */
+  readonly blankBefore: boolean;
+}
+
+/** Group raw markdown lines into paragraphs and list items. A `- ` line
+ *  always starts a new block, blank line before it or not — that is what
+ *  keeps consecutive list items visually distinct even when the source
+ *  never put a blank line between them. Any other line joins whatever block
+ *  is open, or opens a new paragraph if none is. */
+function splitBlocks(source: string): RawBlock[] {
+  const blocks: RawBlock[] = [];
+  let currentLines: string[] | null = null;
+  let currentList = false;
+  let currentBlankBefore = false;
+  let pendingBlank = false;
+
+  const flush = () => {
+    if (currentLines === null) return;
+    blocks.push({
+      source: currentLines.join(" ").replace(/\s+/gu, " ").trim(),
+      list: currentList,
+      blankBefore: currentBlankBefore
+    });
+    currentLines = null;
+  };
+
+  for (const rawLine of source.split("\n")) {
+    const trimmed = rawLine.trim();
+    if (trimmed.length === 0) {
+      flush();
+      pendingBlank = true;
+      continue;
+    }
+    if (trimmed.startsWith("- ")) {
+      flush();
+      currentLines = [trimmed.slice(2).trimStart()];
+      currentList = true;
+      currentBlankBefore = pendingBlank;
+      pendingBlank = false;
+      continue;
+    }
+    if (currentLines === null) {
+      currentLines = [trimmed];
+      currentList = false;
+      currentBlankBefore = pendingBlank;
+      pendingBlank = false;
+    } else {
+      currentLines.push(trimmed);
+    }
+  }
+  flush();
+  return blocks;
+}
+
+/** Strip `**bold**` and `` `code` `` markers from one block's already-flat
+ *  source, left to right, recording where each stripped span landed in the
+ *  output. A marker with no match — a lone `*`, an unclosed backtick — is
+ *  never consumed specially: the loop falls through and copies it one
+ *  character at a time, so the text it introduces survives untouched. */
+function scanInline(source: string): { text: string; runs: StyleRun<NoticeMarkupStyle>[] } {
+  let text = "";
+  const runs: StyleRun<NoticeMarkupStyle>[] = [];
+  let index = 0;
+  while (index < source.length) {
+    if (source.startsWith("**", index)) {
+      const close = source.indexOf("**", index + 2);
+      if (close !== -1) {
+        const start = text.length;
+        text += source.slice(index + 2, close);
+        runs.push({ start, end: text.length, style: "bold" });
+        index = close + 2;
+        continue;
+      }
+    } else if (source[index] === "`") {
+      const close = source.indexOf("`", index + 1);
+      if (close !== -1) {
+        const start = text.length;
+        text += source.slice(index + 1, close);
+        runs.push({ start, end: text.length, style: "code" });
+        index = close + 1;
+        continue;
+      }
+    }
+    text += source[index];
+    index += 1;
+  }
+  return { text, runs };
+}

--- a/tui/src/screens/log.ts
+++ b/tui/src/screens/log.ts
@@ -1,8 +1,13 @@
 import type { HitRow, HitRows } from "../hit.js";
 import { boundedNoticeCursor, type NoticeLog, type SessionNotice } from "../notice-log.js";
+import {
+  noticeMarkupBlocks,
+  parseNoticeMarkup,
+  type NoticeMarkupStyle
+} from "../notice-markup.js";
 import type { StoryScreenState } from "../state.js";
 import { tagGlyph, tagRole } from "../tag-presentation.js";
-import { wrapFeedback } from "./feedback-wrap.js";
+import { wrapText, type WrappedLine } from "../wrap.js";
 import { addInlineHits } from "./story/hits.js";
 import { renderSurfaceBreadcrumb } from "./surface-breadcrumb.js";
 import {
@@ -11,7 +16,8 @@ import {
   segment,
   truncate,
   type FrameComposition,
-  type FrameLine
+  type FrameLine,
+  type FrameSegment
 } from "./story/frame.js";
 
 /** Title rule, blank, closing rule, breadcrumb. */
@@ -101,12 +107,52 @@ function noticeRows(notice: SessionNotice, focused: boolean, width: number): Fra
   if (!focused) {
     return [[...head, segment(truncate(oneLine(notice.text), measure), "prose · dim")]];
   }
-  // The log is the surface with no cap, so the expanded notice wraps as far as
-  // it needs to and keeps its recovery keys on the last row.
-  const wrapped = wrapFeedback(notice.text, measure, null);
-  return wrapped.rows.map((row, index): FrameLine => index === 0
-    ? [...head, segment(row, "prose")]
-    : [segment(" ".repeat(BODY_COLUMN)), segment(row, "prose")]);
+  // The log is the one uncapped surface (C-37): the focused notice keeps its
+  // markdown paragraph, list and emphasis structure instead of collapsing to
+  // one flowing line the way the capped toast/banner/check channels do
+  // (Decision 24's `wrapFeedback`, deliberately untouched by this).
+  const { text, runs } = parseNoticeMarkup(notice.text);
+  const wrapped = wrapText(text, runs, measure);
+  const blocks = noticeMarkupBlocks(text);
+  let blockIndex = 0;
+  return wrapped.map((row, index): FrameLine => {
+    while (blockIndex + 1 < blocks.length && row.start >= blocks[blockIndex + 1]!.start) {
+      blockIndex += 1;
+    }
+    const block = blocks[blockIndex]!;
+    // A list item's own `- ` already sits in `row.text` on its first row; a
+    // continuation row wrapped past it, so it gets the hanging indent back
+    // instead, letting the item read as one block rather than losing its
+    // margin under the bullet above it.
+    const hanging = block.list && row.start > block.start;
+    const content = noticeRowSegments(row);
+    const rowSegments = hanging ? [segment("  "), ...content] : content;
+    return index === 0
+      ? [...head, ...rowSegments]
+      : [segment(" ".repeat(BODY_COLUMN)), ...rowSegments];
+  });
+}
+
+/** One wrapped row's text, split at its style runs into plain, bold and code
+ *  segments. `**bold**` keeps the `prose` role and adds the bold attribute —
+ *  emphasis, not a different kind of text. `` `code` `` takes `chrome`, the
+ *  role a technical value already carries elsewhere (the model name and
+ *  route in request-viewer.ts), rather than inventing a new look for it. */
+function noticeRowSegments(row: WrappedLine<NoticeMarkupStyle>): FrameSegment[] {
+  if (row.text.length === 0) return [];
+  const segments: FrameSegment[] = [];
+  let cursor = 0;
+  for (const run of row.styleRuns) {
+    if (run.start > cursor) segments.push(segment(row.text.slice(cursor, run.start), "prose"));
+    if (run.end > run.start) {
+      segments.push(run.style === "bold"
+        ? { text: row.text.slice(run.start, run.end), role: "prose", bold: true }
+        : segment(row.text.slice(run.start, run.end), "chrome"));
+    }
+    cursor = Math.max(cursor, run.end);
+  }
+  if (cursor < row.text.length) segments.push(segment(row.text.slice(cursor), "prose"));
+  return segments;
 }
 
 /** Keep the focused notice on screen without moving it further than it has to.
@@ -193,8 +239,11 @@ function renderBreadcrumb(
   });
 }
 
+/** The unfocused preview row: one flowing line, same as `wrapFeedback`'s own
+ *  collapse, but markdown-aware so a preview never shows a raw `**` or a
+ *  backtick — only the focused row gets the full paragraph/list structure. */
 function oneLine(text: string): string {
-  return text.replace(/\s+/gu, " ").trim();
+  return parseNoticeMarkup(text).text.replace(/\s+/gu, " ").trim();
 }
 
 /** Wall-clock, because a notice's usefulness is "when did this happen". */

--- a/tui/test/notice-log.test.ts
+++ b/tui/test/notice-log.test.ts
@@ -255,4 +255,113 @@ describe("decision 24 · feedback wraps before it truncates", () => {
     // The tail carries the way out, and `!` reaches the whole message.
     expect(rendered).toContain("! full · , opens settings");
   });
+
+  // Regression guard: the log's own markdown parsing (below) must never
+  // reach a capped channel. Decision 24's flatten-and-cap law only stays
+  // honest if the toast keeps rendering `**`/`` ` `` literally, unparsed.
+  test("the toast still collapses to one line and does not interpret markdown", () => {
+    const { state } = harness();
+    state.toast = "**bold** and `code` stay literal · , opens settings";
+    const rendered = screen(state);
+    expect(rendered).toContain("**bold** and `code` stay literal · , opens settings");
+  });
+});
+
+describe("the log renders a notice's markdown instead of showing it raw", () => {
+  function frame(state: ReturnType<typeof harness>["state"], width = 120, height = 36) {
+    return renderStoryScreen(state, { width, height, wrapCache: createWrapCache<ProseStyle>() }).lines;
+  }
+
+  test("a release-notes body keeps its heading and list items on separate rows", async () => {
+    const { state, press } = harness();
+    const body = [
+      "1667 0.6.0 · what changed since 0.1.2",
+      "",
+      "0.2.1 — 2026-08-01",
+      "- **Facts can now activate only when request context matches their "
+        + "keys.** The default `always` mode keeps the existing behavior.",
+      "- The install command now shows its progress."
+    ].join("\n");
+    recordNotice(state.notices, "toast", body);
+
+    await press(key("!", "!"));
+    expect(state.mode).toBe("LOG");
+    const rows = frame(state).map(plainLine);
+
+    const headlineRow = rows.findIndex((row) => row.includes("what changed since 0.1.2"));
+    const versionRow = rows.findIndex((row) => row.includes("0.2.1 — 2026-08-01"));
+    const factsRow = rows.findIndex((row) => row.includes("Facts can now activate"));
+    const installRow = rows.findIndex((row) => row.includes("install command"));
+
+    // Every part landed somewhere, in source order...
+    expect(headlineRow).toBeGreaterThan(-1);
+    expect(versionRow).toBeGreaterThan(headlineRow);
+    expect(factsRow).toBeGreaterThan(versionRow);
+    expect(installRow).toBeGreaterThan(factsRow);
+    // ...on rows of their own, rather than running together the way the old
+    // flatten-to-one-line bug did.
+    expect(rows[headlineRow]).not.toContain("0.2.1");
+    expect(rows[versionRow]).not.toContain("Facts");
+    expect(rows[factsRow]).not.toContain("install command");
+    // Each list item still opens with its bullet.
+    expect(rows[factsRow]).toContain("- Facts can now activate");
+    expect(rows[installRow]).toContain("- The install command");
+  });
+
+  test("**bold** renders bold with the markers gone", async () => {
+    const { state, press } = harness();
+    recordNotice(state.notices, "toast", "- **Facts can now activate.** Plain trailing text.");
+    await press(key("!", "!"));
+    const lines = frame(state);
+    const row = lines.find((line) => plainLine(line).includes("Facts can now activate"));
+    expect(row).toBeDefined();
+
+    const bold = row!.find((part) => part.text === "Facts can now activate.");
+    expect(bold?.bold).toBe(true);
+    expect(plainLine(row!)).not.toContain("**");
+  });
+
+  test("`code` renders styled with the backticks gone", async () => {
+    const { state, press } = harness();
+    recordNotice(state.notices, "toast", "- The default `always` mode keeps the existing behavior.");
+    await press(key("!", "!"));
+    const lines = frame(state);
+    const row = lines.find((line) => plainLine(line).includes("always"));
+    expect(row).toBeDefined();
+
+    const code = row!.find((part) => part.text === "always");
+    expect(code).toBeDefined();
+    expect(code!.role).toBe("chrome");
+    expect(code!.bold).not.toBe(true);
+    expect(plainLine(row!)).not.toContain("`");
+  });
+
+  test("a long list item's continuation lines get a hanging indent", async () => {
+    const { state, press } = harness();
+    const words = Array.from({ length: 40 }, (_, index) => `word${index}`).join(" ");
+    recordNotice(state.notices, "toast", `- ${words}`);
+    await press(key("!", "!"));
+    const rows = frame(state).map(plainLine);
+
+    const firstRow = rows.findIndex((row) => row.includes("word0 "));
+    expect(firstRow).toBeGreaterThan(-1);
+    const continuation = rows[firstRow + 1]!;
+    expect(continuation).toBeDefined();
+    // BODY_COLUMN is 12 cells; a list continuation hangs two further in, so
+    // its text starts at column 14 rather than column 12.
+    expect(continuation.slice(0, 14).trim()).toBe("");
+    expect(continuation.slice(14, 15)).not.toBe(" ");
+  });
+
+  test("an unfocused preview strips markdown markers instead of showing them raw", async () => {
+    const { state, press } = harness();
+    recordNotice(state.notices, "toast", "**Bold headline.** More text follows.");
+    recordNotice(state.notices, "toast", "a second, shorter notice");
+    await press(key("!", "!"));
+    const rows = frame(state).map(plainLine);
+
+    const preview = rows.find((row) => row.includes("Bold headline"));
+    expect(preview).toBeDefined();
+    expect(preview).not.toContain("**");
+  });
 });

--- a/tui/test/notice-markup.test.ts
+++ b/tui/test/notice-markup.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from "bun:test";
+import { noticeMarkupBlocks, parseNoticeMarkup } from "../src/notice-markup.js";
+
+// `parseNoticeMarkup` is deliberately pure (markdown text in, `{text, runs}`
+// out) so the marker edge cases below — the ones a rendered-frame assertion
+// cannot show cleanly, because a dropped or duplicated character reads the
+// same in a wrapped row either way — are checked directly here. The
+// paragraph/list/bold/code behavior itself is covered end to end against a
+// rendered log frame in notice-log.test.ts; this file does not repeat that.
+describe("parseNoticeMarkup", () => {
+  test("strips ** markers and marks the span bold", () => {
+    const { text, runs } = parseNoticeMarkup("plain **bold** text");
+    expect(text).toBe("plain bold text");
+    expect(runs).toEqual([{ start: 6, end: 10, style: "bold" }]);
+  });
+
+  test("strips backtick markers and marks the span code", () => {
+    const { text, runs } = parseNoticeMarkup("use `always` mode");
+    expect(text).toBe("use always mode");
+    expect(runs).toEqual([{ start: 4, end: 10, style: "code" }]);
+  });
+
+  // The rule this whole module exists to keep: a marker with no partner is
+  // never dropped, only ever left exactly as written.
+  test("a lone, unmatched * survives as literal text", () => {
+    const { text, runs } = parseNoticeMarkup("5 * 3 = 15");
+    expect(text).toBe("5 * 3 = 15");
+    expect(runs).toEqual([]);
+  });
+
+  test("an unclosed ** survives as literal text", () => {
+    const { text, runs } = parseNoticeMarkup("this **never closes");
+    expect(text).toBe("this **never closes");
+    expect(runs).toEqual([]);
+  });
+
+  test("an unclosed backtick survives as literal text", () => {
+    const { text, runs } = parseNoticeMarkup("a stray ` mark");
+    expect(text).toBe("a stray ` mark");
+    expect(runs).toEqual([]);
+  });
+
+  test("a blank line becomes a paragraph break", () => {
+    const { text } = parseNoticeMarkup("first paragraph\n\nsecond paragraph");
+    expect(text).toBe("first paragraph\n\nsecond paragraph");
+  });
+
+  // The source-wrapped continuation lines CHANGELOG.md entries carry (a
+  // 2-space indent, no blank line before the next line) are a formatting
+  // artifact of the markdown source, not a paragraph break.
+  test("continuation lines with no blank line between them join one paragraph", () => {
+    const { text } = parseNoticeMarkup("first line\n  continues here");
+    expect(text).toBe("first line continues here");
+  });
+
+  test("a - list item always starts a new block, blank line before it or not", () => {
+    const { text } = parseNoticeMarkup("- first item\n- second item");
+    expect(text).toBe("- first item\n- second item");
+  });
+
+  test("collapses repeated internal whitespace the way the old flatten did", () => {
+    const { text } = parseNoticeMarkup("too   many    spaces");
+    expect(text).toBe("too many spaces");
+  });
+});
+
+describe("noticeMarkupBlocks", () => {
+  test("finds list items and a plain paragraph in the cleaned text", () => {
+    const { text } = parseNoticeMarkup("heading\n- first item\n- second item");
+    const blocks = noticeMarkupBlocks(text);
+    expect(blocks.map((block) => block.list)).toEqual([false, true, true]);
+    expect(blocks.map((block) => text.slice(block.start, block.end))).toEqual([
+      "heading",
+      "- first item",
+      "- second item"
+    ]);
+  });
+
+  test("a blank-line paragraph break is its own empty block", () => {
+    const { text } = parseNoticeMarkup("first\n\nsecond");
+    const blocks = noticeMarkupBlocks(text);
+    expect(blocks).toHaveLength(3);
+    expect(blocks[1]).toMatchObject({ list: false });
+    expect(text.slice(blocks[1]!.start, blocks[1]!.end)).toBe("");
+  });
+});


### PR DESCRIPTION
Closes #124

## Summary

- The log's focused notice used `wrapFeedback`, which collapses every newline and blank line into a single space before wrapping — correct for the capped toast/banner/check channels (Decision 24), wrong for the log, the one uncapped surface (C-37) where a release note's paragraphs and list items need to stay readable.
- `**bold**` and `` `code` `` markers showed up literally, since nothing interpreted them.
- Added `tui/src/notice-markup.ts`, a small pure parser for the markdown subset CHANGELOG.md entries actually use: `**bold**`, `` `code` ``, `- ` list items, and a blank line as a paragraph break. An unmatched marker (a lone `*`, an unclosed backtick) renders literally rather than disappearing.
- `noticeRows` in `tui/src/screens/log.ts` now parses the focused notice's markdown, wraps the cleaned text plus style runs through `wrapText` (which already wraps per paragraph), and renders one segment per style run per line — bold text gets the bold attribute, code text takes the `chrome` role (matching how a technical value like a model name or route is already styled in `request-viewer.ts`). A list item's continuation lines get a two-column hanging indent so the item reads as one block.
- The unfocused preview row still collapses to one line (unchanged), but now also strips markdown markers so it never shows a raw `**`.
- `wrapFeedback` itself, and every other call site (toast, banner, check, settings result), is untouched — Decision 24's caps keep behaving exactly as before.

## Before / after

Before (log's expanded notice, real 0.2.1 release note):

```
1667 0.6.0 · what changed since 0.1.2 0.2.1 — 2026-08-01 - **Facts can now activate only when request
context matches their keys.** The default `always` mode keeps the existing behavior. The `keyed` mode
scans the recent assembled story context and the current instruction. The Fact editor sets the mode and a
comma-separated key list. The Facts panel and side rail show the keyed activation state for the next
request. Thanks @10fra for the request.
```

After:

```
▸ 22:07:28  1667 0.6.0 · what changed since 0.1.2

            0.2.1 — 2026-08-01
            - Facts can now activate only when request context matches their keys. The default always mode keeps the
              existing behavior. The keyed mode scans the recent assembled story context and the current instruction.
              The Fact editor sets the mode and a comma-separated key list. The Facts panel and side rail show the keyed
              activation state for the next request. Thanks @10fra for the request.
```

("Facts can now activate...their keys." renders with the bold attribute set, and `always`/`keyed` render with the `chrome` role — not visible in a plain-text capture, verified directly against the rendered `FrameSegment`s in the new tests.)

## Test plan

- [x] `npm run typecheck` (root) — clean
- [x] `npm test` (root) — 2119 pass, 0 fail, 200 skipped
- [x] `cd tui && bun test` — 1718 pass, 0 fail (161 files)
- [x] `cd tui && bun run typecheck` — clean
- [x] New `tui/test/notice-markup.test.ts`: pure-parser edge cases (bold/code extraction, unmatched markers survive literally, blank-line paragraph breaks, tight list items, block boundaries)
- [x] New tests in `tui/test/notice-log.test.ts`: a release-notes-shaped notice keeps its heading/list items on separate rows; `**bold**` renders bold with markers gone; `` `code` `` renders with the `chrome` role and backticks gone; a long list item's continuation lines get the hanging indent; the unfocused preview strips markdown; the toast/banner regression guard (raw `**`/backtick still shown literally on the capped channels)
- [x] Existing scroll tests (`notice-log.test.ts`, `release-announcement.test.ts`) still pass unchanged — `windowStart`/`maxNoticeScrollOffset` measurement stayed accurate

No known flakes triggered in this run (`test/settings-activation-in-process.test.ts`, `test/http-operation-sessions.test.ts`, `test/mutation-ledger-store-recovery.test.ts`, `tui/test/lorebook-import-cli.test.ts` all passed).

https://claude.ai/code/session_01Sr685JMg4PnFJvaUoMVHkJ