### PR TITLE
chore(release): prepare 0.9.0-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,22 +5,6 @@ This file records notable changes to 1667. Product terms use the definitions in
 
 ## Unreleased
 
-- **A story that fills the context window can summarize again.** Before this
-  fix, a story that grew to fill the model's context window could not write
-  and could not summarize either: the one operation that shortens the story
-  was refused for being too long itself. 1667 now looks backward for an
-  earlier point that still fits and summarizes there instead. It tells you
-  when the summary covers less than you asked for, and names the point where
-  it stopped. It refuses only when no point fits at all, and that message now
-  names a fix you can act on. Thanks to @10fra.
-
-- **You can attach an image to a request.** Paste an image, or run `attach
-  image` and give a path. The composer shows a row for each attached image.
-  1667 sends the images with your instruction, and the take keeps them, so a
-  later request in the same line sends them again. 1667 offers this only when
-  the selected model states that it accepts images. 1667 does not offer image
-  attachment when it cannot tell. Thanks to @10fra.
-
 - **1667 no longer ends a generation while a model server is still
   processing the prompt.** Prefill is the model server's work before it
   sends the first output token. The server sends no stream output while it
@@ -279,6 +263,24 @@ This file records notable changes to 1667. Product terms use the definitions in
   palette opens a path prompt with `Tab` completion. The `1667 import-card`
   command accepts one or more JSON or PNG files. It adds their Facts to the
   story that `--story` names. Thanks @10fra for the request.
+
+## 0.9.0-rc.1 - 2026-08-12
+
+- **A story that fills the context window can summarize again.** Before this
+  fix, a story that grew to fill the model's context window could not write
+  and could not summarize either: the one operation that shortens the story
+  was refused for being too long itself. 1667 now looks backward for an
+  earlier point that still fits and summarizes there instead. It tells you
+  when the summary covers less than you asked for, and names the point where
+  it stopped. It refuses only when no point fits at all, and that message now
+  names a fix you can act on. Thanks to @10fra.
+
+- **You can attach an image to a request.** Paste an image, or run `attach
+  image` and give a path. The composer shows a row for each attached image.
+  1667 sends the images with your instruction, and the take keeps them, so a
+  later request in the same line sends them again. 1667 offers this only when
+  the selected model states that it accepts images. 1667 does not offer image
+  attachment when it cannot tell. Thanks to @10fra.
 
 ## 0.8.0 - 2026-08-11
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "1667-workspace",
-  "version": "0.8.0",
+  "version": "0.9.0-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "1667-workspace",
-      "version": "0.8.0",
+      "version": "0.9.0-rc.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@silvia-odwyer/photon-node": "0.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667-workspace",
-  "version": "0.8.0",
+  "version": "0.9.0-rc.1",
   "private": true,
   "description": "Source workspace for the 1667 terminal writing environment",
   "license": "Apache-2.0",

--- a/shared/release-notes.ts
+++ b/shared/release-notes.ts
@@ -11,6 +11,11 @@ export interface ReleaseNote {
  *  a release, and is not included. */
 export const RELEASE_NOTES: readonly ReleaseNote[] = [
   {
+    version: "0.9.0-rc.1",
+    date: "2026-08-12",
+    body: "- **A story that fills the context window can summarize again.** Before this\n  fix, a story that grew to fill the model's context window could not write\n  and could not summarize either: the one operation that shortens the story\n  was refused for being too long itself. 1667 now looks backward for an\n  earlier point that still fits and summarizes there instead. It tells you\n  when the summary covers less than you asked for, and names the point where\n  it stopped. It refuses only when no point fits at all, and that message now\n  names a fix you can act on. Thanks to @10fra.\n\n- **You can attach an image to a request.** Paste an image, or run `attach\n  image` and give a path. The composer shows a row for each attached image.\n  1667 sends the images with your instruction, and the take keeps them, so a\n  later request in the same line sends them again. 1667 offers this only when\n  the selected model states that it accepts images. 1667 does not offer image\n  attachment when it cannot tell. Thanks to @10fra."
+  },
+  {
     version: "0.8.0",
     date: "2026-08-11",
     body: "- **1667 prepares to send images to a model.** This release contains the\n  complete Image Input implementation and keeps every entry point closed. It\n  cannot attach an image yet. 1667 releases a new storage schema in two steps:\n  this release reads and validates the successor story and settings documents\n  and refuses to change them, and the next release writes them. That order lets\n  a writer go back one version without losing a story or a setting. The next\n  release opens the feature."

--- a/tui/package.json
+++ b/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667",
-  "version": "0.8.0",
+  "version": "0.9.0-rc.1",
   "private": true,
   "description": "A terminal environment for writing fiction with language models",
   "license": "Apache-2.0",


### PR DESCRIPTION
Prepare the 0.9.0 release candidate.

- Set the workspace and TUI versions.
- Add image attachment and summary-fit release notes.
- Regenerate the release-note registry.

Closes #160