### PR TITLE
fix(summary): stop capping a chapter summary at its own target

### DIFF
--- a/server/chapter-summary.ts
+++ b/server/chapter-summary.ts
@@ -55,7 +55,7 @@ export async function summarizeChapter(
     chapter.parts,
     signal,
     {
-      maxOutputTokens: SUMMARY_TARGET_TOKENS,
+      targetTokens: SUMMARY_TARGET_TOKENS,
       providerStarted: options.providerStarted,
       promptCache: createPromptCacheRequest(
         promptCacheRuntime,

--- a/server/summary-take.ts
+++ b/server/summary-take.ts
@@ -248,14 +248,15 @@ export async function generateSummaryText(
   parts: readonly StoryNode[],
   signal: AbortSignal,
   options: {
-    maxOutputTokens?: number;
+    /** The size the prompt asks for, not a ceiling. See `planSummary`. */
+    targetTokens?: number;
     providerStarted?: () => void | Promise<void>;
     promptCache?: PromptCacheRequest;
   } = {}
 ): Promise<GeneratedSummaryText> {
   const tag = randomUUID().slice(0, 8);
   const marker = `[[summary-complete-${tag}]]`;
-  const plan = planSummary(settings, title, parts, tag, options.maxOutputTokens);
+  const plan = planSummary(settings, title, parts, tag, options.targetTokens);
   const outcome: StreamOutcome = {
     finishReason: null,
     providerTerminal: false
@@ -313,21 +314,35 @@ function summaryPromptRoom(
   return { prompt, room: Math.floor(settings.contextWindow * 0.9) - input };
 }
 
+/** `targetTokens` sizes the summary the prompt asks for. It is not the
+ *  ceiling: the ceiling is the profile's own max output, so a summary that
+ *  runs slightly past its target can still finish its last sentence and emit
+ *  the completion marker `extractConfirmedSummary` requires. Holding the two
+ *  at one number truncated every chapter summary exactly at its target, which
+ *  left no marker, so the result was refused and nothing was saved. */
 function planSummary(
   settings: GenerationSettings,
   title: string,
   prefix: readonly StoryNode[],
   tag: string,
-  maxOutputTokens = settings.maxTokens
+  targetTokens = settings.maxTokens
 ): SummaryPlan {
-  const outputBudget = Math.min(settings.maxTokens, maxOutputTokens);
-  const { prompt, room } = summaryPromptRoom(settings, title, prefix, tag, outputBudget);
-  if (room === null) return { prompt, outputBudget, windowBound: false };
-  if (room < Math.min(MIN_SUMMARY_TOKENS, outputBudget)) {
+  const cap = settings.maxTokens;
+  const target = Math.max(1, Math.min(targetTokens, cap));
+  const { prompt, room } = summaryPromptRoom(settings, title, prefix, tag, target);
+  if (room === null) return { prompt, outputBudget: cap, windowBound: false };
+  if (room < Math.min(MIN_SUMMARY_TOKENS, cap)) {
     throw new HttpError(422, "The story prefix alone nearly fills the configured context window, leaving no room for its summary. Choose an earlier summary point or grow the story from an existing summary.");
   }
-  if (room >= outputBudget) return { prompt, outputBudget, windowBound: false };
-  return { prompt: summaryTakePrompt(title, prefix, room, tag), outputBudget: room, windowBound: true };
+  if (room >= cap) return { prompt, outputBudget: cap, windowBound: false };
+  // The window, not the profile, is the binding constraint here. Ask for no
+  // more than fits, and cap at exactly what is left.
+  const bounded = Math.min(target, room);
+  return {
+    prompt: bounded === target ? prompt : summaryTakePrompt(title, prefix, bounded, tag),
+    outputBudget: room,
+    windowBound: true
+  };
 }
 
 /** A fixed stand-in tag for search probes below — never sent to a model, so

--- a/test/summary-take.test.ts
+++ b/test/summary-take.test.ts
@@ -158,7 +158,12 @@ providerTest("summary take: output budget shrinks to window room", async (t) => 
   assert.ok((model.requests[0]!.max_tokens as number) < 1024);
 });
 
-providerTest("chapter summary: output budget stays within the compact chapter target", async (t) => {
+// The compact chapter target sizes what the prompt asks for. It is not the
+// ceiling. Holding the two at one number cut every chapter summary off at
+// exactly its target, so the completion marker never arrived and the result
+// was refused: the writer saw "increase Max output tokens" for a cap that no
+// setting could move.
+providerTest("chapter summary asks for the compact target but caps at the profile", async (t) => {
   const model = await fakeModel(t, (body, response) =>
     stream(response, [`Compact recap.\n${markerFrom(promptFrom(body))}`]));
   const base = await testApp(t, summarySettings(model.baseUrl, 4096, 1024));
@@ -170,7 +175,14 @@ providerTest("chapter summary: output budget stays within the compact chapter ta
 
   await json(`${base}/api/stories/${story.id}/chapter-breaks/${created.breakId}/summarize`, post({}));
 
-  assert.ok((model.requests[0]!.max_tokens as number) <= SUMMARY_TARGET_TOKENS);
+  const request = model.requests[0]!;
+  // Room above the target, so the last sentence and the marker both fit.
+  assert.equal(request.max_tokens, 1024);
+  assert.ok((request.max_tokens as number) > SUMMARY_TARGET_TOKENS);
+  // The prompt still asks for a compact recap, which is what the context
+  // projection assumes a chapter summary occupies.
+  const asked = Math.floor(SUMMARY_TARGET_TOKENS * 0.68).toLocaleString("en-US");
+  assert.match(promptFrom(request), new RegExp(`aim for up to ${asked} words`));
 });
 
 providerTest("chapter summary rejects an instruction-only source edit", async (t) => {


### PR DESCRIPTION
Closes #170

Summarizing a chapter always failed with *"The summary hit the output-token limit before finishing. Increase Max output tokens and try again; nothing was saved."* Raising Max output tokens changed nothing, and the model server showed the request capped at 240.

## Cause

`SUMMARY_TARGET_TOKENS` is 240. `chapter-summary.ts` passed it as `maxOutputTokens`, and `planSummary` took `min(profile max, 240)`, so 240 always won. The ceiling was a constant in the source, which is why the advice in the message could not work.

`planSummary` then fed that one number into both halves: `summaryTakePrompt` sized the summary it asked for from it, and `summarySettings` capped the response at it. So the model was asked to write about 240 tokens and cut off at exactly 240, with no room to finish its last sentence or emit the `[[summary-complete-...]]` marker. `extractConfirmedSummary` requires that marker, so the result was refused and nothing was saved. That is why it failed every time rather than occasionally.

## What changed

The target and the ceiling are now separate. `targetTokens` sizes what the prompt asks for; the ceiling is the profile max output. A chapter summary still aims at the compact size the context projection assumes, and now has room to finish.

A window-bound plan is unchanged in spirit: it still caps at the room left, and now also asks for no more than fits.

## Tests

The existing chapter-summary test asserted the old contract (`max_tokens <= SUMMARY_TARGET_TOKENS`), which was the bug written down. It now pins both halves: the request caps at the profile, and the prompt still asks for the compact target.

Mutation check: collapsing the ceiling back onto the target fails exactly that test.

Typecheck and `schema:check` clean; summary, chapters, and settings-codec suites green (105 pass).

https://claude.ai/code/session_018bZDAgdqNoAx2WbS2uLT2z