### PR TITLE
chore(release): prepare 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -264,7 +264,7 @@ This file records notable changes to 1667. Product terms use the definitions in
   command accepts one or more JSON or PNG files. It adds their Facts to the
   story that `--story` names. Thanks @10fra for the request.
 
-## 0.8.0-rc.1 - 2026-08-11
+## 0.8.0 - 2026-08-11
 
 - **1667 prepares to send images to a model.** This release contains the
   complete Image Input implementation and keeps every entry point closed. It

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "1667-workspace",
-  "version": "0.8.0-rc.1",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "1667-workspace",
-      "version": "0.8.0-rc.1",
+      "version": "0.8.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@silvia-odwyer/photon-node": "0.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667-workspace",
-  "version": "0.8.0-rc.1",
+  "version": "0.8.0",
   "private": true,
   "description": "Source workspace for the 1667 terminal writing environment",
   "license": "Apache-2.0",

--- a/shared/release-notes.ts
+++ b/shared/release-notes.ts
@@ -11,7 +11,7 @@ export interface ReleaseNote {
  *  a release, and is not included. */
 export const RELEASE_NOTES: readonly ReleaseNote[] = [
   {
-    version: "0.8.0-rc.1",
+    version: "0.8.0",
     date: "2026-08-11",
     body: "- **1667 prepares to send images to a model.** This release contains the\n  complete Image Input implementation and keeps every entry point closed. It\n  cannot attach an image yet. 1667 releases a new storage schema in two steps:\n  this release reads and validates the successor story and settings documents\n  and refuses to change them, and the next release writes them. That order lets\n  a writer go back one version without losing a story or a setting. The next\n  release opens the feature."
   },

--- a/tui/package.json
+++ b/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667",
-  "version": "0.8.0-rc.1",
+  "version": "0.8.0",
   "private": true,
   "description": "A terminal environment for writing fiction with language models",
   "license": "Apache-2.0",


### PR DESCRIPTION
Promote the verified 0.8.0-rc.1 contents to stable 0.8.0.

Closes #153