### PR TITLE
chore(release): prepare 0.9.2-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,6 @@ This file records notable changes to 1667. Product terms use the definitions in
 
 ## Unreleased
 
-- **Local model servers keep the story-writing instruction during a
-  continuation.** An assistant prefill has no final user message. This path
-  could omit the operation contract and make a long continuation lose focus.
-  1667 now keeps the mode-independent part of the contract in the stable
-  prompt prefix. The mode-dependent part stays in the final user message when
-  that message exists.
-
 - **1667 no longer ends a generation while a model server is still
   processing the prompt.** Prefill is the model server's work before it
   sends the first output token. The server sends no stream output while it
@@ -260,6 +253,15 @@ This file records notable changes to 1667. Product terms use the definitions in
   palette opens a path prompt with `Tab` completion. The `1667 import-card`
   command accepts one or more JSON or PNG files. It adds their Facts to the
   story that `--story` names.
+
+## 0.9.2-rc.1 - 2026-08-13
+
+- **Local model servers keep the story-writing instruction during a
+  continuation.** An assistant prefill has no final user message. This path
+  could omit the operation contract and make a long continuation lose focus.
+  1667 now keeps the mode-independent part of the contract in the stable
+  prompt prefix. The mode-dependent part stays in the final user message when
+  that message exists.
 
 ## 0.9.1 - 2026-08-13
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "1667-workspace",
-  "version": "0.9.1",
+  "version": "0.9.2-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "1667-workspace",
-      "version": "0.9.1",
+      "version": "0.9.2-rc.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@silvia-odwyer/photon-node": "0.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667-workspace",
-  "version": "0.9.1",
+  "version": "0.9.2-rc.1",
   "private": true,
   "description": "Source workspace for the 1667 terminal writing environment",
   "license": "Apache-2.0",

--- a/shared/release-notes.ts
+++ b/shared/release-notes.ts
@@ -11,6 +11,11 @@ export interface ReleaseNote {
  *  a release, and is not included. */
 export const RELEASE_NOTES: readonly ReleaseNote[] = [
   {
+    version: "0.9.2-rc.1",
+    date: "2026-08-13",
+    body: "- **Local model servers keep the story-writing instruction during a\n  continuation.** An assistant prefill has no final user message. This path\n  could omit the operation contract and make a long continuation lose focus.\n  1667 now keeps the mode-independent part of the contract in the stable\n  prompt prefix. The mode-dependent part stays in the final user message when\n  that message exists."
+  },
+  {
     version: "0.9.1",
     date: "2026-08-13",
     body: "- **You can save an empty Author Brief.** Clear the Author Brief in Settings\n  when you do not want a system instruction. 1667 now accepts and saves the\n  empty value.\n\n- **Chapter summaries can finish.** 1667 no longer limits a chapter summary to\n  the same token count that it asks the model to target. The configured Max\n  output tokens value now gives the model space to finish.\n\n- **A generation refusal disappears when generation ends.** If you press a key\n  that 1667 refuses during generation, the refusal now clears when generation\n  ends. It no longer tells you to stop a generation that has already ended.\n\n- **Sampling refusal text wraps instead of stopping at the panel edge.** A\n  refusal now keeps its complete reason and recovery instruction visible."

--- a/tui/package.json
+++ b/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667",
-  "version": "0.9.1",
+  "version": "0.9.2-rc.1",
   "private": true,
   "description": "A terminal environment for writing fiction with language models",
   "license": "Apache-2.0",


### PR DESCRIPTION
Closes #186

Tracks #184

## Scope

- publish the local-model continuation contract fix as 0.9.2-rc.1
- keep the existing Unreleased backlog out of this patch release

## Checks

- npm run build
- npm test (2,348 pass; 223 skip; all 19 tokenize-probe cases pass directly)
- cd tui && bun run typecheck
- cd tui && bun test (1,845 pass; 2 platform skips)
- cd tui && bun bench/perf.ts
- cd tui && bun run build:standalone
- npm run notes:check-version -- 0.9.2-rc.1