### PR TITLE
fix(tui): wrap the sampling status instead of clipping it

### DIFF
--- a/tui/src/screens/sampling-panel.ts
+++ b/tui/src/screens/sampling-panel.ts
@@ -24,6 +24,7 @@ import {
 } from "./overlay.js";
 import { panelRowWindow, cellPadStart } from "./panel-table-layout.js";
 import { renderComposerInput } from "./story/composer.js";
+import { wrapFeedback } from "./feedback-wrap.js";
 import {
   truncate,
   visibleWidth,
@@ -47,7 +48,7 @@ export function renderSamplingPanel(
   const nested = settings.sampling!;
   const horizontal = panelHorizontalGeometry(width, 76);
   const contentWidth = horizontal.contentWidth;
-  const status = nested.result === null ? [] : [samplingStatus(nested.result, contentWidth)];
+  const status = nested.result === null ? [] : samplingStatus(nested.result, contentWidth);
   const content = nested.panel === "sampling"
     ? renderSamplingLayer(settings, contentWidth, height, status)
     : renderSamplingListLayer(settings, contentWidth, height, status, nested.panel);
@@ -429,9 +430,28 @@ function plainRow(prefix: string, value: string, width: number, selected: boolea
   ];
 }
 
-function samplingStatus(text: string, width: number): FrameLine {
+/** Decision 24's wrapping law, applied to the sampling panel's own status
+ *  row. This clipped to one line, which is worst for the message that most
+ *  needs reading: a rejected save states the reason in the tail, so a
+ *  provider refusal arrived as a sentence cut mid-word with no way to see
+ *  the rest. Continuation rows hang under the glyph, so the wrap measures
+ *  against the room they actually get. */
+const STATUS_ROW_CAP = 4;
+const STATUS_HANGING_INDENT = 2;
+
+function samplingStatus(text: string, width: number): FrameLine[] {
   const danger = text.includes("kept") || text.includes("disabled") || text.includes("limit");
-  return [raisedSegment(truncate(`  ${danger ? "▲" : "●"} ${text}`, width), danger ? "danger text" : "focus / accent")];
+  const role = danger ? "danger text" : "focus / accent";
+  const wrapped = wrapFeedback(
+    text, Math.max(8, width - 4 - STATUS_HANGING_INDENT), STATUS_ROW_CAP, "! full"
+  );
+  if (wrapped.rows.length === 0) return [];
+  return wrapped.rows.map((row, index): FrameLine => [
+    raisedSegment(
+      truncate(index === 0 ? `  ${danger ? "▲" : "●"} ${row}` : `    ${row}`, width),
+      role
+    )
+  ]);
 }
 
 interface SamplingFooter {

--- a/tui/test/sampling-settings.test.ts
+++ b/tui/test/sampling-settings.test.ts
@@ -1191,6 +1191,29 @@ function publishSamplingRefresh(
   });
 }
 
+// The status row clipped to one line, which is worst for the message that
+// most needs reading: a refused save states its reason in the tail, so the
+// writer saw a sentence cut mid-word with no way to reach the rest.
+test("a long sampling status wraps instead of losing its tail", async () => {
+  const { state, press } = settingsHarness();
+  await enterSampling(state, press);
+  // Comfortably past one row of a panel this wide, so a clip would have to
+  // drop something, and the tail is what a clip drops.
+  const reason = "logitBias must be an object, and the provider refused this"
+    + " draft because the phrase resolved to no usable token identifier at all"
+    + " · clear the entry or choose a model with an exact tokenizer";
+  state.settings!.sampling!.result = reason;
+
+  const frame = render(state, 80, 24);
+
+  // The tail carries the recovery, which is exactly what a one-line clip
+  // loses. Assert on fragments that survive a wrap boundary rather than the
+  // whole sentence, which the border splits across rows.
+  expect(frame).toContain("exact tokenizer");
+  expect(frame).toContain("logitBias must be an object");
+  expect(frame.split("\n").every((line) => visibleWidth(line) <= 80)).toBeTrue();
+});
+
 function render(
   state: ReturnType<typeof initialState>,
   width: number,


### PR DESCRIPTION
Closes #179

A refused sampling save states its reason in the tail, and this row truncated to the panel width. A banned-strings entry reported `logitBias must be an...` and stopped there, so the one message that had to be read to act on it was the one cut off.

## What changed

Decision 24 already defines the wrapping law for this feedback family, and `wrapFeedback` implements it, including the binding rule that the last row keeps the recovery text. The story toast uses it; this row did not. It does now, with a hanging indent under the glyph and the same row cap.

## On the test

Worth recording, because the first version of it was useless. It asserted on a message that fit within the panel at the test width, so clipping changed nothing and the mutation check passed with the fix reverted. The message is now comfortably longer than one row, and the assertions sit on the tail, which is what a clip destroys.

The second version then failed for a different reason: the recovery phrase wraps across a row boundary, so a whole-sentence `toContain` cannot match a rendered frame. It asserts on fragments that survive the wrap.

Mutation check, after both corrections: replacing the wrap with a single row fails exactly this test.

TUI suite 1847 tests, 0 fail, typecheck clean.

https://claude.ai/code/session_018bZDAgdqNoAx2WbS2uLT2z