### PR TITLE
chore(release): prepare 0.9.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -260,7 +260,7 @@ This file records notable changes to 1667. Product terms use the definitions in
   command accepts one or more JSON or PNG files. It adds their Facts to the
   story that `--story` names.
 
-## 0.9.5-rc.2 - 2026-08-14
+## 0.9.5 - 2026-08-14
 
 - **Banned strings now save from Settings.** Adding a banned string no longer
   reports `logitBias must be an object`. Settings now copies each sampling

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "1667-workspace",
-  "version": "0.9.5-rc.2",
+  "version": "0.9.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "1667-workspace",
-      "version": "0.9.5-rc.2",
+      "version": "0.9.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@silvia-odwyer/photon-node": "0.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667-workspace",
-  "version": "0.9.5-rc.2",
+  "version": "0.9.5",
   "private": true,
   "description": "Source workspace for the 1667 terminal writing environment",
   "license": "Apache-2.0",

--- a/shared/release-notes.ts
+++ b/shared/release-notes.ts
@@ -11,7 +11,7 @@ export interface ReleaseNote {
  *  a release, and is not included. */
 export const RELEASE_NOTES: readonly ReleaseNote[] = [
   {
-    version: "0.9.5-rc.2",
+    version: "0.9.5",
     date: "2026-08-14",
     body: "- **Banned strings now save from Settings.** Adding a banned string no longer\n  reports `logitBias must be an object`. Settings now copies each sampling\n  value before it sends the settings document to the worker."
   },

--- a/tui/package.json
+++ b/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667",
-  "version": "0.9.5-rc.2",
+  "version": "0.9.5",
   "private": true,
   "description": "A terminal environment for writing fiction with language models",
   "license": "Apache-2.0",


### PR DESCRIPTION
Closes #227

## What changed
- Promote 0.9.5-rc.2 as stable 0.9.5.
- Set the workspace and TUI versions to 0.9.5.
- Regenerate embedded release notes.

## Verification
- 0.9.5-rc.2 publication completed for all six packages and five native targets.
- npm run build
- bun run typecheck
- bun run build:standalone
- npm run notes:check-version -- 0.9.5