### PR TITLE
fix(generation): restore coherent local continuations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ This file records notable changes to 1667. Product terms use the definitions in
 
 ## Unreleased
 
+- **Local Chat Completions keep a continuation on the active assistant
+  passage.** The stable prompt now tells the model how to continue the final
+  assistant message. 1667 also sends the llama.cpp continuation fields when
+  the final message is an assistant message.
+
 - **1667 no longer ends a generation while a model server is still
   processing the prompt.** Prefill is the model server's work before it
   sends the first output token. The server sends no stream output while it

--- a/docs/generation-boundaries.md
+++ b/docs/generation-boundaries.md
@@ -9,11 +9,15 @@ read_when:
 
 # Generation boundaries
 
-Empty Continue is not a new user turn. On providers that support assistant
-prefill, the active passage remains the final assistant message so generation
-begins after its last character. Providers known to reject prefills receive a
-short exact left-boundary echo contract; 1667 verifies and removes the
-echo before saving.
+Empty Continue is not a new user turn. On a route with a known assistant
+prefill contract, the active passage remains the final assistant message so
+generation begins after its last character. The stable operation contract
+also gives the exact continuation rule. This rule helps a small model identify
+the active passage. The llama.cpp Chat Completions route also uses
+`add_generation_prompt: false` and `continue_final_message: true`. These fields
+keep the final assistant message open. A route declared without assistant
+prefill support receives a short exact left-boundary echo contract. 1667
+verifies and removes the echo before saving.
 
 A highlighted rewrite is an infill operation with two constraints. The request
 prefills or echoes a short exact left anchor, then requires the model to reproduce

--- a/server/llama-cpp-template.ts
+++ b/server/llama-cpp-template.ts
@@ -1,5 +1,14 @@
 import type { ChatMessage } from "../shared/prompt-plan.js";
 
+/** llama.cpp fields that keep a final assistant message open. */
+export function llamaCppAssistantContinuationFields(
+  continuesAssistant: boolean
+): Record<string, unknown> {
+  return continuesAssistant
+    ? { add_generation_prompt: false, continue_final_message: true }
+    : {};
+}
+
 /** Build one llama.cpp template request with explicit continuation semantics. */
 export function llamaCppTemplateRequest(
   model: string,
@@ -11,6 +20,6 @@ export function llamaCppTemplateRequest(
     ...route,
     messages,
     add_generation_prompt: !continuesAssistant,
-    ...(continuesAssistant ? { continue_final_message: true } : {})
+    ...llamaCppAssistantContinuationFields(continuesAssistant)
   };
 }

--- a/server/provider-request-body.ts
+++ b/server/provider-request-body.ts
@@ -12,6 +12,7 @@ import type {
 } from "./prompt-cache-breakpoints.js";
 import type { PromptCacheWirePlan } from "./provider-cache-policy.js";
 import { ProviderError } from "./errors.js";
+import { llamaCppAssistantContinuationFields } from "./llama-cpp-template.js";
 import { applySamplingFields } from "./provider-sampling.js";
 import { providerRuntimeFor } from "./provider-runtime.js";
 import { resolveTokenProbabilities } from "../shared/token-probability-capabilities.js";
@@ -77,11 +78,25 @@ export async function buildOpenAiChatRequestBody(
     stream: true,
     ...cacheFields
   };
+  if (usesLlamaCppAssistantContinuation(settings, loweredPrompt)) {
+    Object.assign(body, llamaCppAssistantContinuationFields(true));
+  }
   if (sendsTemperature(settings)) body.temperature = settings.temperature;
   await applySamplingFields(body, settings, "openai-chat-completions", request);
   applyTokenProbabilities(body, settings);
   applyGenerationEffort(body, settings, "openai");
   return body;
+}
+
+function usesLlamaCppAssistantContinuation(
+  settings: GenerationSettings,
+  prompt: PromptPlan
+): boolean {
+  const runtime = providerRuntimeFor(settings);
+  return runtime.protocol === "openai-chat-completions"
+    && runtime.preset === "llama-cpp"
+    && runtime.capabilities.assistantPrefill !== "unsupported"
+    && prompt.turns.at(-1)?.role === "assistant";
 }
 
 /** `logprobs` / `top_logprobs` only when the route documents them (issue #291

--- a/shared/continuation-plan.ts
+++ b/shared/continuation-plan.ts
@@ -30,8 +30,10 @@ const CONTINUE_CONTRACT = [
  *  one — the assistant prefill. See issue #176. */
 const STORY_CONTRACT = [
   "You are writing prose for an ongoing story.",
-  "Return only story text: no preamble, summary, explanation, commentary, or headings.",
-  "Never restart, retell, or quote passages that are already written."
+  "Use the final message to choose the operation.",
+  "If the final message is an assistant message, it is an unfinished passage: continue directly from its exact final character, even when that character is in the middle of a word, and return only the new characters after that boundary.",
+  "If the final message is a user message, follow its direction and write the next passage.",
+  "In all cases, return only story text: no preamble, summary, explanation, commentary, headings, restart, retelling, or quotation of existing passages."
 ].join(" ");
 
 export type ContinuationPromptEntry =
@@ -226,12 +228,9 @@ export function continuationPlan(
     // A prefilled continuation ends with the story's own unfinished assistant
     // message, unchanged, so the provider can extend that exact token stream
     // — nothing can follow it without turning the completion into a fresh
-    // turn instead of a continuation. The contract text has nowhere left to
-    // go without either breaking that or reopening the same prefix
-    // instability this function exists to close, so it is not sent on this
-    // path. The instruction is not lost: the prefill mechanism itself
-    // already enforces exact, unprefaced continuation, which is what the
-    // contract text would otherwise have to say. See issue #138.
+    // turn instead of a continuation. The mode-dependent contract cannot go
+    // after it. The stable story contract already carries the exact boundary
+    // rule without changing the cacheable prefix. See issues #138 and #176.
     assertAuthorsNoteFollowedByUser(entries);
     return continuationResult(entries, contextPartIds, "", false);
   }

--- a/test/generation-prompts.test.ts
+++ b/test/generation-prompts.test.ts
@@ -21,12 +21,10 @@ test("empty Continue ends on the unfinished assistant passage", () => {
 
   assert.equal(messages.at(-1)?.role, "assistant");
   assert.equal(messages.at(-1)?.content, "The latch was unlo");
-  // A prefilled continuation carries no operation-contract text at all
-  // (issue #138's `appendOperationContract`): nothing can follow the
-  // unfinished assistant passage without breaking the prefill, so the
-  // "continue from the exact boundary" instruction is not sent here — the
-  // prefill mechanism itself already enforces that.
-  assert.equal(messages.some((message) => /exact final character/.test(message.content)), false);
+  // The stable story contract carries the exact continuation rule because
+  // nothing can follow the unfinished assistant passage without breaking the
+  // prefill. The transport contract then makes that rule effective server-side.
+  assert.equal(messages.some((message) => /exact final character/.test(message.content)), true);
   assert.equal(messages.some((message) => message.role === "user" && /final character/i.test(message.content)), false);
 });
 
@@ -68,7 +66,7 @@ test("structural empty endpoints never become empty assistant messages", () => {
   assert.equal(appendedMessages.some(({ role }) => role === "assistant"), false);
   assert.equal(appendedMessages.at(-1)?.role, "user");
   assert.equal(appendedMessages.at(-1)?.content.endsWith("\n\nContinue the story."), true);
-  assert.equal(appendedMessages.some(({ content }) => /unfinished passage/.test(content)), false);
+  assert.equal(appendedMessages.some(({ content }) => /exact final character/.test(content)), true);
 });
 
 test("highlight regeneration bridges exact left and right character boundaries", () => {

--- a/test/model-connection-e2e.test.ts
+++ b/test/model-connection-e2e.test.ts
@@ -1,13 +1,20 @@
 import assert from "node:assert/strict";
-import { createServer, type Server } from "node:http";
+import { createServer, type IncomingMessage, type Server } from "node:http";
 import test from "node:test";
 import { applyBasicSettingsDraft } from "../shared/settings-basic-draft.js";
+import {
+  continuationPlan,
+  supportsAssistantPrefill
+} from "../shared/continuation-plan.js";
 import type { PromptPlan } from "../shared/prompt-plan.js";
 import { discoverProviderModels } from "../server/model-discovery.js";
 import { ownedLoopbackHttpSupported } from "../server/provider-fetch.js";
+import { attachProviderRuntime } from "../server/provider-runtime.js";
 import { streamCompletion } from "../server/providers.js";
 import { SettingsStore } from "../server/settings.js";
 import { INITIAL_SETTINGS_DOCUMENT_V2 } from "../server/settings-v2-default.js";
+import { EMPTY_SAMPLING_V2 } from "../shared/settings-v2-types.js";
+import type { StoryNode } from "../shared/types.js";
 import {
   FIXED_TIME,
   MUTATION_A,
@@ -100,6 +107,97 @@ test("saved KoboldCpp localhost HTTP discovers, streams, and survives restart", 
   assert.equal(generations, 2);
 });
 
+test("llama.cpp Chat Completions continues the final assistant message on the wire", {
+  skip: !ownedLoopbackHttpSupported()
+}, async (t) => {
+  const requests: Record<string, unknown>[] = [];
+  const server = createServer(async (request, response) => {
+    requests.push(JSON.parse(await requestText(request)) as Record<string, unknown>);
+    response.writeHead(200, { "content-type": "text/event-stream" });
+    response.end([
+      'data: {"choices":[{"delta":{"content":" into the hall"},"finish_reason":null}]}',
+      "",
+      "data: [DONE]",
+      "",
+      ""
+    ].join("\n"));
+  });
+  const origin = await listen(server);
+  t.after(() => server.close());
+
+  const settings = attachProviderRuntime({
+    provider: "openai-compatible" as const,
+    baseUrl: `${origin}/v1`,
+    model: "gemma-31b",
+    apiKeyEnv: null,
+    temperature: 0.7,
+    maxTokens: 128,
+    systemPrompt: "Write coherent prose.",
+    contextWindow: 8_192
+  }, {
+    preset: "llama-cpp",
+    protocol: "openai-chat-completions",
+    auth: { type: "none" },
+    headers: [],
+    timeouts: {
+      responseHeaderMs: 5_000,
+      firstTokenMs: 5_000,
+      idleMs: 5_000,
+      totalMs: 20_000
+    },
+    allowInsecureHttp: true,
+    effort: "default",
+    tokenProbabilities: null,
+    sampling: EMPTY_SAMPLING_V2,
+    capabilities: {
+      temperature: "supported",
+      assistantPrefill: "unknown",
+      reasoningEffort: "unknown",
+      promptCaching: "unknown"
+    }
+  });
+  const parts: StoryNode[] = [{
+    id: "part-1",
+    parentId: null,
+    instruction: "The door opened.",
+    text: "Cold air spilled",
+    model: "gemma-31b",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    activeChildId: null
+  }];
+  const prompt = continuationPlan(
+    "Write coherent prose.",
+    "The lantern is blue.",
+    null,
+    parts,
+    "Continue the story.",
+    true,
+    supportsAssistantPrefill(settings),
+    "ct-gemma",
+    [],
+    parts
+  ).prompt;
+
+  assert.equal(
+    await collect(streamCompletion(settings, prompt, new AbortController().signal)),
+    " into the hall"
+  );
+  assert.equal(requests.length, 1);
+  assert.equal(requests[0]!.add_generation_prompt, false);
+  assert.equal(requests[0]!.continue_final_message, true);
+  assert.deepEqual(
+    (requests[0]!.messages as Array<{ role: string; content: string }>).at(-1),
+    { role: "assistant", content: "Cold air spilled" }
+  );
+  const messages = requests[0]!.messages as Array<{ role: string; content: string }>;
+  const facts = messages.find((message) => message.role === "system" && message.content.includes("lantern"));
+  assert.equal(facts?.content, "The lantern is blue.");
+  assert.equal(
+    messages.some((message) => /exact final character/.test(message.content)),
+    true
+  );
+});
+
 async function listen(server: Server): Promise<string> {
   await new Promise<void>((resolve, reject) => {
     server.once("error", reject);
@@ -116,4 +214,12 @@ async function collect(stream: AsyncIterable<string>): Promise<string> {
   let result = "";
   for await (const chunk of stream) result += chunk;
   return result;
+}
+
+async function requestText(request: IncomingMessage): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of request) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk)));
+  }
+  return Buffer.concat(chunks).toString("utf8");
 }

--- a/test/prompt-plan.test.ts
+++ b/test/prompt-plan.test.ts
@@ -84,7 +84,7 @@ test("continue renders the existing provider wire shape exactly", () => {
     { role: "system", content: "CANONICAL FACTS" },
     {
       role: "system",
-      content: "You are writing prose for an ongoing story. Return only story text: no preamble, summary, explanation, commentary, or headings. Never restart, retell, or quote passages that are already written."
+      content: "You are writing prose for an ongoing story. Use the final message to choose the operation. If the final message is an assistant message, it is an unfinished passage: continue directly from its exact final character, even when that character is in the middle of a word, and return only the new characters after that boundary. If the final message is a user message, follow its direction and write the next passage. In all cases, return only story text: no preamble, summary, explanation, commentary, headings, restart, retelling, or quotation of existing passages."
     },
     { role: "user", content: "Open the door." },
     { role: "assistant", content: "The latch clicked." },
@@ -462,7 +462,7 @@ test("stable rendered-prefix hashes are golden for every generation operation", 
   ), {
     // Changed by issue #176, which returned the mode-independent contract to
     // the prelude. Only `continue` moves: no other operation shares it.
-    continue: "e10472c737b09dc191c1cbb0d6807812f6e65725543c7452702893bb34dfb369",
+    continue: "b99dd1db41be3369faa1c3b0a9de3583e7ed3cae36bb8b5e7c499d89e756e116",
     rewrite: "915a92f74c89251f1a90cae595e7682f7f4287a1bc273ac9e2fc01099cbd4462",
     phrase: "928f1145fa90b9f398b67be8eb84164fdc17ce58b2e85704505f322ff8099752",
     title: "8ce79bf5ea50fb067d4a53a1f228b0df1b2a3c4ff6f4b698c781d00cbf3c8d72",

--- a/test/provider-continuation-request.test.ts
+++ b/test/provider-continuation-request.test.ts
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { buildOpenAiChatRequestBody } from "../server/provider-request-body.js";
+import {
+  attachProviderRuntime,
+  providerRuntimeFor
+} from "../server/provider-runtime.js";
+import type { PromptPlan } from "../shared/prompt-plan.js";
+import type { GenerationSettings } from "../shared/types.js";
+
+const PROMPT: PromptPlan = {
+  operation: "continue",
+  turns: [
+    {
+      role: "system",
+      blocks: [{
+        stability: "stable",
+        kind: "author-brief",
+        text: "Write with restraint.",
+        boundaryAfter: "candidate"
+      }]
+    },
+    {
+      role: "user",
+      blocks: [{
+        stability: "stable",
+        kind: "source",
+        text: "Rain crossed the window.",
+        boundaryAfter: "none"
+      }]
+    },
+    {
+      role: "assistant",
+      blocks: [{
+        stability: "volatile",
+        kind: "boundary",
+        text: "The lantern dimmed",
+        boundaryAfter: "none"
+      }]
+    }
+  ]
+};
+
+const OMIT_CACHE = { kind: "omit", reason: "policy-off" } as const;
+
+test("llama.cpp Chat Completions keeps a trailing assistant message open", async () => {
+  const body = await buildOpenAiChatRequestBody(
+    { ...settings(), baseUrl: "http://127.0.0.1:8080/v1" },
+    PROMPT,
+    OMIT_CACHE
+  );
+  assert.equal(body.add_generation_prompt, false);
+  assert.equal(body.continue_final_message, true);
+});
+
+test("a non-llama.cpp route does not receive llama.cpp-only fields", async () => {
+  const body = await buildOpenAiChatRequestBody(settings(), PROMPT, OMIT_CACHE);
+  assert.equal("add_generation_prompt" in body, false);
+  assert.equal("continue_final_message" in body, false);
+});
+
+test("an explicitly supported custom route does not receive llama.cpp-only fields", async () => {
+  const base = settings();
+  const runtime = providerRuntimeFor(base);
+  const supported = attachProviderRuntime(base, {
+    ...runtime,
+    capabilities: { ...runtime.capabilities, assistantPrefill: "supported" }
+  }, true);
+  const body = await buildOpenAiChatRequestBody(supported, PROMPT, OMIT_CACHE);
+  assert.equal("add_generation_prompt" in body, false);
+  assert.equal("continue_final_message" in body, false);
+});
+
+function settings(): GenerationSettings {
+  return {
+    provider: "openai-compatible",
+    baseUrl: "https://provider.example/v1",
+    model: "model-fixture",
+    apiKeyEnv: null,
+    temperature: 0.25,
+    maxTokens: 321,
+    systemPrompt: "Write with restraint.",
+    contextWindow: null
+  };
+}

--- a/tui/test/context-meter.test.ts
+++ b/tui/test/context-meter.test.ts
@@ -898,7 +898,7 @@ describe("honest next-request context meter", () => {
         meter: rail.filter((line) => /free|next request|─{12}/.test(plainLine(line))).length,
         header: text.includes("facts · 5"),
         expanded: text.includes("context · request + response"),
-        request: text.includes("next request  ~927 / 8k") || text.includes("~927 / 8k · 7.1k free")
+        request: text.includes("next request  ~1k / 8k") || text.includes("~1k / 8k · 7k free")
       };
     };
 
@@ -935,16 +935,16 @@ describe("honest next-request context meter", () => {
     const meter = (rows: number) => contextMeterLines(model, false, rows).map((line) => plainLine(line).trim());
 
     expect(meter(4)).toEqual([
-      "─".repeat(33), "next request  ~927 / 8k", `▮▮${"▮".repeat(18)}    7.1k free`,
+      "─".repeat(33), "next request  ~1k / 8k", `▮▮${"▮".repeat(18)}      7k free`,
       "ch 12 · summarize frees ~12.3k"
     ]);
     // The rule is decoration; the gauge repeats what the numbers already say.
     // Both go before the chapter's fix, which is the one actionable line here.
     expect(meter(3)).toEqual([
-      "next request  ~927 / 8k", `▮▮${"▮".repeat(18)}    7.1k free`, "ch 12 · summarize frees ~12.3k"
+      "next request  ~1k / 8k", `▮▮${"▮".repeat(18)}      7k free`, "ch 12 · summarize frees ~12.3k"
     ]);
-    expect(meter(2)).toEqual(["next request  ~927 / 8k", "ch 12 · summarize frees ~12.3k"]);
-    expect(meter(1)).toEqual(["next request  ~927 / 8k"]);
+    expect(meter(2)).toEqual(["next request  ~1k / 8k", "ch 12 · summarize frees ~12.3k"]);
+    expect(meter(1)).toEqual(["next request  ~1k / 8k"]);
     expect(meter(0)).toEqual([]);
 
     // With no window there is no gauge to shed, and the way to set one is the
@@ -952,7 +952,7 @@ describe("honest next-request context meter", () => {
     const unknown = (rows: number) =>
       contextMeterLines({ ...model, window: null, chapterNotice: null }, false, rows)
         .map((line) => plainLine(line).trim());
-    expect(unknown(2)).toEqual(["next request  ~927 tokens", "set context window · settings (,)"]);
+    expect(unknown(2)).toEqual(["next request  ~1,019 tokens", "set context window · settings (,)"]);
   });
 
   test("a fact-drop notice states the count and dominant reason, ahead of the chapter notice", () => {
@@ -973,23 +973,23 @@ describe("honest next-request context meter", () => {
     // Both notices fit: the drop notice leads, naming the majority reason
     // among this request's drops ("total-budget", 2 of 3).
     expect(meter(5)).toEqual([
-      "─".repeat(33), "next request  ~927 / 8k", `▮▮${"▮".repeat(18)}    7.1k free`,
+      "─".repeat(33), "next request  ~1k / 8k", `▮▮${"▮".repeat(18)}      7k free`,
       "3 facts dropped · over budget",
       "ch 12 · summarize frees ~12.3k"
     ]);
     expect(meter(3)).toEqual([
-      "next request  ~927 / 8k", "3 facts dropped · over budget", "ch 12 · summarize frees ~12.3k"
+      "next request  ~1k / 8k", "3 facts dropped · over budget", "ch 12 · summarize frees ~12.3k"
     ]);
     // Two notices no longer both fit alongside the request line: shedding is
     // still all-or-nothing per tail (as it already was for remedy+chapter),
     // so at this height neither notice survives — only the request does.
-    expect(meter(2)).toEqual(["next request  ~927 / 8k"]);
+    expect(meter(2)).toEqual(["next request  ~1k / 8k"]);
 
     // With no chapter notice competing for the row, the drop notice alone
     // survives down to the same floor the chapter notice used to reach.
     const withoutChapterNotice = { ...model, chapterNotice: null };
     expect(contextMeterLines(withoutChapterNotice, false, 2).map((line) => plainLine(line).trim()))
-      .toEqual(["next request  ~927 / 8k", "3 facts dropped · over budget"]);
+      .toEqual(["next request  ~1k / 8k", "3 facts dropped · over budget"]);
 
     // Review finding J: "priority" means window pressure selected a droppable
     // Fact, not that the Fact itself is ranked low — a keyed Fact at any
@@ -998,12 +998,12 @@ describe("honest next-request context meter", () => {
     // own rank.
     const single = { ...withoutChapterNotice, droppedFacts: [{ factId: "fact-a", reason: "priority" as const }] };
     expect(contextMeterLines(single, false, 2).map((line) => plainLine(line).trim())).toEqual([
-      "next request  ~927 / 8k", "1 fact dropped · over window"
+      "next request  ~1k / 8k", "1 fact dropped · over window"
     ]);
 
     const none = { ...withoutChapterNotice, droppedFacts: [] };
     expect(contextMeterLines(none, false, 2).map((line) => plainLine(line).trim())).toEqual([
-      "next request  ~927 / 8k", `▮▮${"▮".repeat(18)}    7.1k free`
+      "next request  ~1k / 8k", `▮▮${"▮".repeat(18)}      7k free`
     ]);
   });
 
@@ -1299,7 +1299,7 @@ describe("honest next-request context meter", () => {
     state.mode = "COMPOSE";
     state.composer.fullscreen = true;
     const expected = new Map([
-      [80, " COMPOSE · fullscreen   the la… · ⚑ canon-storm · ¶ 12/13 · 3/5 next ~933/32.8k"],
+      [80, " COMPOSE · fullscreen   the lan… · ⚑ canon-storm · ¶ 12/13 · 3/5 next ~1k/32.8k"],
       [100, " COMPOSE · fullscreen   the lantern keeper · ⚑ canon-storm · part 12/13 · take 3/5        qwen3-32b"],
       [110, " COMPOSE · fullscreen   the lantern keeper · ⚑ canon-storm · part 12/13 · take 3/5 · 307 words      qwen3-32b"],
       [120, composeStatusWithBuildTag(120)]

--- a/tui/test/golden-panels.test.ts
+++ b/tui/test/golden-panels.test.ts
@@ -440,9 +440,9 @@ describe("run C overlay frames", () => {
     const frame = await renderOnce(demoAppSource(), 150, 30);
     expect(frame).toContain("│");
     expect(frame).toContain("facts · 5 ───────────────────────");
-    expect(frame).toContain("next request  ~933 / 32.8k");
+    expect(frame).toContain("next request  ~1k / 32.8k");
     expect(frame).not.toContain("+≤");
-    expect(frame).toContain(`▮${"▮".repeat(19)}   31.8k free`);
+    expect(frame).toContain(`▮${"▮".repeat(19)}   31.7k free`);
     // A gauge is not a quota readout: no percentage anywhere on the rail.
     expect(/\d+%/.test(frame)).toBeFalse();
     expect(frame).not.toContain("1,667");
@@ -459,7 +459,7 @@ describe("run C overlay frames", () => {
       effectiveProse: source.settings
     };
     const frame = await renderOnce(source, 150, 30);
-    expect(frame).toContain("next request  ~933 tokens");
+    expect(frame).toContain("next request  ~1,025 tokens");
     expect(frame).not.toContain("+≤");
     expect(frame).toContain("set context window · settings (,)");
     expect(frame).not.toContain("free");
@@ -524,7 +524,7 @@ describe("run C overlay frames", () => {
     expect(frame).toContain("┏━ chapters · 3 on this storyline");
     expect(frame).toContain("72 ✓ summary");
     expect(frame).toContain("208 raw — no summary");
-    expect(frame).toContain("total 933 / 32.8k");
+    expect(frame).toContain("total 1k / 32.8k");
     expect(frame).toContain("s summarize · e rename · n break · d remove");
   });
 

--- a/tui/test/sampling-settings.test.ts
+++ b/tui/test/sampling-settings.test.ts
@@ -1254,7 +1254,7 @@ function selectedNestedHit(
 }
 
 /** Rows inside the panel frame only. Matching the whole frame also caught the
- *  status bar, whose "next ~933/32.8k" estimate contains the same digits as a
+ *  status bar, whose next-request estimate contains the same digits as a
  *  token ID, so an unrelated change to prompt size could fail this. */
 function renderedLogitRows(frame: string, tokens: readonly string[]): string[] {
   return frame.split("\n")


### PR DESCRIPTION
Closes #176

## What changed

- Restore an explicit, byte-stable story contract for both final-assistant continuation and final-user direction.
- Send llama.cpp Chat Completions the explicit fields that keep a final assistant message open.
- Preserve Facts, history, cache-prefix stability, rewrite behavior, text completions, and custom-provider wire shapes.
- Add planner, request-adapter, and provider HTTP integration coverage.
- Update honest TUI context estimates for the larger contract.

## How it was verified

- Root typecheck: passed.
- Focused planner, provider, HTTP, rewrite, and text-completion tests: passed.
- Backend suite: 2,555 passed, 0 failed, 20 skipped. Six release-pack tests were blocked by the local npm lifecycle path; all six passed separately with the real pinned npm and Node paths.
- TUI typecheck: passed.
- TUI suite: 1,843 passed, 0 failed, 4 platform skips.
- autoreview: clean.
- thermo-nuclear-code-quality-review: clean.
