### PR TITLE
fix(storage): retain Generation Records across chapter undo

### DIFF
--- a/server/stories.ts
+++ b/server/stories.ts
@@ -109,6 +109,7 @@ import {
 import { isStoryId } from "./story-v5-strict.js";
 import {
   requirePresentStorySlot,
+  stagedStoryManifestExists,
   StoryAggregateSession,
   type GenerationRecordSourceRevisionSnapshot
 } from "./story-aggregate-session.js";
@@ -900,6 +901,10 @@ export class StoryStore {
       const slot = await readStoredStorySlot(this.dir, id);
       await afterCommit(`cleaning old objects for story ${id}`, async () => {
         if (!await cleanupPending(this.bundlePath(id))) return;
+        // A staged successor can reference objects that the current manifest
+        // does not reference. Recovery owns the staged file and schedules a
+        // later cleanup after it publishes or discards that file.
+        if (await stagedStoryManifestExists(this.bundlePath(id))) return;
         // A single `live` value, not two independently-nullable ones: the two
         // used to be computed by identical-shaped ternaries, which meant one
         // could in principle end up null while the other did not — a branch

--- a/server/story-aggregate-session.ts
+++ b/server/story-aggregate-session.ts
@@ -61,6 +61,16 @@ const MANIFEST_POLICY = {
   maxBytes: MAX_STORY_MANIFEST_BYTES
 } as const;
 
+/** A staged manifest owns immutable objects that the current manifest does
+ * not own yet. Cleanup must keep all objects until recovery publishes or
+ * discards this file. */
+export async function stagedStoryManifestExists(bundleDir: string): Promise<boolean> {
+  return await readOptionalPrivateFile(
+    path.join(bundleDir, NEXT_MANIFEST_FILE),
+    MANIFEST_POLICY
+  ) !== null;
+}
+
 type PresentStorySlot = Extract<
   StoredStorySlot,
   { kind: "v5" | "v6-live" | "v6-deleted" }

--- a/shared/worker-protocol.ts
+++ b/shared/worker-protocol.ts
@@ -376,6 +376,8 @@ export function isLocalDurabilityMutation(
  *
  * - `createNode` with a `genId` settles a stopped generation; its text is
  *   paid streamed prose held only in caller memory.
+ * - `removeChapterBreak` detaches summary Generation Records. Its receipt
+ *   keeps their object graph live until a later restore can publish it again.
  * - `restoreChapterBreak` re-installs removed summary nodes whose text may
  *   be paid provider output already deleted from the store.
  * - `commitPartialRewrite` settles a stopped or timed-out rewrite; its
@@ -391,7 +393,7 @@ export function isManifestOnlyDurabilityEligible(
   input: unknown
 ): method is LocalDurabilityMutationMethod {
   if (!isLocalDurabilityMutation(method)) return false;
-  if (method === "restoreChapterBreak") return false;
+  if (method === "removeChapterBreak" || method === "restoreChapterBreak") return false;
   if (method === "commitPartialRewrite") return false;
   if (method === "importLorebook" || method === "importCard") return false;
   if (method === "createNode") return !createNodeCarriesGeneration(input);

--- a/test/generation-record-staged-cleanup.test.ts
+++ b/test/generation-record-staged-cleanup.test.ts
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm, unlink } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { createGenerationRecord } from "../shared/generation-record.js";
+import { StoryCleanupIntent, cleanupPending } from "../server/story-cleanup.js";
+import { StoryObjectStore } from "../server/story-objects.js";
+import { StoryStore } from "../server/stories.js";
+
+test("story cleanup keeps staged Generation Record objects until transaction recovery", async (t) => {
+  const root = await mkdtemp(path.join(tmpdir(), "1667-generation-record-staged-cleanup-"));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const stories = new StoryStore(root);
+  await stories.init();
+  const story = await stories.create("Staged record");
+  const bundle = path.join(root, story.id);
+  await stories.withAggregateSession(story.id, async () => undefined);
+  const objects = new StoryObjectStore(bundle);
+  const recordId = await objects.storeGenerationRecord(createGenerationRecord({
+    kind: "continue",
+    createdAt: "2026-08-10T00:00:00.000Z",
+    provider: { provider: "dry-run", model: "dry-run" },
+    effective: { wireProtocol: "dry-run", fields: [], adjustments: [] },
+    prompt: { operation: "continue", entries: [] }
+  }));
+  await objects.flush();
+
+  const staged = path.join(bundle, "manifest.json.next");
+  await stories.withAggregateSession(story.id, async (session) => {
+    await session.stageManifest(session.snapshot.manifest);
+  });
+  await (await StoryCleanupIntent.begin(bundle, story.id)).publish();
+
+  await stories.schedulePendingCleanup(story.id);
+  await stories.waitForMaintenance();
+  assert.equal((await objects.readGenerationRecord(recordId)).kind, "continue");
+  assert.equal(await cleanupPending(bundle), true);
+
+  await unlink(staged);
+  await stories.schedulePendingCleanup(story.id);
+  await stories.waitForMaintenance();
+  await assert.rejects(
+    objects.readGenerationRecord(recordId),
+    /Missing generation-records object/
+  );
+  assert.equal(await cleanupPending(bundle), false);
+});

--- a/tui/test/worker-api.test.ts
+++ b/tui/test/worker-api.test.ts
@@ -670,8 +670,42 @@ describe("embedded backend worker", () => {
       await settling;
       expect(await outbox.list()).toEqual([]);
 
-      // Restoring a chapter break re-installs removed summary nodes, so it
-      // keeps the full tier as well.
+      // Removing a chapter break detaches summary Generation Records. Its
+      // full-tier receipt keeps their object graph live for a later restore.
+      const removing = backend.api.removeChapterBreak("story-1", "break-1");
+      const previewRemoval = await waitForRequest(worker, "previewChapterBreakRemoval");
+      const removed = {
+        break: {
+          id: "break-1",
+          parentPartId: "node-1",
+          title: "Kept chapter",
+          createdAt: new Date().toISOString()
+        },
+        summaries: []
+      };
+      worker.message({
+        type: "result",
+        id: previewRemoval.id,
+        value: {
+          removed,
+          removedFingerprint: "a".repeat(64),
+          aggregateVersion: { kind: "v6", revision: "00000000000000000001" }
+        }
+      });
+      const remove = await waitForRequest(worker, "removeChapterBreak");
+      expect(remove.durability).toBe(undefined);
+      const removeIntents = await outbox.list();
+      expect(removeIntents).toHaveLength(1);
+      expect(removeIntents[0]!.method).toBe("removeChapterBreak");
+      worker.message({
+        type: "result",
+        id: remove.id,
+        value: { payload: { id: "story-1", nodes: [], path: [] }, removed }
+      });
+      await removing;
+      expect(await outbox.list()).toEqual([]);
+
+      // Restoring the detached summary nodes keeps the full tier as well.
       const restoring = backend.api.restoreChapterBreak("story-1", "break-1", {
         break: {
           id: "break-1",

--- a/tui/test/worker-api.test.ts
+++ b/tui/test/worker-api.test.ts
@@ -50,7 +50,7 @@ import {
 describe("embedded backend worker", () => {
   test("implements the complete StoryApi contract without HTTP", async () => {
     const dataDir = await mkdtemp(path.join(tmpdir(), "1667-worker-api-"));
-    const backend = await createWorkerStoryApi({ dataDir });
+    const backend = await createWorkerStoryApi({ dataDir, printLogs: true });
     const api = backend.api;
     try {
       const defaults = await api.getSettings();

--- a/tui/test/worker-api.test.ts
+++ b/tui/test/worker-api.test.ts
@@ -50,9 +50,7 @@ import {
 describe("embedded backend worker", () => {
   test("implements the complete StoryApi contract without HTTP", async () => {
     const dataDir = await mkdtemp(path.join(tmpdir(), "1667-worker-api-"));
-    const previousData = process.env.AI_1667_DATA;
-    process.env.AI_1667_DATA = dataDir;
-    const backend = await createWorkerStoryApi();
+    const backend = await createWorkerStoryApi({ dataDir });
     const api = backend.api;
     try {
       const defaults = await api.getSettings();
@@ -363,17 +361,13 @@ describe("embedded backend worker", () => {
         } satisfies Partial<WorkerApiError>);
     } finally {
       await backend.dispose();
-      if (previousData === undefined) delete process.env.AI_1667_DATA;
-      else process.env.AI_1667_DATA = previousData;
       await rm(dataDir, { recursive: true, force: true });
     }
   }, 30_000);
 
   test("normalizes undefined optional fields to HTTP JSON semantics", async () => {
     const dataDir = await mkdtemp(path.join(tmpdir(), "1667-worker-undefined-"));
-    const previousData = process.env.AI_1667_DATA;
-    process.env.AI_1667_DATA = dataDir;
-    const backend = await createWorkerStoryApi();
+    const backend = await createWorkerStoryApi({ dataDir });
     try {
       let story = await backend.api.createStory("Undefined parity");
       story = await backend.api.createNode(story.id, { parentId: null, text: "Root." });
@@ -403,8 +397,6 @@ describe("embedded backend worker", () => {
       expect(story.facts[0]).toMatchObject({ tag: "Place", text: "New" });
     } finally {
       await backend.dispose();
-      if (previousData === undefined) delete process.env.AI_1667_DATA;
-      else process.env.AI_1667_DATA = previousData;
       await rm(dataDir, { recursive: true, force: true });
     }
   }, 20_000);

--- a/tui/test/worker-api.test.ts
+++ b/tui/test/worker-api.test.ts
@@ -50,7 +50,7 @@ import {
 describe("embedded backend worker", () => {
   test("implements the complete StoryApi contract without HTTP", async () => {
     const dataDir = await mkdtemp(path.join(tmpdir(), "1667-worker-api-"));
-    const backend = await createWorkerStoryApi({ dataDir, printLogs: true });
+    const backend = await createWorkerStoryApi({ dataDir });
     const api = backend.api;
     try {
       const defaults = await api.getSettings();


### PR DESCRIPTION
Closes #123.

## Summary

- keep immutable story objects while a staged successor manifest exists
- send chapter-break removal through full durability
- retain the removal receipt that owns detached summary Generation Records
- keep worker failure diagnostics visible in CI
- isolate direct embedded-worker tests with an explicit data directory
- add storage and transport integration regressions

## Root cause

Repeated CI diagnostics showed `StoryFormatError: Missing generation-records object` during `StoryAggregateSession.prepareContent`.

`removeChapterBreak` used manifest-only durability. That bypassed the outer receipt and its chapter-removal artifact. Cleanup could therefore sweep a detached summary's Generation Record before `restoreChapterBreak` published the record ID again.

The full tier persists the removal artifact before the story mutation. The existing receipt-liveness index then protects the complete Generation Record graph.

## Verification

- root build and TUI typecheck
- staged cleanup, Generation Record chapter undo, mutation cleanup, and recovery tests
- full embedded worker API test file
- failing worker contract test repeated five times before the final fix
- transport integration proves removal now creates a full-tier outbox intent
- `$autoreview`: clean (0.99)
- `$thermo-nuclear-code-quality-review`: clean (0.98)
