### PR TITLE
chore(release): prepare 0.9.4-rc.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -254,6 +254,37 @@ This file records notable changes to 1667. Product terms use the definitions in
   command accepts one or more JSON or PNG files. It adds their Facts to the
   story that `--story` names.
 
+## 0.9.4-rc.4 - 2026-08-13
+
+- **`1667 upgrade --list` shows published launcher releases.** It writes one
+  version on each line, with the newest version first. Use `--json` to get a
+  `versions` array. 1667 checks platform support when `--version` selects a
+  release.
+
+- **An exact version can reuse the previous executable.** If
+  `.1667-previous` has the version that `--version` selects, 1667 verifies and
+  uses it. It does not download that version again. `--rollback` continues to
+  use the same file offline.
+
+- **The chapter title editor now has a movable caret.** The left and right
+  arrow keys move the caret. Insert, delete, and paste operations use the caret
+  position.
+
+- **The mouse now selects fields in the Fact editor.** A click selects the
+  Fact text field or choice field under the pointer. Use the left and right
+  arrow keys to change a selected choice. The mouse wheel scrolls a long Fact
+  body.
+
+- **Chapter summarization now identifies its work and its limits.** The
+  status line shows the chapter, the current stage, and that the model does not
+  report progress. Press `Esc` to stop the summary request.
+
+- **1667 prepares to save non-canon Side Notes with a story.** This release
+  contains the Aside implementation and keeps every entry point closed. It
+  cannot open `/aside` yet. This release reads and validates the successor
+  story document and refuses to change it. A later release can write that
+  document and open Aside without making this release damage the story.
+
 ## 0.9.4-rc.3 - 2026-08-13
 
 - **Continuation prompts now match version 0.8.0.** 1667 again sends the

--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ version can be older than the current version. Before a downgrade, 1667 warns
 that the downgrade can make the Vault unreadable or damage Vault data. Back up
 the Vault before you continue.
 
+Run `1667 upgrade --list` to show the published launcher releases. 1667 checks
+platform support when `--version` selects a release. An exact version reuses
+the previous executable when that executable has the selected version.
+
 Install with npm:
 
 ```sh

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -551,6 +551,15 @@ release can be older than the active release. Before a downgrade, 1667 warns
 that the downgrade can make the Vault unreadable or damage Vault data. An exact
 version does not change the update channel in the Ownership Record.
 
+`1667 upgrade --list` reads the abbreviated npm package metadata. It lists all
+published launcher releases that are not deprecated. It writes one
+version on each line. `--json` writes one object with a `versions` array. The
+command checks platform support when `--version` selects a release.
+
+An exact version reuses `.1667-previous` when that executable has the selected
+version and the correct Artifact Target. Otherwise, it downloads the Platform
+Package.
+
 `1667 upgrade --rollback` works offline.
 
 Windows does not replace the running `1667.exe` file. On Windows, `1667 upgrade`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "1667-workspace",
-  "version": "0.9.4-rc.3",
+  "version": "0.9.4-rc.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "1667-workspace",
-      "version": "0.9.4-rc.3",
+      "version": "0.9.4-rc.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@silvia-odwyer/photon-node": "0.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667-workspace",
-  "version": "0.9.4-rc.3",
+  "version": "0.9.4-rc.4",
   "private": true,
   "description": "Source workspace for the 1667 terminal writing environment",
   "license": "Apache-2.0",

--- a/shared/release-notes.ts
+++ b/shared/release-notes.ts
@@ -11,6 +11,11 @@ export interface ReleaseNote {
  *  a release, and is not included. */
 export const RELEASE_NOTES: readonly ReleaseNote[] = [
   {
+    version: "0.9.4-rc.4",
+    date: "2026-08-13",
+    body: "- **`1667 upgrade --list` shows published launcher releases.** It writes one\n  version on each line, with the newest version first. Use `--json` to get a\n  `versions` array. 1667 checks platform support when `--version` selects a\n  release.\n\n- **An exact version can reuse the previous executable.** If\n  `.1667-previous` has the version that `--version` selects, 1667 verifies and\n  uses it. It does not download that version again. `--rollback` continues to\n  use the same file offline.\n\n- **The chapter title editor now has a movable caret.** The left and right\n  arrow keys move the caret. Insert, delete, and paste operations use the caret\n  position.\n\n- **The mouse now selects fields in the Fact editor.** A click selects the\n  Fact text field or choice field under the pointer. Use the left and right\n  arrow keys to change a selected choice. The mouse wheel scrolls a long Fact\n  body.\n\n- **Chapter summarization now identifies its work and its limits.** The\n  status line shows the chapter, the current stage, and that the model does not\n  report progress. Press `Esc` to stop the summary request.\n\n- **1667 prepares to save non-canon Side Notes with a story.** This release\n  contains the Aside implementation and keeps every entry point closed. It\n  cannot open `/aside` yet. This release reads and validates the successor\n  story document and refuses to change it. A later release can write that\n  document and open Aside without making this release damage the story."
+  },
+  {
     version: "0.9.4-rc.3",
     date: "2026-08-13",
     body: "- **Continuation prompts now match version 0.8.0.** 1667 again sends the\n  operation-specific contract before the story. It no longer sends the generic\n  story contract or llama.cpp Chat Completions continuation fields."

--- a/tui/package.json
+++ b/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667",
-  "version": "0.9.4-rc.3",
+  "version": "0.9.4-rc.4",
   "private": true,
   "description": "A terminal environment for writing fiction with language models",
   "license": "Apache-2.0",

--- a/tui/src/api.ts
+++ b/tui/src/api.ts
@@ -262,7 +262,7 @@ export interface StoryApi {
   renameChapterBreak(storyId: string, breakId: string | null, title: string): Promise<StoryPayload>;
   removeChapterBreak(storyId: string, breakId: string): Promise<{ payload: StoryPayload; removed: RemovedChapterBreak }>;
   restoreChapterBreak(storyId: string, breakId: string, removed: RemovedChapterBreak): Promise<StoryPayload>;
-  summarizeChapter(storyId: string, breakId: string): Promise<StoryPayload>;
+  summarizeChapter(storyId: string, breakId: string, signal?: AbortSignal): Promise<StoryPayload>;
   editChapterSummary(storyId: string, summaryId: string, text: string, expected: string): Promise<StoryPayload>;
   getSettings(): Promise<SettingsView>;
   saveSettings(command: SaveSettingsCommand): Promise<SettingsMutationResult>;
@@ -588,14 +588,16 @@ export function createApi(
     method: string,
     path: string,
     body?: unknown,
-    timeoutMs = HTTP_REQUEST_TIMEOUT_MS
+    timeoutMs = HTTP_REQUEST_TIMEOUT_MS,
+    callerSignal?: AbortSignal
   ): Promise<StoryPayload> => versions.rememberPayload(await request(
     method,
     path,
     decodeStoryResponse,
     body,
     timeoutMs,
-    await expectedVersion(storyId)
+    await expectedVersion(storyId, callerSignal),
+    callerSignal
   ));
 
   const runAbsentImportMutation = async <T>(
@@ -1038,13 +1040,14 @@ export function createApi(
         `/api/stories/${storyId}/chapter-breaks/${breakId}/restore`,
         removed
       ),
-    summarizeChapter: (storyId, breakId) =>
+    summarizeChapter: (storyId, breakId, signal) =>
       runProviderMutation(storyId, () => mutateStoryPayload(
         storyId,
         "POST",
         `/api/stories/${storyId}/chapter-breaks/${breakId}/summarize`,
         {},
-        HTTP_GENERATION_REQUEST_TIMEOUT_MS
+        HTTP_GENERATION_REQUEST_TIMEOUT_MS,
+        signal
       )),
     editChapterSummary: async (storyId, summaryId, text, expected) =>
       mutateStoryPayload(

--- a/tui/src/app.ts
+++ b/tui/src/app.ts
@@ -10,7 +10,7 @@ import type { SettingsView } from "../../shared/settings-v2-types.js";
 import type { StoryApi } from "./api.js";
 import type { RecoveryWarningFeed } from "./recovery-warning-feed.js";
 import type { ConnectionMonitor } from "./connection.js";
-import { directChapterRowAction } from "./chapter-actions.js";
+import { cancelChapterSummary, directChapterRowAction } from "./chapter-actions.js";
 import { saveConfig, type ThemeName, type UserConfig } from "./config.js";
 import { createInteractiveFrameRuntime } from "./interactive-frame-runtime.js";
 import type { TuiFrameProfileReport } from "./frame-profile.js";
@@ -26,6 +26,7 @@ import {
 import { captureMouseActionState } from "./mouse-actions.js";
 import { createInteractiveInputAdmission } from "./interactive-input-admission.js";
 import { createStoryViewModel, lastPartRowIndex, rowIndexForPathIndex } from "./model.js";
+import { chapterWord } from "./chapter-model.js";
 import { openingFocusIndex, readingPartIdFor, type ReadingPositions } from "./reading-position.js";
 import { bindLiveReadingPositionState } from "./reading-position-persist.js";
 import { handleOverlayAction } from "./overlay-actions.js";
@@ -330,7 +331,9 @@ export async function runInteractive(source: AppSource): Promise<void> {
     if (state.stream === null && state.abort === null) return quit();
     if (!state.quitArmed) {
       state.quitArmed = true;
-      state.toast = "streaming · press Ctrl+C again to discard and quit";
+      state.toast = state.chapterSummary !== null
+        ? "chapter summary running · press Ctrl+C again to stop and quit"
+        : "streaming · press Ctrl+C again to discard and quit";
       repaint();
       return;
     }
@@ -653,6 +656,13 @@ export async function dispatch(
   backend: ActionRunner = new ActionRuntime(state, repaint)
 ): Promise<void> {
   const previousMode = state.mode;
+  if (state.chapterSummary !== null && resolved.action === "cancel"
+    && state.textActions === null
+    && (isPlainNavigation(state) || state.mode === "CHAPTERS")) {
+    beginInteraction(state);
+    cancelChapterSummary(state, repaint);
+    return;
+  }
   beginInteraction(state);
   if (resolved.action !== "cut-selection") {
     const composer = activeTextComposer(state);
@@ -666,6 +676,11 @@ export async function dispatch(
   if (generationBusy(state) && state.actions === null && state.textActions === null
     && actionConflictsWithGeneration(resolved.action, state)) {
     state.toast = "stream running · esc stops it first";
+    return repaint();
+  }
+  if (state.chapterSummary !== null && state.actions === null && state.textActions === null
+    && actionConflictsWithGeneration(resolved.action, state)) {
+    state.toast = `Chapter ${chapterWord(state.chapterSummary.chapterNumber)} summary running · esc cancels`;
     return repaint();
   }
   const context: ActionContext = {
@@ -819,6 +834,7 @@ export function initialState(source: AppSource, renderMode: boolean): RuntimeSta
     lastViewportStart: 0,
     composerScrollTop: 0,
     editorScrollTop: 0,
+    editorScrollDetached: false,
     keysScrollTop: 0,
     composerSelectionProjection: null,
     storySelectionProjection: null,
@@ -833,6 +849,7 @@ export function initialState(source: AppSource, renderMode: boolean): RuntimeSta
     chapters: null,
     settings: null,
     summary: null,
+    chapterSummary: null,
     connection: source.connection?.state() ?? { down: false, attempt: 0, nextRetryAt: null, error: null },
     undo: [],
     history: [],

--- a/tui/src/chapter-actions.ts
+++ b/tui/src/chapter-actions.ts
@@ -1,5 +1,5 @@
 import { formatTokensEstimate } from "./rail.js";
-import { applyTextKey, type ResolvedKey } from "./keys.js";
+import { type ResolvedKey } from "./keys.js";
 import { chapterListModel, chapterWord } from "./chapter-model.js";
 import {
   chapterForRow,
@@ -19,8 +19,12 @@ import type { ActionContext, BackendActionContext } from "./action-context.js";
 import { rememberFocus } from "./reading-position-persist.js";
 import { adoptSameStoryPayload } from "./story-adoption.js";
 import { followStoryViewport } from "./viewport-intent.js";
+import { createComposer, insertComposerText } from "./composer-model.js";
+import { composerSurfaceAction } from "./composer-surface-action.js";
+import { SINGLE_LINE_COMPOSER_MOTION } from "./composer-motion.js";
+import type { ChapterSummaryOverlayState } from "./state.js";
 
-type ChapterActionContext = Pick<ActionContext, "backend" | "cache" | "renderer">;
+type ChapterActionContext = Pick<ActionContext, "backend" | "cache" | "renderer" | "repaint">;
 
 export function openChapters(state: RuntimeState, chapterNumber?: number): void {
   const view = createStoryViewModel(state.payload, state.stream);
@@ -52,21 +56,29 @@ export async function chaptersAction(
     return;
   }
   if (overlay.rename !== null) {
+    const rename = overlay.rename;
     if (resolved.action === "open-selected") {
-      const rename = overlay.rename;
-      const submittedTitle = rename.value.trim();
+      const submittedTitle = rename.composer.text.trim();
       await context.backend.run("renaming chapter", async (task) => {
         const payload = await source.api.renameChapterBreak(task.storyId, rename.breakId, submittedTitle);
         if (!task.storyCurrent()) return;
         adoptSameStoryPayload(state, payload, context.cache);
-        if (state.chapters === overlay && overlay.rename === rename && rename.value.trim() === submittedTitle) {
+        if (state.chapters === overlay && overlay.rename === rename && rename.composer.text.trim() === submittedTitle) {
           overlay.rename = null;
           state.toast = "chapter title saved";
         }
       });
     } else {
-      const value = applyTextKey(overlay.rename.value, resolved);
-      if (value !== null) overlay.rename.value = value;
+      if (resolved.action === "input") {
+        insertComposerText(overlay.rename.composer, resolved.text ?? "");
+      } else {
+        await composerSurfaceAction(resolved, state, overlay.rename.composer, {
+          isCurrent: () => state.chapters === overlay && overlay.rename?.composer === rename.composer,
+          pageRows: 1,
+          motion: SINGLE_LINE_COMPOSER_MOTION,
+          insert: (text) => text.replace(/\n+/g, " ")
+        });
+      }
     }
     return;
   }
@@ -227,13 +239,16 @@ function beginRename(state: RuntimeState, chapter: StoryChapter): void {
   // Chapter one has no opening break, so its current name comes from the
   // story rather than from a break. It is nameable all the same.
   if (breakId === null) {
-    state.chapters.rename = { breakId: null, value: state.payload.firstChapterTitle ?? "" };
+    state.chapters.rename = {
+      breakId: null,
+      composer: createComposer(state.payload.firstChapterTitle ?? "")
+    };
     state.chapters.deleteArmedId = null;
     return;
   }
   const chapterBreak = state.payload.chapterBreaks.find((candidate) => candidate.id === breakId);
   if (chapterBreak === undefined) return;
-  state.chapters.rename = { breakId, value: chapterBreak.title };
+  state.chapters.rename = { breakId, composer: createComposer(chapterBreak.title) };
   state.chapters.deleteArmedId = null;
 }
 
@@ -270,27 +285,100 @@ async function summarizeChapter(
   state: RuntimeState,
   source: AppSource,
   chapter: StoryChapter,
-  context: BackendActionContext
+  context: ChapterActionContext
 ): Promise<void> {
   const breakId = chapter.closedBy?.id;
   if (breakId === undefined) return void (state.toast = "current chapter stays raw until it ends");
   const refreshed = chapter.summary !== null;
+  const controller = new AbortController();
+  const progress: ChapterSummaryOverlayState = {
+    chapterNumber: chapter.number,
+    stage: "writing",
+    controller
+  };
   await context.backend.run("summarizing chapter", async (task) => {
-    const payload = await source.api.summarizeChapter(task.storyId, breakId);
-    if (!task.storyCurrent()) return;
-    adoptSameStoryPayload(state, payload, context.cache);
-    if (task.interactionCurrent()) {
-      const view = createStoryViewModel(payload);
-      const summaryIndex = view.rows.findIndex((row) => row.kind === "chapter-summary" && row.chapter.closedBy?.id === breakId);
-      if (summaryIndex >= 0) {
-        state.focusIndex = summaryIndex;
-        rememberFocus(state, source);
+    const active = { kind: "summary" as const, controller };
+    state.chapterSummary = progress;
+    state.abort = active;
+    context.repaint();
+    try {
+      const payload = await source.api.summarizeChapter(task.storyId, breakId, controller.signal);
+      if (!task.storyCurrent()) return;
+      adoptSameStoryPayload(state, payload, context.cache);
+      if (controller.signal.aborted) {
+        state.toast = chapterSummaryExists(payload, breakId)
+          ? `Chapter ${chapterWord(chapter.number)} summary completed before stop`
+          : `Chapter ${chapterWord(chapter.number)} summary stopped`;
+      } else if (task.interactionCurrent()) {
+        const view = createStoryViewModel(payload);
+        const summaryIndex = view.rows.findIndex((row) => row.kind === "chapter-summary" && row.chapter.closedBy?.id === breakId);
+        if (summaryIndex >= 0) {
+          state.focusIndex = summaryIndex;
+          rememberFocus(state, source);
+        }
       }
-      state.toast = refreshed
-        ? `Chapter ${chapterWord(chapter.number)} summary refreshed`
-        : `Chapter ${chapterWord(chapter.number)} summarized · ${formatTokensEstimate(chapter.rawTokens)} raw · prose untouched`;
+      if (!controller.signal.aborted) {
+        state.toast = refreshed
+          ? `Chapter ${chapterWord(chapter.number)} summary refreshed`
+          : `Chapter ${chapterWord(chapter.number)} summarized · ${formatTokensEstimate(chapter.rawTokens)} raw · prose untouched`;
+      }
+    } catch (error) {
+      if (controller.signal.aborted) {
+        await reloadChapterAfterStop(
+          state, source, task.storyId, breakId, chapter.number, refreshed,
+          task.storyCurrent, context.cache
+        );
+      } else if (task.storyCurrent()) {
+        state.toast = error instanceof Error ? error.message : String(error);
+      }
+    } finally {
+      if (state.abort === active) state.abort = null;
+      if (state.chapterSummary === progress) state.chapterSummary = null;
+      context.repaint();
     }
   });
+}
+
+function chapterSummaryExists(payload: RuntimeState["payload"], breakId: string): boolean {
+  return createStoryViewModel(payload).chapters.some(
+    (candidate) => candidate.closedBy?.id === breakId && candidate.summary !== null
+  );
+}
+
+async function reloadChapterAfterStop(
+  state: RuntimeState,
+  source: AppSource,
+  storyId: string,
+  breakId: string,
+  chapterNumber: number,
+  refreshed: boolean,
+  storyCurrent: () => boolean,
+  cache: ActionContext["cache"]
+): Promise<void> {
+  if (!storyCurrent()) return;
+  try {
+    const payload = await source.api.loadStory(storyId);
+    if (!storyCurrent()) return;
+    adoptSameStoryPayload(state, payload, cache);
+    const settled = !refreshed && chapterSummaryExists(payload, breakId)
+      ? "completed before stop"
+      : refreshed ? "stop settled · story reloaded" : "stopped";
+    state.toast = `Chapter ${chapterWord(chapterNumber)} summary ${settled}`;
+  } catch (error) {
+    if (storyCurrent()) state.toast = error instanceof Error ? error.message : String(error);
+  }
+}
+
+export function cancelChapterSummary(
+  state: RuntimeState,
+  repaint: (() => void) | undefined = undefined
+): void {
+  const progress = state.chapterSummary;
+  if (progress === null) return;
+  progress.stage = "stopping";
+  progress.controller.abort();
+  state.toast = `stopping Chapter ${chapterWord(progress.chapterNumber)} summary · waiting for backend`;
+  repaint?.();
 }
 
 function editSummary(

--- a/tui/src/copy-actions.ts
+++ b/tui/src/copy-actions.ts
@@ -19,6 +19,7 @@ import {
   factEditorSelectionMessage
 } from "./fact-editor-policy.js";
 import { settingsEditDisplayComposer } from "./settings-overlay-model.js";
+import { activeTextComposer } from "./text-actions.js";
 
 export interface SelectionCopyResult {
   text: string;
@@ -143,14 +144,15 @@ export function handleMainCopyShortcut(
 /** Composer surfaces consume Ctrl+C even without a selection. EDITOR handles
  * the chord in its reducer; this identifies ownership before input queues. */
 export function consumesEmptyCopyShortcut(
-  state: Pick<RuntimeState, "mode" | "settings" | "library">
+  state: Pick<RuntimeState, "mode" | "settings" | "library" | "chapters">
 ): boolean {
   return state.mode === "COMPOSE"
     || state.mode === "ASIDE"
     || state.mode === "EDITOR"
     || state.mode === "SETTINGS"
       && (state.settings?.edit != null || state.settings?.sampling?.edit != null)
-    || state.mode === "LIBRARY" && state.library?.prompt?.kind === "rename";
+    || state.mode === "LIBRARY" && state.library?.prompt?.kind === "rename"
+    || state.mode === "CHAPTERS" && state.chapters?.rename != null;
 }
 
 /** Convert OpenTUI's painted-cell range into the same raw document selection
@@ -272,23 +274,7 @@ function activeComposer(
   if (editor?.kind === "fact") {
     return factEditorComposerForSource(editor, sourceId);
   }
-  return editor !== null
-    ? sourceId === undefined ? editor.composer : null
-    : state.mode === "COMPOSE"
-      ? sourceId === undefined ? state.composer : null
-      : state.mode === "SETTINGS"
-        ? sourceId === undefined
-          ? state.settings?.sampling?.edit?.composer
-            ?? state.settings?.edit?.composer
-            ?? null
-          : null
-        : state.mode === "LIBRARY"
-          ? sourceId === undefined && state.library?.prompt?.kind === "rename"
-            ? state.library.prompt.composer
-            : null
-          : state.mode === "ASIDE"
-            ? sourceId === undefined ? state.aside?.composer ?? null : null
-          : null;
+  return sourceId === undefined ? activeTextComposer(state) : null;
 }
 
 /** Translate generic multi-buffer selection outcomes at the editor boundary. */

--- a/tui/src/editor-action.ts
+++ b/tui/src/editor-action.ts
@@ -16,6 +16,7 @@ import { editorInsertionPolicy } from "./editor-text-insertion.js";
 import { factEditorChanged, factEditorSavePayload } from "./fact-editor-draft.js";
 import {
   factEditorBuffer,
+  factEditorComposerForSource,
   handleFactEditorVerticalMove,
   handleFactEditorCommand,
   handleFactEditorHistory
@@ -56,6 +57,17 @@ export async function inlineEditorAction(
   const host = state.mode === "EDITOR" ? state.editor : null;
   if (host === null) return;
   const editor = host;
+  const wheelScroll = resolved.action === "scroll-line-up"
+    || resolved.action === "scroll-line-down";
+  if (!wheelScroll) state.editorScrollDetached = false;
+
+  if (editor.kind === "fact" && resolved.composerSourceId !== undefined) {
+    const source = factEditorComposerForSource(editor, resolved.composerSourceId);
+    // Choice rows intentionally have no composer. They are still valid mouse
+    // targets because the source lookup sets their focus before this return.
+    if (source === null) return;
+    if (resolved.action === "compose") return;
+  }
 
   // Author's Note grammar owns the depth control, the same way the Fact
   // header owns its own commands below.
@@ -73,6 +85,18 @@ export async function inlineEditorAction(
     state.config.wordWrap === "on",
     () => Math.max(1, (context.renderer?.width ?? 80) - 4)
   );
+  // Wheel input uses the scroll-line vocabulary shared by document viewers.
+  // Keep it on the Fact body composer so the fixed header rows never receive
+  // focus while the existing composer viewport follows the caret.
+  if (editor.kind === "fact"
+    && wheelScroll) {
+    state.editorScrollTop = Math.max(
+      0,
+      state.editorScrollTop + (resolved.action === "scroll-line-up" ? -1 : 1)
+    );
+    state.editorScrollDetached = true;
+    return;
+  }
   if (editor.kind === "fact"
     && handleFactEditorVerticalMove(resolved, editor, motion)) {
     return;
@@ -104,6 +128,7 @@ function closeInlineEditor(
   state.textActions = null;
   state.editor = null;
   state.editorScrollTop = 0;
+  state.editorScrollDetached = false;
   if (editor.returnMode === "FACTS" && state.facts !== null) {
     state.mode = "FACTS";
   } else if (editor.returnMode === "SETTINGS"

--- a/tui/src/editor-open.ts
+++ b/tui/src/editor-open.ts
@@ -168,6 +168,7 @@ function openInlineEditor(
   state.textActions = null;
   state.editor = { kind: "document", ...editor };
   state.editorScrollTop = 0;
+  state.editorScrollDetached = false;
   state.mode = "EDITOR";
 }
 
@@ -178,5 +179,6 @@ function openFactSession(
   state.textActions = null;
   state.editor = { kind: "fact", ...editor };
   state.editorScrollTop = 0;
+  state.editorScrollDetached = false;
   state.mode = "EDITOR";
 }

--- a/tui/src/keys-text-surface.ts
+++ b/tui/src/keys-text-surface.ts
@@ -7,13 +7,11 @@ import type { ResolvedKey } from "./keys.js";
  * They move and delete by character, word, line, buffer, and page.
  * They also share cut, undo, and redo.
  *
- * Three other surfaces hold a plain string, not a composer: the FACTS
- * filter, the CHAPTERS rename field, and the TAG name. These surfaces use
- * `applyTextKey`. They do not use this table.
+ * The FACTS filter and TAG name hold a plain string, not a composer. These
+ * surfaces use `applyTextKey`. They do not use this table.
  *
- * The LIBRARY prompt is split: its filter and its delete confirmation are
- * still plain strings on `applyTextKey`, but its rename field is composer-
- * backed and reads this table, the same as Direct and the settings fields.
+ * The LIBRARY prompt is split. Its filter and delete confirmation use plain
+ * strings. Its rename field and the CHAPTERS rename field read this table.
  *
  * Each surface checks its own chords before it checks this table.
  * This order keeps the intentional differences.

--- a/tui/src/keys.ts
+++ b/tui/src/keys.ts
@@ -225,7 +225,7 @@ export function pasteInto(
     facts: { filtering: boolean; query: string; cursor: number } | null;
     commands: { view: string; query: string } | null;
     search: { query: string } | null;
-    chapters?: { rename: { value: string } | null } | null;
+    chapters?: { rename: { composer: ComposerState } | null } | null;
     settings: {
       edit: SettingsInlineEditState | null;
       sampling?: { edit: { composer: ComposerState } | null } | null;
@@ -335,7 +335,7 @@ export function pasteInto(
   }
   const chapterRename = state.mode === "CHAPTERS" ? state.chapters?.rename : null;
   if (chapterRename != null) {
-    chapterRename.value += line;
+    insertComposerText(chapterRename.composer, line);
     return true;
   }
   const settingsEdit = state.mode === "SETTINGS" ? state.settings?.edit : null;
@@ -616,10 +616,8 @@ export function resolveKey(key: KeyEvent, mode: AppMode, options: ResolveOptions
     if (key.name === "backspace") return { action: "backspace" };
     return textInput(key) ?? { action: "none" };
   }
-  // The LIBRARY rename field alone is composer-backed (its filter and its
-  // delete confirmation stay plain strings below). Resolved ahead of the
-  // blanket chord guard just below so cut/paste/select-all/word-motion
-  // chords reach it instead of being rejected as unknown chords.
+  // The two rename fields are composer-backed. Resolve them ahead of the
+  // blanket chord guard so their editing chords reach the composer.
   if (mode === "LIBRARY" && libraryRenaming) {
     if (key.name === "return") return { action: "open-selected" };
     // Up/down still move the row behind the prompt, exactly as they do
@@ -627,6 +625,11 @@ export function resolveKey(key: KeyEvent, mode: AppMode, options: ResolveOptions
     // motion of its own to give them instead.
     if (key.name === "down") return { action: "focus-next" };
     if (key.name === "up") return { action: "focus-previous" };
+    if ((key.ctrl || key.super) && key.name.toLowerCase() === "v") return { action: "paste-clipboard" };
+    return composerBackedInput(key);
+  }
+  if (mode === "CHAPTERS" && overlayTyping) {
+    if (key.name === "return") return { action: "open-selected" };
     if ((key.ctrl || key.super) && key.name.toLowerCase() === "v") return { action: "paste-clipboard" };
     return composerBackedInput(key);
   }
@@ -680,11 +683,6 @@ export function resolveKey(key: KeyEvent, mode: AppMode, options: ResolveOptions
     return { action: "none" };
   }
   if (mode === "CHAPTERS") {
-    if (overlayTyping) {
-      if (key.name === "return") return { action: "open-selected" };
-      if (key.name === "backspace") return { action: "backspace" };
-      return textInput(key) ?? { action: "none" };
-    }
     if (key.name === "down") return { action: "focus-next" };
     if (key.name === "up") return { action: "focus-previous" };
     if (key.name === "return") return { action: "open-selected" };

--- a/tui/src/mouse-actions.ts
+++ b/tui/src/mouse-actions.ts
@@ -193,7 +193,7 @@ export function captureMouseActionState(state: RuntimeState): MouseActionState {
     // The palette's rows depend on both, so identifying one means seeing what
     // the frame that drew it saw.
     connection: state.connection,
-    requestActive: generationBusy(state) || state.summary !== null,
+    requestActive: generationBusy(state) || state.summary !== null || state.chapterSummary != null,
     map: state.map === null ? null : {
       ...state.map,
       rowIds: [...state.map.rowIds],
@@ -219,7 +219,12 @@ export function captureMouseActionState(state: RuntimeState): MouseActionState {
     },
     facts: state.facts === null ? null : { ...state.facts },
     commands: state.commands === null ? null : { ...state.commands },
-    chapters: state.chapters === null ? null : { ...state.chapters },
+    chapters: state.chapters === null ? null : {
+      ...state.chapters,
+      rename: state.chapters.rename === null
+        ? null
+        : { ...state.chapters.rename, composer: { ...state.chapters.rename.composer } }
+    },
     settings: state.settings === null ? null : captureSettingsOverlay(state.settings),
     search: state.search === null ? null : { ...state.search },
     request: state.request === null ? null : { ...state.request }
@@ -285,6 +290,13 @@ export function mouseToAction(
   if (event.type === "scroll") {
     const down = event.scroll?.direction === "down";
     if (state.mode === "REQUEST") return { action: down ? "scroll-line-down" : "scroll-line-up" };
+    // The Fact editor owns several header rows above a scrollable body. Wheel
+    // input must move that body one visual row at a time; routing it through
+    // the overlay's focus actions would move the header selection instead.
+    if (state.mode === "EDITOR" && state.editor?.kind === "fact"
+      && state.textActions === null) {
+      return { action: down ? "scroll-line-down" : "scroll-line-up" };
+    }
     if (overlayOpen(state)) return { action: down ? "focus-next" : "focus-previous" };
     return { action: down ? "scroll-down" : "scroll-up" };
   }
@@ -352,7 +364,21 @@ export function mouseToAction(
   if (target.kind === "thought" && event.button === 0 && state.mode === "NAV") {
     return { action: "toggle-thought", index: target.index, rowId: target.rowId };
   }
-  if (target.kind === "composer" && event.button === 0) return { action: "compose" };
+  if (target.kind === "composer" && event.button === 0) {
+    // A Fact editor has one composer hit target per header/body field. Keep
+    // that source identity on the existing composer action so EDITOR can move
+    // focus to the field the writer clicked. Choice rows use the same focus
+    // action; their values still change only through the existing left/right
+    // keyboard controls.
+    if (state.mode === "EDITOR" && state.editor?.kind === "fact"
+      && target.composerSourceId !== undefined) {
+      return {
+        action: "compose",
+        composerSourceId: target.composerSourceId
+      };
+    }
+    return { action: "compose" };
+  }
   if (target.kind === "part") {
     // Carry the row identity its neighbours carry: an index alone cannot
     // survive a part landing or leaving above this one.

--- a/tui/src/npm-upgrade-registry.ts
+++ b/tui/src/npm-upgrade-registry.ts
@@ -4,7 +4,7 @@ import {
   NPM_REGISTRY_ORIGIN as SHARED_NPM_REGISTRY_ORIGIN
 } from "../../shared/npm-tarball-url.js";
 import { distTagForChannel } from "../../shared/release-dist-tags.js";
-import { isSemVer, parseSemVer } from "../../shared/semver.js";
+import { compareSemVer, isSemVer, parseSemVer } from "../../shared/semver.js";
 import { parseJsonRejectingDuplicateKeys } from "../../shared/strict-json.js";
 import {
   PUBLISHED_PLATFORM_PACKAGES,
@@ -20,6 +20,7 @@ import {
 
 export const NPM_REGISTRY_ORIGIN = SHARED_NPM_REGISTRY_ORIGIN;
 export const NPM_METADATA_MAX_BYTES = SHARED_NPM_METADATA_MAX_BYTES;
+export const NPM_VERSION_INDEX_MAX_BYTES = 1024 * 1024;
 export const LAUNCHER_PACKAGE = RELEASE_LAUNCHER_PACKAGE;
 // The registry only answers for packages that were published, so a held
 // target's package is not something this client may look up or expect.
@@ -62,6 +63,16 @@ export class NpmUpgradeRegistry {
     private readonly fetcher: RegistryFetch = (input, init) => fetch(input, init),
     private readonly timeoutMs = 5_000
   ) {}
+
+  async availableVersions(signal: AbortSignal): Promise<readonly string[]> {
+    const body = await this.get(
+      `/${registryPathForPackage(LAUNCHER_PACKAGE)}`,
+      signal,
+      "application/vnd.npm.install-v1+json",
+      NPM_VERSION_INDEX_MAX_BYTES
+    );
+    return parseNpmAvailableVersions(body);
+  }
 
   async channelHead(channel: UpgradeChannel, signal: AbortSignal): Promise<string> {
     const body = await this.get(
@@ -114,7 +125,12 @@ export class NpmUpgradeRegistry {
     );
   }
 
-  private async get(path: string, signal: AbortSignal): Promise<Uint8Array> {
+  private async get(
+    path: string,
+    signal: AbortSignal,
+    accept = "application/json",
+    maxBytes = NPM_METADATA_MAX_BYTES
+  ): Promise<Uint8Array> {
     const timeout = new AbortController();
     const timer = setTimeout(
       () => timeout.abort(new DOMException("Registry request timed out", "TimeoutError")),
@@ -124,7 +140,9 @@ export class NpmUpgradeRegistry {
       return await this.getWithSignal(
         path,
         signal,
-        AbortSignal.any([signal, timeout.signal])
+        AbortSignal.any([signal, timeout.signal]),
+        accept,
+        maxBytes
       );
     } finally {
       clearTimeout(timer);
@@ -134,13 +152,15 @@ export class NpmUpgradeRegistry {
   private async getWithSignal(
     path: string,
     callerSignal: AbortSignal,
-    requestSignal: AbortSignal
+    requestSignal: AbortSignal,
+    accept: string,
+    maxBytes: number
   ): Promise<Uint8Array> {
     let response: Response;
     try {
       response = await this.fetcher(`${NPM_REGISTRY_ORIGIN}${path}`, {
         method: "GET",
-        headers: { accept: "application/json" },
+        headers: { accept },
         redirect: "error",
         signal: requestSignal
       });
@@ -161,12 +181,37 @@ export class NpmUpgradeRegistry {
       );
     }
     const contentType = response.headers.get("content-type")?.split(";", 1)[0]?.trim().toLowerCase();
-    if (contentType !== "application/json") {
+    if (contentType !== "application/json" && contentType !== accept) {
       await cancelResponse(response);
       throw metadataFailure();
     }
-    return readBoundedBody(response, callerSignal);
+    return readBoundedBody(response, callerSignal, maxBytes);
   }
+}
+
+/** Published, non-deprecated launcher releases, newest first. */
+export function parseNpmAvailableVersions(
+  body: Uint8Array | string
+): readonly string[] {
+  const value = parseBoundedJson(body, NPM_VERSION_INDEX_MAX_BYTES);
+  if (!isRecord(value) || value.name !== LAUNCHER_PACKAGE || !isRecord(value.versions)) {
+    throw metadataFailure();
+  }
+  const entries = Object.entries(value.versions);
+  if (entries.length === 0 || entries.length > 1024) throw metadataFailure();
+  const versions: string[] = [];
+  for (const [key, metadata] of entries) {
+    if (!isSemVer(key) || !isRecord(metadata) || metadata.name !== LAUNCHER_PACKAGE
+      || metadata.version !== key) {
+      throw metadataFailure();
+    }
+    const deprecated = metadata.deprecated;
+    if (deprecated !== undefined && typeof deprecated !== "string") throw metadataFailure();
+    if ((deprecated === undefined || deprecated.length === 0)
+      && !Object.hasOwn(metadata, "revoked")) versions.push(key);
+  }
+  versions.sort((left, right) => compareSemVer(right, left));
+  return Object.freeze(versions);
 }
 
 export function parseNpmDistTags(
@@ -207,7 +252,8 @@ export function parseNpmExactVersionMetadata(
   if (name !== expected.name || version !== expected.version) {
     throw new UpgradeFailure("verification_failed", "Registry package identity did not match the target.");
   }
-  if (Object.hasOwn(value, "deprecated") || Object.hasOwn(value, "revoked")) {
+  const deprecated = value.deprecated;
+  if ((deprecated !== undefined && deprecated !== "") || Object.hasOwn(value, "revoked")) {
     throw new UpgradeFailure("unsupported_target", "The requested release is deprecated or revoked.");
   }
   if (!isRecord(value.dist)) throw metadataFailure();
@@ -348,9 +394,13 @@ function singleStringArrayEquals(value: unknown, expected: string): boolean {
   return Array.isArray(value) && value.length === 1 && value[0] === expected;
 }
 
-async function readBoundedBody(response: Response, callerSignal: AbortSignal): Promise<Uint8Array> {
+async function readBoundedBody(
+  response: Response,
+  callerSignal: AbortSignal,
+  maxBytes: number
+): Promise<Uint8Array> {
   const declared = response.headers.get("content-length");
-  if (declared !== null && (!/^\d+$/.test(declared) || Number(declared) > NPM_METADATA_MAX_BYTES)) {
+  if (declared !== null && (!/^\d+$/.test(declared) || Number(declared) > maxBytes)) {
     await cancelResponse(response);
     throw metadataFailure();
   }
@@ -363,7 +413,7 @@ async function readBoundedBody(response: Response, callerSignal: AbortSignal): P
       const next = await reader.read();
       if (next.done) break;
       length += next.value.byteLength;
-      if (length > NPM_METADATA_MAX_BYTES) throw metadataFailure();
+      if (length > maxBytes) throw metadataFailure();
       chunks.push(next.value);
     }
   } catch (error) {
@@ -389,9 +439,12 @@ async function cancelResponse(response: Response): Promise<void> {
   await response.body?.cancel().catch(() => undefined);
 }
 
-function parseBoundedJson(body: Uint8Array | string): unknown {
+function parseBoundedJson(
+  body: Uint8Array | string,
+  maxBytes = NPM_METADATA_MAX_BYTES
+): unknown {
   const bytes = typeof body === "string" ? new TextEncoder().encode(body) : body;
-  if (bytes.byteLength === 0 || bytes.byteLength > NPM_METADATA_MAX_BYTES) throw metadataFailure();
+  if (bytes.byteLength === 0 || bytes.byteLength > maxBytes) throw metadataFailure();
   let text: string;
   try {
     text = new TextDecoder("utf-8", { fatal: true }).decode(bytes);

--- a/tui/src/overlay-actions.ts
+++ b/tui/src/overlay-actions.ts
@@ -673,7 +673,7 @@ function liveCommandMatches(
     state.demo,
     commandContext(state.payload, {
       connectionDown: state.connection.down,
-      requestActive: generationBusy(state) || state.summary !== null,
+      requestActive: generationBusy(state) || state.summary !== null || state.chapterSummary != null,
       canRewriteSelection: canRewriteSelection(selection?.spans ?? []),
       asideEntryPointsOpen: asideOpen
     })

--- a/tui/src/screens/panels.ts
+++ b/tui/src/screens/panels.ts
@@ -67,6 +67,9 @@ export const CHAPTERS_FOOTER_ACTIONS = [
 export const RENAME_FOOTER_ACTIONS = [
   { token: "↵", action: "open-selected" }, { token: "esc", action: "cancel" }
 ] as const satisfies ReadonlyArray<{ token: string; action: KeyAction }>;
+const CHAPTER_SUMMARY_FOOTER_ACTIONS = [
+  { token: "esc cancels", action: "cancel" }
+] as const satisfies ReadonlyArray<{ token: string; action: KeyAction }>;
 export const LIBRARY_FOOTER_ACTIONS = [
   { token: "↑", action: "focus-previous" }, { token: "↓", action: "focus-next" },
   { token: "↵", action: "open-selected" }, { token: "n new", action: "new-item" },
@@ -123,7 +126,7 @@ export function renderPanels(
   const local: PanelRenderState = {
     ...state,
     hitRows,
-    requestActive: generationBusy(state) || state.summary !== null
+    requestActive: generationBusy(state) || state.summary !== null || state.chapterSummary != null
   };
   let composition: FrameComposition = { lines: base, selectable: null };
   if (state.archive !== null) {
@@ -248,13 +251,17 @@ function renderChapters(
   const content: FrameLine[] = [];
   const targets: Array<HitTarget | null> = [];
   if (overlay.rename !== null) {
-    content.push(promptLine("chapter title", overlay.rename.value, contentWidth));
+    content.push(renameLine("chapter title", overlay.rename.composer, contentWidth));
     targets.push(null);
   }
   // 13, not 11: the context status below costs two content rows. Under-reserving
   // overflows the panel, and placePanel clamps by dropping from the bottom —
   // which is exactly the status this panel moved inside to stop hiding.
-  const rowBudget = Math.max(1, height - 13 - (overlay.rename === null ? 0 : 1));
+  const rowBudget = Math.max(
+    1,
+    height - 13
+      - (overlay.rename === null ? 0 : 1)
+  );
   const window = chapterWindow(model.rows.length, overlay.cursor, rowBudget);
   const range = model.rows.length <= rowBudget ? "" : ` · ${window.start + 1}–${window.end}/${model.rows.length}`;
   content.push([
@@ -297,7 +304,9 @@ function renderChapters(
     raisedSegment(fix, "accent · deep")
   ]);
   targets.push(null, null);
-  const footer = overlay.rename !== null
+  const footer = state.chapterSummary != null
+    ? "esc cancels"
+    : overlay.rename !== null
     ? "↵ saves the title · esc keeps the old one"
     : overlay.deleteArmedId !== null
     ? "↵ jump · s sum · e rename · n break · d confirms · esc keeps"
@@ -308,7 +317,9 @@ function renderChapters(
     footer, width, height, 106, { rows: state.hitRows, targets,
       // Renaming accepts only save, cancel and text: advertising the other verbs
       // would register clicks its handler drops on the floor.
-      footerActions: overlay.rename === null ? CHAPTERS_FOOTER_ACTIONS : RENAME_FOOTER_ACTIONS });
+      footerActions: state.chapterSummary != null
+        ? CHAPTER_SUMMARY_FOOTER_ACTIONS
+        : overlay.rename === null ? CHAPTERS_FOOTER_ACTIONS : RENAME_FOOTER_ACTIONS });
 }
 
 function renderLibrary(
@@ -330,7 +341,7 @@ function renderLibrary(
   // filters and carry no count.
   const filterCount = `${rows.length} of ${overlay.stories.length}`;
   if (overlay.prompt?.kind === "rename") {
-    content.push(renameLine(overlay.prompt.composer, contentWidth));
+    content.push(renameLine("rename", overlay.prompt.composer, contentWidth));
   }
   else if (overlay.prompt !== null) {
     content.push(promptLine(
@@ -399,8 +410,8 @@ function libraryLine(
   ];
 }
 
-function renameLine(composer: ComposerState, width: number): FrameLine {
-  const prefix = truncate("  › rename: ", Math.max(0, width - 1));
+function renameLine(label: string, composer: ComposerState, width: number): FrameLine {
+  const prefix = truncate(`  › ${label}: `, Math.max(0, width - 1));
   const valueWidth = Math.max(1, width - visibleWidth(prefix));
   return [
     raisedSegment(prefix, "accent · deep"),

--- a/tui/src/screens/story.ts
+++ b/tui/src/screens/story.ts
@@ -777,6 +777,7 @@ function renderInlineEditor(
         height,
         footerNotice,
         scrollTop: state.editorScrollTop,
+        followCursor: state.editorScrollDetached !== true,
         narrow: width < 100,
         softWrap: state.config.wordWrap === "on"
       })

--- a/tui/src/screens/story/composer.ts
+++ b/tui/src/screens/story/composer.ts
@@ -68,6 +68,8 @@ export interface ComposerLayoutOptions {
   footerNotice?: string | null;
   /** First logical row from the previous frame, retained until focus exits it. */
   scrollTop?: number | null;
+  /** Keep a wheel-owned viewport even when it does not contain the caret. */
+  followCursor?: boolean;
   focusDim?: boolean;
   narrow?: boolean;
   /** Enter commits a retake or a rewrite of an existing part, so the footer
@@ -143,7 +145,13 @@ export function renderComposerLayout(options: ComposerLayoutOptions): ComposerLa
       ? Math.max(1, terminalHeight - 2 - footer.length)
       : Math.max(1, Math.min(cap, terminalHeight - 3 - footer.length));
   const bodyRows = fullscreen ? bodyCapacity : Math.min(rowCount, bodyCapacity);
-  const scrollTop = retainedScrollTop(rowCount, bodyRows, cursorRow, options.scrollTop);
+  const scrollTop = retainedScrollTop(
+    rowCount,
+    bodyRows,
+    cursorRow,
+    options.scrollTop,
+    options.followCursor !== false
+  );
   const title = options.title ?? composerTitle(fullscreen, options.directingPart);
   const counter = !fullscreen && lineCount > 1 ? `${lineCount} / ${cap} lines` : "";
   const status = options.status ?? (counter.length > 0 ? { text: counter } : undefined);
@@ -442,15 +450,18 @@ function retainedScrollTop(
   lineCount: number,
   bodyRows: number,
   cursorLine: number,
-  previous: number | null | undefined
+  previous: number | null | undefined,
+  followCursor: boolean
 ): number {
   const maximum = Math.max(0, lineCount - bodyRows);
   const initial = previous !== null && previous !== undefined && Number.isFinite(previous)
     ? Math.floor(previous)
     : cursorLine - bodyRows + 1;
   let top = Math.max(0, Math.min(maximum, initial));
-  if (cursorLine < top) top = cursorLine;
-  else if (cursorLine >= top + bodyRows) top = cursorLine - bodyRows + 1;
+  if (followCursor) {
+    if (cursorLine < top) top = cursorLine;
+    else if (cursorLine >= top + bodyRows) top = cursorLine - bodyRows + 1;
+  }
   return Math.max(0, Math.min(maximum, top));
 }
 

--- a/tui/src/screens/story/fact-editor-layout.ts
+++ b/tui/src/screens/story/fact-editor-layout.ts
@@ -37,6 +37,7 @@ interface FactEditorLayoutOptions {
   scrollTop: number;
   narrow: boolean;
   softWrap: boolean;
+  followCursor: boolean;
 }
 
 /** Render the typed tag field as a sibling of the Fact body composer. */
@@ -60,6 +61,7 @@ export function renderFactEditorLayout(
     placeholder: editor.placeholder,
     footerNotice: options.footerNotice,
     scrollTop: options.scrollTop,
+    followCursor: options.followCursor,
     narrow: options.narrow,
     softWrap: options.softWrap,
     caret: editor.focus === "body" ? "focused" : "none",

--- a/tui/src/screens/story/status.ts
+++ b/tui/src/screens/story/status.ts
@@ -4,6 +4,7 @@ import { tagGlyph, tagRole } from "../../tag-presentation.js";
 import { chapterForRow, rowPart, type StoryViewModel } from "../../model.js";
 import { pruneConfirmText } from "../../prune-model.js";
 import { samplingListPanelStatusLabel } from "../../sampling-panel-spec.js";
+import { isPlainNavigation } from "../../keys.js";
 import { contextSeverity, formatTokensScaled, formatTokensEstimate, requestWindow } from "../../rail.js";
 import type { NextRequestEstimate } from "../../request-projection.js";
 import type { StoryScreenState } from "../../state.js";
@@ -79,10 +80,21 @@ export function renderStatus(
   // Only work in flight earns a cell. The backend is local unless someone went
   // out of their way to point it elsewhere for debugging, so saying so on every
   // frame reports the default back to the writer and nothing more.
-  const backendStatus = state.backendTask === null
-    ? null
-    : `working · ${truncate(state.backendTask.label, narrow ? 18 : 28)}`;
-  let narrowRight = state.backendTask === null
+  const summaryStage = state.chapterSummary?.stage === "writing" ? "writing · model progress unavailable"
+    : state.chapterSummary?.stage === "stopping" ? "stopping · waiting for backend"
+    : null;
+  const summaryCancel = state.textActions === null
+    && (isPlainNavigation(state) || state.mode === "CHAPTERS")
+    ? " · esc cancels"
+    : "";
+  const backendStatus = state.chapterSummary != null
+    ? `working · Chapter ${state.chapterSummary.chapterNumber} summary · ${summaryStage}${summaryCancel}`
+    : state.backendTask === null
+      ? null
+      : `working · ${truncate(state.backendTask.label, narrow ? 18 : 28)}`;
+  let narrowRight = state.chapterSummary != null
+    ? `ch ${state.chapterSummary.chapterNumber} · ${summaryStage}${summaryCancel}`
+    : state.backendTask === null
     ? `${chapterPrefix}${requestMeter}${centered}`
     : `${backendStatus} · ${requestMeter}${centered}`;
   // On the canonical 80-column frame the complete request value outranks the
@@ -93,14 +105,19 @@ export function renderStatus(
     ? visibleWidth(plainLine(left))
     : minimumLeftWidth;
   if (priorityLeftWidth + visibleWidth(narrowRight) + 2 > width) {
-    narrowRight = state.backendTask === null
+    narrowRight = state.chapterSummary != null
+      ? `ch ${state.chapterSummary.chapterNumber} · ${state.chapterSummary.stage}${summaryCancel}`
+      : state.backendTask === null
       ? `${requestMeter}${centered}`
       : `working · ${requestMeter}${centered}`;
   }
   if (minimumLeftWidth + visibleWidth(narrowRight) + 2 > width && centered.length > 0) {
-    narrowRight = state.backendTask === null ? requestMeter : `working · ${requestMeter}`;
+    narrowRight = state.chapterSummary != null ? `working${summaryCancel}`
+      : state.backendTask === null ? requestMeter : `working · ${requestMeter}`;
   }
-  if (minimumLeftWidth + visibleWidth(narrowRight) + 2 > width) narrowRight = requestMeter;
+  if (minimumLeftWidth + visibleWidth(narrowRight) + 2 > width) {
+    narrowRight = state.chapterSummary != null ? summaryCancel.slice(3) || "working" : requestMeter;
+  }
   // Which build is running, in the corner where it stays out of the way. It is
   // reference rather than status, so it takes slack and nothing else: never a
   // cell from the story's title, line name, location, or word count. `?`
@@ -118,6 +135,10 @@ export function renderStatus(
     segment(`${centered}${buildTag ? ` · ${AI_1667_VERSION_TAG}` : ""} `, "chrome")
   ];
   const tagged = wideRight(true);
+  const compactSummaryRight: FrameLine = [segment(
+    ` ${narrowRight} `,
+    "chrome"
+  )];
   const right: FrameLine = narrow
     ? [segment(
       ` ${narrowRight} `,
@@ -126,7 +147,7 @@ export function renderStatus(
     )]
     : visibleWidth(plainLine(left)) + visibleWidth(plainLine(tagged)) <= width
       ? tagged
-      : wideRight(false);
+      : state.chapterSummary != null ? compactSummaryRight : wideRight(false);
   const rightWidth = visibleWidth(plainLine(right));
   if (rightWidth >= width) return fitLine(right, width);
   const leftWidth = width - rightWidth;

--- a/tui/src/settings-prompt-editor.ts
+++ b/tui/src/settings-prompt-editor.ts
@@ -25,6 +25,7 @@ export function openSystemPromptEditor(state: RuntimeState): void {
   };
   state.editor = editor;
   state.editorScrollTop = 0;
+  state.editorScrollDetached = false;
   state.mode = "EDITOR";
 }
 

--- a/tui/src/state.ts
+++ b/tui/src/state.ts
@@ -194,7 +194,7 @@ export interface CommandsOverlayState {
 }
 export interface ChaptersOverlayState {
   cursor: number;
-  rename: { breakId: string | null; value: string } | null;
+  rename: { breakId: string | null; composer: ComposerState } | null;
   deleteArmedId: string | null;
 }
 export type SettingsRowId =
@@ -367,6 +367,15 @@ export interface SummaryOverlayState {
   end: number;
   totalParts: number;
   text: string;
+  controller: AbortController;
+}
+
+/** A chapter summary is a unary provider operation, so the provider cannot
+ *  report source-consumption progress. Keep the honest stage and chapter
+ *  identity visible while the action runtime owns the request. */
+export interface ChapterSummaryOverlayState {
+  chapterNumber: number;
+  stage: "writing" | "stopping";
   controller: AbortController;
 }
 
@@ -608,6 +617,7 @@ export interface OverlayState {
   chapters: ChaptersOverlayState | null;
   settings: SettingsOverlayState | null;
   summary: SummaryOverlayState | null;
+  chapterSummary: ChapterSummaryOverlayState | null;
   connection: ConnectionState;
 }
 
@@ -707,6 +717,8 @@ export interface StoryScreenState extends OverlayState {
   composerScrollTop: number;
   /** First logical row painted by the full-screen in-TUI editor. */
   editorScrollTop: number;
+  /** True while a Fact-body wheel gesture owns the viewport instead of the caret. */
+  editorScrollDetached: boolean;
   /** First row of the key reference shown, for terminals too short for it. */
   keysScrollTop: number;
   /** Last presented page-buffer cells that correspond to raw editor text. */

--- a/tui/src/story-adoption.ts
+++ b/tui/src/story-adoption.ts
@@ -339,6 +339,7 @@ function reconcileStoryBoundIntent(
       state.textActions = null;
       state.editor = null;
       state.editorScrollTop = 0;
+      state.editorScrollDetached = false;
       if (state.mode === "EDITOR") {
         state.mode = editor.returnMode === "FACTS" && state.facts !== null
           ? "FACTS"
@@ -399,11 +400,13 @@ export function adoptStoryState(state: RuntimeState, payload: StoryPayload, cach
   state.archive = null;
   state.settings = null;
   state.summary = null;
+  state.chapterSummary = null;
   if (changingStory) state.aside = null;
   state.hitRows = [];
   followStoryViewport(state);
   state.lastViewportStart = 0;
   state.composerScrollTop = 0;
   state.editorScrollTop = 0;
+  state.editorScrollDetached = false;
   state.quitArmed = false;
 }

--- a/tui/src/text-actions.ts
+++ b/tui/src/text-actions.ts
@@ -26,7 +26,7 @@ export function availableTextActions(
   return overlay.copyOnly ? TEXT_ACTIONS.slice(0, 1) : TEXT_ACTIONS;
 }
 
-type TextOwnerState = Pick<RuntimeState, "mode" | "composer" | "editor" | "settings" | "library">
+type TextOwnerState = Pick<RuntimeState, "mode" | "composer" | "editor" | "settings" | "library" | "chapters">
   & { aside?: RuntimeState["aside"] };
 
 /** Find the composer-backed field that currently owns text input. */
@@ -41,6 +41,7 @@ export function activeTextComposer(state: TextOwnerState): ComposerState | null 
   if (state.mode === "LIBRARY") {
     return state.library?.prompt?.kind === "rename" ? state.library.prompt.composer : null;
   }
+  if (state.mode === "CHAPTERS") return state.chapters?.rename?.composer ?? null;
   if (state.mode !== "SETTINGS" || state.settings === null) return null;
   const sampling = state.settings.sampling?.edit;
   if (sampling !== null && sampling !== undefined) return sampling.composer;

--- a/tui/src/upgrade-apply.ts
+++ b/tui/src/upgrade-apply.ts
@@ -1,6 +1,9 @@
 import { existsSync } from "node:fs";
 import { compareSemVer } from "../../shared/semver.js";
-import { releaseTargetForPackage } from "../../shared/release-targets.js";
+import {
+  releaseTargetForPackage,
+  type BuiltArtifactTarget
+} from "../../shared/release-targets.js";
 import type { InstallationAuthority } from "./install-ownership.js";
 import {
   activateCandidate,
@@ -117,23 +120,33 @@ export async function applyUpgrade(
       if (compareSemVer(targetVersion, lockedVersion) < 0) {
         dependencies.onDowngradeWarning?.(DOWNGRADE_WARNING);
       }
-      await downloadPlatformPackage({
-        tarballUrl: meta.tarball,
-        packageName: dependencies.observation.platformPackage,
-        version: targetVersion,
-        integrity: meta.integrity,
-        destinationPath: paths.packageStaging,
-        signal: lockedSignal,
-        fetcher: dependencies.fetcher,
-        onProgress: dependencies.onDownloadProgress
-      });
-      await materializeCandidate({
-        packagePath: paths.packageStaging,
-        destinationPath: paths.candidate,
-        packageName: dependencies.observation.platformPackage,
-        version: targetVersion,
-        signal: lockedSignal
-      });
+      const reusedPrevious = command.version !== null
+        && await copyPreviousVersion(
+          paths.previous,
+          paths.candidate,
+          targetVersion,
+          authority.record.artifactTarget,
+          lockedSignal
+        );
+      if (!reusedPrevious) {
+        await downloadPlatformPackage({
+          tarballUrl: meta.tarball,
+          packageName: dependencies.observation.platformPackage,
+          version: targetVersion,
+          integrity: meta.integrity,
+          destinationPath: paths.packageStaging,
+          signal: lockedSignal,
+          fetcher: dependencies.fetcher,
+          onProgress: dependencies.onDownloadProgress
+        });
+        await materializeCandidate({
+          packagePath: paths.packageStaging,
+          destinationPath: paths.candidate,
+          packageName: dependencies.observation.platformPackage,
+          version: targetVersion,
+          signal: lockedSignal
+        });
+      }
       await activateCandidate({
         authority,
         paths,
@@ -154,6 +167,27 @@ export async function applyUpgrade(
     },
     dependencies.force === true
   );
+}
+
+/** Reuse the one verified executable retained for rollback. */
+async function copyPreviousVersion(
+  previousPath: string,
+  candidatePath: string,
+  version: string,
+  artifactTarget: BuiltArtifactTarget,
+  signal: AbortSignal
+): Promise<boolean> {
+  if (!existsSync(previousPath)) return false;
+  try {
+    removeQuietly(candidatePath);
+    await copyExclusive(previousPath, candidatePath, 0o755, signal);
+    await probeCandidateVersion(candidatePath, version, artifactTarget, signal);
+    return true;
+  } catch (error) {
+    removeQuietly(candidatePath);
+    if (signal.aborted) throwUpgradeProbeFailure(error, signal, "Previous executable version probe failed.");
+    return false;
+  }
 }
 
 export const DOWNGRADE_WARNING =

--- a/tui/src/upgrade-cli.ts
+++ b/tui/src/upgrade-cli.ts
@@ -50,10 +50,12 @@ export type {
   UpgradeApplyCommand,
   UpgradeCheckCommand,
   UpgradeCommand,
+  UpgradeListCommand,
   UpgradeRollbackCommand
 } from "./upgrade-command.js";
 
 export const UPGRADE_HELP = `Usage:
+  1667 upgrade --list [--json]
   1667 upgrade --check [--channel <stable|beta>] [--json]
   1667 upgrade [--version <semver>] [--channel <stable|beta>] [--json] [--force]
   1667 upgrade --rollback [--json] [--force]
@@ -63,6 +65,9 @@ It waives no checksum, attestation, or version check.
 
 --version selects one exact published release. It can downgrade 1667.
 ${DOWNGRADE_WARNING.trimEnd()}
+
+--list shows published launcher releases. Platform support is checked when
+--version selects a release.
 
 If you installed 1667 with npm, or you built it from source, update it the same
 way you installed it.
@@ -94,6 +99,7 @@ const INSTRUCTIONS_ORIGIN =
 export interface UpgradeCliDependencies {
   readonly observation?: UpgradeObservation;
   readonly registry?: UpgradeRegistry;
+  readonly versionRegistry?: Pick<NpmUpgradeRegistry, "availableVersions">;
   readonly authority?: InstallationAuthority;
   readonly fetcher?: RegistryFetch;
   readonly signal?: AbortSignal;
@@ -144,6 +150,34 @@ export async function executeUpgradeCli(
   if (parsed === null) {
     return { exitCode: 0, stdout: `${UPGRADE_HELP}\n`, stderr: "", envelope: null };
   }
+  if (parsed.command.kind === "list") {
+    try {
+      const versions = await (
+        dependencies.versionRegistry ?? new NpmUpgradeRegistry(dependencies.fetcher)
+      ).availableVersions(
+        dependencies.signal ?? new AbortController().signal
+      );
+      return {
+        exitCode: 0,
+        stdout: parsed.json
+          ? `${JSON.stringify({ versions })}\n`
+          : versions.length === 0 ? "" : `${versions.join("\n")}\n`,
+        stderr: "",
+        envelope: null
+      };
+    } catch (error) {
+      const failure = normalizeFailure(error);
+      return failedOutput(
+        failure,
+        parsed.json,
+        { currentVersion: AI_1667_PRODUCT_VERSION },
+        null,
+        authorityMethod(authority),
+        failure.code === "interrupted" ? 130 : 1
+      );
+    }
+  }
+  const registry = dependencies.registry ?? new NpmUpgradeRegistry(dependencies.fetcher);
   let observation: UpgradeObservation;
   try {
     observation = dependencies.observation ?? defaultObservation();
@@ -159,7 +193,6 @@ export async function executeUpgradeCli(
     );
   }
   const method = authorityMethod(authority);
-  const registry = dependencies.registry ?? new NpmUpgradeRegistry(dependencies.fetcher);
   const downgradeWarnings: string[] = [];
   const onDowngradeWarning = dependencies.onDowngradeWarning
     ?? ((warning: string) => downgradeWarnings.push(warning));
@@ -212,6 +245,8 @@ async function dispatchUpgradeCommand(
   onDowngradeWarning: (warning: string) => void
 ): Promise<UpgradeSuccessEnvelope> {
   switch (command.kind) {
+    case "list":
+      throw new UpgradeFailure("internal_error", "The release list was not handled.");
     case "rollback": {
       if (authority.kind === "powershell") {
         requireServableWindowsChannel(authority.channel);

--- a/tui/src/upgrade-command.ts
+++ b/tui/src/upgrade-command.ts
@@ -11,6 +11,11 @@ export interface UpgradeCheckCommand {
   readonly channel: UpgradeChannel;
 }
 
+/** List published releases. Does not change the installation. */
+export interface UpgradeListCommand {
+  readonly kind: "list";
+}
+
 /** Apply or plan a channel head or one exact published version. */
 export interface UpgradeApplyCommand {
   readonly kind: "apply";
@@ -30,6 +35,7 @@ export interface UpgradeRollbackCommand {
  */
 export type UpgradeCommand =
   | UpgradeCheckCommand
+  | UpgradeListCommand
   | UpgradeApplyCommand
   | UpgradeRollbackCommand;
 
@@ -59,6 +65,8 @@ export function parseUpgradeArguments(
   let check = false;
   let checkSeen = false;
   let jsonSeen = false;
+  let list = false;
+  let listSeen = false;
   let rollback = false;
   let rollbackSeen = false;
   let version: string | null = null;
@@ -75,6 +83,10 @@ export function parseUpgradeArguments(
       if (checkSeen) throw invalidArguments("--check may be specified only once.");
       check = true;
       checkSeen = true;
+    } else if (argument === "--list") {
+      if (listSeen) throw invalidArguments("--list may be specified only once.");
+      list = true;
+      listSeen = true;
     } else if (argument === "--rollback") {
       if (rollbackSeen) throw invalidArguments("--rollback may be specified only once.");
       rollback = true;
@@ -106,13 +118,23 @@ export function parseUpgradeArguments(
   if (check && version !== null) {
     throw invalidArguments("--check and --version cannot be used together.");
   }
+  if (list && (check || rollback || version !== null || channelSeen)) {
+    throw invalidArguments("--list cannot be combined with --check, --rollback, --version, or --channel.");
+  }
   if (rollback && (check || version !== null || channelSeen)) {
     throw invalidArguments("--rollback cannot be combined with --check, --version, or --channel.");
   }
   // A read-only check writes nothing, so waiving a write refusal means nothing
   // there. Saying so beats accepting a flag that does nothing.
-  if (forceSeen && check) {
-    throw invalidArguments("--force cannot be used with --check, which changes no file.");
+  if (forceSeen && (check || list)) {
+    throw invalidArguments(`--force cannot be used with --${list ? "list" : "check"}, which changes no file.`);
+  }
+  if (list) {
+    return Object.freeze({
+      command: Object.freeze({ kind: "list" as const }),
+      json: jsonSeen,
+      force: false
+    });
   }
   if (rollback) {
     return Object.freeze({
@@ -144,6 +166,8 @@ export function upgradeCommandChannel(
     case "check":
     case "apply":
       return command.channel;
+    case "list":
+      return fallback;
     case "rollback":
       return fallback;
   }

--- a/tui/src/worker-story-api.ts
+++ b/tui/src/worker-story-api.ts
@@ -45,10 +45,19 @@ export function storyApiFromWorkerTransport(transport: StoryWorkerTransport): St
     }
     return summaries;
   };
-  const expectedVersion = async (storyId: string): Promise<StoryAggregateVersion> => {
+  const expectedVersion = async (
+    storyId: string,
+    signal?: AbortSignal
+  ): Promise<StoryAggregateVersion> => {
     const held = versions.get(storyId);
     if (held !== undefined) return held;
-    const loaded = rememberPayload(await transport.call("loadStory", { id: storyId }));
+    const payload = await transport.call(
+      "loadStory",
+      { id: storyId },
+      signal === undefined ? {} : { signal }
+    );
+    signal?.throwIfAborted();
+    const loaded = rememberPayload(payload);
     if (loaded.aggregateVersion === undefined) {
       throw new Error("This story was loaded without successor-Q version metadata.");
     }
@@ -366,15 +375,25 @@ export function storyApiFromWorkerTransport(transport: StoryWorkerTransport): St
         { expectedAggregateVersion: await expectedVersion(storyId) }
       )
     ),
-    summarizeChapter: async (storyId, breakId) => runProviderMutation(
+    summarizeChapter: async (storyId, breakId, signal) => runProviderMutation(
       storyId,
-      async () => rememberPayload(
-        await transport.call(
+      async () => {
+        const expectedAggregateVersion = await expectedVersion(storyId, signal);
+        signal?.throwIfAborted();
+        const payload = await transport.call(
           "summarizeChapter",
           { storyId, breakId },
-          { expectedAggregateVersion: await expectedVersion(storyId) }
-        )
-      )
+          {
+            expectedAggregateVersion,
+            ...(signal === undefined ? {} : { signal })
+          }
+        );
+        if (payload === null) {
+          signal?.throwIfAborted();
+          throw new Error("Chapter summary returned no story payload.");
+        }
+        return rememberPayload(payload);
+      }
     ),
     editChapterSummary: async (storyId, summaryId, text, expected) =>
       rememberPayload(await transport.call(

--- a/tui/test/actions-runtime.test.ts
+++ b/tui/test/actions-runtime.test.ts
@@ -654,7 +654,7 @@ describe("demo action runtime and input", () => {
     expect(state.toast).toBe("nothing to undo · u takes back an added or removed chapter break");
   });
 
-  test("a chapter rename records nothing to undo", async () => {
+test("a chapter rename records nothing to undo", async () => {
     // "chapter change" was too wide a word for what `u` holds: a rename and a
     // summary edit are chapter changes, and neither is undoable. Naming the
     // category rebuilt the ambiguity this key was narrowed to remove.
@@ -669,13 +669,200 @@ describe("demo action runtime and input", () => {
     // the rename itself would have added.
     const target = state.payload.chapterBreaks.find(({ id }) => id !== (created as { breakId: string }).breakId)!;
     state.mode = "CHAPTERS";
-    state.chapters = { cursor: 0, rename: { breakId: target.id, value: "Renamed" }, deleteArmedId: null };
+    state.chapters = {
+      cursor: 0,
+      rename: { breakId: target.id, composer: createComposer("Renamed") },
+      deleteArmedId: null
+    };
     await press("return");
 
     // The rename landed, and it left the stack exactly as it found it.
     expect((await source.api.loadStory(state.payload.id)).chapterBreaks
       .find((chapterBreak) => chapterBreak.id === target.id)?.title).toBe("Renamed");
     expect(state.undo).toEqual([created]);
+});
+
+  test("chapter rename moves a real caret before it inserts and deletes", async () => {
+    const { state, press } = harness();
+    await press("c");
+    await press("up");
+    await press("e");
+
+    const rename = state.chapters?.rename;
+    expect(rename).not.toBe(null);
+    const original = rename!.composer.text;
+    const cursorBefore = rename!.composer.cursor;
+    await press("left");
+    expect(rename!.composer.cursor).toBe(cursorBefore - 1);
+    await press("X");
+    expect(rename!.composer.text).toBe(
+      `${original.slice(0, cursorBefore - 1)}X${original.slice(cursorBefore - 1)}`
+    );
+    await press("backspace");
+    expect(rename!.composer.text).toBe(original);
+
+    const frame = renderStoryScreen(state, { width: 80, height: 30 });
+    expect(frame.lines.flat().some((part) =>
+      part.composerStart === rename!.composer.cursor
+        && part.background === "compose accent"
+    )).toBeTrue();
+  });
+
+  test("chapter summarization names its stage and cancels through the API signal", async () => {
+    const { source, state, press } = harness();
+    const entered = deferred<void>();
+    let signal: AbortSignal | undefined;
+    source.api.summarizeChapter = async (_storyId, _breakId, callerSignal) => {
+      signal = callerSignal;
+      await entered.promise;
+      return state.payload;
+    };
+
+    await press("c");
+    await press("up");
+    const pending = press("s");
+    await Promise.resolve();
+
+    expect(state.chapterSummary).toMatchObject({ chapterNumber: 2, stage: "writing" });
+    expect(signal?.aborted).toBeFalse();
+    state.chapters = null;
+    const frame = renderStoryScreen(state, { width: 120, height: 30 });
+    expect(frameText(frame.lines)).toContain("ch 2");
+    expect(frameText(frame.lines)).toContain("model progress unavailable");
+    expect(frameText(frame.lines)).toContain("esc cancels");
+
+    await press("escape", "\u001b");
+    expect(signal?.aborted).toBeTrue();
+    expect(state.chapterSummary?.stage).toBe("stopping");
+    entered.resolve();
+    await pending;
+
+    expect(state.chapterSummary).toBe(null);
+    expect(state.abort).toBe(null);
+    expect(state.toast).toBe("Chapter Two summary stopped");
+  });
+
+  test("navigation stays available and does not hide chapter summary completion", async () => {
+    const { source, state, press } = harness();
+    const entered = deferred<void>();
+    const release = deferred<void>();
+    const summarize = source.api.summarizeChapter;
+    source.api.summarizeChapter = async (...args) => {
+      entered.resolve();
+      await release.promise;
+      return await summarize(...args);
+    };
+
+    await press("c");
+    await press("up");
+    const pending = press("s");
+    await entered.promise;
+    const interactionVersion = state.interactionVersion;
+    const cursor = state.chapters!.cursor;
+
+    await press("down");
+    expect(state.interactionVersion).toBe(interactionVersion + 1);
+    expect(state.chapters!.cursor).not.toBe(cursor);
+
+    release.resolve();
+    await pending;
+    expect(state.toast).toContain("summarized");
+    expect(state.toast).not.toContain("esc cancels");
+  });
+
+  test("escape closes an action menu without cancelling a chapter summary", async () => {
+    const { source, state, press } = harness();
+    const entered = deferred<void>();
+    const release = deferred<void>();
+    let signal: AbortSignal | undefined;
+    source.api.summarizeChapter = async (_storyId, _breakId, callerSignal) => {
+      signal = callerSignal;
+      entered.resolve();
+      await release.promise;
+      return state.payload;
+    };
+
+    await press("c");
+    await press("up");
+    const pending = press("s");
+    await entered.promise;
+    state.mode = "NAV";
+    state.chapters = null;
+    await press("x");
+    expect(state.actions).not.toBe(null);
+    expect(frameText(renderStoryScreen(state, { width: 120, height: 30 }).lines))
+      .not.toContain("esc cancels");
+
+    await press("escape", "\u001b");
+    expect(state.actions).toBe(null);
+    expect(signal?.aborted).toBeFalse();
+    expect(frameText(renderStoryScreen(state, { width: 120, height: 30 }).lines))
+      .toContain("esc cancels");
+
+    release.resolve();
+    await pending;
+  });
+
+  test("escape closes a text menu without cancelling a chapter summary", async () => {
+    const { source, state, press } = harness();
+    const entered = deferred<void>();
+    const release = deferred<void>();
+    let signal: AbortSignal | undefined;
+    source.api.summarizeChapter = async (_storyId, _breakId, callerSignal) => {
+      signal = callerSignal;
+      entered.resolve();
+      await release.promise;
+      return state.payload;
+    };
+
+    await press("c");
+    await press("up");
+    const pending = press("s");
+    await entered.promise;
+    state.mode = "NAV";
+    state.chapters = null;
+    state.textActions = {
+      cursor: 0,
+      owner: null,
+      ownerSnapshot: null,
+      nativeSelection: undefined,
+      composerSelectionProjection: null,
+      copyOnly: true
+    };
+    expect(frameText(renderStoryScreen(state, { width: 120, height: 30 }).lines))
+      .not.toContain("esc cancels");
+
+    await press("escape", "\u001b");
+    expect(state.textActions).toBe(null);
+    expect(signal?.aborted).toBeFalse();
+    expect(frameText(renderStoryScreen(state, { width: 120, height: 30 }).lines))
+      .toContain("esc cancels");
+
+    release.resolve();
+    await pending;
+  });
+
+  test("a chapter summary that commits before cancellation wins is adopted", async () => {
+    const { source, state, press } = harness();
+    const entered = deferred<void>();
+    const release = deferred<void>();
+    const summarize = source.api.summarizeChapter;
+    source.api.summarizeChapter = async (...args) => {
+      entered.resolve();
+      await release.promise;
+      return await summarize(...args);
+    };
+
+    await press("c");
+    await press("up");
+    const pending = press("s");
+    await entered.promise;
+    await press("escape", "\u001b");
+    release.resolve();
+    await pending;
+
+    expect(createStoryViewModel(state.payload).chapters[1]?.summary).not.toBe(null);
+    expect(state.toast).toBe("Chapter Two summary completed before stop");
   });
 
   test("C creates a focused-part chapter break and u removes it", async () => {

--- a/tui/test/command-palette.test.ts
+++ b/tui/test/command-palette.test.ts
@@ -235,6 +235,7 @@ function renderCommands(
     chapters: null,
     settings: null,
     summary: null,
+    chapterSummary: null,
     connection: { down: false, attempt: 0, nextRetryAt: null, error: null }
   };
   const request = {

--- a/tui/test/fact-editor-scroll.test.ts
+++ b/tui/test/fact-editor-scroll.test.ts
@@ -1,8 +1,13 @@
 import { describe, expect, test } from "bun:test";
+import type { MouseEvent } from "@opentui/core";
+import { dispatch, initialState } from "../src/app.js";
+import { demoAppSource } from "../src/demo.js";
+import { mouseToAction } from "../src/mouse-actions.js";
 import { openFactEditor } from "../src/editor-open.js";
 import { renderStoryScreen } from "../src/screens/story.js";
 import { frameText } from "../src/screens/story/frame.js";
 import { editorHarness } from "./editor-harness.js";
+import { createWrapCache } from "../src/wrap.js";
 
 const TERMINAL_WIDTH = 100;
 const BODY_LINES = 60;
@@ -44,5 +49,59 @@ describe("Fact editor scrolling", () => {
       expect(lines.some((line) => line.includes(`line ${BODY_LINES} of the long fact body`)))
         .toBeTrue();
     }
+  });
+
+  test("the mouse wheel scrolls the Fact body without moving header focus", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const fact = state.payload.facts[0]!;
+    const text = Array.from(
+      { length: BODY_LINES },
+      (_, index) => `line ${index + 1} of the long fact body`
+    ).join("\n");
+    openFactEditor(state, { ...fact, text });
+    const width = TERMINAL_WIDTH;
+    const height = 24;
+    const render = () => {
+      const frame = renderStoryScreen(state, { width, height });
+      Object.assign(state, frame.derived);
+      return frame;
+    };
+    const wheelUp = {
+      type: "scroll",
+      button: 0,
+      x: 40,
+      y: 12,
+      modifiers: { shift: false, alt: false, ctrl: false },
+      scroll: { direction: "up" }
+    } as unknown as MouseEvent;
+
+    const before = render();
+    const start = before.derived.editorScrollTop;
+    const cursor = state.editor?.composer.cursor;
+    const anchor = state.editor?.composer.anchor;
+    const action = mouseToAction(wheelUp, state);
+    expect(action).toEqual({ action: "scroll-line-up" });
+    for (let tick = 0; tick < 16; tick += 1) {
+      await dispatch(
+        action!,
+        state,
+        source,
+        createWrapCache(),
+        () => {},
+        async () => {},
+        () => {},
+        { width, height } as never
+      );
+    }
+    const after = render();
+
+    const editor = state.editor;
+    expect(editor?.kind).toBe("fact");
+    if (editor?.kind !== "fact") throw new Error("Fact editor closed during wheel scroll");
+    expect(editor.focus).toBe("body");
+    expect(editor.composer.cursor).toBe(cursor);
+    expect(editor.composer.anchor).toBe(anchor);
+    expect(after.derived.editorScrollTop).toBeLessThan(start);
   });
 });

--- a/tui/test/hit-map-chrome.test.ts
+++ b/tui/test/hit-map-chrome.test.ts
@@ -6,6 +6,7 @@ import { demoAppSource } from "../src/demo.js";
 import { openFactEditor } from "../src/editor-action.js";
 import {
   FACT_ACTIVATION_COMPOSER_SOURCE,
+  FACT_BODY_COMPOSER_SOURCE,
   FACT_KEYS_COMPOSER_SOURCE,
   FACT_TAG_COMPOSER_SOURCE,
   setFactEditorFocus
@@ -1112,6 +1113,48 @@ describe("hit map clickable chrome", () => {
     );
     expect(state.mode).toBe("COMPOSE");
     expect(state.composer.text).toBe("draft stays ");
+  });
+
+  test("left-clicking Fact fields focuses text and choice sources", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    state.stream = null;
+    openFactEditor(state, null);
+
+    const sourceRow = (sourceId: string): number => {
+      render(state);
+      const row = state.hitRows.findIndex((hit) => hit?.target.kind === "composer"
+        && hit.target.composerSourceId === sourceId);
+      expect(row).toBeGreaterThan(-1);
+      return row;
+    };
+
+    let row = sourceRow(FACT_TAG_COMPOSER_SOURCE);
+    let action = mouseToAction(click(2, row), state);
+    expect(action).toEqual({ action: "compose", composerSourceId: FACT_TAG_COMPOSER_SOURCE });
+    await dispatch(action!, state, source, createWrapCache(), () => {}, async () => {}, () => {});
+    expect(currentFactEditor(state).focus).toBe("tag");
+    await dispatch(
+      { action: "input", text: "weather" }, state, source, createWrapCache(), () => {}, async () => {}, () => {}
+    );
+    expect(currentFactEditor(state).tag.text).toBe("weather");
+
+    row = sourceRow(FACT_BODY_COMPOSER_SOURCE);
+    action = mouseToAction(click(2, row), state);
+    expect(action).toEqual({ action: "compose", composerSourceId: FACT_BODY_COMPOSER_SOURCE });
+    await dispatch(action!, state, source, createWrapCache(), () => {}, async () => {}, () => {});
+    expect(currentFactEditor(state).focus).toBe("body");
+    await dispatch(
+      { action: "input", text: "A rainy street." }, state, source, createWrapCache(), () => {}, async () => {}, () => {}
+    );
+    expect(currentFactEditor(state).composer.text).toBe("A rainy street.");
+
+    row = sourceRow(FACT_ACTIVATION_COMPOSER_SOURCE);
+    action = mouseToAction(click(2, row), state);
+    expect(action).toEqual({ action: "compose", composerSourceId: FACT_ACTIVATION_COMPOSER_SOURCE });
+    await dispatch(action!, state, source, createWrapCache(), () => {}, async () => {}, () => {});
+    expect(currentFactEditor(state).focus).toBe("activation");
+    expect(currentFactEditor(state).activation).toBe("always");
   });
 
   test("every screen footer renders untruncated at wide and compact sizes", () => {

--- a/tui/test/keys.test.ts
+++ b/tui/test/keys.test.ts
@@ -516,6 +516,10 @@ describe("text surfaces and palette", () => {
     expect(resolveKey(key("d"), "CHAPTERS").action).toBe("delete-item");
     expect(resolveKey(key("n"), "CHAPTERS").action).toBe("new-item");
     expect(resolveKey(key("e"), "CHAPTERS", { overlayTyping: true })).toEqual({ action: "input", text: "e" });
+    expect(resolveKey(key("left", { ctrl: true }), "CHAPTERS", { overlayTyping: true }).action)
+      .toBe("cursor-word-left");
+    expect(resolveKey(key("v", { ctrl: true }), "CHAPTERS", { overlayTyping: true }).action)
+      .toBe("paste-clipboard");
   });
   test("overlay text prompts own letters that are otherwise hotkeys", () => {
     const typing = { overlayTyping: true };

--- a/tui/test/managed-install-upgrade.test.ts
+++ b/tui/test/managed-install-upgrade.test.ts
@@ -73,6 +73,81 @@ test("an exact older version warns before download and replaces the managed exec
   }
 });
 
+test("an exact version reuses the retained previous executable", async () => {
+  const root = managedScratchRoot("reuse-previous-");
+  try {
+    const installRoot = path.join(root, "bin");
+    mkdirSync(installRoot, { mode: 0o755 });
+    chmodSync(installRoot, 0o755);
+    const { authority, paths } = shellManagedAuthority(installRoot, "beta", NEXT);
+    writeManagedStub(paths.previous, OLDER);
+    const pkg = buildCanonicalPlatformPackage({
+      packageName: PACKAGE,
+      version: OLDER,
+      target: TARGET
+    });
+    let downloads = 0;
+    const result = await executeUpgradeCli(["--version", OLDER], {
+      authority,
+      observation: {
+        currentVersion: NEXT,
+        platformPackage: PACKAGE
+      },
+      registry: fakeManagedRegistry(NEXT, PACKAGE, pkg.integrity, pkg.tarballUrl),
+      fetcher: async () => {
+        downloads += 1;
+        throw new Error("the retained executable must avoid the package download");
+      }
+    });
+    expect(result.exitCode).toBe(0);
+    expect(downloads).toBe(0);
+    expect(readFileSync(paths.active, "utf8")).toContain(OLDER);
+    expect(readFileSync(paths.previous, "utf8")).toContain(NEXT);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("an unusable retained previous executable falls back to download", async () => {
+  const root = managedScratchRoot("reuse-fallback-");
+  try {
+    const installRoot = path.join(root, "bin");
+    mkdirSync(installRoot, { mode: 0o755 });
+    chmodSync(installRoot, 0o755);
+    const { authority, paths } = shellManagedAuthority(installRoot, "beta", NEXT);
+    const linkedPrevious = path.join(root, "linked-previous");
+    const executed = path.join(root, "linked-previous-executed");
+    writeFileSync(
+      linkedPrevious,
+      `#!/bin/sh\nprintf touched > ${JSON.stringify(executed)}\nexit 1\n`,
+      { mode: 0o755 }
+    );
+    chmodSync(linkedPrevious, 0o755);
+    symlinkSync(linkedPrevious, paths.previous);
+    const pkg = buildCanonicalPlatformPackage({
+      packageName: PACKAGE,
+      version: OLDER,
+      target: TARGET
+    });
+    let downloads = 0;
+    const result = await executeUpgradeCli(["--version", OLDER], {
+      authority,
+      observation: { currentVersion: NEXT, platformPackage: PACKAGE },
+      registry: fakeManagedRegistry(NEXT, PACKAGE, pkg.integrity, pkg.tarballUrl),
+      fetcher: async () => {
+        downloads += 1;
+        return new Response(new Uint8Array(pkg.bytes), { status: 200 });
+      }
+    });
+    expect(result.exitCode).toBe(0);
+    expect(downloads).toBe(1);
+    expect(existsSync(executed)).toBeFalse();
+    expect(readFileSync(paths.active, "utf8")).toContain(OLDER);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("unqualified managed upgrade defaults to Ownership Record channel beta", async () => {
   const root = managedScratchRoot();
   try {

--- a/tui/test/npm-upgrade-registry.test.ts
+++ b/tui/test/npm-upgrade-registry.test.ts
@@ -3,8 +3,10 @@ import { releaseTargetForArtifact } from "../../shared/release-targets.js";
 import {
   LAUNCHER_PACKAGE,
   NPM_METADATA_MAX_BYTES,
+  NPM_VERSION_INDEX_MAX_BYTES,
   NpmUpgradeRegistry,
   PLATFORM_PACKAGES,
+  parseNpmAvailableVersions,
   parseNpmDistTags,
   parseNpmExactVersionMetadata
 } from "../src/npm-upgrade-registry.js";
@@ -23,6 +25,24 @@ function tarballUrl(packageName: string, version: string): string {
 }
 
 const TARBALL = tarballUrl(LAUNCHER_PACKAGE, "2.0.0");
+
+test("npm package metadata lists non-deprecated releases newest first", () => {
+  expect(parseNpmAvailableVersions(JSON.stringify({
+    name: LAUNCHER_PACKAGE,
+    versions: {
+      "1.0.0": { name: LAUNCHER_PACKAGE, version: "1.0.0" },
+      "1.1.0": { name: LAUNCHER_PACKAGE, version: "1.1.0", deprecated: "" },
+      "2.0.0-rc.1": { name: LAUNCHER_PACKAGE, version: "2.0.0-rc.1" },
+      "0.5.0": { name: LAUNCHER_PACKAGE, version: "0.5.0", revoked: true },
+      "0.0.0": { name: LAUNCHER_PACKAGE, version: "0.0.0", deprecated: "reserved" },
+      "2.0.0": { name: LAUNCHER_PACKAGE, version: "2.0.0" }
+    }
+  }))).toEqual(["2.0.0", "2.0.0-rc.1", "1.1.0", "1.0.0"]);
+  expect(() => parseNpmAvailableVersions(JSON.stringify({
+    name: LAUNCHER_PACKAGE,
+    versions: { "1.0.0": { name: "foreign", version: "1.0.0" } }
+  }))).toThrow();
+});
 
 test("npm dist tags select strict stable and beta channel heads", () => {
   const body = JSON.stringify({
@@ -142,6 +162,10 @@ test("exact npm metadata rejects deprecated targets and graph or identity drift"
     version: "2.0.0",
     launcherGraph: { requiredPlatformPackage: PLATFORM_PACKAGE }
   };
+  expect(parseNpmExactVersionMetadata(
+    JSON.stringify({ ...valid, deprecated: "" }),
+    expected
+  ).version).toBe("2.0.0");
   for (const value of [
     { ...valid, name: "other" },
     { ...valid, deprecated: "bad release" },
@@ -197,6 +221,38 @@ test("registry client fixes the canonical origin and bounds streamed responses",
     );
     expect((invalidError as UpgradeFailure).code).toBe("metadata_invalid");
   }
+});
+
+test("registry client requests the bounded abbreviated version index", async () => {
+  const calls: Array<{ input: string; accept: string | null }> = [];
+  const registry = new NpmUpgradeRegistry(async (input, init) => {
+    calls.push({
+      input,
+      accept: new Headers(init.headers).get("accept")
+    });
+    return new Response(JSON.stringify({
+      name: LAUNCHER_PACKAGE,
+      versions: {
+        "1.0.0": { name: LAUNCHER_PACKAGE, version: "1.0.0" },
+        "1.1.0-rc.1": { name: LAUNCHER_PACKAGE, version: "1.1.0-rc.1" }
+      }
+    }), { headers: { "content-type": "application/vnd.npm.install-v1+json" } });
+  });
+  expect(await registry.availableVersions(new AbortController().signal))
+    .toEqual(["1.1.0-rc.1", "1.0.0"]);
+  expect(calls).toEqual([{
+    input: "https://registry.npmjs.org/@1667-ai%2fcli",
+    accept: "application/vnd.npm.install-v1+json"
+  }]);
+
+  const oversized = new NpmUpgradeRegistry(async () => new Response(
+    new Uint8Array(NPM_VERSION_INDEX_MAX_BYTES + 1),
+    { headers: { "content-type": "application/vnd.npm.install-v1+json" } }
+  ));
+  const error = await rejection(
+    oversized.availableVersions(new AbortController().signal)
+  );
+  expect((error as UpgradeFailure).code).toBe("metadata_invalid");
 });
 
 test("registry client derives exact launcher and platform endpoints locally", async () => {

--- a/tui/test/recovery-orchestration.test.ts
+++ b/tui/test/recovery-orchestration.test.ts
@@ -1022,7 +1022,7 @@ describe("backend recovery orchestration", () => {
     state.chapterDeleteArmedId = "chapter-break-1";
     state.chapters = {
       cursor: 1,
-      rename: { breakId: "chapter-break-1", value: "newer title" }, deleteArmedId: "chapter-break-1"
+      rename: { breakId: "chapter-break-1", composer: createComposer("newer title") }, deleteArmedId: "chapter-break-1"
     };
     state.facts = {
       cursor: 0, query: "", chip: 0, selectedTag: null, filtering: false, deleteArmedId: "fact-1"
@@ -1084,7 +1084,7 @@ describe("backend recovery orchestration", () => {
       nodeId: "p12-t4", name: "typed while loading", statusIndex: 2,
       choosingStatus: true, existing: false, returnMode: "NAV" as const
     };
-    const rename = { breakId: "chapter-break-1", value: "typed chapter title" };
+    const rename = { breakId: "chapter-break-1", composer: createComposer("typed chapter title") };
     state.undo = [{ kind: "create-break", breakId: "chapter-break-1" }];
     state.prune = prune;
     state.tag = tag;

--- a/tui/test/selection-copy.test.ts
+++ b/tui/test/selection-copy.test.ts
@@ -12,6 +12,7 @@ import {
   captureNativeSelection,
   copyActiveSelection,
   handleMainCopyShortcut,
+  isCopyShortcut,
   nativeSelectionMatches,
   syncMouseComposerSelection
 } from "../src/copy-actions.js";
@@ -31,6 +32,39 @@ import {
 } from "../src/fact-editor-policy.js";
 
 describe("active selection copy", () => {
+  test("Ctrl and Command copy own a selected chapter rename", async () => {
+    for (const modifier of ["ctrl", "super"] as const) {
+      const state = initialState(demoAppSource(), false);
+      const composer = createComposer("Chapter title");
+      composer.anchor = 0;
+      state.mode = "CHAPTERS";
+      state.chapters = {
+        cursor: 0,
+        rename: { breakId: null, composer },
+        deleteArmedId: null
+      };
+      let quit = false;
+      const copied: string[] = [];
+      const shortcut = { name: "c", ctrl: modifier === "ctrl", super: modifier === "super" } as never;
+
+      expect(isCopyShortcut(shortcut)).toBeTrue();
+      expect(handleMainCopyShortcut(
+        EMPTY_NATIVE_SELECTION,
+        state,
+        () => undefined,
+        () => { quit = true; },
+        undefined,
+        async (text) => {
+          copied.push(text);
+          return "command";
+        }
+      )).toBeTrue();
+      await Promise.resolve();
+      expect(copied).toEqual(["Chapter title"]);
+      expect(quit).toBeFalse();
+    }
+  });
+
   test("inline Settings owns empty Ctrl+C and copies its selected draft", async () => {
     const source = demoAppSource();
     const state = initialState(source, false);

--- a/tui/test/upgrade-cli.test.ts
+++ b/tui/test/upgrade-cli.test.ts
@@ -49,6 +49,11 @@ test("upgrade argument parser preserves global version semantics and rejects amb
     json: false,
     force: false
   });
+  expect(parseUpgradeArguments(["--list", "--json"])).toEqual({
+    command: { kind: "list" },
+    json: true,
+    force: false
+  });
   expect(parseUpgradeArguments(["--rollback", "--json"])).toEqual({
     command: { kind: "rollback" },
     json: true,
@@ -60,6 +65,8 @@ test("upgrade argument parser preserves global version semantics and rejects amb
   expect(() => parseUpgradeArguments(["--json", "--json"])).toThrow();
   expect(() => parseUpgradeArguments(["--rollback", "--check"])).toThrow();
   expect(() => parseUpgradeArguments(["--rollback", "--channel", "beta"])).toThrow();
+  expect(() => parseUpgradeArguments(["--list", "--channel", "beta"])).toThrow();
+  expect(() => parseUpgradeArguments(["--list", "--version", "2.0.0"])).toThrow();
 });
 
 test("--force is an apply-time waiver and says so when it would do nothing", () => {
@@ -126,6 +133,36 @@ test("JSON success emits exactly one stable envelope and command stays null", as
     "error"
   ]);
   expect(JSON.parse(result.stdout).command).toBe(null);
+});
+
+test("--list shows every published release newest first", async () => {
+  const calls: string[] = [];
+  const versionRegistry = {
+    async availableVersions() {
+      calls.push("versions");
+      return ["2.0.0", "2.0.0-rc.1", "1.2.3"];
+    }
+  };
+  const human = await executeUpgradeCli(["--list"], { versionRegistry });
+  expect(human).toMatchObject({
+    exitCode: 0,
+    stdout: "2.0.0\n2.0.0-rc.1\n1.2.3\n",
+    stderr: "",
+    envelope: null
+  });
+  const json = await executeUpgradeCli(["--list", "--json"], { versionRegistry });
+  expect(JSON.parse(json.stdout)).toEqual({
+    versions: ["2.0.0", "2.0.0-rc.1", "1.2.3"]
+  });
+  expect(calls).toEqual(["versions", "versions"]);
+});
+
+test("--list prints no phantom row when no published release is available", async () => {
+  const versionRegistry = { async availableVersions() { return []; } };
+  const human = await executeUpgradeCli(["--list"], { versionRegistry });
+  expect(human).toMatchObject({ exitCode: 0, stdout: "", stderr: "", envelope: null });
+  const json = await executeUpgradeCli(["--list", "--json"], { versionRegistry });
+  expect(JSON.parse(json.stdout)).toEqual({ versions: [] });
 });
 
 test("JSON usage and operational failures retain the same envelope", async () => {

--- a/tui/test/worker-api.test.ts
+++ b/tui/test/worker-api.test.ts
@@ -962,6 +962,33 @@ describe("embedded backend worker", () => {
     }
   });
 
+  test("cancels a cold chapter version lookup before generation starts", async () => {
+    const worker = new FakeWorker(true);
+    const backend = await createWorkerStoryApi({ worker, readyTimeoutMs: 100 });
+    try {
+      const controller = new AbortController();
+      const pending = backend.api.summarizeChapter("story", "break", controller.signal);
+      const request = await waitForRequest(worker, "loadStory");
+      controller.abort();
+      worker.message({
+        type: "result",
+        id: request.id,
+        value: {
+          id: "story",
+          nodes: [],
+          path: [],
+          aggregateVersion: { kind: "v6", revision: "1" }
+        }
+      });
+      expect((await rejection(pending)).name).toBe("AbortError");
+      expect(worker.messages.some((message) =>
+        message.type === "request" && message.method === "summarizeChapter"
+      )).toBeFalse();
+    } finally {
+      await backend.dispose();
+    }
+  });
+
   test("gives provider checks their own deadline", async () => {
     const worker = new FakeWorker(true);
     const backend = await createWorkerStoryApi({


### PR DESCRIPTION
## Summary

- Add `1667 upgrade --list` and JSON output for published versions.
- Reuse a verified previous executable for exact-version installs.
- Add full caret editing to chapter titles.
- Add Fact field mouse focus, selection, and body wheel scrolling.
- Show honest chapter-summary status and support Esc cancellation.
- Prepare `0.9.4-rc.4`, including the inactive Aside foundation from PR #194.

## Validation

- Root tests: 2,435 passed; 225 skipped; 0 failed.
- TUI tests: 1,910 passed; 2 Windows-only skips; 0 failed.
- Root build and TUI typecheck passed.
- Standalone build and performance budgets passed.
- Release notes and patch hygiene checks passed.
- Autoreview, thermonuclear maintainability review, and Claude UX review are clean.

Closes #208
