### PR TITLE
fix(sampling): accept omitted empty logit bias map

### DIFF
--- a/server/sampling-phrase-bias.ts
+++ b/server/sampling-phrase-bias.ts
@@ -1235,7 +1235,8 @@ export function parseResolveSamplingBiasInput(value: unknown): ResolveSamplingBi
   }
   const record = value as Record<string, unknown>;
   return {
-    logitBias: parseLogitBiasField(record.logitBias),
+    // An older preview can omit its empty raw map. Keep malformed values strict.
+    logitBias: record.logitBias === undefined ? {} : parseLogitBiasField(record.logitBias),
     phraseBias: parsePhraseBiasField(record.phraseBias),
     bannedStrings: parseBannedStringsField(record.bannedStrings),
     ...(record.storyPhraseBias === undefined ? {} : { storyPhraseBias: parsePhraseBiasField(record.storyPhraseBias) }),

--- a/test/sampling-phrase-tokenize.test.ts
+++ b/test/sampling-phrase-tokenize.test.ts
@@ -87,6 +87,30 @@ test("resolveSamplingBias resolves real, encoding-specific token IDs for every s
   assert.equal(result.bannedStrings.length, 0);
 });
 
+test("resolveSamplingBias treats an omitted logitBias as empty when it checks a banned string", async (t) => {
+  const service = StoryService.withoutDiagnostics({
+    dataDir: await temporaryDataDirectory(t, "1667-resolve-banned-string-")
+  });
+  await service.init();
+  t.after(() => service.dispose());
+
+  const result = await service.resolveSamplingBias({
+    settings: OPENAI_PROBE_TARGET,
+    phraseBias: [],
+    bannedStrings: ["hello"]
+  });
+
+  assert.equal(result.kind, "resolved");
+  if (result.kind !== "resolved") throw new Error("unreachable");
+  assert.deepEqual(result.logitBias, {
+    "24912": -100,
+    "40617": -100,
+    "13225": -100,
+    "32949": -100
+  });
+  assert.equal(result.bannedStrings[0]?.kind, "resolved");
+});
+
 // Issue #341: the editor's preview (this worker method) and the request
 // (server/provider-sampling.ts) must never disagree about a draft that
 // combines a story overlay with the profile — this proves the preview side


### PR DESCRIPTION
## Summary

- Treat an omitted raw `logitBias` map as empty in the sampling-bias preview.
- Keep malformed non-object values rejected.
- Cover the banned-string preview through `StoryService`.

Closes #212

## Verification

- `npm run build`
- `npm test`
- `cd tui && bun run typecheck`
- `cd tui && bun test --timeout 30000`
- `cd tui && bun bench/perf.ts`
- `cd tui && bun run build:standalone`