### PR TITLE
chore(release): prepare 0.9.4-rc.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -254,6 +254,12 @@ This file records notable changes to 1667. Product terms use the definitions in
   command accepts one or more JSON or PNG files. It adds their Facts to the
   story that `--story` names.
 
+## 0.9.4-rc.5 - 2026-08-13
+
+- **Banned strings can be added when the raw token bias map is empty.** The
+  preview now treats an omitted empty map as an empty map. It continues to
+  refuse malformed maps.
+
 ## 0.9.4-rc.4 - 2026-08-13
 
 - **`1667 upgrade --list` shows published launcher releases.** It writes one

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "1667-workspace",
-  "version": "0.9.4-rc.4",
+  "version": "0.9.4-rc.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "1667-workspace",
-      "version": "0.9.4-rc.4",
+      "version": "0.9.4-rc.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@silvia-odwyer/photon-node": "0.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667-workspace",
-  "version": "0.9.4-rc.4",
+  "version": "0.9.4-rc.5",
   "private": true,
   "description": "Source workspace for the 1667 terminal writing environment",
   "license": "Apache-2.0",

--- a/shared/release-notes.ts
+++ b/shared/release-notes.ts
@@ -11,6 +11,11 @@ export interface ReleaseNote {
  *  a release, and is not included. */
 export const RELEASE_NOTES: readonly ReleaseNote[] = [
   {
+    version: "0.9.4-rc.5",
+    date: "2026-08-13",
+    body: "- **Banned strings can be added when the raw token bias map is empty.** The\n  preview now treats an omitted empty map as an empty map. It continues to\n  refuse malformed maps."
+  },
+  {
     version: "0.9.4-rc.4",
     date: "2026-08-13",
     body: "- **`1667 upgrade --list` shows published launcher releases.** It writes one\n  version on each line, with the newest version first. Use `--json` to get a\n  `versions` array. 1667 checks platform support when `--version` selects a\n  release.\n\n- **An exact version can reuse the previous executable.** If\n  `.1667-previous` has the version that `--version` selects, 1667 verifies and\n  uses it. It does not download that version again. `--rollback` continues to\n  use the same file offline.\n\n- **The chapter title editor now has a movable caret.** The left and right\n  arrow keys move the caret. Insert, delete, and paste operations use the caret\n  position.\n\n- **The mouse now selects fields in the Fact editor.** A click selects the\n  Fact text field or choice field under the pointer. Use the left and right\n  arrow keys to change a selected choice. The mouse wheel scrolls a long Fact\n  body.\n\n- **Chapter summarization now identifies its work and its limits.** The\n  status line shows the chapter, the current stage, and that the model does not\n  report progress. Press `Esc` to stop the summary request.\n\n- **1667 prepares to save non-canon Side Notes with a story.** This release\n  contains the Aside implementation and keeps every entry point closed. It\n  cannot open `/aside` yet. This release reads and validates the successor\n  story document and refuses to change it. A later release can write that\n  document and open Aside without making this release damage the story."

--- a/tui/package.json
+++ b/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667",
-  "version": "0.9.4-rc.4",
+  "version": "0.9.4-rc.5",
   "private": true,
   "description": "A terminal environment for writing fiction with language models",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary

- Publish the banned string preview fix from PR #213.
- Prepare `0.9.4-rc.5`.

## Validation

- `npm run build`
- Release notes and patch hygiene checks passed.
- PR #213 passed the full test and packaged-candidate matrix.

Closes #214