### PR TITLE
chore(release): prepare 0.9.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -254,7 +254,7 @@ This file records notable changes to 1667. Product terms use the definitions in
   command accepts one or more JSON or PNG files. It adds their Facts to the
   story that `--story` names.
 
-## 0.9.4-rc.5 - 2026-08-13
+## 0.9.4 - 2026-08-13
 
 - **Banned strings can be added when the raw token bias map is empty.** The
   preview now treats an omitted empty map as an empty map. It continues to

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "1667-workspace",
-  "version": "0.9.4-rc.5",
+  "version": "0.9.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "1667-workspace",
-      "version": "0.9.4-rc.5",
+      "version": "0.9.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@silvia-odwyer/photon-node": "0.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667-workspace",
-  "version": "0.9.4-rc.5",
+  "version": "0.9.4",
   "private": true,
   "description": "Source workspace for the 1667 terminal writing environment",
   "license": "Apache-2.0",

--- a/shared/release-notes.ts
+++ b/shared/release-notes.ts
@@ -11,7 +11,7 @@ export interface ReleaseNote {
  *  a release, and is not included. */
 export const RELEASE_NOTES: readonly ReleaseNote[] = [
   {
-    version: "0.9.4-rc.5",
+    version: "0.9.4",
     date: "2026-08-13",
     body: "- **Banned strings can be added when the raw token bias map is empty.** The\n  preview now treats an omitted empty map as an empty map. It continues to\n  refuse malformed maps."
   },

--- a/tui/package.json
+++ b/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667",
-  "version": "0.9.4-rc.5",
+  "version": "0.9.4",
   "private": true,
   "description": "A terminal environment for writing fiction with language models",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary

- Promote the verified `0.9.4-rc.5` lineage to stable `0.9.4`.
- Change only release versions and generated notes.

## Validation

- `npm run build`
- Release notes and patch hygiene checks passed.
- `0.9.4-rc.5` publication verified all six npm packages and 27 immutable GitHub assets.

Closes #216