### PR TITLE
chore(release): prepare 0.9.4-rc.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -254,6 +254,13 @@ This file records notable changes to 1667. Product terms use the definitions in
   command accepts one or more JSON or PNG files. It adds their Facts to the
   story that `--story` names.
 
+## 0.9.4-rc.2 - 2026-08-13
+
+- **The Windows Installer keeps inherited permissions on the Install Root.**
+  Before this fix, the Installer replaced the Install Root permissions. A
+  restricted user shell could create files there but could not replace those
+  permissions, so installation failed with an access denied error.
+
 ## 0.9.4-rc.1 - 2026-08-13
 
 - **Local Chat Completions keep a continuation on the active assistant

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "1667-workspace",
-  "version": "0.9.4-rc.1",
+  "version": "0.9.4-rc.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "1667-workspace",
-      "version": "0.9.4-rc.1",
+      "version": "0.9.4-rc.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@silvia-odwyer/photon-node": "0.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667-workspace",
-  "version": "0.9.4-rc.1",
+  "version": "0.9.4-rc.2",
   "private": true,
   "description": "Source workspace for the 1667 terminal writing environment",
   "license": "Apache-2.0",

--- a/shared/release-notes.ts
+++ b/shared/release-notes.ts
@@ -11,6 +11,11 @@ export interface ReleaseNote {
  *  a release, and is not included. */
 export const RELEASE_NOTES: readonly ReleaseNote[] = [
   {
+    version: "0.9.4-rc.2",
+    date: "2026-08-13",
+    body: "- **The Windows Installer keeps inherited permissions on the Install Root.**\n  Before this fix, the Installer replaced the Install Root permissions. A\n  restricted user shell could create files there but could not replace those\n  permissions, so installation failed with an access denied error."
+  },
+  {
     version: "0.9.4-rc.1",
     date: "2026-08-13",
     body: "- **Local Chat Completions keep a continuation on the active assistant\n  passage.** The stable prompt now tells the model how to continue the final\n  assistant message. 1667 also sends the llama.cpp continuation fields when\n  the final message is an assistant message."

--- a/tui/package.json
+++ b/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667",
-  "version": "0.9.4-rc.1",
+  "version": "0.9.4-rc.2",
   "private": true,
   "description": "A terminal environment for writing fiction with language models",
   "license": "Apache-2.0",


### PR DESCRIPTION
Closes #200

## Scope

- prepare 0.9.4-rc.2
- include the Windows Installer permission fix from PR #194
- include no owner attribution

## Checks

- npm run notes:check-version -- 0.9.4-rc.2
- npm run build
- cd tui && bun run typecheck