### PR TITLE
fix(vault): prefer the innermost vault registration

### DIFF
--- a/server/vault-key-registry.ts
+++ b/server/vault-key-registry.ts
@@ -50,14 +50,18 @@ export function vaultKeyForPath(file: string): Buffer | null {
   // read/write hot path for an unsealed project.
   if (keys.size === 0) return null;
   const resolved = path.resolve(file);
+  let selected: { readonly root: string; readonly registration: VaultKeyRegistrationImpl } | null = null;
   for (const [root, registration] of keys) {
     const relative = path.relative(root, resolved);
     if (relative === "" || relative === ".." || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) {
       continue;
     }
-    if (!isVaultControlPath(root, resolved)) return registration.key;
+    if (selected === null || root.length > selected.root.length) {
+      selected = { root, registration };
+    }
   }
-  return null;
+  if (selected === null || isVaultControlPath(selected.root, resolved)) return null;
+  return selected.registration.key;
 }
 
 class VaultKeyRegistrationImpl implements VaultKeyRegistration {

--- a/test/vault-storage-hooks.integration.test.ts
+++ b/test/vault-storage-hooks.integration.test.ts
@@ -91,20 +91,24 @@ test("a nested vault registration takes precedence over its containing vault", a
   t.after(async () => await rm(outer, { recursive: true, force: true }));
   const inner = path.join(outer, "nested", ".1667");
   await mkdir(inner, { recursive: true });
-  const outerKey = randomBytes(32);
-  const innerKey = randomBytes(32);
-  const outerRegistration = registerVaultKey(outer, outerKey);
-  const innerRegistration = registerVaultKey(inner, innerKey);
-  t.after(() => {
-    innerRegistration.clear();
-    outerRegistration.clear();
-  });
 
-  assert.deepEqual(
-    vaultKeyForPath(path.join(inner, "story.json")),
-    innerKey
-  );
-  assert.equal(vaultKeyForPath(path.join(inner, "vault.json")), null);
+  // Containment decides which vault seals a file, so the order the two vaults
+  // registered in must not change any of these four answers.
+  for (const outerFirst of [true, false]) {
+    const outerKey = randomBytes(32);
+    const innerKey = randomBytes(32);
+    const registrations = outerFirst
+      ? [registerVaultKey(outer, outerKey), registerVaultKey(inner, innerKey)]
+      : [registerVaultKey(inner, innerKey), registerVaultKey(outer, outerKey)];
+    try {
+      assert.deepEqual(vaultKeyForPath(path.join(inner, "story.json")), innerKey);
+      assert.equal(vaultKeyForPath(path.join(inner, "vault.json")), null);
+      assert.deepEqual(vaultKeyForPath(path.join(outer, "story.json")), outerKey);
+      assert.equal(vaultKeyForPath(path.join(outer, "vault.json")), null);
+    } finally {
+      for (const registration of registrations) registration.clear();
+    }
+  }
 });
 
 test("only the documented story cleanup marker remains plaintext", async (t) => {

--- a/test/vault-storage-hooks.integration.test.ts
+++ b/test/vault-storage-hooks.integration.test.ts
@@ -86,6 +86,27 @@ test("an alias collision can clear a failed scoped registration without leaving 
   assert.equal(registeredKey!.every((byte) => byte === 0), true);
 });
 
+test("a nested vault registration takes precedence over its containing vault", async (t) => {
+  const outer = await mkdtemp(path.join(tmpdir(), "1667-vault-nested-registration-"));
+  t.after(async () => await rm(outer, { recursive: true, force: true }));
+  const inner = path.join(outer, "nested", ".1667");
+  await mkdir(inner, { recursive: true });
+  const outerKey = randomBytes(32);
+  const innerKey = randomBytes(32);
+  const outerRegistration = registerVaultKey(outer, outerKey);
+  const innerRegistration = registerVaultKey(inner, innerKey);
+  t.after(() => {
+    innerRegistration.clear();
+    outerRegistration.clear();
+  });
+
+  assert.deepEqual(
+    vaultKeyForPath(path.join(inner, "story.json")),
+    innerKey
+  );
+  assert.equal(vaultKeyForPath(path.join(inner, "vault.json")), null);
+});
+
 test("only the documented story cleanup marker remains plaintext", async (t) => {
   const root = await mkdtemp(path.join(tmpdir(), "1667-vault-cleanup-control-"));
   t.after(async () => await rm(root, { recursive: true, force: true }));


### PR DESCRIPTION
Closes #161

## Summary

`vaultKeyForPath` picked a vault by registration order rather than by containment. This makes the selection depend on containment, and stops a vault's own Keyslot from being sealed under a different vault's key.

## The defect

The function returned the first registered root containing the file, then checked the control-path rule against that root:

```ts
for (const [root, registration] of keys) {
  if (!contained) continue;
  if (!isVaultControlPath(root, resolved)) return registration.key;
  // a control path falls through to the next root
}
```

Two things follow. `keys` is a `Map`, so "first match" means whichever registered first, not the innermost. And when the innermost match *was* a control path the loop did not stop: it fell through and could return an outer vault's key, sealing a file that must stay plaintext. `.1667/vault.json` is the Keyslot, which holds the sealed Vault Key. Sealing it under another vault's key means the inner vault cannot be opened without the outer key.

With two vaults registered, one nested inside the other, the code on `main` gives:

```
a story file inside the nested vault -> OUTER key      (expected INNER key)
the nested vault's own vault.json    -> OUTER key      (expected null, plaintext)
```

## Reachability: this is latent, not a live defect

Both effects need two registrations to coexist, and no shipping call site creates that. `server/worker.ts:305` refuses a second bootstrap with a 409 and clears the previous registration; `tui/src/worker-api.ts:62` registers one vault per lock acquisition and clears it on any failure. A single registration can hold several roots through `addAlias`, but those roots are disjoint rather than nested: on Linux the lock's `authorityPath` is `/proc/self/fd/<n>`, not a path below the data directory.

So this fixes a wrong invariant rather than a user-visible failure. It is worth fixing on its own terms, because the wrongness is silent, unrecoverable, and sits directly on the read/write path, but the PR should not be read as repairing something users hit today.

The reachable variant of the same defect is **#164**: `1667 encrypt` classifies files against its own root without consulting this registry, so it seals a nested vault's Keyslot with the outer key. That needs no second registration.

## The fix

Select the innermost containing vault (the longest matching root), then apply the control-path rule to that vault:

```ts
if (selected === null || isVaultControlPath(selected.root, resolved)) return null;
return selected.registration.key;
```

An innermost match that is a control file now returns null instead of falling through.

## Verification

- new integration test: a story file under the nested vault gets the inner key, that vault's own `vault.json` returns null, and the outer vault still seals its own files
- the test runs under both registration orders, so it pins ordering independence rather than one example of it
- mutation: restoring `main`'s version fails exactly that test; so does a "last matching registration wins" mutant, which the first version of the test let through
- server suite 2549 pass / 0 fail; `tsc --noEmit` and `schema:check` clean

## Known gap, filed not fixed

**#165**: the module decides identity with case-sensitive `Map` keys but containment with `path.relative`, which ignores case on win32. Two roots differing only in case therefore tie on length, and the tie resolves by insertion order. Both reviewers found this independently. It is pre-existing, unreachable on POSIX, and needs two registrations, so it is not a blocker here; #165 carries the fix and the ancestor-walk simplification it unblocks.

## Provenance

The fix and its test were written on the unmerged `encrypt` branch before vault encryption landed on `main` by a different route. The rest of that branch is superseded by what shipped; this was the only part still missing, so it is cherry-picked here on its own rather than merged with 177 commits of duplicate feature work.
