### PR TITLE
chore(release): prepare 0.9.5-rc.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -260,6 +260,12 @@ This file records notable changes to 1667. Product terms use the definitions in
   command accepts one or more JSON or PNG files. It adds their Facts to the
   story that `--story` names.
 
+## 0.9.5-rc.2 - 2026-08-14
+
+- **Banned strings now save from Settings.** Adding a banned string no longer
+  reports `logitBias must be an object`. Settings now copies each sampling
+  value before it sends the settings document to the worker.
+
 ## 0.9.5-rc.1 - 2026-08-13
 
 - **Aside adds non-canon Side Notes to a story.** Use `/aside` or the Command

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "1667-workspace",
-  "version": "0.9.5-rc.1",
+  "version": "0.9.5-rc.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "1667-workspace",
-      "version": "0.9.5-rc.1",
+      "version": "0.9.5-rc.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@silvia-odwyer/photon-node": "0.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667-workspace",
-  "version": "0.9.5-rc.1",
+  "version": "0.9.5-rc.2",
   "private": true,
   "description": "Source workspace for the 1667 terminal writing environment",
   "license": "Apache-2.0",

--- a/shared/release-notes.ts
+++ b/shared/release-notes.ts
@@ -11,6 +11,11 @@ export interface ReleaseNote {
  *  a release, and is not included. */
 export const RELEASE_NOTES: readonly ReleaseNote[] = [
   {
+    version: "0.9.5-rc.2",
+    date: "2026-08-14",
+    body: "- **Banned strings now save from Settings.** Adding a banned string no longer\n  reports `logitBias must be an object`. Settings now copies each sampling\n  value before it sends the settings document to the worker."
+  },
+  {
     version: "0.9.5-rc.1",
     date: "2026-08-13",
     body: "- **Aside adds non-canon Side Notes to a story.** Use `/aside` or the Command\n  Palette to discuss the open story. Each question and answer stays with that\n  story. Side Notes never enter Write prompts or Markdown exports. Use\n  `/clear` in Aside to remove all Side Notes from the story."

--- a/tui/package.json
+++ b/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667",
-  "version": "0.9.5-rc.1",
+  "version": "0.9.5-rc.2",
   "private": true,
   "description": "A terminal environment for writing fiction with language models",
   "license": "Apache-2.0",


### PR DESCRIPTION
Closes #225

## What changed
- Set the workspace and TUI versions to 0.9.5-rc.2.
- Add the banned-string Settings fix to the changelog.
- Regenerate embedded release notes.

## Verification
- npm run build
- npm test (2,494 passed; one timing test passed on isolated rerun)
- bun run typecheck
- bun test (1,911 passed; two timing tests passed on isolated rerun)
- bun bench/perf.ts
- bun run build:standalone
- npm run notes:check-version -- 0.9.5-rc.2