### PR TITLE
fix(tui): preserve sampling bias across worker boundary

### DIFF
--- a/tui/src/sampling-bias-resolution.ts
+++ b/tui/src/sampling-bias-resolution.ts
@@ -205,9 +205,12 @@ async function resolveNow(
   try {
     result = await source.api.resolveSamplingBias({
       settings,
-      logitBias: sampling.logitBias,
-      phraseBias: sampling.phraseBias,
-      bannedStrings: sampling.bannedStrings
+      // The settings-document probe already contains these values. Keep the
+      // preview fields as separate wire objects so the worker message does not
+      // carry repeated references to the same draft containers.
+      logitBias: { ...sampling.logitBias },
+      phraseBias: sampling.phraseBias.map((entry) => ({ ...entry })),
+      bannedStrings: [...sampling.bannedStrings]
     });
   } catch (error) {
     // Issue #282 review round 2, finding 5: the worker call throwing — the

--- a/tui/test/sampling-settings-worker.integration.test.ts
+++ b/tui/test/sampling-settings-worker.integration.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { applyBasicSettingsDraft, basicSettingsFromDocument } from "../../shared/settings-basic-draft.js";
+import { samplingLayerRowIndex } from "../src/sampling-model.js";
+import { setComposerText } from "../src/composer-model.js";
+import { createWorkerStoryApi, type WorkerStoryApi } from "../src/worker-api.js";
+import { key, openSettings, selectRow, settingsHarness } from "./settings-test-harness.js";
+
+const workers: WorkerStoryApi[] = [];
+const directories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(workers.splice(0).map(async (worker) => await worker.dispose()));
+  await Promise.all(directories.splice(0).map(async (directory) => {
+    await rm(directory, { recursive: true, force: true });
+  }));
+});
+
+describe("Sampling Settings through the embedded worker", () => {
+  test("adds a banned string from the Sampling UI when numeric logit bias is empty", async () => {
+    const directory = await mkdtemp(path.join(tmpdir(), "1667-sampling-ui-worker-"));
+    directories.push(directory);
+    const worker = await createWorkerStoryApi({ dataDir: directory });
+    workers.push(worker);
+
+    const { source, state, press } = settingsHarness();
+    useOpenAiSettings(source);
+    source.api.resolveSamplingBias = worker.api.resolveSamplingBias;
+
+    await openSettings(press);
+    await selectRow(press, state, "sampling");
+    await press(key("return"));
+    for (let index = 0; index < samplingLayerRowIndex("banned-strings"); index += 1) {
+      await press(key("down"));
+    }
+    await press(key("return"));
+    await press(key("n"));
+    const edit = state.settings?.sampling?.edit;
+    if (edit === null || edit === undefined) throw new Error("banned-string editor did not open");
+    setComposerText(edit.composer, "hello");
+    await press(key("return"));
+    await waitForSamplingResolution(state);
+
+    expect(state.settings?.sampling?.result).not.toContain("logitBias must be an object");
+    expect(state.settings?.sampling?.biasResolution.kind).toBe("ready");
+    expect(state.settings?.draft.sampling.bannedStrings).toEqual(["hello"]);
+  });
+});
+
+function useOpenAiSettings(source: ReturnType<typeof settingsHarness>["source"]): void {
+  const active = source.settingsView;
+  if (!active.editable) throw new Error("settings must be editable");
+  const generation = {
+    ...source.settings,
+    provider: "openai-compatible" as const,
+    baseUrl: "https://api.openai.com/v1",
+    model: "gpt-4o",
+    apiKeyEnv: null
+  };
+  const document = applyBasicSettingsDraft(active.document, generation);
+  source.settingsView = {
+    ...active,
+    document,
+    effective: basicSettingsFromDocument(document)
+  };
+  source.api.getSettings = async () => source.settingsView;
+}
+
+async function waitForSamplingResolution(
+  state: ReturnType<typeof settingsHarness>["state"]
+): Promise<void> {
+  const deadline = Date.now() + 5_000;
+  while (state.settings?.sampling?.biasResolution.kind === "pending") {
+    if (Date.now() >= deadline) throw new Error("sampling resolution did not settle");
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}


### PR DESCRIPTION
## What changed

- Copy sampling bias containers before the embedded worker request.
- Add a UI-to-worker integration test for adding a banned string with an empty numeric logit bias map.

## Why

The settings document and the preview fields shared the same container references. The embedded worker boundary did not preserve the repeated map reference correctly. The service then received an invalid `logitBias` value and returned `logitBias must be an object`.

The request now sends independent copies of numeric logit bias, phrase bias, and banned strings.

## User impact

Writers can add banned strings and phrase bias entries from Sampling Settings. Empty numeric logit bias no longer blocks preview or save.

## Verification

- Reproduced the error through the installed `0.9.5-rc.1` UI.
- Verified the fix through a newly built standalone UI. The banned string resolved to token IDs and Settings saved it.
- `npm test`: 2,495 passed; 226 skipped.
- `bun test --timeout 30000`: 1,913 passed; 2 skipped.
- Root and TUI typechecks passed.
- Structured autoreview with strict maintainability scope: clean.

Closes #224
