### PR TITLE
chore(release): prepare 0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -279,6 +279,10 @@ This file records notable changes to 1667. Product terms use the definitions in
   ends. It no longer tells you to stop a generation that has already ended.
   Thanks to @10fra.
 
+- **Sampling refusal text wraps instead of stopping at the panel edge.** A
+  refusal now keeps its complete reason and recovery instruction visible.
+  Thanks to @10fra.
+
 ## 0.9.0 - 2026-08-12
 
 - **A story that fills the context window can summarize again.** Before this

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -264,7 +264,7 @@ This file records notable changes to 1667. Product terms use the definitions in
   command accepts one or more JSON or PNG files. It adds their Facts to the
   story that `--story` names. Thanks @10fra for the request.
 
-## 0.9.1-rc.1 - 2026-08-12
+## 0.9.1 - 2026-08-12
 
 - **You can save an empty Author Brief.** Clear the Author Brief in Settings
   when you do not want a system instruction. 1667 now accepts and saves the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -264,7 +264,7 @@ This file records notable changes to 1667. Product terms use the definitions in
   command accepts one or more JSON or PNG files. It adds their Facts to the
   story that `--story` names. Thanks @10fra for the request.
 
-## 0.9.1 - 2026-08-12
+## 0.9.1 - 2026-08-13
 
 - **You can save an empty Author Brief.** Clear the Author Brief in Settings
   when you do not want a system instruction. 1667 now accepts and saves the

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "1667-workspace",
-  "version": "0.9.1-rc.1",
+  "version": "0.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "1667-workspace",
-      "version": "0.9.1-rc.1",
+      "version": "0.9.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@silvia-odwyer/photon-node": "0.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667-workspace",
-  "version": "0.9.1-rc.1",
+  "version": "0.9.1",
   "private": true,
   "description": "Source workspace for the 1667 terminal writing environment",
   "license": "Apache-2.0",

--- a/shared/release-notes.ts
+++ b/shared/release-notes.ts
@@ -13,7 +13,7 @@ export const RELEASE_NOTES: readonly ReleaseNote[] = [
   {
     version: "0.9.1",
     date: "2026-08-12",
-    body: "- **You can save an empty Author Brief.** Clear the Author Brief in Settings\n  when you do not want a system instruction. 1667 now accepts and saves the\n  empty value. Thanks to @10fra.\n\n- **Chapter summaries can finish.** 1667 no longer limits a chapter summary to\n  the same token count that it asks the model to target. The configured Max\n  output tokens value now gives the model space to finish. Thanks to @10fra.\n\n- **A generation refusal disappears when generation ends.** If you press a key\n  that 1667 refuses during generation, the refusal now clears when generation\n  ends. It no longer tells you to stop a generation that has already ended.\n  Thanks to @10fra."
+    body: "- **You can save an empty Author Brief.** Clear the Author Brief in Settings\n  when you do not want a system instruction. 1667 now accepts and saves the\n  empty value. Thanks to @10fra.\n\n- **Chapter summaries can finish.** 1667 no longer limits a chapter summary to\n  the same token count that it asks the model to target. The configured Max\n  output tokens value now gives the model space to finish. Thanks to @10fra.\n\n- **A generation refusal disappears when generation ends.** If you press a key\n  that 1667 refuses during generation, the refusal now clears when generation\n  ends. It no longer tells you to stop a generation that has already ended.\n  Thanks to @10fra.\n\n- **Sampling refusal text wraps instead of stopping at the panel edge.** A\n  refusal now keeps its complete reason and recovery instruction visible.\n  Thanks to @10fra."
   },
   {
     version: "0.9.0",

--- a/shared/release-notes.ts
+++ b/shared/release-notes.ts
@@ -12,7 +12,7 @@ export interface ReleaseNote {
 export const RELEASE_NOTES: readonly ReleaseNote[] = [
   {
     version: "0.9.1",
-    date: "2026-08-12",
+    date: "2026-08-13",
     body: "- **You can save an empty Author Brief.** Clear the Author Brief in Settings\n  when you do not want a system instruction. 1667 now accepts and saves the\n  empty value. Thanks to @10fra.\n\n- **Chapter summaries can finish.** 1667 no longer limits a chapter summary to\n  the same token count that it asks the model to target. The configured Max\n  output tokens value now gives the model space to finish. Thanks to @10fra.\n\n- **A generation refusal disappears when generation ends.** If you press a key\n  that 1667 refuses during generation, the refusal now clears when generation\n  ends. It no longer tells you to stop a generation that has already ended.\n  Thanks to @10fra.\n\n- **Sampling refusal text wraps instead of stopping at the panel edge.** A\n  refusal now keeps its complete reason and recovery instruction visible.\n  Thanks to @10fra."
   },
   {

--- a/shared/release-notes.ts
+++ b/shared/release-notes.ts
@@ -11,7 +11,7 @@ export interface ReleaseNote {
  *  a release, and is not included. */
 export const RELEASE_NOTES: readonly ReleaseNote[] = [
   {
-    version: "0.9.1-rc.1",
+    version: "0.9.1",
     date: "2026-08-12",
     body: "- **You can save an empty Author Brief.** Clear the Author Brief in Settings\n  when you do not want a system instruction. 1667 now accepts and saves the\n  empty value. Thanks to @10fra.\n\n- **Chapter summaries can finish.** 1667 no longer limits a chapter summary to\n  the same token count that it asks the model to target. The configured Max\n  output tokens value now gives the model space to finish. Thanks to @10fra.\n\n- **A generation refusal disappears when generation ends.** If you press a key\n  that 1667 refuses during generation, the refusal now clears when generation\n  ends. It no longer tells you to stop a generation that has already ended.\n  Thanks to @10fra."
   },

--- a/tui/package.json
+++ b/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667",
-  "version": "0.9.1-rc.1",
+  "version": "0.9.1",
   "private": true,
   "description": "A terminal environment for writing fiction with language models",
   "license": "Apache-2.0",


### PR DESCRIPTION
Promote the verified 0.9.1 release candidate to stable.

- Set the workspace and TUI versions to 0.9.1.
- Promote the release-note heading to 0.9.1.
- Regenerate the release-note registry.
- Include the Sampling refusal-wrap fix from #180, which merged before stable promotion.

Closes #177