### PR TITLE
chore(release): prepare 0.9.4-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,6 @@ This file records notable changes to 1667. Product terms use the definitions in
 
 ## Unreleased
 
-- **Local Chat Completions keep a continuation on the active assistant
-  passage.** The stable prompt now tells the model how to continue the final
-  assistant message. 1667 also sends the llama.cpp continuation fields when
-  the final message is an assistant message.
-
 - **1667 no longer ends a generation while a model server is still
   processing the prompt.** Prefill is the model server's work before it
   sends the first output token. The server sends no stream output while it
@@ -258,6 +253,13 @@ This file records notable changes to 1667. Product terms use the definitions in
   palette opens a path prompt with `Tab` completion. The `1667 import-card`
   command accepts one or more JSON or PNG files. It adds their Facts to the
   story that `--story` names.
+
+## 0.9.4-rc.1 - 2026-08-13
+
+- **Local Chat Completions keep a continuation on the active assistant
+  passage.** The stable prompt now tells the model how to continue the final
+  assistant message. 1667 also sends the llama.cpp continuation fields when
+  the final message is an assistant message.
 
 ## 0.9.3 - 2026-08-13
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "1667-workspace",
-  "version": "0.9.3",
+  "version": "0.9.4-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "1667-workspace",
-      "version": "0.9.3",
+      "version": "0.9.4-rc.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@silvia-odwyer/photon-node": "0.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667-workspace",
-  "version": "0.9.3",
+  "version": "0.9.4-rc.1",
   "private": true,
   "description": "Source workspace for the 1667 terminal writing environment",
   "license": "Apache-2.0",

--- a/shared/release-notes.ts
+++ b/shared/release-notes.ts
@@ -11,6 +11,11 @@ export interface ReleaseNote {
  *  a release, and is not included. */
 export const RELEASE_NOTES: readonly ReleaseNote[] = [
   {
+    version: "0.9.4-rc.1",
+    date: "2026-08-13",
+    body: "- **Local Chat Completions keep a continuation on the active assistant\n  passage.** The stable prompt now tells the model how to continue the final\n  assistant message. 1667 also sends the llama.cpp continuation fields when\n  the final message is an assistant message."
+  },
+  {
     version: "0.9.3",
     date: "2026-08-13",
     body: "- **`1667 upgrade --version` can select an older release.** 1667 verifies the\n  exact published release before it replaces the current executable. Before it\n  downloads a downgrade, it warns that the downgrade can make the Vault\n  unreadable or damage Vault data. Back up the Vault before you continue. An\n  exact version does not change the saved update channel."

--- a/tui/package.json
+++ b/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667",
-  "version": "0.9.3",
+  "version": "0.9.4-rc.1",
   "private": true,
   "description": "A terminal environment for writing fiction with language models",
   "license": "Apache-2.0",


### PR DESCRIPTION
Closes #196

## Scope

- prepare 0.9.4-rc.1
- include the coherent local continuation fix
- preserve the existing Unreleased backlog
- include no owner attribution

## Checks

- npm run notes:check-version -- 0.9.4-rc.1
- npm run build
- cd tui && bun run typecheck