### PR TITLE
fix(tui): refuse a Direct composer claim while a stream runs

### DIFF
--- a/tui/src/command-model.ts
+++ b/tui/src/command-model.ts
@@ -24,6 +24,11 @@ export interface PaletteCommand {
   shortcut?: string;
   demoOnly?: boolean;
   mutating?: boolean;
+  /** Refuse while the model is still streaming. Narrower than `mutating`,
+   *  which gates on generationBusy and so stays shut through post-Stop
+   *  settlement. A command that only claims an editor uses this instead, so
+   *  the writer can still reach the draft Stop restored. */
+  blockedByLiveStream?: boolean;
   theme?: ThemeName;
   /** Extra live gate beyond demo/mutating, e.g. rewrite-selection needing a
    *  selection this build can actually rewrite. Absent means always allowed. */
@@ -99,7 +104,7 @@ const COMMANDS: readonly PaletteCommand[] = [
   { id: "phrase-bias", section: "story", name: "phrase bias", description: "bias phrases for this story only, adding to the profile's own", mutating: true },
   { id: "banned-strings", section: "story", name: "banned strings", description: "ban strings for this story only, adding to the profile's own", mutating: true },
 
-  { id: "direct-take", section: "take", name: "direct take", description: "write the next take from an instruction", shortcut: "i" },
+  { id: "direct-take", section: "take", name: "direct take", description: "write the next take from an instruction", shortcut: "i", blockedByLiveStream: true },
   {
     id: "attach-image", section: "take", name: "attach image",
     description: "attach an image file to the next take",

--- a/tui/src/composer-ownership.ts
+++ b/tui/src/composer-ownership.ts
@@ -13,6 +13,11 @@ type RetakeFocusState = Pick<RuntimeState,
   "payload" | "stream" | "focusIndex" | "viewScroll" | "viewScrollDelta"
 >;
 
+/** Claiming Direct needs the stream so it can refuse mid-stream. Every door
+ * into the Direct editor passes RuntimeState, so requiring the field here
+ * makes a caller that cannot answer the question a type error. */
+type DirectClaimState = ComposerOwnershipState & Pick<RuntimeState, "stream">;
+
 /** Resume the persistent Direct editor. Explicit Direct ownership also retires
  * a pending retake so late settlement cannot resurrect it.
  *
@@ -43,9 +48,20 @@ export function resumeDirectComposer(
   return prompt !== null;
 }
 
-export function openDirectComposer(state: ComposerOwnershipState): void {
+/** Open the persistent Direct editor, and report whether the writer got it.
+ * A claim burns the composer claim epoch, and the in-flight submission's own
+ * draft is fenced by that epoch, so claiming mid-stream strands the prompt
+ * exactly when a failed generation needs it back. Refuse instead, and leave
+ * the wording to the caller that knows which door the writer used.
+ *
+ * The condition is the live stream rather than generationBusy: Stop clears
+ * the stream but holds the abort fence until the task settles, and the writer
+ * must still be able to reopen the editor on the draft Stop just restored. */
+export function openDirectComposer(state: DirectClaimState): boolean {
+  if (state.stream !== null) return false;
   claimDirectComposer(state);
   state.mode = "COMPOSE";
+  return true;
 }
 
 export function capturePendingDirectDraft(

--- a/tui/src/generation-action.ts
+++ b/tui/src/generation-action.ts
@@ -42,6 +42,14 @@ export function generationBusy(state: Pick<StoryScreenState, "stream" | "abort">
   return state.stream !== null || state.abort?.kind === "generation";
 }
 
+/** Narrower than generationBusy: only while the model is still streaming.
+ * Stop clears the stream but holds the abort fence until the task settles,
+ * and the writer must be able to reach the draft Stop just restored, so a
+ * composer claim gates on this and not on generationBusy. */
+export function streamLive(state: Pick<StoryScreenState, "stream">): boolean {
+  return state.stream !== null;
+}
+
 /** Escape hides the transient stream now; its task keeps the abort fence. */
 export function requestGenerationStop(state: RuntimeState, repaint: () => void): void {
   const active = state.abort?.kind === "generation" ? state.abort : null;

--- a/tui/src/keys.ts
+++ b/tui/src/keys.ts
@@ -251,6 +251,7 @@ export function pasteInto(
     retakePrompt: RetakePromptSession | null;
     pendingGenerationDraft: PendingGenerationDraft | null;
     composerClaimEpoch: number;
+    stream: RuntimeState["stream"];
   },
   raw: string
 ): boolean {
@@ -342,7 +343,13 @@ export function pasteInto(
     return true;
   }
   if (isPlainNavigation(state)) {
-    openDirectComposer(state);
+    // A refused claim leaves no visible editor, so inserting here would bury
+    // the pasted text in a composer the writer cannot see, on top of the
+    // submitted draft. Consume the paste and say why instead.
+    if (!openDirectComposer(state)) {
+      state.toast = "stream running · esc stops it first";
+      return true;
+    }
     insertComposerText(state.composer, clean);
     return true;
   }

--- a/tui/src/overlay-actions.ts
+++ b/tui/src/overlay-actions.ts
@@ -20,7 +20,7 @@ import {
   openFactsBudgetEditor,
   openPhraseBiasEditor
 } from "./editor-action.js";
-import { generationBusy, openTag, runPartAction } from "./story-actions.js";
+import { generationBusy, openTag, runPartAction, streamLive } from "./story-actions.js";
 import { openDirectComposer } from "./composer-ownership.js";
 import { createUnusedTakesPrunePlan } from "./prune-model.js";
 import { chaptersAction, createBreakAtFocus, openChapters } from "./chapter-actions.js";
@@ -488,7 +488,11 @@ async function commandsAction(resolved: ResolvedKey, state: RuntimeState, source
 }
 
 async function runCommand(command: PaletteCommand, state: RuntimeState, source: AppSource, context: OverlayActionContext): Promise<void> {
-  if (command.mutating === true && generationBusy(state)) {
+  // Both refusals belong here, ahead of the `state.mode = "NAV"` below: a
+  // command that refuses after that commit strands whatever surface the
+  // palette was opened from, the trap the next-request branch documents.
+  if ((command.mutating === true && generationBusy(state))
+    || (command.blockedByLiveStream === true && streamLive(state))) {
     state.toast = "stream running · esc stops it first";
     return;
   }

--- a/tui/src/story-actions.ts
+++ b/tui/src/story-actions.ts
@@ -74,6 +74,7 @@ export type { ActionContext } from "./action-context.js";
 export {
   generate,
   generationBusy,
+  streamLive,
   requestGenerationStop,
   restorePendingGenerationDraft,
   restoreStoppedGenerationDraft
@@ -159,7 +160,9 @@ export async function navAction(
       queueThoughtLoad(state, source, context, view);
     }
   }
-  else if (resolved.action === "compose") openDirectComposer(state);
+  else if (resolved.action === "compose") {
+    if (!openDirectComposer(state)) state.toast = "stream running · esc stops it first";
+  }
   else if (resolved.action === "new-item") await createNewStory(state, source, context);
   else if (resolved.action === "continue") {
     if (generationBusy(state)) state.toast = "stream running · esc stops it first";
@@ -344,7 +347,9 @@ export async function runPartAction(
   }
   if (id === "continue") await context.backend.run("generating prose", (task) =>
     generate(state, source, context.cache, context.repaint, "", null, null, task));
-  else if (id === "direct") openDirectComposer(state);
+  else if (id === "direct") {
+    if (!openDirectComposer(state)) state.toast = "stream running · esc stops it first";
+  }
   else if (id === "retake") await context.backend.run("retaking prose", (task) =>
     generate(state, source, context.cache, context.repaint, node.instruction, node, null, task));
   else if (id === "retake-with-prompt") openRetakeComposer(state, node.id, node.instruction, { kind: "retake" });

--- a/tui/test/generation-draft-restoration.test.ts
+++ b/tui/test/generation-draft-restoration.test.ts
@@ -15,6 +15,9 @@ import {
   restoreStoppedGenerationDraft
 } from "../src/generation-action.js";
 import { composeAction, navAction, runPartAction } from "../src/story-actions.js";
+import { handleOverlayAction } from "../src/overlay-actions.js";
+import { pasteInto } from "../src/keys.js";
+import type { AppSource } from "../src/app.js";
 import { createStoryViewModel, rowIndexForNode } from "../src/model.js";
 import { nextRequestContext } from "../src/request-context.js";
 import { renderStoryScreen } from "../src/screens/story.js";
@@ -38,6 +41,16 @@ function context(state: RuntimeState) {
     applyTheme: () => undefined,
     previewTheme: () => undefined,
     backend: new ActionRuntime(state, () => undefined)
+  };
+}
+
+/** NAV is the only mode that binds `open-commands` (reference-bindings.ts),
+ *  so a palette session can only ever return to NAV. */
+function openCommandPalette(state: RuntimeState): void {
+  state.mode = "COMMANDS";
+  state.commands = {
+    query: "direct take", cursor: 0, selectedId: "direct-take",
+    view: "commands", returnMode: "NAV"
   };
 }
 
@@ -545,6 +558,117 @@ describe("generation draft restoration", () => {
     expect(promptedRetake.composer).toBe(newerRetake.composer);
     expect(promptedRetake.composer.text).toBe("");
   });
+
+  // Every door into the Direct editor claims it, and a claim mid-stream burns
+  // the epoch that fences the submitted draft. Cover the doors, not one key.
+  // A retake or rewrite prompt burns the same epoch and is deliberately still
+  // allowed mid-stream, so these cover the Direct doors and not the whole
+  // class of draft loss.
+  const DIRECT_CLAIM_DOORS: Array<{
+    name: string;
+    claim: (state: RuntimeState, source: AppSource) => Promise<void>;
+    /** A refused palette command keeps the palette open, so the writer stays
+     *  where the command was typed. The other doors refuse in place in NAV. */
+    refusedMode: RuntimeState["mode"];
+  }> = [
+    {
+      name: "NAV compose",
+      refusedMode: "NAV",
+      claim: (state, source) =>
+        navAction({ action: "compose" }, state, source, context(state), () => undefined)
+    },
+    {
+      name: "actions menu Direct",
+      refusedMode: "NAV",
+      claim: (state, source) => runPartAction("direct", state, source, context(state))
+    },
+    {
+      name: "command palette direct take",
+      refusedMode: "COMMANDS",
+      claim: async (state, source) => {
+        openCommandPalette(state);
+        await handleOverlayAction({ action: "open-selected" }, state, source, context(state));
+      }
+    },
+    {
+      name: "paste into NAV",
+      refusedMode: "NAV",
+      claim: async (state) => void pasteInto(state, "pasted while it streams")
+    }
+  ];
+
+  for (const door of DIRECT_CLAIM_DOORS) {
+    test(`${door.name} during a running stream keeps the submitted draft restorable`, async () => {
+      const source = demoAppSource();
+      const state = initialState(source, false);
+      const entered = deferred<void>();
+      const gate = deferred<null>();
+      state.mode = "COMPOSE";
+      state.composer = createComposer("keep this while it streams");
+      source.api.continueStory = async () => {
+        entered.resolve();
+        return gate.promise;
+      };
+
+      const pending = composeAction({ action: "send" }, state, source, context(state));
+      await entered.promise;
+      const submittedDraft = state.pendingGenerationDraft;
+      const claimEpoch = state.composerClaimEpoch;
+      expect(state.mode).toBe("NAV");
+      expect(state.composer.text).toBe("");
+
+      await door.claim(state, source);
+
+      expect(state.mode).toBe(door.refusedMode);
+      expect(state.composerClaimEpoch).toBe(claimEpoch);
+      expect(state.composer.text).toBe("");
+      expect(state.toast).toBe("stream running · esc stops it first");
+
+      gate.resolve(null);
+      await pending;
+
+      expect(state.composer.text).toBe("keep this while it streams");
+      expect(state.pendingGenerationDraft).toMatchObject({ restored: true });
+      expect(state.pendingGenerationDraft).toBe(submittedDraft);
+    });
+  }
+
+  // The refusal gates on the live stream and not on generationBusy, which
+  // stays true through post-Stop settlement. Every door has to reopen the
+  // draft Stop just restored, or the writer cannot reach their own prompt.
+  for (const door of DIRECT_CLAIM_DOORS) {
+    test(`${door.name} reopens the restored draft while Stop settles`, async () => {
+      const source = demoAppSource();
+      const state = initialState(source, false);
+      const entered = deferred<void>();
+      state.mode = "COMPOSE";
+      state.composer = createComposer("reopen this after stopping");
+      source.api.continueStory = async (
+        _storyId, _instruction, _genId, _target, _onDelta, signal
+      ) => {
+        entered.resolve();
+        await new Promise<void>((_resolve, reject) => {
+          signal.addEventListener("abort", () => reject(new Error("aborted")), { once: true });
+        });
+        return null;
+      };
+
+      const pending = composeAction({ action: "send" }, state, source, context(state));
+      await entered.promise;
+      requestGenerationStop(state, () => undefined);
+
+      expect(state.stream).toBe(null);
+      expect(state.abort).not.toBe(null);
+      expect(state.composer.text).toBe("reopen this after stopping");
+      state.mode = "NAV";
+
+      await door.claim(state, source);
+
+      expect(state.mode).toBe("COMPOSE");
+      expect(state.composer.text).toContain("reopen this after stopping");
+      await pending;
+    });
+  }
 
   test("late settlement cannot resurrect a restored Direct draft the writer deleted", () => {
     const state = initialState(demoAppSource(), false);

--- a/tui/test/keys-paste.test.ts
+++ b/tui/test/keys-paste.test.ts
@@ -8,7 +8,7 @@ test("paste inserts at the composer cursor and flattens single-line prompts", ()
     editor: null, settings: null, card: null, archive: null,
     prune: null, chapterDeleteArmedId: null, actions: null, retakePrompt: null,
     composerScrollTop: 0, history: [] as string[], historyIndex: 0, historyDraft: null,
-    pendingGenerationDraft: null, composerClaimEpoch: 0
+    pendingGenerationDraft: null, composerClaimEpoch: 0, stream: null
   };
   base.composer.cursor = 1;
   const compose = { ...base, mode: "COMPOSE" as const };


### PR DESCRIPTION
Closes #143

A claim on the Direct editor increments `composerClaimEpoch`. The in-flight submission captured the previous epoch, so every settlement path in `generation-action.ts` then refuses its draft. Press `Enter` during a slow generation and the submitted prompt is gone, which hurts most when the generation fails.

Four doors reached the claim and all four had the defect: the NAV compose key, the actions menu `Direct` entry, the command palette `direct take`, and a paste into plain NAV.

## What changed

The refusal moved into `openDirectComposer`, which now reports whether the writer got the editor. Its state type requires `stream`, so a caller that cannot answer the question is a type error rather than a silent gap.

The palette refuses through a new `blockedByLiveStream` precondition instead of in the command body. `runCommand` nulls the palette and commits to NAV before it dispatches, so a body refusal strands whatever surface the palette was opened from. The `next-request` branch documents that same trap.

The paste door consumes the paste and explains itself, rather than burying the text in an editor that never became visible.

## Why the live stream and not generationBusy

`requestGenerationStop` clears the stream but holds the abort fence until the task settles. Gating on `generationBusy` locked the writer out of the draft Stop had just restored, which broke `input-lanes.test.ts`. `streamLive` names the narrower predicate beside `generationBusy`.

## Tests

`generation-draft-restoration.test.ts` covers all four doors twice: a refusal mid-stream that keeps the draft restorable, and a successful reopen during post-Stop settlement. The palette door also asserts that a refusal leaves the palette open.

Mutation checks: removing the guard fails exactly the four mid-stream door tests; swapping `blockedByLiveStream` for `mutating` fails exactly the palette settlement test.

TUI suite green on this base (1822 pass, 4 skip, 0 fail), typecheck clean.

https://claude.ai/code/session_018bZDAgdqNoAx2WbS2uLT2z