### PR TITLE
fix: preserve inherited Windows installer permissions

### DIFF
--- a/scripts/release-install-powershell-body.ts
+++ b/scripts/release-install-powershell-body.ts
@@ -122,26 +122,6 @@ function Assert-NoReparsePoint([string]$PathValue, [switch]$AllowMissingLeaf) {
   }
 }
 
-function Protect-InstallRoot([string]$Root) {
-  $user = [Security.Principal.WindowsIdentity]::GetCurrent().User
-  if ($null -eq $user) { Fail 'The current Windows user SID is unavailable.' }
-  $system = New-Object Security.Principal.SecurityIdentifier('S-1-5-18')
-  $acl = New-Object Security.AccessControl.DirectorySecurity
-  $acl.SetOwner($user)
-  $acl.SetAccessRuleProtection($true, $false)
-  $inherit = [Security.AccessControl.InheritanceFlags]::ContainerInherit -bor
-    [Security.AccessControl.InheritanceFlags]::ObjectInherit
-  $propagation = [Security.AccessControl.PropagationFlags]::None
-  $allow = [Security.AccessControl.AccessControlType]::Allow
-  $acl.AddAccessRule((New-Object Security.AccessControl.FileSystemAccessRule(
-    $user, [Security.AccessControl.FileSystemRights]::FullControl,
-    $inherit, $propagation, $allow)))
-  $acl.AddAccessRule((New-Object Security.AccessControl.FileSystemAccessRule(
-    $system, [Security.AccessControl.FileSystemRights]::FullControl,
-    $inherit, $propagation, $allow)))
-  [IO.Directory]::SetAccessControl($Root, $acl)
-}
-
 # Path fields compare case-insensitively, because Windows paths are. The rest
 # stay case-sensitive. Rerunning the Installer with an equivalently spelled root
 # must not make the Installer reject the record it wrote itself.
@@ -410,8 +390,6 @@ function Main {
       })
     if ($other.Count -gt 0) { Fail 'Fresh Install Root is not empty.' }
   }
-  Protect-InstallRoot $root
-
   $lockPath = [IO.Path]::Combine($root, $LockName)
   $lock = $null
   try {

--- a/test/release-install-powershell.test.ts
+++ b/test/release-install-powershell.test.ts
@@ -77,6 +77,7 @@ test("PowerShell Installer handles install, repeat, and upgrade cases", async (t
   const fresh = await runInstaller(v1.url, installRoot);
   assert.match(fresh.stdout, /Installed 1667 1\.2\.3 \(stable\)/u);
   assert.equal(await installedVersion(installRoot), "1.2.3");
+  assert.equal(await accessRulesAreProtected(installRoot), false);
   const firstRecord = await ownershipRecord(installRoot);
   assert.equal(firstRecord.method, "powershell");
   assert.equal(firstRecord.artifactTarget, WINDOWS_TARGET);
@@ -445,6 +446,21 @@ async function installedVersion(installRoot: string): Promise<string> {
     "--json"
   ]);
   return (JSON.parse(stdout) as { productVersion: string }).productVersion;
+}
+
+async function accessRulesAreProtected(installRoot: string): Promise<boolean> {
+  const { stdout } = await execFileAsync("powershell.exe", [
+    "-NoLogo",
+    "-NoProfile",
+    "-Command",
+    "(Get-Acl -LiteralPath $env:AI_1667_TEST_INSTALL_ROOT).AreAccessRulesProtected"
+  ], {
+    env: {
+      ...process.env,
+      AI_1667_TEST_INSTALL_ROOT: installRoot
+    }
+  });
+  return stdout.trim().toLowerCase() === "true";
 }
 
 async function ownershipRecord(installRoot: string): Promise<Record<string, string>> {

--- a/test/release-install-powershell.test.ts
+++ b/test/release-install-powershell.test.ts
@@ -453,7 +453,7 @@ async function accessRulesAreProtected(installRoot: string): Promise<boolean> {
     "-NoLogo",
     "-NoProfile",
     "-Command",
-    "(Get-Acl -LiteralPath $env:AI_1667_TEST_INSTALL_ROOT).AreAccessRulesProtected"
+    "[IO.Directory]::GetAccessControl($env:AI_1667_TEST_INSTALL_ROOT).AreAccessRulesProtected"
   ], {
     env: {
       ...process.env,


### PR DESCRIPTION
## Summary

- Remove the Windows Installer ACL replacement.
- Keep inherited permissions on the user Install Root.
- Add an integration test for inherited permissions.

## Root cause

The Installer replaced the Install Root ACL. A restricted shell can create files in the user profile but cannot always change directory security.

## User impact

The PowerShell Installer now works in more restricted user shells. Existing ownership, digest, reparse-point, and lock checks remain.

## Checks

- `node --import tsx --import ./test/setup.ts --test test/release-install-powershell.test.ts`
- `npm run typecheck`
- `git diff --check`

Closes #195
