### PR TITLE
fix: allow exact version downgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ This file records notable changes to 1667. Product terms use the definitions in
 
 ## Unreleased
 
+- **`1667 upgrade --version` can select an older release.** 1667 verifies the
+  exact published release before it replaces the current executable. Before it
+  downloads a downgrade, it warns that the downgrade can make the Vault
+  unreadable or damage Vault data. Back up the Vault before you continue. An
+  exact version does not change the saved update channel.
+
 - **1667 no longer ends a generation while a model server is still
   processing the prompt.** Prefill is the model server's work before it
   sends the first output token. The server sends no stream output while it

--- a/README.md
+++ b/README.md
@@ -59,6 +59,11 @@ created. The command shows download progress in a terminal. On Windows, exit
 1667 and run the PowerShell Installer again. The Installer shows download
 progress. `1667 upgrade` shows the required command.
 
+`1667 upgrade --version <version>` selects an exact published release. The
+version can be older than the current version. Before a downgrade, 1667 warns
+that the downgrade can make the Vault unreadable or damage Vault data. Back up
+the Vault before you continue.
+
 Install with npm:
 
 ```sh

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -546,11 +546,16 @@ SHA-512 integrity value. It extracts the Candidate. It probes the build
 identity. It uses a recoverable transaction to replace the executable. The
 transaction stays in the Install Root.
 
+`1667 upgrade --version <version>` selects an exact published release. The
+release can be older than the active release. Before a downgrade, 1667 warns
+that the downgrade can make the Vault unreadable or damage Vault data. An exact
+version does not change the update channel in the Ownership Record.
+
 `1667 upgrade --rollback` works offline.
 
 Windows does not replace the running `1667.exe` file. On Windows, `1667 upgrade`
 verifies the available release and shows the applicable PowerShell Installer
-command. The command downloads `install-stable.ps1` from the exact, immutable
+command. The command downloads `install-<channel>.ps1` from the exact, immutable
 `v<version>` GitHub release that the plan selected; it does not re-resolve the
 moving homepage route. Exit 1667 before you run that command. Run the same
 command again for an upgrade. The PowerShell Installer keeps the Installation

--- a/tui/src/upgrade-apply.ts
+++ b/tui/src/upgrade-apply.ts
@@ -1,4 +1,5 @@
 import { existsSync } from "node:fs";
+import { compareSemVer } from "../../shared/semver.js";
 import { releaseTargetForPackage } from "../../shared/release-targets.js";
 import type { InstallationAuthority } from "./install-ownership.js";
 import {
@@ -44,6 +45,7 @@ export interface UpgradeApplyDependencies {
   readonly fetcher?: RegistryFetch;
   readonly signal?: AbortSignal;
   readonly onDownloadProgress?: PackageDownloadProgressHandler;
+  readonly onDowngradeWarning?: (warning: string) => void;
   /** `--force`: accept an Install Root another account can write. */
   readonly force?: boolean;
 }
@@ -112,6 +114,9 @@ export async function applyUpgrade(
       }
       const targetVersion = plan.target;
       const meta = plan.platformMetadata;
+      if (compareSemVer(targetVersion, lockedVersion) < 0) {
+        dependencies.onDowngradeWarning?.(DOWNGRADE_WARNING);
+      }
       await downloadPlatformPackage({
         tarballUrl: meta.tarball,
         packageName: dependencies.observation.platformPackage,
@@ -150,6 +155,10 @@ export async function applyUpgrade(
     dependencies.force === true
   );
 }
+
+export const DOWNGRADE_WARNING =
+  "Warning: A downgrade can make the Vault unreadable or damage Vault data. "
+  + "Back up the Vault before you continue.\n";
 
 export async function applyRollback(
   dependencies: {

--- a/tui/src/upgrade-cli.ts
+++ b/tui/src/upgrade-cli.ts
@@ -1,4 +1,4 @@
-import { isSemVer } from "../../shared/semver.js";
+import { compareSemVer, isSemVer } from "../../shared/semver.js";
 import { AI_1667_PRODUCT_VERSION } from "../../shared/build-identity.js";
 import {
   heldTargetRefusal,
@@ -15,7 +15,11 @@ import {
   type PlatformPackage,
   type RegistryFetch
 } from "./npm-upgrade-registry.js";
-import { applyRollback, applyUpgrade } from "./upgrade-apply.js";
+import {
+  applyRollback,
+  applyUpgrade,
+  DOWNGRADE_WARNING
+} from "./upgrade-apply.js";
 import type { PackageDownloadProgressHandler } from "./upgrade-download.js";
 import { createUpgradeProgressRenderer } from "./upgrade-progress.js";
 import {
@@ -57,13 +61,17 @@ export const UPGRADE_HELP = `Usage:
 --force accepts an Install Root that another account on this machine can write.
 It waives no checksum, attestation, or version check.
 
+--version selects one exact published release. It can downgrade 1667.
+${DOWNGRADE_WARNING.trimEnd()}
+
 If you installed 1667 with npm, or you built it from source, update it the same
 way you installed it.
 On Windows, exit 1667 and run the PowerShell Installer again.`;
 
 export function windowsInstallCommand(
   installRoot: string,
-  targetVersion?: string
+  targetVersion?: string,
+  channel: UpgradeChannel = "stable"
 ): string {
   if (targetVersion !== undefined && !isSemVer(targetVersion)) {
     throw new TypeError("Windows Installer target version must be SemVer");
@@ -73,7 +81,7 @@ export function windowsInstallCommand(
     ? "https://1667.ai/install.ps1"
     : `https://github.com/1667-ai/1667/releases/download/v${
       encodeURIComponent(targetVersion)
-    }/install-stable.ps1`;
+    }/install-${channel}.ps1`;
   const script = `& ([scriptblock]::Create((irm ${installerUrl}))) `
     + "-InstallRoot '" + root + "'";
   return "powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -EncodedCommand "
@@ -91,6 +99,7 @@ export interface UpgradeCliDependencies {
   readonly signal?: AbortSignal;
   readonly defaultChannel?: UpgradeChannel;
   readonly onDownloadProgress?: PackageDownloadProgressHandler;
+  readonly onDowngradeWarning?: (warning: string) => void;
 }
 
 export interface UpgradeCliOutput {
@@ -151,6 +160,9 @@ export async function executeUpgradeCli(
   }
   const method = authorityMethod(authority);
   const registry = dependencies.registry ?? new NpmUpgradeRegistry(dependencies.fetcher);
+  const downgradeWarnings: string[] = [];
+  const onDowngradeWarning = dependencies.onDowngradeWarning
+    ?? ((warning: string) => downgradeWarnings.push(warning));
   try {
     const envelope = await dispatchUpgradeCommand(
       parsed.command,
@@ -160,20 +172,21 @@ export async function executeUpgradeCli(
       registry,
       dependencies,
       parsed.force,
-      parsed.json ? undefined : dependencies.onDownloadProgress
+      parsed.json ? undefined : dependencies.onDownloadProgress,
+      onDowngradeWarning
     );
     return {
       exitCode: 0,
       stdout: parsed.json
         ? `${JSON.stringify(envelope)}\n`
         : renderUpgrade(envelope, parsed.command),
-      stderr: "",
+      stderr: downgradeWarnings.join(""),
       envelope
     };
   } catch (error) {
     const failure = normalizeFailure(error);
     const exitCode = failure.code === "interrupted" ? 130 : 1;
-    return failedOutput(
+    const output = failedOutput(
       failure,
       parsed.json,
       observation,
@@ -181,6 +194,9 @@ export async function executeUpgradeCli(
       method,
       exitCode
     );
+    return downgradeWarnings.length === 0
+      ? output
+      : { ...output, stderr: downgradeWarnings.join("") + output.stderr };
   }
 }
 
@@ -192,7 +208,8 @@ async function dispatchUpgradeCommand(
   registry: UpgradeRegistry,
   dependencies: UpgradeCliDependencies,
   force: boolean,
-  onDownloadProgress: PackageDownloadProgressHandler | undefined
+  onDownloadProgress: PackageDownloadProgressHandler | undefined,
+  onDowngradeWarning: (warning: string) => void
 ): Promise<UpgradeSuccessEnvelope> {
   switch (command.kind) {
     case "rollback": {
@@ -238,6 +255,7 @@ async function dispatchUpgradeCommand(
           fetcher: dependencies.fetcher,
           signal: dependencies.signal,
           onDownloadProgress,
+          onDowngradeWarning,
           force
         });
       }
@@ -248,13 +266,27 @@ async function dispatchUpgradeCommand(
         registry,
         dependencies.signal
       );
-      const channelSwitch = authority.kind === "powershell"
+      const channelSwitch = command.version === null
+        && authority.kind === "powershell"
         && command.channel !== authority.channel;
-      if (method === "powershell" && (plan.status !== "up-to-date" || channelSwitch)) {
+      warnIfDowngrade(plan, onDowngradeWarning);
+      if (method === "powershell"
+        && command.version === null
+        && (plan.status !== "up-to-date" || channelSwitch)) {
         requireServableWindowsChannel(plan.channel);
       }
       return publicEnvelopeFromPlan(plan, authority, channelSwitch);
     }
+  }
+}
+
+function warnIfDowngrade(
+  plan: UpgradeCorePlan,
+  onDowngradeWarning: (warning: string) => void
+): void {
+  if (plan.status === "target-available"
+    && compareSemVer(plan.target, plan.current) < 0) {
+    onDowngradeWarning(DOWNGRADE_WARNING);
   }
 }
 
@@ -268,7 +300,9 @@ export function publicEnvelopeFromPlan(
   forcePowerShellInstall = false
 ): UpgradeSuccessEnvelope {
   const method = authorityMethod(authority);
-  if (forcePowerShellInstall && authority.kind === "powershell") {
+  if (forcePowerShellInstall
+    && authority.kind === "powershell"
+    && plan.status === "up-to-date") {
     return upgradeEnvelope({
       status: "manual",
       current: plan.current,
@@ -276,7 +310,7 @@ export function publicEnvelopeFromPlan(
       target: plan.latest,
       channel: plan.channel,
       method: "powershell",
-      command: windowsInstallCommand(authority.installRoot, plan.latest)
+      command: windowsInstallCommand(authority.installRoot, plan.latest, plan.channel)
     });
   }
   if (plan.status === "up-to-date") {
@@ -306,7 +340,7 @@ export function publicEnvelopeFromPlan(
       target: plan.target,
       channel: plan.channel,
       method: "powershell",
-      command: windowsInstallCommand(authority.installRoot, plan.target)
+      command: windowsInstallCommand(authority.installRoot, plan.target, plan.channel)
     });
   }
   return upgradeEnvelope({
@@ -364,7 +398,10 @@ export async function runProcessUpgrade(
       registry: new NpmUpgradeRegistry(fetcher),
       fetcher,
       defaultChannel: loadConfig().updates.channel,
-      onDownloadProgress
+      onDownloadProgress,
+      onDowngradeWarning: (warning) => {
+        process.stderr.write(warning);
+      }
     });
     if (output.stdout.length > 0) process.stdout.write(output.stdout);
     if (output.stderr.length > 0) process.stderr.write(output.stderr);
@@ -390,12 +427,18 @@ function renderUpgrade(
       lines.push(
         command.kind === "rollback"
           ? `Rolled back 1667 from ${envelope.current} to ${envelope.target}.`
-          : `Upgraded 1667 from ${envelope.current} to ${envelope.target}.`
+          : compareSemVer(envelope.target, envelope.current) < 0
+            ? `Downgraded 1667 from ${envelope.current} to ${envelope.target}.`
+            : `Upgraded 1667 from ${envelope.current} to ${envelope.target}.`
       );
       break;
     case "available":
     case "manual":
-      lines.push(`1667 ${envelope.target} is available on ${envelope.channel}.`);
+      lines.push(
+        command.kind === "apply" && command.version !== null
+          ? `1667 ${envelope.target} is available.`
+          : `1667 ${envelope.target} is available on ${envelope.channel}.`
+      );
       break;
   }
   // A Managed Installation says nothing about itself: the update it can do is

--- a/tui/src/upgrade-command.ts
+++ b/tui/src/upgrade-command.ts
@@ -11,7 +11,7 @@ export interface UpgradeCheckCommand {
   readonly channel: UpgradeChannel;
 }
 
-/** Apply or plan an upgrade for a channel head or exact version. */
+/** Apply or plan a channel head or one exact published version. */
 export interface UpgradeApplyCommand {
   readonly kind: "apply";
   readonly channel: UpgradeChannel;

--- a/tui/src/upgrade-plan.ts
+++ b/tui/src/upgrade-plan.ts
@@ -43,7 +43,7 @@ export interface UpgradeUpToDatePlan {
   readonly channel: UpgradeChannel;
 }
 
-/** Neutral plan: a newer channel head is available. Check has no metadata. */
+/** Neutral plan: a channel target is available. Check has no metadata. */
 export interface UpgradeCheckTargetPlan {
   readonly status: "target-available";
   readonly current: string;
@@ -53,7 +53,7 @@ export interface UpgradeCheckTargetPlan {
 }
 
 /**
- * Neutral plan: a newer channel head is available and platform metadata was
+ * Neutral plan: a requested target is available and platform metadata was
  * verified once. Apply reuses this metadata and does not fetch again.
  */
 export interface UpgradeApplyTargetPlan {
@@ -94,16 +94,9 @@ export async function planUpgrade(
   const version = command.kind === "apply" ? command.version : null;
   const latest = await registry.channelHead(command.channel, signal);
   if (signal.aborted) throw new UpgradeFailure("interrupted", "The update check was interrupted.");
-  if (version !== null && version !== latest) {
-    throw new UpgradeFailure(
-      "unsupported_target",
-      "The requested version is no longer the selected channel head."
-    );
-  }
-  if (!isSemVerUpgradeAvailable(latest, observation.currentVersion)) {
-    if (version !== null && latest !== observation.currentVersion) {
-      throw new UpgradeFailure("unsupported_target", "Downgrades are not supported.");
-    }
+  const target = version ?? latest;
+  if (target === observation.currentVersion
+    || (version === null && !isSemVerUpgradeAvailable(latest, observation.currentVersion))) {
     return upToDatePlan(observation.currentVersion, latest, command.channel);
   }
   if (command.kind === "check") {
@@ -120,8 +113,8 @@ export async function planUpgrade(
   let platformMetadata: NpmVersionMetadata;
   try {
     const [, platform] = await Promise.all([
-      registry.launcher(latest, observation.platformPackage, exactSignal),
-      registry.platform(observation.platformPackage, latest, exactSignal)
+      registry.launcher(target, observation.platformPackage, exactSignal),
+      registry.platform(observation.platformPackage, target, exactSignal)
     ]);
     platformMetadata = platform;
   } finally {
@@ -132,7 +125,7 @@ export async function planUpgrade(
     status: "target-available",
     current: observation.currentVersion,
     latest,
-    target: latest,
+    target,
     channel: command.channel,
     platformMetadata
   });

--- a/tui/test/managed-install-upgrade.test.ts
+++ b/tui/test/managed-install-upgrade.test.ts
@@ -22,6 +22,7 @@ import { createUpgradeProgressRenderer } from "../src/upgrade-progress.js";
 import {
   MANAGED_TEST_CURRENT as CURRENT,
   MANAGED_TEST_NEXT as NEXT,
+  MANAGED_TEST_OLDER as OLDER,
   MANAGED_TEST_PACKAGE as PACKAGE,
   MANAGED_TEST_TARGET as TARGET,
   buildCanonicalPlatformPackage,
@@ -31,6 +32,46 @@ import {
   shellManagedAuthority,
   writeManagedStub
 } from "./managed-package-fixture.js";
+
+test("an exact older version warns before download and replaces the managed executable", async () => {
+  const root = managedScratchRoot("downgrade-");
+  try {
+    const installRoot = path.join(root, "bin");
+    mkdirSync(installRoot, { mode: 0o755 });
+    chmodSync(installRoot, 0o755);
+    const { authority, paths } = shellManagedAuthority(installRoot, "beta", NEXT);
+    const pkg = buildCanonicalPlatformPackage({
+      packageName: PACKAGE,
+      version: OLDER,
+      target: TARGET
+    });
+    const events: string[] = [];
+    const result = await executeUpgradeCli(["--version", OLDER], {
+      authority,
+      observation: {
+        currentVersion: NEXT,
+        platformPackage: PACKAGE
+      },
+      registry: fakeManagedRegistry(NEXT, PACKAGE, pkg.integrity, pkg.tarballUrl),
+      fetcher: async () => {
+        events.push("download");
+        return new Response(new Uint8Array(pkg.bytes), { status: 200 });
+      },
+      onDowngradeWarning: (warning) => events.push(warning)
+    });
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain(`Downgraded 1667 from ${NEXT} to ${OLDER}.`);
+    expect(events).toHaveLength(2);
+    expect(events[0]).toContain("make the Vault unreadable or damage Vault data");
+    expect(events[1]).toBe("download");
+    expect(readFileSync(paths.active, "utf8")).toContain(OLDER);
+    expect(readFileSync(paths.previous, "utf8")).toContain(NEXT);
+    const ownership = JSON.parse(readFileSync(paths.ownership, "utf8")) as { channel: string };
+    expect(ownership.channel).toBe("beta");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
 
 test("unqualified managed upgrade defaults to Ownership Record channel beta", async () => {
   const root = managedScratchRoot();

--- a/tui/test/upgrade-cli.test.ts
+++ b/tui/test/upgrade-cli.test.ts
@@ -214,6 +214,19 @@ test("human plan output uses only locally derived fixed instructions", async () 
   }
 });
 
+test("manual exact downgrade warns about Vault damage and points at that release", async () => {
+  const result = await executeUpgradeCli(["--version", "1.0.0"], {
+    observation,
+    registry: fakeRegistry("2.0.0")
+  });
+  expect(result.exitCode).toBe(0);
+  expect(result.stderr).toContain("make the Vault unreadable or damage Vault data");
+  expect(result.stderr).toContain("Back up the Vault before you continue.");
+  expect(result.stdout).toContain("1667 1.0.0 is available.");
+  expect(result.stdout).toContain("/@1667-ai/cli/v/1.0.0");
+  expect(result.stdout).not.toContain("available on stable");
+});
+
 test("human checks defer exact instructions until a fresh plan", async () => {
   const result = await executeUpgradeCli(["--check"], {
     observation,
@@ -299,6 +312,53 @@ test("PowerShell plans bind the command to the exact immutable stable Installer"
   expect(script).not.toContain("https://1667.ai/install.ps1");
 });
 
+test("an exact PowerShell downgrade keeps the selected channel", async () => {
+  const applied = await executeUpgradeCli(["--version", "1.0.0", "--json"], {
+    observation,
+    authority: powershellAuthority("beta"),
+    registry: fakeRegistry("2.0.0-beta.1")
+  });
+  expect(applied.exitCode).toBe(0);
+  expect(applied.stderr).toContain("make the Vault unreadable or damage Vault data");
+  const envelope = JSON.parse(applied.stdout);
+  expect(envelope).toMatchObject({
+    status: "manual",
+    current: "1.2.3",
+    latest: "2.0.0-beta.1",
+    target: "1.0.0",
+    channel: "beta",
+    method: "powershell"
+  });
+  const encoded = (envelope.command as string).split(" ").at(-1)!;
+  const script = Buffer.from(encoded, "base64").toString("utf16le");
+  expect(script).toContain(
+    "irm https://github.com/1667-ai/1667/releases/download/v1.0.0/install-beta.ps1"
+  );
+});
+
+test("an exact current PowerShell version does not install the channel head", async () => {
+  const applied = await executeUpgradeCli([
+    "--version",
+    observation.currentVersion,
+    "--channel",
+    "stable",
+    "--json"
+  ], {
+    observation,
+    authority: powershellAuthority("beta"),
+    registry: fakeRegistry("2.0.0")
+  });
+  expect(applied.exitCode).toBe(0);
+  expect(JSON.parse(applied.stdout)).toMatchObject({
+    status: "up-to-date",
+    current: observation.currentVersion,
+    target: null,
+    channel: "stable",
+    method: "powershell",
+    command: null
+  });
+});
+
 test("PowerShell reruns preserve custom roots and explicit channel switches", async () => {
   const encoded = windowsInstallCommand("C:\\Writer's $tools", "2.0.0")
     .split(" ").at(-1)!;
@@ -371,6 +431,8 @@ test("help is local and performs no registry I/O", async () => {
   const result = await executeUpgradeCli(["--help"], { observation, registry });
   expect(result.exitCode).toBe(0);
   expect(result.stdout).toContain("--rollback");
+  expect(result.stdout).toContain("--version selects one exact published release");
+  expect(result.stdout).toContain("make the Vault unreadable or damage Vault data");
   // Help speaks to the person running the command. Internal names for the
   // install model do not tell them what to do. Assert the whole sentence: a
   // substring still passes if the guidance loses a case or is reversed.

--- a/tui/test/upgrade-plan.test.ts
+++ b/tui/test/upgrade-plan.test.ts
@@ -52,18 +52,27 @@ test("apply plans always verify exact metadata when a target is available", asyn
   expect(registry.calls).toHaveLength(3);
 });
 
-test("explicit versions must equal the fresh channel head", async () => {
+test("explicit versions select an exact published release instead of the channel head", async () => {
   const registry = fakeRegistry("1.3.1");
-  const error = await rejection(planUpgrade(
+  const plan = await planUpgrade(
     applyCommand({ version: "1.3.0" }),
     observation,
     registry
-  ));
-  expect((error as UpgradeFailure).code).toBe("unsupported_target");
-  expect(registry.calls).toEqual(["tags:stable"]);
+  );
+  expect(plan).toMatchObject({
+    status: "target-available",
+    current: "1.2.3",
+    latest: "1.3.1",
+    target: "1.3.0"
+  });
+  expect(registry.calls).toEqual([
+    "tags:stable",
+    "launcher:1.3.0",
+    `platform:${observation.platformPackage}:1.3.0`
+  ]);
 });
 
-test("a newer local build is current unless an explicit downgrade was requested", async () => {
+test("a newer local build stays current without an exact version", async () => {
   const implicitRegistry = fakeRegistry("1.2.2");
   const implicit = await planUpgrade(applyCommand(), observation, implicitRegistry);
   expect(implicit).toMatchObject({
@@ -73,15 +82,28 @@ test("a newer local build is current unless an explicit downgrade was requested"
     target: null
   });
   expect(implicitRegistry.calls).toEqual(["tags:stable"]);
+});
 
-  const explicitRegistry = fakeRegistry("1.2.2");
-  const error = await rejection(planUpgrade(
-    applyCommand({ version: "1.2.2" }),
+test("an exact older version creates a verified downgrade plan", async () => {
+  const registry = fakeRegistry("1.3.0");
+  const plan = await planUpgrade(
+    applyCommand({ version: "1.1.0" }),
     observation,
-    explicitRegistry
-  ));
-  expect((error as UpgradeFailure).code).toBe("unsupported_target");
-  expect(explicitRegistry.calls).toEqual(["tags:stable"]);
+    registry
+  );
+  expect(plan).toMatchObject({
+    status: "target-available",
+    current: "1.2.3",
+    latest: "1.3.0",
+    target: "1.1.0"
+  });
+  if (plan.status !== "target-available") throw new Error("expected target");
+  expect(plan.platformMetadata.version).toBe("1.1.0");
+  expect(registry.calls).toEqual([
+    "tags:stable",
+    "launcher:1.1.0",
+    `platform:${observation.platformPackage}:1.1.0`
+  ]);
 });
 
 test("exact SemVer string equality is the only up-to-date identity", async () => {


### PR DESCRIPTION
Closes #188

## Scope

- let `1667 upgrade --version` select any exact published release
- warn before a downgrade that it can make the Vault unreadable or damage Vault data
- preserve release verification and the saved update channel

## Checks

- npm run build
- root tests: 2,354 pass; 223 skip
- cd tui && bun run typecheck
- cd tui && bun test: 1,850 pass; 2 platform skips