### PR TITLE
chore(release): prepare 0.9.4-rc.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,6 @@ This file records notable changes to 1667. Product terms use the definitions in
 
 ## Unreleased
 
-- **Continuation prompts now match version 0.8.0.** 1667 again sends the
-  operation-specific contract before the story. It no longer sends the generic
-  story contract or llama.cpp Chat Completions continuation fields.
-
 - **1667 no longer ends a generation while a model server is still
   processing the prompt.** Prefill is the model server's work before it
   sends the first output token. The server sends no stream output while it
@@ -257,6 +253,12 @@ This file records notable changes to 1667. Product terms use the definitions in
   palette opens a path prompt with `Tab` completion. The `1667 import-card`
   command accepts one or more JSON or PNG files. It adds their Facts to the
   story that `--story` names.
+
+## 0.9.4-rc.3 - 2026-08-13
+
+- **Continuation prompts now match version 0.8.0.** 1667 again sends the
+  operation-specific contract before the story. It no longer sends the generic
+  story contract or llama.cpp Chat Completions continuation fields.
 
 ## 0.9.4-rc.2 - 2026-08-13
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "1667-workspace",
-  "version": "0.9.4-rc.2",
+  "version": "0.9.4-rc.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "1667-workspace",
-      "version": "0.9.4-rc.2",
+      "version": "0.9.4-rc.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@silvia-odwyer/photon-node": "0.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667-workspace",
-  "version": "0.9.4-rc.2",
+  "version": "0.9.4-rc.3",
   "private": true,
   "description": "Source workspace for the 1667 terminal writing environment",
   "license": "Apache-2.0",

--- a/shared/release-notes.ts
+++ b/shared/release-notes.ts
@@ -11,6 +11,11 @@ export interface ReleaseNote {
  *  a release, and is not included. */
 export const RELEASE_NOTES: readonly ReleaseNote[] = [
   {
+    version: "0.9.4-rc.3",
+    date: "2026-08-13",
+    body: "- **Continuation prompts now match version 0.8.0.** 1667 again sends the\n  operation-specific contract before the story. It no longer sends the generic\n  story contract or llama.cpp Chat Completions continuation fields."
+  },
+  {
     version: "0.9.4-rc.2",
     date: "2026-08-13",
     body: "- **The Windows Installer keeps inherited permissions on the Install Root.**\n  Before this fix, the Installer replaced the Install Root permissions. A\n  restricted user shell could create files there but could not replace those\n  permissions, so installation failed with an access denied error."

--- a/tui/package.json
+++ b/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667",
-  "version": "0.9.4-rc.2",
+  "version": "0.9.4-rc.3",
   "private": true,
   "description": "A terminal environment for writing fiction with language models",
   "license": "Apache-2.0",


### PR DESCRIPTION
Closes #204

## Scope

- prepare 0.9.4-rc.3
- include the continuation prompt restoration from PR #202
- preserve the existing Unreleased backlog
- include no owner attribution

## Checks

- npm run notes:check-version -- 0.9.4-rc.3
- npm run build
- cd tui && bun run typecheck