### PR TITLE
fix(log): scope markdown rendering to markdown notices only

### DIFF
--- a/tui/src/notice-log.ts
+++ b/tui/src/notice-log.ts
@@ -10,12 +10,22 @@ import type { ResolvedKey } from "./keys.js";
  *  is also written here, truncated or not. */
 export type NoticeChannel = "toast" | "banner" | "check";
 
+/** How the log's focused row should read `text`. `plain` is the default and
+ *  the common case: most notices carry arbitrary user- or backend-supplied
+ *  values — a story title, a typed model identifier, a file path, backend
+ *  error text — and must render exactly as written, or the log stops being
+ *  the faithful record C-37 promises. `markdown` opts a notice into the
+ *  small CHANGELOG.md subset `notice-markup.ts` parses (release notes are
+ *  the one caller today); everything else stays `plain` on purpose. */
+export type NoticeMarkupKind = "plain" | "markdown";
+
 export interface SessionNotice {
   readonly id: number;
   /** Client wall-clock time the message first appeared. */
   readonly at: number;
   readonly channel: NoticeChannel;
   readonly text: string;
+  readonly kind: NoticeMarkupKind;
 }
 
 export interface NoticeLog {
@@ -64,7 +74,11 @@ export interface NoticeSources {
 
 /** Write anything new to the log. Idempotent: calling it twice for the same
  *  frame records nothing the second time, which is what lets both the
- *  dispatcher and the repaint call it without agreeing on who owns the seam. */
+ *  dispatcher and the repaint call it without agreeing on who owns the seam.
+ *
+ *  Always `plain`: a toast, a banner and a check message are app text built
+ *  around arbitrary values (a story title, a model name, a provider error) —
+ *  none of them are markdown, and none should ever be parsed as it. */
 export function recordNotices(log: NoticeLog, sources: NoticeSources): void {
   for (const channel of ["toast", "banner", "check"] as const) {
     const text = sources[channel];
@@ -75,7 +89,7 @@ export function recordNotices(log: NoticeLog, sources: NoticeSources): void {
     // dispatcher nulls a toast before the reducer can set the same one back.
     if (text === null || text.trim().length === 0) continue;
     // Newest first, and the cursor stays on the notice the writer came from.
-    log.entries.unshift({ id: log.nextId, at: sources.now, channel, text });
+    log.entries.unshift({ id: log.nextId, at: sources.now, channel, text, kind: "plain" });
     log.nextId += 1;
     setNoticeCursor(log, 0);
   }
@@ -87,15 +101,20 @@ export function recordNotices(log: NoticeLog, sources: NoticeSources): void {
  * C-37 is what makes that cap honest, so the whole report is written here while
  * the toast keeps the headline. This is a discrete event rather than a channel
  * state, so it bypasses the repeat guard: importing the same file twice is two
- * events. */
+ * events.
+ *
+ * `kind` defaults to `plain`, so every existing caller keeps its current,
+ * correct behavior with no edit. Pass `"markdown"` only where `text` really
+ * is markdown — `release-announcement.ts` is the one caller that does. */
 export function recordNotice(
   log: NoticeLog,
   channel: NoticeChannel,
   text: string,
+  kind: NoticeMarkupKind = "plain",
   now = Date.now()
 ): void {
   if (text.trim().length === 0) return;
-  log.entries.unshift({ id: log.nextId, at: now, channel, text });
+  log.entries.unshift({ id: log.nextId, at: now, channel, text, kind });
   log.nextId += 1;
   setNoticeCursor(log, 0);
 }

--- a/tui/src/release-announcement.ts
+++ b/tui/src/release-announcement.ts
@@ -211,7 +211,10 @@ export function announceRelease(
   // The toast holds a few rows; the announcement's full body does not. This
   // is the same split the archive-import fidelity report uses: the toast
   // headline, and the whole account written to the log directly.
-  recordNotice(state.notices, "toast", announcement.body);
+  // `announcement.body` is release-note markdown (headline, version
+  // headers, and each note's own `**bold**`/`` `code` ``/list-item body) —
+  // the one caller `notice-log.ts` documents as passing `"markdown"`.
+  recordNotice(state.notices, "toast", announcement.body, "markdown");
   // Never clobber a toast startup already raised for another reason.
   if (state.toast === null) {
     state.toast = announcement.toast;

--- a/tui/src/screens/log.ts
+++ b/tui/src/screens/log.ts
@@ -105,15 +105,26 @@ function noticeRows(notice: SessionNotice, focused: boolean, width: number): Fra
     segment(stamp(notice.at).padEnd(STAMP_WIDTH), "chrome")
   ];
   if (!focused) {
-    return [[...head, segment(truncate(oneLine(notice.text), measure), "prose · dim")]];
+    return [[...head, segment(truncate(oneLine(notice), measure), "prose · dim")]];
   }
   // The log is the one uncapped surface (C-37): the focused notice keeps its
-  // markdown paragraph, list and emphasis structure instead of collapsing to
-  // one flowing line the way the capped toast/banner/check channels do
-  // (Decision 24's `wrapFeedback`, deliberately untouched by this).
-  const { text, runs } = parseNoticeMarkup(notice.text);
-  const wrapped = wrapText(text, runs, measure);
-  const blocks = noticeMarkupBlocks(text);
+  // line structure instead of collapsing to one flowing line the way the
+  // capped toast/banner/check channels do (Decision 24's `wrapFeedback`,
+  // deliberately untouched by this). Only a `markdown` notice — release
+  // notes, today the one caller — also gets its `**bold**`/`` `code` ``/list
+  // markers interpreted. A `plain` notice, which is most of them and carries
+  // arbitrary user- or backend-supplied text, renders exactly as written:
+  // interpreting markup there would let a story renamed to `**draft**` come
+  // back from the log quietly rewritten to bold.
+  return notice.kind === "markdown"
+    ? markdownNoticeRows(notice.text, measure, head)
+    : plainNoticeRows(notice.text, measure, head);
+}
+
+function markdownNoticeRows(text: string, measure: number, head: FrameLine): FrameLine[] {
+  const { text: cleaned, runs } = parseNoticeMarkup(text);
+  const wrapped = wrapText(cleaned, runs, measure);
+  const blocks = noticeMarkupBlocks(cleaned);
   let blockIndex = 0;
   return wrapped.map((row, index): FrameLine => {
     while (blockIndex + 1 < blocks.length && row.start >= blocks[blockIndex + 1]!.start) {
@@ -130,6 +141,21 @@ function noticeRows(notice: SessionNotice, focused: boolean, width: number): Fra
     return index === 0
       ? [...head, ...rowSegments]
       : [segment(" ".repeat(BODY_COLUMN)), ...rowSegments];
+  });
+}
+
+/** A plain notice's text, wrapped with no markup interpretation at all —
+ *  `wrapText` still wraps it one paragraph per source `\n` (so a multi-line
+ *  notice, an import fidelity report say, keeps its own line breaks), but
+ *  every character renders exactly as the app wrote it. No style runs, no
+ *  list detection, no hanging indent: those are markdown-notice concerns. */
+function plainNoticeRows(text: string, measure: number, head: FrameLine): FrameLine[] {
+  const wrapped = wrapText(text, [], measure);
+  return wrapped.map((row, index): FrameLine => {
+    const content: FrameSegment[] = row.text.length === 0 ? [] : [segment(row.text, "prose")];
+    return index === 0
+      ? [...head, ...content]
+      : [segment(" ".repeat(BODY_COLUMN)), ...content];
   });
 }
 
@@ -240,10 +266,13 @@ function renderBreadcrumb(
 }
 
 /** The unfocused preview row: one flowing line, same as `wrapFeedback`'s own
- *  collapse, but markdown-aware so a preview never shows a raw `**` or a
- *  backtick — only the focused row gets the full paragraph/list structure. */
-function oneLine(text: string): string {
-  return parseNoticeMarkup(text).text.replace(/\s+/gu, " ").trim();
+ *  collapse. A `markdown` notice's markers are stripped first, the same as
+ *  the focused row's own parse, so a preview never shows a raw `**` or a
+ *  backtick. A `plain` notice skips that parse entirely — its `**`/backtick
+ *  characters, if it has any, are the writer's own text, not a marker. */
+function oneLine(notice: SessionNotice): string {
+  const text = notice.kind === "markdown" ? parseNoticeMarkup(notice.text).text : notice.text;
+  return text.replace(/\s+/gu, " ").trim();
 }
 
 /** Wall-clock, because a notice's usefulness is "when did this happen". */

--- a/tui/test/notice-log.test.ts
+++ b/tui/test/notice-log.test.ts
@@ -267,7 +267,61 @@ describe("decision 24 · feedback wraps before it truncates", () => {
   });
 });
 
-describe("the log renders a notice's markdown instead of showing it raw", () => {
+describe("a plain notice is never treated as markdown", () => {
+  function frame(state: ReturnType<typeof harness>["state"], width = 120, height = 36) {
+    return renderStoryScreen(state, { width, height, wrapCache: createWrapCache<ProseStyle>() }).lines;
+  }
+
+  // Regression guard: `recordNotice` defaults to `"plain"`, and most real
+  // notices are — a renamed story, a typed model identifier, backend error
+  // text. None of that is markdown, and the log must never quietly rewrite
+  // it (a story renamed to `**draft**` must not come back bold).
+  test("** and ` in a plain notice render literally, focused and unfocused", async () => {
+    const { state, press } = harness();
+    recordNotice(state.notices, "toast", "renamed **draft** with a `feature` branch name");
+    await press(key("!", "!"));
+    const focusedRow = frame(state).map(plainLine)
+      .find((row) => row.includes("renamed"));
+    expect(focusedRow).toBeDefined();
+    expect(focusedRow).toContain("renamed **draft** with a `feature` branch name");
+
+    // Focus a second notice, so the first becomes the unfocused preview row.
+    recordNotice(state.notices, "toast", "a second, shorter notice");
+    const previewRow = frame(state).map(plainLine)
+      .find((row) => row.includes("renamed"));
+    expect(previewRow).toBeDefined();
+    expect(previewRow).toContain("renamed **draft** with a `feature` branch name");
+  });
+
+  // Guards the part of the original fix that must survive scoping it: a
+  // plain notice's own line breaks are still real structure, not markdown's
+  // tight-continuation-line joining to collapse — an import fidelity report
+  // reads one item per line.
+  test("a plain multi-line notice keeps its own line breaks", async () => {
+    const { state, press } = harness();
+    const body = [
+      "3 facts imported",
+      "1 fact skipped: over the character limit",
+      "0 facts renamed"
+    ].join("\n");
+    recordNotice(state.notices, "toast", body);
+    await press(key("!", "!"));
+    const rows = frame(state).map(plainLine);
+
+    const factsRow = rows.findIndex((row) => row.includes("3 facts imported"));
+    const skippedRow = rows.findIndex((row) => row.includes("1 fact skipped"));
+    const renamedRow = rows.findIndex((row) => row.includes("0 facts renamed"));
+
+    expect(factsRow).toBeGreaterThan(-1);
+    expect(skippedRow).toBe(factsRow + 1);
+    expect(renamedRow).toBe(skippedRow + 1);
+    // Not run together onto one row, the way markdown's own tight-line
+    // joining would have done with no blank line between them.
+    expect(rows[factsRow]).not.toContain("fact skipped");
+  });
+});
+
+describe("the log renders a markdown notice instead of showing it raw", () => {
   function frame(state: ReturnType<typeof harness>["state"], width = 120, height = 36) {
     return renderStoryScreen(state, { width, height, wrapCache: createWrapCache<ProseStyle>() }).lines;
   }
@@ -282,7 +336,7 @@ describe("the log renders a notice's markdown instead of showing it raw", () => 
         + "keys.** The default `always` mode keeps the existing behavior.",
       "- The install command now shows its progress."
     ].join("\n");
-    recordNotice(state.notices, "toast", body);
+    recordNotice(state.notices, "toast", body, "markdown");
 
     await press(key("!", "!"));
     expect(state.mode).toBe("LOG");
@@ -310,7 +364,7 @@ describe("the log renders a notice's markdown instead of showing it raw", () => 
 
   test("**bold** renders bold with the markers gone", async () => {
     const { state, press } = harness();
-    recordNotice(state.notices, "toast", "- **Facts can now activate.** Plain trailing text.");
+    recordNotice(state.notices, "toast", "- **Facts can now activate.** Plain trailing text.", "markdown");
     await press(key("!", "!"));
     const lines = frame(state);
     const row = lines.find((line) => plainLine(line).includes("Facts can now activate"));
@@ -323,7 +377,7 @@ describe("the log renders a notice's markdown instead of showing it raw", () => 
 
   test("`code` renders styled with the backticks gone", async () => {
     const { state, press } = harness();
-    recordNotice(state.notices, "toast", "- The default `always` mode keeps the existing behavior.");
+    recordNotice(state.notices, "toast", "- The default `always` mode keeps the existing behavior.", "markdown");
     await press(key("!", "!"));
     const lines = frame(state);
     const row = lines.find((line) => plainLine(line).includes("always"));
@@ -339,7 +393,7 @@ describe("the log renders a notice's markdown instead of showing it raw", () => 
   test("a long list item's continuation lines get a hanging indent", async () => {
     const { state, press } = harness();
     const words = Array.from({ length: 40 }, (_, index) => `word${index}`).join(" ");
-    recordNotice(state.notices, "toast", `- ${words}`);
+    recordNotice(state.notices, "toast", `- ${words}`, "markdown");
     await press(key("!", "!"));
     const rows = frame(state).map(plainLine);
 
@@ -355,7 +409,7 @@ describe("the log renders a notice's markdown instead of showing it raw", () => 
 
   test("an unfocused preview strips markdown markers instead of showing them raw", async () => {
     const { state, press } = harness();
-    recordNotice(state.notices, "toast", "**Bold headline.** More text follows.");
+    recordNotice(state.notices, "toast", "**Bold headline.** More text follows.", "markdown");
     recordNotice(state.notices, "toast", "a second, shorter notice");
     await press(key("!", "!"));
     const rows = frame(state).map(plainLine);


### PR DESCRIPTION
Closes #128

## Summary

- PR #125's fix ran **every** focused notice through the markdown parser, not just release notes. A plain notice — a renamed story title, a typed model identifier, backend error text — got its own `**`/backtick characters silently stripped or restyled. C-37 exists so nothing the app said is unrecoverable, and the log is the faithful record that makes the capped toast/banner/check caps honest; it must not rewrite what it records.
- Added `NoticeMarkupKind` (`"plain" | "markdown"`) to `SessionNotice` (`tui/src/notice-log.ts`). `recordNotice` takes it as an optional 4th argument, defaulting to `"plain"`, so every existing call site (`archive-import-actions.ts`, `card-import-actions.ts`, `generation-action.ts` x2, `profile-transfer-actions.ts`, `overlay-actions.ts`) keeps its current, correct behavior untouched. `release-announcement.ts` is the one caller that now passes `"markdown"` — checked the whole tree for `recordNotice`/`recordNotices` call sites to be sure that list is exhaustive.
- `recordNotices` (the toast/banner/check channel mirror) always records `"plain"` — checked whether any of those three sources are already markdown-ish (they're template-literal app messages embedding arbitrary values: story titles, filenames, provider error text) and found none, so `"plain"` is the correct default there too, not just the safe one.
- `noticeRows` in `tui/src/screens/log.ts` now branches on `notice.kind`: `markdownNoticeRows` (the PR #125 path, unchanged) for `"markdown"`, and a new `plainNoticeRows` for `"plain"` that wraps the raw text through `wrapText` with no style runs, no marker interpretation, no list detection. It still wraps one paragraph per source newline — a plain multi-line notice (an import fidelity report, for instance) keeps its own line breaks; only the marker interpretation became conditional, per the follow-up's explicit "do not regress that."
- The preview row's `oneLine` parses markup only for a `"markdown"` notice too.
- `copy-part` (`tui/src/overlay-actions.ts`) already copies `notice.text` raw and needed no change — the display/clipboard disagreement the reviewer found goes away on its own once display stops altering plain notices.

## Before / after

Raw notice text (a story renamed to a title that happens to contain markdown-looking characters):

```
renamed **draft** with a `feature` branch name
```

Before (PR #125's unscoped parse — what a plain notice like this would have rendered as): the parser stripped both marker pairs and marked "draft" bold and "feature" as code, so the writer would have seen "renamed draft with a feature branch name" with draft in bold and feature in the code style — neither is what the app actually recorded.

After (this branch, real rendered frame, both the focused row and — after a second notice is recorded — the unfocused preview row):

```
renamed **draft** with a `feature` branch name
```

The `**` and backticks are the writer's own text now, not a stripped marker, in both rows.

## Test plan

- [x] `npm run typecheck` (root) — clean
- [x] `npm test` (root) — 2189 pass, 0 fail, 209 skipped
- [x] `cd tui && bun test` — 1761 pass, 0 fail (166 files)
- [x] `cd tui && bun run typecheck` — clean
- [x] New tests in `tui/test/notice-log.test.ts`: `**`/backtick in a plain notice render literally in both the focused and unfocused preview rows (the regression guard); a plain multi-line notice keeps its own line breaks (guards the part of the original fix that must survive scoping it)
- [x] Existing markdown tests (bold, code, list structure, hanging indent, release-notes paragraph/list separation) updated to pass `"markdown"` explicitly and still pass unchanged in behavior
- [x] Existing scroll tests (`notice-log.test.ts`, `release-announcement.test.ts`) still pass unchanged — they use plain text, so `plainNoticeRows` wraps them identically to before

No known flakes triggered in this run (`test/settings-activation-in-process.test.ts`, `test/http-operation-sessions.test.ts`, `test/mutation-ledger-store-recovery.test.ts`, `tui/test/lorebook-import-cli.test.ts` all passed).

https://claude.ai/code/session_01Sr685JMg4PnFJvaUoMVHkJ
