### PR TITLE
chore(release): prepare 0.9.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -254,7 +254,7 @@ This file records notable changes to 1667. Product terms use the definitions in
   command accepts one or more JSON or PNG files. It adds their Facts to the
   story that `--story` names.
 
-## 0.9.3-rc.1 - 2026-08-13
+## 0.9.3 - 2026-08-13
 
 - **`1667 upgrade --version` can select an older release.** 1667 verifies the
   exact published release before it replaces the current executable. Before it

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "1667-workspace",
-  "version": "0.9.3-rc.1",
+  "version": "0.9.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "1667-workspace",
-      "version": "0.9.3-rc.1",
+      "version": "0.9.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@silvia-odwyer/photon-node": "0.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667-workspace",
-  "version": "0.9.3-rc.1",
+  "version": "0.9.3",
   "private": true,
   "description": "Source workspace for the 1667 terminal writing environment",
   "license": "Apache-2.0",

--- a/shared/release-notes.ts
+++ b/shared/release-notes.ts
@@ -11,7 +11,7 @@ export interface ReleaseNote {
  *  a release, and is not included. */
 export const RELEASE_NOTES: readonly ReleaseNote[] = [
   {
-    version: "0.9.3-rc.1",
+    version: "0.9.3",
     date: "2026-08-13",
     body: "- **`1667 upgrade --version` can select an older release.** 1667 verifies the\n  exact published release before it replaces the current executable. Before it\n  downloads a downgrade, it warns that the downgrade can make the Vault\n  unreadable or damage Vault data. Back up the Vault before you continue. An\n  exact version does not change the saved update channel."
   },

--- a/tui/package.json
+++ b/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667",
-  "version": "0.9.3-rc.1",
+  "version": "0.9.3",
   "private": true,
   "description": "A terminal environment for writing fiction with language models",
   "license": "Apache-2.0",


### PR DESCRIPTION
Closes #189

## Scope

- promote the certified 0.9.3-rc.1 behavior to stable 0.9.3
- change version metadata only
- include no repository-owner attribution

## Checks

- npm run notes:check-version -- 0.9.3
- npm run build
- cd tui && bun run typecheck
- 0.9.3-rc.1 release workflow passed all targets
- published RC installed and downgraded to 0.8.0 with the Vault warning and saved channel intact