### PR TITLE
chore(release): prepare 0.9.5-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -254,6 +254,13 @@ This file records notable changes to 1667. Product terms use the definitions in
   command accepts one or more JSON or PNG files. It adds their Facts to the
   story that `--story` names.
 
+## 0.9.5-rc.1 - 2026-08-13
+
+- **Aside adds non-canon Side Notes to a story.** Use `/aside` or the Command
+  Palette to discuss the open story. Each question and answer stays with that
+  story. Side Notes never enter Write prompts or Markdown exports. Use
+  `/clear` in Aside to remove all Side Notes from the story.
+
 ## 0.9.4 - 2026-08-13
 
 - **Banned strings can be added when the raw token bias map is empty.** The

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "1667-workspace",
-  "version": "0.9.4",
+  "version": "0.9.5-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "1667-workspace",
-      "version": "0.9.4",
+      "version": "0.9.5-rc.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@silvia-odwyer/photon-node": "0.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667-workspace",
-  "version": "0.9.4",
+  "version": "0.9.5-rc.1",
   "private": true,
   "description": "Source workspace for the 1667 terminal writing environment",
   "license": "Apache-2.0",

--- a/shared/aside-release.ts
+++ b/shared/aside-release.ts
@@ -2,20 +2,14 @@
  * The one switch that decides whether this build WRITES the Aside story
  * document field and opens every user-facing Aside entry point.
  *
- * 1667 releases a schema in two steps. A release learns to read and validate
- * a successor document and refuses to mutate it before any release writes
- * that document. That order means the previous stable executable can always
- * open a data directory the newest one wrote.
+ * 1667 releases a schema in two steps. Version 0.9.4-rc.4 learned to read and
+ * validate the successor document and refused to mutate it. This release can
+ * now write that document and open every Aside entry point.
  *
- * This predecessor release reads the Aside successor STORY document but does
- * not write it. It also keeps `/aside`, the Command Palette entry, and the
- * askAside / clearAside / getAside surfaces closed. The successor release can
- * open all writes and entry points by changing this one constant.
- *
- * Deliberately not an environment variable. A writer who set one would produce
- * a document the previous stable executable cannot read.
+ * Deliberately not an environment variable. A build must not write successor
+ * data before its predecessor release can read it.
  */
-export const ASIDE_ACTIVATED = false;
+export const ASIDE_ACTIVATED = true;
 
 /** Resolve the effective activation for one store. A caller that passes
  *  nothing gets the release default. */

--- a/shared/release-notes.ts
+++ b/shared/release-notes.ts
@@ -11,6 +11,11 @@ export interface ReleaseNote {
  *  a release, and is not included. */
 export const RELEASE_NOTES: readonly ReleaseNote[] = [
   {
+    version: "0.9.5-rc.1",
+    date: "2026-08-13",
+    body: "- **Aside adds non-canon Side Notes to a story.** Use `/aside` or the Command\n  Palette to discuss the open story. Each question and answer stays with that\n  story. Side Notes never enter Write prompts or Markdown exports. Use\n  `/clear` in Aside to remove all Side Notes from the story."
+  },
+  {
     version: "0.9.4",
     date: "2026-08-13",
     body: "- **Banned strings can be added when the raw token bias map is empty.** The\n  preview now treats an omitted empty map as an empty map. It continues to\n  refuse malformed maps."

--- a/test/aside-service.integration.test.ts
+++ b/test/aside-service.integration.test.ts
@@ -39,7 +39,10 @@ import {
 test("the predecessor service keeps every Aside entry point closed", async (t) => {
   const root = await mkdtemp(path.join(tmpdir(), "1667-aside-closed-"));
   const dataDir = path.join(root, "project");
-  const service = StoryService.withoutDiagnostics({ dataDir });
+  const service = StoryService.withoutDiagnostics({
+    dataDir,
+    asideActivation: false
+  });
   await service.init();
   t.after(async () => {
     await service.dispose();
@@ -82,7 +85,10 @@ test("the inactive predecessor replays supplied Aside identities, but not new re
   assert.ok(saved !== null);
   await writer.dispose();
 
-  const predecessor = StoryService.withoutDiagnostics({ dataDir });
+  const predecessor = StoryService.withoutDiagnostics({
+    dataDir,
+    asideActivation: false
+  });
   await predecessor.init();
   const replayed = await predecessor.askAside(
     created.id,
@@ -201,7 +207,10 @@ test("activated direct local and provider mutations keep V10 writable", async (t
   assert.equal(autonamed.title, "The Quiet After Rain");
   await writer.dispose();
 
-  const predecessor = StoryService.withoutDiagnostics({ dataDir });
+  const predecessor = StoryService.withoutDiagnostics({
+    dataDir,
+    asideActivation: false
+  });
   await predecessor.init();
   await assert.rejects(
     () => predecessor.renameStory(created.id, "Must stay closed"),

--- a/test/chapters.test.ts
+++ b/test/chapters.test.ts
@@ -215,7 +215,7 @@ test("renaming a chapter accepts the null break of chapter one and an empty name
 test("naming chapter one is refused where the directory never took the fence", async () => {
   const refusals: unknown[] = [];
   const chapters = new StoryServiceChapters({
-    stories: {} as never,
+    stories: { asideActivation: false } as never,
     storyMutations: {} as never,
     ensureOpen: () => undefined,
     // A legacy-preview directory keeps format 1 by design, so it is the one
@@ -231,7 +231,10 @@ test("naming chapter one is refused where the directory never took the fence", a
 
   // A break rename carries no new shape, so it is not fenced.
   const unfenced = new StoryServiceChapters({
-    stories: { mutate: async () => { throw new Error("reached the store"); } } as never,
+    stories: {
+      asideActivation: false,
+      mutate: async () => { throw new Error("reached the store"); }
+    } as never,
     storyMutations: {} as never,
     ensureOpen: () => undefined,
     dataFormat: () => 1

--- a/test/node-preview.integration.test.ts
+++ b/test/node-preview.integration.test.ts
@@ -60,7 +60,10 @@ test("a preview stops at 100 code units when the first line is long", async (t) 
 
 test("a bundle written before the first-line rule still loads and shows one line", async (t) => {
   const dataDir = await openDataDir(t);
-  let service = StoryService.withoutDiagnostics({ dataDir });
+  let service = StoryService.withoutDiagnostics({
+    dataDir,
+    asideActivation: false
+  });
   await service.init();
   const created = await service.createStory("Preview");
   const text = `${SHORT_FIRST_LINE}\n\n${SECOND_LINE}`;
@@ -74,7 +77,10 @@ test("a bundle written before the first-line rule still loads and shows one line
   stored.nodes[0]!.preview = text.slice(0, 100);
   await writeFile(file, `${JSON.stringify(stored, null, 2)}\n`);
 
-  service = StoryService.withoutDiagnostics({ dataDir });
+  service = StoryService.withoutDiagnostics({
+    dataDir,
+    asideActivation: false
+  });
   await service.init();
   t.after(() => service.dispose());
 

--- a/test/story-provider-compatibility-recovery.test.ts
+++ b/test/story-provider-compatibility-recovery.test.ts
@@ -346,7 +346,10 @@ async function legacyProviderService(
     }),
     { encoding: "utf8", mode: 0o600 }
   );
-  const service = StoryService.withoutDiagnostics({ dataDir });
+  const service = StoryService.withoutDiagnostics({
+    dataDir,
+    asideActivation: false
+  });
   await service.init();
   return { dataDir, service };
 }

--- a/test/story-service-idempotency.test.ts
+++ b/test/story-service-idempotency.test.ts
@@ -36,7 +36,7 @@ test("pending receipts recover committed entity creation without duplicates afte
   const nodeId = mutationId("2");
   const factId = mutationId("3");
   const cutId = mutationId("4");
-  let service = StoryService.withoutDiagnostics({ dataDir });
+  let service = legacyWorkerService(dataDir);
   await service.init();
 
   await leavePendingAfterCommit(service, createId, "createStory", createInput);
@@ -51,7 +51,7 @@ test("pending receipts recover committed entity creation without duplicates afte
   const committedRevision = (await service.loadStory(storyId)).updatedAt;
   await service.dispose();
 
-  service = StoryService.withoutDiagnostics({ dataDir });
+  service = legacyWorkerService(dataDir);
   await service.init();
   try {
     const recovered = await runWorkerMutation(service, createId, "createStory", createInput);
@@ -77,7 +77,7 @@ test("pending Markdown import replay re-enters canonical creation recovery", asy
   const input = {
     markdown: "# Replayed\n\nFirst.\n\n## Later\n\nSecond."
   };
-  let service = StoryService.withoutDiagnostics({ dataDir });
+  let service = legacyWorkerService(dataDir);
   await service.init();
   const first = await leavePendingAfterCommit(
     service,
@@ -87,7 +87,7 @@ test("pending Markdown import replay re-enters canonical creation recovery", asy
   );
   await service.dispose();
 
-  service = StoryService.withoutDiagnostics({ dataDir });
+  service = legacyWorkerService(dataDir);
   await service.init();
   try {
     const replayed = await runWorkerMutation(
@@ -129,7 +129,7 @@ test("pending NovelAI import replay re-enters canonical creation recovery", asyn
       }
     })
   };
-  let service = StoryService.withoutDiagnostics({ dataDir });
+  let service = legacyWorkerService(dataDir);
   await service.init();
   const first = await leavePendingAfterCommit(
     service,
@@ -139,7 +139,7 @@ test("pending NovelAI import replay re-enters canonical creation recovery", asyn
   );
   await service.dispose();
 
-  service = StoryService.withoutDiagnostics({ dataDir });
+  service = legacyWorkerService(dataDir);
   await service.init();
   try {
     const replayed = await runWorkerMutation(
@@ -162,7 +162,7 @@ test("pending NovelAI import replay re-enters canonical creation recovery", asyn
 test("deterministic fact recovery wins before the capacity guard", async (t) => {
   const dataDir = await mkdtemp(path.join(tmpdir(), "1667-fact-capacity-recovery-"));
   t.after(() => rm(dataDir, { recursive: true, force: true }));
-  const service = StoryService.withoutDiagnostics({ dataDir });
+  const service = legacyWorkerService(dataDir);
   await service.init();
   try {
     const story = await service.createStory("Full facts");
@@ -191,7 +191,7 @@ test("a patchFact replay does not mistake a priority/budget-only edit for one al
   // prior attempt had committed.
   const dataDir = await mkdtemp(path.join(tmpdir(), "1667-fact-patch-recovery-"));
   t.after(() => rm(dataDir, { recursive: true, force: true }));
-  const service = StoryService.withoutDiagnostics({ dataDir });
+  const service = legacyWorkerService(dataDir);
   await service.init();
   try {
     const story = await service.createFact(
@@ -233,7 +233,7 @@ test("a patchFact replay does not mistake a priority/budget-only edit for one al
 test("pending overwrite recovery never clobbers newer authoritative state", async (t) => {
   const dataDir = await mkdtemp(path.join(tmpdir(), "1667-overwrite-recovery-"));
   t.after(() => rm(dataDir, { recursive: true, force: true }));
-  const service = StoryService.withoutDiagnostics({ dataDir });
+  const service = legacyWorkerService(dataDir);
   await service.init();
   try {
     const story = await service.createStory("Original");
@@ -255,7 +255,7 @@ test("pending overwrite recovery never clobbers newer authoritative state", asyn
 test("pending destructive mutations converge and clear without repeat writes", async (t) => {
   const dataDir = await mkdtemp(path.join(tmpdir(), "1667-destructive-recovery-"));
   t.after(() => rm(dataDir, { recursive: true, force: true }));
-  const service = StoryService.withoutDiagnostics({ dataDir });
+  const service = legacyWorkerService(dataDir);
   await service.init();
   try {
     let story = await service.createStory("Destructive recovery");
@@ -351,7 +351,7 @@ test("pending destructive mutations converge and clear without repeat writes", a
 test("pending dry-run summaries reconcile by deterministic node ID", async (t) => {
   const dataDir = await mkdtemp(path.join(tmpdir(), "1667-summary-recovery-"));
   t.after(() => rm(dataDir, { recursive: true, force: true }));
-  const service = StoryService.withoutDiagnostics({ dataDir });
+  const service = legacyWorkerService(dataDir);
   await service.init();
   try {
     let story = await service.createStory("Summary recovery");
@@ -374,7 +374,7 @@ test("pending dry-run summaries reconcile by deterministic node ID", async (t) =
 test("pending pre-provider summaries resume with deterministic commit IDs", async (t) => {
   const dataDir = await mkdtemp(path.join(tmpdir(), "1667-summary-pending-"));
   t.after(() => rm(dataDir, { recursive: true, force: true }));
-  const service = StoryService.withoutDiagnostics({ dataDir });
+  const service = legacyWorkerService(dataDir);
   await service.init();
   try {
     let story = await service.createStory("Pending summary");
@@ -395,7 +395,7 @@ test("pending pre-provider summaries resume with deterministic commit IDs", asyn
 test("pending dry-run rewrites reconcile a committed take without duplicating it", async (t) => {
   const dataDir = await mkdtemp(path.join(tmpdir(), "1667-rewrite-recovery-"));
   t.after(() => rm(dataDir, { recursive: true, force: true }));
-  const service = StoryService.withoutDiagnostics({ dataDir });
+  const service = legacyWorkerService(dataDir);
   await service.init();
   try {
     let story = await service.createStory("Rewrite recovery");
@@ -432,7 +432,7 @@ test("pending dry-run rewrites reconcile a committed take without duplicating it
 test("pending dry-run rewrites reconcile a committed in-place edit without duplicating it", async (t) => {
   const dataDir = await mkdtemp(path.join(tmpdir(), "1667-rewrite-inplace-recovery-"));
   t.after(() => rm(dataDir, { recursive: true, force: true }));
-  const service = StoryService.withoutDiagnostics({ dataDir });
+  const service = legacyWorkerService(dataDir);
   await service.init();
   try {
     let story = await service.createStory("Rewrite recovery");
@@ -471,7 +471,7 @@ test("pending dry-run rewrites reconcile a committed in-place edit without dupli
 test("a partial-rewrite receipt replays after the volatile stash is lost", async (t) => {
   const dataDir = await mkdtemp(path.join(tmpdir(), "1667-partial-rewrite-replay-"));
   t.after(() => rm(dataDir, { recursive: true, force: true }));
-  let service = StoryService.withoutDiagnostics({ dataDir });
+  let service = legacyWorkerService(dataDir);
   await service.init();
   let disposed = false;
   try {
@@ -531,7 +531,7 @@ test("a partial-rewrite receipt replays after the volatile stash is lost", async
     // must still return the same take and must not apply the splice again.
     await service.dispose();
     disposed = true;
-    service = StoryService.withoutDiagnostics({ dataDir });
+    service = legacyWorkerService(dataDir);
     await service.init();
     disposed = false;
     const replayed = await runWorkerMutation(
@@ -657,7 +657,7 @@ test("a retryable partial settlement keeps its outer receipt pending", async (t)
 test("a completed partial-rewrite replay does not consume a later attempt", async (t) => {
   const dataDir = await mkdtemp(path.join(tmpdir(), "1667-partial-rewrite-attempts-"));
   t.after(() => rm(dataDir, { recursive: true, force: true }));
-  const service = StoryService.withoutDiagnostics({ dataDir });
+  const service = legacyWorkerService(dataDir);
   await service.init();
   try {
     let story = await service.createStory("Partial rewrite attempts");
@@ -848,7 +848,7 @@ test("a terminal partial-rewrite conflict releases its exact stash slot", async 
 test("pending autoname resumes before admission and reconciles after commit", async (t) => {
   const dataDir = await mkdtemp(path.join(tmpdir(), "1667-autoname-recovery-"));
   t.after(() => rm(dataDir, { recursive: true, force: true }));
-  const service = StoryService.withoutDiagnostics({ dataDir });
+  const service = legacyWorkerService(dataDir);
   await service.init();
   try {
     let story = await service.createStory("Original title");
@@ -875,7 +875,7 @@ test("pending autoname resumes before admission and reconciles after commit", as
 test("autoname recovery preserves newer manual titles", async (t) => {
   const dataDir = await mkdtemp(path.join(tmpdir(), "1667-autoname-newer-title-"));
   t.after(() => rm(dataDir, { recursive: true, force: true }));
-  const service = StoryService.withoutDiagnostics({ dataDir });
+  const service = legacyWorkerService(dataDir);
   await service.init();
   try {
     let story = await service.createStory("Original title");
@@ -908,7 +908,7 @@ test("autoname recovery preserves newer manual titles", async (t) => {
 test("summary cancellation after provider admission completes as null", async (t) => {
   const dataDir = await mkdtemp(path.join(tmpdir(), "1667-summary-cancel-"));
   t.after(() => rm(dataDir, { recursive: true, force: true }));
-  const service = StoryService.withoutDiagnostics({ dataDir });
+  const service = legacyWorkerService(dataDir);
   await service.init();
   const originalFetch = globalThis.fetch;
   try {
@@ -952,7 +952,7 @@ test("summary cancellation after provider admission completes as null", async (t
 test("replaying a cleared Author's Note recovers instead of reporting an unknown outcome", async (t) => {
   const dataDir = await mkdtemp(path.join(tmpdir(), "1667-note-clear-replay-"));
   t.after(() => rm(dataDir, { recursive: true, force: true }));
-  const service = StoryService.withoutDiagnostics({ dataDir });
+  const service = legacyWorkerService(dataDir);
   await service.init();
   try {
     let story = await service.createStory("Depth story");
@@ -977,7 +977,7 @@ test("replaying a cleared Author's Note recovers instead of reporting an unknown
 test("replaying a depth-only Author's Note save recovers on a story with no note", async (t) => {
   const dataDir = await mkdtemp(path.join(tmpdir(), "1667-note-depth-only-replay-"));
   t.after(() => rm(dataDir, { recursive: true, force: true }));
-  const service = StoryService.withoutDiagnostics({ dataDir });
+  const service = legacyWorkerService(dataDir);
   await service.init();
   try {
     let story = await service.createStory("Depth story");
@@ -1025,8 +1025,19 @@ async function runWorkerMutation<M extends MutatingWorkerMethod>(
           })
     }),
     undefined,
-    (plan) => preflightWorkerMutation(service, input, plan)
+    (plan) => expectedAggregateVersion === undefined
+      ? preflightWorkerMutation(service, input, plan)
+      : undefined
   );
+}
+
+/** These cases exercise retained worker requests that have no aggregate
+ * version. Keep their setup on the predecessor path. */
+function legacyWorkerService(dataDir: string): StoryService {
+  return StoryService.withoutDiagnostics({
+    dataDir,
+    asideActivation: false
+  });
 }
 
 async function leavePendingAfterCommit<M extends MutatingWorkerMethod>(

--- a/test/story-v6-store.test.ts
+++ b/test/story-v6-store.test.ts
@@ -23,7 +23,10 @@ const SUCCESSOR_CODE = "story_manifest_requires_successor";
 
 test("story V6 store: existing list, read, and export surfaces support live state and hide deleted state", async (t) => {
   const dataDir = await mkdtemp(path.join(tmpdir(), "1667-v6-read-"));
-  const service = StoryService.withoutDiagnostics({ dataDir });
+  const service = StoryService.withoutDiagnostics({
+    dataDir,
+    asideActivation: false
+  });
   await service.init();
   t.after(async () => { await service.dispose(); await rm(dataDir, { recursive: true, force: true }); });
 

--- a/test/storytavern-data-migration.test.ts
+++ b/test/storytavern-data-migration.test.ts
@@ -68,22 +68,26 @@ test("offline migration opens StoryTavern bundles and normalizes later writes", 
   const migratedManifest = JSON.parse(await readFile(
     path.join(destination, "stories", STORY_ID, "manifest.json"),
     "utf8"
-  )) as { format: string; schemaVersion: number; title: string; nodes: Array<{ revisionId: string }> };
+  )) as {
+    format: string;
+    schemaVersion: number;
+    content: { title: string; nodes: Array<{ revisionId: string }> };
+  };
   assert.equal(migratedManifest.format, STORY_FORMAT);
-  assert.equal(migratedManifest.schemaVersion, 5);
-  assert.equal(migratedManifest.title, "Migrated story");
+  assert.equal(migratedManifest.schemaVersion, 6);
+  assert.equal(migratedManifest.content.title, "Migrated story");
   const sourceDocument = JSON.parse(sourceManifest) as {
     format: string;
     nodes: Array<{ revisionId: string }>;
   };
   assert.equal(
-    migratedManifest.nodes[0]!.revisionId,
+    migratedManifest.content.nodes[0]!.revisionId,
     sourceDocument.nodes[0]!.revisionId
   );
 
   const retainedRevision = JSON.parse(await readFile(revisionPath(
     path.join(destination, "stories", STORY_ID),
-    migratedManifest.nodes[0]!.revisionId
+    migratedManifest.content.nodes[0]!.revisionId
   ), "utf8")) as { format: string };
   assert.equal(retainedRevision.format, STORYTAVERN_REVISION_FORMAT);
   assert.equal(sourceDocument.format, STORYTAVERN_STORY_FORMAT);

--- a/tui/package.json
+++ b/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667",
-  "version": "0.9.4",
+  "version": "0.9.5-rc.1",
   "private": true,
   "description": "A terminal environment for writing fiction with language models",
   "license": "Apache-2.0",

--- a/tui/src/aside-actions.ts
+++ b/tui/src/aside-actions.ts
@@ -128,7 +128,7 @@ export function asideFooterHint(surface: AsideSurfaceState): string {
   if (surface.confirmClear) return "Clear all Side Notes? Enter confirms · Esc cancels";
   if (surface.busy && surface.inflightQuestion === null) return "Clearing…";
   if (surface.busy) return "Esc stop · PageUp/PageDown scroll · Shift+Up/Down line scroll";
-  return "PageUp/PageDown scroll · Shift+Up/Down line scroll · Enter send · Shift+Enter newline · Esc write · clear: type /clear";
+  return "Esc write · /clear clear · Enter send · Shift+Enter newline · PageUp/PageDown scroll · Shift+Up/Down line scroll";
 }
 
 function asideFooterRows(surface: AsideSurfaceState, cols: number): string[] {

--- a/tui/src/mouse-actions.ts
+++ b/tui/src/mouse-actions.ts
@@ -289,7 +289,10 @@ export function mouseToAction(
   if (event.modifiers.shift) return null;
   if (event.type === "scroll") {
     const down = event.scroll?.direction === "down";
-    if (state.mode === "REQUEST") return { action: down ? "scroll-line-down" : "scroll-line-up" };
+    if (state.mode === "REQUEST"
+      || state.mode === "ASIDE" && state.textActions === null) {
+      return { action: down ? "scroll-line-down" : "scroll-line-up" };
+    }
     // The Fact editor owns several header rows above a scrollable body. Wheel
     // input must move that body one visual row at a time; routing it through
     // the overlay's focus actions would move the header selection instead.

--- a/tui/test/aside-layout.test.ts
+++ b/tui/test/aside-layout.test.ts
@@ -40,13 +40,28 @@ test("long Aside titles keep the full-screen composer and footer visible", () =>
     expect(lines[0]).toContain("ASIDE ·");
     expect(text).toContain("aside · prompt");
     expect(text).toContain("Why?");
-    expect(text).toContain("PageUp/PageDown");
+    expect(text).toContain("Esc write");
+    expect(text).toContain("/clear");
     expect(lines.some((line) => line.includes("┗━"))).toBeTrue();
     expect(frame.lines.flat().some((part) => part.composerStart === 0
       && part.background === "compose accent")).toBeTrue();
     expect(frame.derived.composerSelectionProjection?.some((cell) => cell?.start === 0
       && cell.end === 1)).toBeTrue();
   }
+});
+
+test("idle Aside keeps exit and Clear visible at standard width", () => {
+  const source = demoAppSource();
+  const state = initialState(source, false);
+  state.mode = "ASIDE";
+  state.aside = createAsideSurface(state.payload.id, state.payload.title);
+
+  const text = renderStoryScreen(state, { width: 80, height: 24 }).lines
+    .map(plainLine)
+    .join("\n");
+
+  expect(text).toContain("Esc write");
+  expect(text).toContain("/clear clear");
 });
 
 test("shows a submitted Aside question before the first provider delta", () => {

--- a/tui/test/aside.test.ts
+++ b/tui/test/aside.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import type { KeyEvent } from "@opentui/core";
+import type { KeyEvent, MouseEvent } from "@opentui/core";
 import {
   createAsideSurface,
   ASIDE_INPUT_PLACEHOLDER,
@@ -29,7 +29,8 @@ import { openDirectComposer } from "../src/composer-ownership.js";
 import { moveComposerTo, setComposerText } from "../src/composer-model.js";
 import { visibleWidth } from "../src/screens/story/frame.js";
 import { renderStoryScreen } from "../src/screens/story.js";
-import { activeTextComposer } from "../src/text-actions.js";
+import { activeTextComposer, openTextActions } from "../src/text-actions.js";
+import { mouseToAction } from "../src/mouse-actions.js";
 
 function key(
   name: string,
@@ -130,6 +131,42 @@ describe("Aside TUI contract", () => {
     expect(surface.scrollTop).toBeNull();
     surface.notes.push({ question: "new-tail", answer: "followed" });
     expect(renderAsideFrame(surface, width, height).join("\n")).toContain("new-tail");
+  });
+
+  test("the mouse wheel scrolls Side Note history", async () => {
+    const notes = Array.from({ length: 8 }, (_, index) => ({
+      question: `older-${index}`,
+      answer: `answer-${index}`
+    }));
+    const surface = createAsideSurface("s1", "Lantern Story", notes);
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    state.aside = surface;
+    state.mode = "ASIDE";
+    const width = 40;
+    const height = 12;
+    const wheelUp = {
+      type: "scroll",
+      button: 0,
+      x: 20,
+      y: 5,
+      modifiers: { shift: false, alt: false, ctrl: false },
+      scroll: { direction: "up" }
+    } as unknown as MouseEvent;
+
+    const action = mouseToAction(wheelUp, state);
+    expect(action).toEqual({ action: "scroll-line-up" });
+    await handleOverlayAction(
+      action!,
+      state,
+      source,
+      overlayContext(state, width, height)
+    );
+
+    expect(surface.scrollTop).not.toBeNull();
+
+    openTextActions(state);
+    expect(mouseToAction(wheelUp, state)).toEqual({ action: "focus-previous" });
   });
 
   test("ASIDE mode: Enter sends, Shift+Enter newlines, Esc cancels", () => {

--- a/tui/test/worker-api.test.ts
+++ b/tui/test/worker-api.test.ts
@@ -526,16 +526,22 @@ describe("embedded backend worker", () => {
 
   test("executes an unsent durable caller outbox after restart", async () => {
     const dataDir = await mkdtemp(path.join(tmpdir(), "1667-worker-unsent-outbox-"));
-    const mutationId = `m1-${Date.now().toString(36)}-${"8".padStart(32, "0")}`;
+    const mutationId = createDurableMutationId();
     const service = StoryService.withoutDiagnostics({ dataDir });
     await service.init();
     let story = await service.createStory("Sent after restart");
     story = await service.createNode(story.id, { parentId: null, text: "A summary source." });
+    const expectedAggregateVersion = story.aggregateVersion!;
     await service.dispose();
     const input = { storyId: story.id, body: { nodeId: story.nodes[0]!.id } };
     const outbox = new MutationOutbox(path.join(dataDir, "mutation-outbox"));
     await outbox.init();
-    await outbox.enqueue(mutationId, "createSummaryTake", input);
+    await outbox.enqueue(
+      mutationId,
+      "createSummaryTake",
+      input,
+      expectedAggregateVersion
+    );
 
     // Real worker startup competes with the full test pool; fake-worker tests
     // below retain the tight 100 ms liveness deadline.
@@ -550,7 +556,7 @@ describe("embedded backend worker", () => {
         backend.api.listStories().then(() => "api" as const)
       ]);
       expect(first).toBe("api");
-      await backend.recovery;
+      expect(await backend.recovery).toEqual([]);
       expect((await backend.api.loadStory(story.id)).nodes.some((node) => node.role === "summary")).toBeTrue();
       expect(await outbox.list()).toEqual([]);
     } finally {

--- a/tui/test/worker-deadline.test.ts
+++ b/tui/test/worker-deadline.test.ts
@@ -91,6 +91,38 @@ describe("embedded worker deadlines", () => {
         throw new Error("Deadline fixture is missing successor aggregate metadata");
       }
       const expectedAggregateVersion = rootedStory.aggregateVersion;
+      const createdSummaryStory = await request(worker, {
+        type: "request",
+        id: operationId(),
+        method: "createStory",
+        input: { title: "Summary deadline proof" },
+        protocolVersion: WORKER_PROTOCOL_VERSION,
+        mutationId: mutationId("summary-1"),
+        deadlineMs: Date.now() + 60_000
+      });
+      expect(createdSummaryStory.type).toBe("result");
+      const summaryStory = (
+        createdSummaryStory as Extract<WorkerToMainMessage, { type: "result" }>
+      ).value as StoryPayload;
+      const summaryWithRoot = await request(worker, {
+        type: "request",
+        id: operationId(),
+        method: "createNode",
+        input: {
+          storyId: summaryStory.id,
+          body: { parentId: null, text: "The second door opened." }
+        },
+        protocolVersion: WORKER_PROTOCOL_VERSION,
+        mutationId: mutationId("summary-2"),
+        deadlineMs: Date.now() + 60_000
+      });
+      expect(summaryWithRoot.type).toBe("result");
+      const rootedSummaryStory = (
+        summaryWithRoot as Extract<WorkerToMainMessage, { type: "result" }>
+      ).value as StoryPayload;
+      if (rootedSummaryStory.aggregateVersion === undefined) {
+        throw new Error("Summary deadline fixture is missing aggregate metadata");
+      }
 
       const generationMutationId = mutationId("3");
       const generationInput = {
@@ -135,7 +167,10 @@ describe("embedded worker deadlines", () => {
       });
 
       const summaryMutationId = mutationId("4");
-      const summaryInput = { storyId: storyId.id, body: { nodeId: rootedStory.path[0]!.id } };
+      const summaryInput = {
+        storyId: summaryStory.id,
+        body: { nodeId: rootedSummaryStory.path[0]!.id }
+      };
       const summaryProviderStarted = nextProviderRequest(providerRequestWaiters);
       const expiredSummaryRequest = request(worker, {
         type: "request",
@@ -144,7 +179,7 @@ describe("embedded worker deadlines", () => {
         input: summaryInput,
         protocolVersion: WORKER_PROTOCOL_VERSION,
         mutationId: summaryMutationId,
-        expectedAggregateVersion,
+        expectedAggregateVersion: rootedSummaryStory.aggregateVersion,
         deadlineMs: Date.now() + PROVIDER_START_DEADLINE_MS
       });
       expect(await providerStartsBeforeResult(summaryProviderStarted, expiredSummaryRequest)).toBe(true);
@@ -162,7 +197,7 @@ describe("embedded worker deadlines", () => {
         input: summaryInput,
         protocolVersion: WORKER_PROTOCOL_VERSION,
         mutationId: summaryMutationId,
-        expectedAggregateVersion,
+        expectedAggregateVersion: rootedSummaryStory.aggregateVersion,
         deadlineMs: Date.now() + 60_000
       });
       expect(replayedSummary).toMatchObject({

--- a/tui/test/worker-deadline.test.ts
+++ b/tui/test/worker-deadline.test.ts
@@ -86,6 +86,10 @@ describe("embedded worker deadlines", () => {
         deadlineMs: Date.now() + 60_000
       });
       const rootedStory = (withRoot as Extract<WorkerToMainMessage, { type: "result" }>).value as StoryPayload;
+      if (rootedStory.aggregateVersion === undefined) {
+        throw new Error("Deadline fixture is missing successor aggregate metadata");
+      }
+      const expectedAggregateVersion = rootedStory.aggregateVersion;
 
       const generationMutationId = mutationId("3");
       const generationInput = {
@@ -102,6 +106,7 @@ describe("embedded worker deadlines", () => {
         input: generationInput,
         protocolVersion: WORKER_PROTOCOL_VERSION,
         mutationId: generationMutationId,
+        expectedAggregateVersion,
         deadlineMs: Date.now() + PROVIDER_START_DEADLINE_MS
       });
       expect(await providerStartsBeforeResult(generationProviderStarted, expiredGeneration)).toBe(true);
@@ -119,6 +124,7 @@ describe("embedded worker deadlines", () => {
         input: generationInput,
         protocolVersion: WORKER_PROTOCOL_VERSION,
         mutationId: generationMutationId,
+        expectedAggregateVersion,
         deadlineMs: Date.now() + 60_000
       });
       expect(replayed).toMatchObject({
@@ -137,6 +143,7 @@ describe("embedded worker deadlines", () => {
         input: summaryInput,
         protocolVersion: WORKER_PROTOCOL_VERSION,
         mutationId: summaryMutationId,
+        expectedAggregateVersion,
         deadlineMs: Date.now() + PROVIDER_START_DEADLINE_MS
       });
       expect(await providerStartsBeforeResult(summaryProviderStarted, expiredSummaryRequest)).toBe(true);
@@ -154,6 +161,7 @@ describe("embedded worker deadlines", () => {
         input: summaryInput,
         protocolVersion: WORKER_PROTOCOL_VERSION,
         mutationId: summaryMutationId,
+        expectedAggregateVersion,
         deadlineMs: Date.now() + 60_000
       });
       expect(replayedSummary).toMatchObject({
@@ -232,6 +240,9 @@ describe("embedded worker deadlines", () => {
         deadlineMs: Date.now() + 60_000
       });
       const rootedStory = (withRoot as Extract<WorkerToMainMessage, { type: "result" }>).value as StoryPayload;
+      if (rootedStory.aggregateVersion === undefined) {
+        throw new Error("Deadline fixture is missing successor aggregate metadata");
+      }
 
       // The harness plays the main transport whose deadline timer fires: it
       // never acknowledges a delta, so the worker's credit window
@@ -252,6 +263,7 @@ describe("embedded worker deadlines", () => {
         },
         protocolVersion: WORKER_PROTOCOL_VERSION,
         mutationId: mutationId("3"),
+        expectedAggregateVersion: rootedStory.aggregateVersion,
         deadlineMs: Date.now() + 60_000
       }, collected.listener);
       const response = await providerResponse;

--- a/tui/test/worker-deadline.test.ts
+++ b/tui/test/worker-deadline.test.ts
@@ -7,6 +7,7 @@ import path from "node:path";
 import { platformPerformanceBudget } from "../../test/performance-budget.js";
 import { DataDirectoryLock } from "../../server/data-directory-lock.js";
 import { ownedLoopbackHttpSupported } from "../../server/provider-fetch.js";
+import { createDurableMutationId } from "../../shared/durable-mutation-id.js";
 import {
   MAX_DELTA_BATCH_BYTES,
   MAX_UNACKNOWLEDGED_DELTA_BATCHES,
@@ -417,6 +418,6 @@ function nextMessageOfType<T extends WorkerToMainMessage["type"]>(
   });
 }
 
-function mutationId(suffix: string): string {
-  return `m1-${Date.now().toString(36)}-${suffix.padStart(32, "0")}`;
+function mutationId(_suffix: string): string {
+  return createDurableMutationId();
 }


### PR DESCRIPTION
## Outcome

Enable Aside and prepare the 0.9.5-rc.1 prerelease. This release lets a writer save non-canon Side Notes with a story after 0.9.4 introduced read-only successor support.

## Changes

- Open the Aside command, service, and storage write paths.
- Pin predecessor compatibility tests to the closed release path.
- Keep Aside mouse-wheel scrolling and text-menu selection distinct.
- Keep Exit and Clear visible in the Aside footer.
- Set all package versions and release notes to 0.9.5-rc.1.

## Verification

- `npm run build`
- `npm test`
- `cd tui && bun run typecheck`
- `cd tui && bun test --timeout 30000` (1,912 passed; 2 platform skips)
- `cd tui && bun run build:standalone`
- Structured autoreview: clean
- Thermonuclear maintainability review: clean
- Claude UI/UX review: clean after the wheel and footer fixes

## Risk and follow-up

This release activates the successor story format. The 0.9.4 predecessor fixtures verify that the stable release remains read-only for that format. No known release blocker remains.

Closes #218