### PR TITLE
chore(release): prepare 0.9.3-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,6 @@ This file records notable changes to 1667. Product terms use the definitions in
 
 ## Unreleased
 
-- **`1667 upgrade --version` can select an older release.** 1667 verifies the
-  exact published release before it replaces the current executable. Before it
-  downloads a downgrade, it warns that the downgrade can make the Vault
-  unreadable or damage Vault data. Back up the Vault before you continue. An
-  exact version does not change the saved update channel.
-
 - **1667 no longer ends a generation while a model server is still
   processing the prompt.** Prefill is the model server's work before it
   sends the first output token. The server sends no stream output while it
@@ -259,6 +253,14 @@ This file records notable changes to 1667. Product terms use the definitions in
   palette opens a path prompt with `Tab` completion. The `1667 import-card`
   command accepts one or more JSON or PNG files. It adds their Facts to the
   story that `--story` names.
+
+## 0.9.3-rc.1 - 2026-08-13
+
+- **`1667 upgrade --version` can select an older release.** 1667 verifies the
+  exact published release before it replaces the current executable. Before it
+  downloads a downgrade, it warns that the downgrade can make the Vault
+  unreadable or damage Vault data. Back up the Vault before you continue. An
+  exact version does not change the saved update channel.
 
 ## 0.9.2 - 2026-08-13
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "1667-workspace",
-  "version": "0.9.2",
+  "version": "0.9.3-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "1667-workspace",
-      "version": "0.9.2",
+      "version": "0.9.3-rc.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@silvia-odwyer/photon-node": "0.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667-workspace",
-  "version": "0.9.2",
+  "version": "0.9.3-rc.1",
   "private": true,
   "description": "Source workspace for the 1667 terminal writing environment",
   "license": "Apache-2.0",

--- a/shared/release-notes.ts
+++ b/shared/release-notes.ts
@@ -11,6 +11,11 @@ export interface ReleaseNote {
  *  a release, and is not included. */
 export const RELEASE_NOTES: readonly ReleaseNote[] = [
   {
+    version: "0.9.3-rc.1",
+    date: "2026-08-13",
+    body: "- **`1667 upgrade --version` can select an older release.** 1667 verifies the\n  exact published release before it replaces the current executable. Before it\n  downloads a downgrade, it warns that the downgrade can make the Vault\n  unreadable or damage Vault data. Back up the Vault before you continue. An\n  exact version does not change the saved update channel."
+  },
+  {
     version: "0.9.2",
     date: "2026-08-13",
     body: "- **Local model servers keep the story-writing instruction during a\n  continuation.** An assistant prefill has no final user message. This path\n  could omit the operation contract and make a long continuation lose focus.\n  1667 now keeps the mode-independent part of the contract in the stable\n  prompt prefix. The mode-dependent part stays in the final user message when\n  that message exists."

--- a/tui/package.json
+++ b/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667",
-  "version": "0.9.2",
+  "version": "0.9.3-rc.1",
   "private": true,
   "description": "A terminal environment for writing fiction with language models",
   "license": "Apache-2.0",


### PR DESCRIPTION
Closes #189

Tracks #188

## Scope

- publish exact-version downgrade support as 0.9.3-rc.1
- keep the existing Unreleased backlog out of this patch release
- include no repository-owner attribution

## Checks

- npm run notes:check-version -- 0.9.3-rc.1
- npm run build
- cd tui && bun run typecheck
- fix PR #190 passed the complete CI matrix