### PR TITLE
feat(aside): add Side Note insertion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,6 @@ This file records notable changes to 1667. Product terms use the definitions in
 
 ## Unreleased
 
-- **A Side Note can now add text to Direct or to the story.** In Aside, press
-  `Tab` to focus the saved Side Notes. Press `Enter` to open the use menu.
-  **insert into compose** puts the complete answer at the Direct cursor and
-  keeps the existing draft. **insert into story…** opens Placement mode. Use
-  the Up Arrow and Down Arrow keys to select an existing Part for a new Take,
-  or select the final gap for a new Part. Press `Enter` to add the text. Press
-  `Esc` to return to Aside without a story change.
-
 - **Prompt-plan changes now have a Gemma quality gate.** The gate compares the
   v0.8.0 prompt with a candidate on one frozen story and one fixed profile. It
   uses blind Retake and Continue scores. It requires no score regression for
@@ -267,6 +259,16 @@ This file records notable changes to 1667. Product terms use the definitions in
   palette opens a path prompt with `Tab` completion. The `1667 import-card`
   command accepts one or more JSON or PNG files. It adds their Facts to the
   story that `--story` names.
+
+## 0.9.6-rc.1 - 2026-08-15
+
+- **A Side Note can now add text to Direct or to the story.** In Aside, press
+  `Tab` to focus the saved Side Notes. Press `Enter` to open the use menu.
+  **insert into compose** puts the complete answer at the Direct cursor and
+  keeps the existing draft. **insert into story…** opens Placement mode. Use
+  the Up Arrow and Down Arrow keys to select an existing Part for a new Take,
+  or select the final gap for a new Part. Press `Enter` to add the text. Press
+  `Esc` to return to Aside without a story change.
 
 ## 0.9.5 - 2026-08-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ This file records notable changes to 1667. Product terms use the definitions in
 
 ## Unreleased
 
+- **A Side Note can now add text to Direct or to the story.** In Aside, press
+  `Tab` to focus the saved Side Notes. Press `Enter` to open the use menu.
+  **insert into compose** puts the complete answer at the Direct cursor and
+  keeps the existing draft. **insert into story…** opens Placement mode. Use
+  the Up Arrow and Down Arrow keys to select an existing Part for a new Take,
+  or select the final gap for a new Part. Press `Enter` to add the text. Press
+  `Esc` to return to Aside without a story change.
+
 - **Prompt-plan changes now have a Gemma quality gate.** The gate compares the
   v0.8.0 prompt with a candidate on one frozen story and one fixed profile. It
   uses blind Retake and Continue scores. It requires no score regression for

--- a/docs/technical-terms.md
+++ b/docs/technical-terms.md
@@ -112,6 +112,7 @@ read_when:
 | Aside | The full-screen mode where the writer discusses the story without changing it |
 | Side Note | One saved question-and-answer pair from Aside |
 | Aside document | The one bounded, content-addressed document that holds every Side Note for one story |
+| Placement mode | The mode where the writer selects a story position for Side Note text |
 
 Add a term to this table before you use it in another document.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "1667-workspace",
-  "version": "0.9.5",
+  "version": "0.9.6-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "1667-workspace",
-      "version": "0.9.5",
+      "version": "0.9.6-rc.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@silvia-odwyer/photon-node": "0.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667-workspace",
-  "version": "0.9.5",
+  "version": "0.9.6-rc.1",
   "private": true,
   "description": "Source workspace for the 1667 terminal writing environment",
   "license": "Apache-2.0",

--- a/shared/release-notes.ts
+++ b/shared/release-notes.ts
@@ -11,6 +11,11 @@ export interface ReleaseNote {
  *  a release, and is not included. */
 export const RELEASE_NOTES: readonly ReleaseNote[] = [
   {
+    version: "0.9.6-rc.1",
+    date: "2026-08-15",
+    body: "- **A Side Note can now add text to Direct or to the story.** In Aside, press\n  `Tab` to focus the saved Side Notes. Press `Enter` to open the use menu.\n  **insert into compose** puts the complete answer at the Direct cursor and\n  keeps the existing draft. **insert into story…** opens Placement mode. Use\n  the Up Arrow and Down Arrow keys to select an existing Part for a new Take,\n  or select the final gap for a new Part. Press `Enter` to add the text. Press\n  `Esc` to return to Aside without a story change."
+  },
+  {
     version: "0.9.5",
     date: "2026-08-14",
     body: "- **Banned strings now save from Settings.** Adding a banned string no longer\n  reports `logitBias must be an object`. Settings now copies each sampling\n  value before it sends the settings document to the worker."

--- a/tui/package.json
+++ b/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667",
-  "version": "0.9.5",
+  "version": "0.9.6-rc.1",
   "private": true,
   "description": "A terminal environment for writing fiction with language models",
   "license": "Apache-2.0",

--- a/tui/src/api-error.ts
+++ b/tui/src/api-error.ts
@@ -20,11 +20,58 @@ export class ApiError extends Error {
 }
 
 export class ApiRecoveryRequiredError extends ApiError {
-  constructor() {
-    super(
-      "Backend recovery changed authoritative state; the operation was not sent. Review the reloaded state and retry."
+  constructor(
+    message = "Backend recovery changed authoritative state; the operation was not sent. Review the reloaded state and retry."
+  ) {
+    super(message);
+  }
+}
+
+/**
+ * Transport-neutral proof that a mutation never left the client.
+ * Orthogonal to ApiError (application / stay online) vs plain Error
+ * (transport / connection monitor goes down).
+ */
+export type ExplicitMutationUnsent = {
+  readonly mutationNotSent: true;
+};
+
+export function markExplicitMutationUnsent<E extends Error>(
+  error: E
+): E & ExplicitMutationUnsent {
+  return Object.assign(error, { mutationNotSent: true as const });
+}
+
+export function isExplicitMutationUnsent(error: unknown): boolean {
+  return typeof error === "object"
+    && error !== null
+    && (error as ExplicitMutationUnsent).mutationNotSent === true;
+}
+
+/**
+ * Explicit-unsent preflight failure. Application ApiError causes stay online;
+ * other causes keep non-ApiError transport classification and preserve cause.
+ */
+export function explicitMutationUnsentFromCause(
+  cause: unknown,
+  detailPrefix: string,
+  fallbackMessage: string
+): Error {
+  if (isExplicitMutationUnsent(cause) && cause instanceof Error) return cause;
+  if (cause instanceof ApiRecoveryRequiredError) {
+    return markExplicitMutationUnsent(cause);
+  }
+  if (cause instanceof ApiError) {
+    return markExplicitMutationUnsent(
+      new ApiRecoveryRequiredError(`${detailPrefix}: ${cause.message}`)
     );
   }
+  if (cause instanceof Error) {
+    return markExplicitMutationUnsent(
+      new Error(`${detailPrefix}: ${cause.message}`, { cause })
+    );
+  }
+  return markExplicitMutationUnsent(new Error(fallbackMessage));
 }
 
 /** One envelope-backed application error shared by HTTP and worker clients. */

--- a/tui/src/api.ts
+++ b/tui/src/api.ts
@@ -109,7 +109,8 @@ import {
   ApiError,
   ApiHttpError,
   ApiRecoveryRequiredError,
-  apiHttpErrorFromPayload
+  apiHttpErrorFromPayload,
+  explicitMutationUnsentFromCause
 } from "./api-error.js";
 import { HttpApiConnection } from "./http-api-connection.js";
 import { importMethods } from "./api-import-methods.js";
@@ -126,7 +127,10 @@ export {
   ApiError,
   ApiHttpError,
   ApiRecoveryRequiredError,
-  apiErrorCode
+  apiErrorCode,
+  explicitMutationUnsentFromCause,
+  isExplicitMutationUnsent,
+  markExplicitMutationUnsent
 } from "./api-error.js";
 
 const HTTP_REQUEST_TIMEOUT_MS = 15_000;
@@ -915,12 +919,30 @@ export function createApi(
       `/api/stories/${storyId}/switch`,
       { nodeId, ...options } satisfies SwitchRequest
     ),
-    createNode: (storyId, body) => mutateStoryPayload(
-      storyId,
-      "POST",
-      `/api/stories/${storyId}/nodes`,
-      body
-    ),
+    // createNode only: version preflight is adapter-owned and runs before any
+    // node mutation is reserved or sent. Failures here are definitely unsent
+    // (Placement may already hold a singular guard). Other mutations keep the
+    // shared mutateStoryPayload path unchanged.
+    createNode: async (storyId, body) => {
+      let expectedAggregateVersion: StoryAggregateVersion;
+      try {
+        expectedAggregateVersion = await expectedVersion(storyId);
+      } catch (error) {
+        throw explicitMutationUnsentFromCause(
+          error,
+          "createNode was not sent",
+          "createNode was not sent; story version preflight failed."
+        );
+      }
+      return versions.rememberPayload(await request(
+        "POST",
+        `/api/stories/${storyId}/nodes`,
+        decodeStoryResponse,
+        body,
+        HTTP_REQUEST_TIMEOUT_MS,
+        expectedAggregateVersion
+      ));
+    },
     editNode: async (storyId, node, patch) => mutateStoryPayload(
       storyId,
       "PATCH",

--- a/tui/src/app.ts
+++ b/tui/src/app.ts
@@ -16,6 +16,7 @@ import { createInteractiveFrameRuntime } from "./interactive-frame-runtime.js";
 import type { TuiFrameProfileReport } from "./frame-profile.js";
 import {
   actionConflictsWithGeneration,
+  asideKeyboardLayer,
   isPlainNavigation,
   overlayTextInputActive,
   pasteInto,
@@ -633,6 +634,9 @@ export async function handleKey(
     commandsTags: state.commands?.view === "tags",
     settingsPicker: state.settings?.modelPicker != null,
     textActionsOpen: state.textActions !== null,
+    asideLayer: state.mode === "ASIDE"
+      ? asideKeyboardLayer(state.aside)
+      : undefined,
     factEditor: state.editor?.kind === "fact",
     authorsNoteEditor: state.editor?.kind === "document" && state.editor.target.kind === "authors-note",
     mapView: state.map?.view
@@ -811,6 +815,8 @@ export function initialState(source: AppSource, renderMode: boolean): RuntimeSta
     probs: null,
     record: null,
     aside: null,
+    placement: null,
+    unresolvedPlacement: null,
     toast: null,
     notices: createNoticeLog(),
     stream: renderMode && source.demo ? leafStreamView(source.payload) : null,

--- a/tui/src/aside-actions.ts
+++ b/tui/src/aside-actions.ts
@@ -13,14 +13,26 @@ import {
   createAsideSurface,
   type AsideSurfaceState
 } from "./aside-surface.js";
+import { noteCursorAfterHistoryScroll } from "./aside-note-scroll.js";
 import type { RuntimeState } from "./state.js";
 import { adoptSameStoryPayload } from "./story-adoption.js";
+import { createStoryViewModel } from "./model.js";
+import { persistablePartId } from "./reading-position.js";
 import { truncate } from "./screens/story/frame.js";
 import { wrapText, type ProseStyle, type WrapCache } from "./wrap.js";
 
 export interface AsideHistoryLayout {
   header: string[];
   body: string[];
+  /** First body row for each saved Side Note. */
+  noteStarts: readonly number[];
+  /** Exclusive end of each note's content rows (separator blank excluded). */
+  noteContentEnds: readonly number[];
+  /**
+   * Note index owning each body row. Null for separator blanks, empty-state
+   * rows, and inflight stream rows (not saved notes).
+   */
+  rowNoteIndex: readonly (number | null)[];
 }
 
 type AsideWrapCache = WrapCache<ProseStyle>;
@@ -64,6 +76,21 @@ function asideHeaderLines(surface: AsideSurfaceState, width: number): string[] {
   ];
 }
 
+function clampAsideNoteCursor(surface: AsideSurfaceState): void {
+  if (surface.notes.length === 0) {
+    surface.noteCursor = 0;
+    if (surface.focus === "notes") surface.focus = "composer";
+    surface.useMenu = null;
+    return;
+  }
+  surface.noteCursor = Math.max(0, Math.min(surface.notes.length - 1, surface.noteCursor));
+  if (surface.useMenu !== null
+    && (surface.useMenu.noteIndex < 0
+      || surface.useMenu.noteIndex >= surface.notes.length)) {
+    surface.useMenu = null;
+  }
+}
+
 function clippedTitleRows(titleRows: string[], width: number, limit: number): string[] {
   if (limit <= 0) return [];
   const visible = titleRows.slice(0, limit);
@@ -102,33 +129,105 @@ export function asideHeaderWindow(
 export function asideHistoryLayout(surface: AsideSurfaceState, cols: number): AsideHistoryLayout {
   const width = dimension(cols, 80);
   const body: string[] = [];
+  const noteStarts: number[] = [];
+  const noteContentEnds: number[] = [];
+  const rowNoteIndex: (number | null)[] = [];
   if (surface.notes.length === 0
     && surface.streamText.length === 0
     && surface.inflightQuestion === null) {
     body.push("(no Side Notes yet)");
+    rowNoteIndex.push(null);
   }
-  for (const note of surface.notes) {
-    body.push(...wrappedRows(note.question, width, "Q: "));
+  // Focus-neutral prefixes: wrap never depends on which note is selected.
+  // The visible window decorates the first on-screen row of the focused note.
+  const questionPrefix = "  Q: ";
+  const answerPrefix = "  A: ";
+  for (let index = 0; index < surface.notes.length; index += 1) {
+    const note = surface.notes[index]!;
+    noteStarts.push(body.length);
+    const questionRows = wrappedRows(note.question, width, questionPrefix);
+    body.push(...questionRows);
+    for (let row = 0; row < questionRows.length; row += 1) rowNoteIndex.push(index);
     for (const paragraph of note.answer.split("\n")) {
-      body.push(...wrappedRows(paragraph, width, "A: "));
+      const answerRows = wrappedRows(paragraph, width, answerPrefix);
+      body.push(...answerRows);
+      for (let row = 0; row < answerRows.length; row += 1) rowNoteIndex.push(index);
     }
+    noteContentEnds.push(body.length);
+    // Separator blank is not note content for visibility / focus.
     body.push("");
+    rowNoteIndex.push(null);
   }
   if (surface.inflightQuestion !== null || surface.streamText.length > 0) {
-    body.push(...wrappedRows(surface.inflightQuestion ?? "", width, "Q: "));
-    body.push(...wrappedRows(surface.streamText, width, "A: "));
+    // Same five-cell prefixes as saved notes so stream → save does not rewrap.
+    const inflightQ = wrappedRows(surface.inflightQuestion ?? "", width, questionPrefix);
+    const inflightA = wrappedRows(surface.streamText, width, answerPrefix);
+    body.push(...inflightQ, ...inflightA);
+    for (let row = 0; row < inflightQ.length + inflightA.length; row += 1) {
+      rowNoteIndex.push(null);
+    }
   }
   return {
     header: asideHeaderLines(surface, width),
-    body
+    body,
+    noteStarts,
+    noteContentEnds,
+    rowNoteIndex
   };
+}
+
+/**
+ * Keep the focused Side Note inside the history viewport. Call after note
+ * focus moves. Null scrollTop still means follow the newest rows when the
+ * focused note already sits in the trailing window.
+ */
+export function revealAsideFocusedNote(
+  surface: AsideSurfaceState,
+  cols: number,
+  bodyRows: number
+): void {
+  revealAsideFocusedNoteWithLayout(
+    surface,
+    asideHistoryLayout(surface, cols),
+    bodyRows
+  );
+}
+
+/** Same as {@link revealAsideFocusedNote} using a layout already computed. */
+function revealAsideFocusedNoteWithLayout(
+  surface: AsideSurfaceState,
+  layout: AsideHistoryLayout,
+  bodyRows: number
+): void {
+  if (surface.focus !== "notes" || surface.notes.length === 0) return;
+  const height = Math.max(0, Math.floor(bodyRows));
+  if (height === 0) return;
+  const noteStart = layout.noteStarts[surface.noteCursor];
+  if (noteStart === undefined) return;
+  const max = Math.max(0, layout.body.length - height);
+  const current = surface.scrollTop === null
+    ? max
+    : Math.max(0, Math.min(max, surface.scrollTop));
+  let next = current;
+  if (noteStart < current) next = noteStart;
+  else if (noteStart >= current + height) next = noteStart - height + 1;
+  next = Math.max(0, Math.min(max, next));
+  surface.scrollTop = next === max ? null : next;
 }
 
 export function asideFooterHint(surface: AsideSurfaceState): string {
   if (surface.confirmClear) return "Clear all Side Notes? Enter confirms · Esc cancels";
   if (surface.busy && surface.inflightQuestion === null) return "Clearing…";
   if (surface.busy) return "Esc stop · PageUp/PageDown scroll · Shift+Up/Down line scroll";
-  return "Esc write · /clear clear · Enter send · Shift+Enter newline · PageUp/PageDown scroll · Shift+Up/Down line scroll";
+  if (surface.useMenu !== null) {
+    return "↑↓ · Enter · Esc notes";
+  }
+  if (surface.focus === "notes") {
+    return "Esc ask · Enter use · ↑↓ notes · Tab ask · PageUp/PageDown scroll";
+  }
+  // Keep both escape and Clear visible before optional navigation hints.
+  const notesHint = surface.notes.length > 0 ? " · Tab notes" : "";
+  return `Esc write · /clear clear · Enter ask · Shift+Enter newline${notesHint} · PageUp/PageDown scroll`;
 }
 
 function asideFooterRows(surface: AsideSurfaceState, cols: number): string[] {
@@ -162,10 +261,29 @@ export function asideHistoryWindow(
     ? max
     : Math.max(0, Math.min(max, surface.scrollTop));
   const visibleBody = layout.body.slice(start, start + height);
+  // First visible owned content row gets ▸ — labelled Q/A or a wrap continuation.
+  if (surface.focus === "notes" && surface.notes.length > 0) {
+    const focused = surface.noteCursor;
+    for (let offset = 0; offset < visibleBody.length; offset += 1) {
+      if (layout.rowNoteIndex[start + offset] === focused) {
+        visibleBody[offset] = decorateFocusedHistoryRow(visibleBody[offset]!);
+        break;
+      }
+    }
+  }
   return [
     ...visibleBody,
     ...Array.from({ length: Math.max(0, height - visibleBody.length) }, () => "")
   ];
+}
+
+/**
+ * Swap one pad space for ▸ without reflowing wrap. Labelled rows keep Q:/A:;
+ * wrap continuations keep the remaining indent (prefix-width spaces).
+ */
+function decorateFocusedHistoryRow(line: string): string {
+  if (line.startsWith(" ")) return `▸${line.slice(1)}`;
+  return line;
 }
 
 export function asideBodyHeight(
@@ -182,16 +300,6 @@ export function asideBodyHeight(
   return Math.max(1, height - headerHeight - footerHeight);
 }
 
-function asideMaxScroll(
-  surface: AsideSurfaceState,
-  cols: number,
-  rows: number,
-  composerRows?: number
-): number {
-  const layout = asideHistoryLayout(surface, cols);
-  return Math.max(0, layout.body.length - asideBodyHeight(surface, cols, rows, composerRows));
-}
-
 /** Move the history viewport. Null scrollTop means follow the newest rows. */
 export function scrollAside(
   surface: AsideSurfaceState,
@@ -200,10 +308,33 @@ export function scrollAside(
   rows: number,
   composerRows?: number
 ): void {
-  const max = asideMaxScroll(surface, cols, rows, composerRows);
+  // One layout + bodyRows for this action: max scroll, cursor follow, reveal.
+  const layout = asideHistoryLayout(surface, cols);
+  const bodyRows = asideBodyHeight(surface, cols, rows, composerRows);
+  const max = Math.max(0, layout.body.length - bodyRows);
   const current = surface.scrollTop ?? max;
   const next = Math.max(0, Math.min(max, current + delta));
   surface.scrollTop = next === max ? null : next;
+  // Notes focus: keep the selected Side Note visible, or move selection to a
+  // note that is in the new viewport for this scroll direction.
+  if (surface.focus === "notes" && surface.notes.length > 0 && delta !== 0) {
+    const nextCursor = noteCursorAfterHistoryScroll(
+      surface.notes.length,
+      layout.noteStarts,
+      layout.noteContentEnds,
+      layout.body.length,
+      surface.scrollTop,
+      bodyRows,
+      surface.noteCursor,
+      delta
+    );
+    if (nextCursor !== surface.noteCursor) {
+      surface.noteCursor = nextCursor;
+      // Focus-neutral wrap; reveal keeps a ▸ marker in view when selection
+      // moved to a note that intersects the viewport only in lower answer rows.
+      revealAsideFocusedNoteWithLayout(surface, layout, bodyRows);
+    }
+  }
 }
 export async function openAside(
   state: RuntimeState,
@@ -220,6 +351,12 @@ export async function openAside(
   }
   const requestedStoryId = state.payload.id;
   const requestedInteractionVersion = state.interactionVersion;
+  // Capture before the load await so a focus change while getAside is pending
+  // cannot move Placement's initial stop off the Part the writer invoked on.
+  // Summary/divider NAV rows have no rowPart; persistablePartId maps them to a
+  // chapter Part so Placement still opens on the visible chapter position.
+  const view = createStoryViewModel(state.payload, state.stream);
+  const openingPartId = persistablePartId(view, state.focusIndex, state.payload);
   const current = () => state.payload.id === requestedStoryId
     && state.interactionVersion === requestedInteractionVersion
     && (options.task?.owns() ?? true)
@@ -231,7 +368,8 @@ export async function openAside(
     requestedStoryId,
     state.payload.title,
     document.notes,
-    options.pendingAsk ?? null
+    options.pendingAsk ?? null,
+    openingPartId
   );
   state.mode = "ASIDE";
   state.commands = null;
@@ -312,6 +450,8 @@ export async function sendAsideQuestion(
       question: note.question,
       answer: note.answer
     }));
+    surface.noteCursor = Math.max(0, surface.notes.length - 1);
+    clampAsideNoteCursor(surface);
     surface.streamText = "";
     surface.inflightQuestion = null;
     surface.scrollTop = null;
@@ -403,6 +543,7 @@ export async function clearAsideSurface(
     } else {
       surface.notes = [];
     }
+    clampAsideNoteCursor(surface);
     surface.scrollTop = null;
     surface.confirmClear = false;
     surface.busy = false;

--- a/tui/src/aside-note-scroll.ts
+++ b/tui/src/aside-note-scroll.ts
@@ -1,0 +1,62 @@
+/**
+ * Keep notes-focused Side Note selection aligned with history scroll.
+ */
+
+/**
+ * Choose the note cursor after a history scroll while notes own focus.
+ * `noteContentEnds[i]` is the exclusive end of note i's content rows
+ * (separator blanks are excluded from visibility).
+ */
+export function noteCursorAfterHistoryScroll(
+  noteCount: number,
+  noteStarts: readonly number[],
+  noteContentEnds: readonly number[],
+  bodyLength: number,
+  scrollTop: number | null,
+  bodyRows: number,
+  currentCursor: number,
+  delta: number
+): number {
+  if (noteCount === 0 || delta === 0 || bodyRows <= 0) return currentCursor;
+  const height = Math.max(0, Math.floor(bodyRows));
+  if (height === 0) return currentCursor;
+  const max = Math.max(0, bodyLength - height);
+  const start = scrollTop === null
+    ? max
+    : Math.max(0, Math.min(max, scrollTop));
+  const end = start + height;
+
+  const rangeOf = (index: number): { start: number; end: number } => {
+    const noteStart = noteStarts[index] ?? 0;
+    const contentEnd = noteContentEnds[index] ?? noteStart;
+    // Content only: trailing separator blanks are not note visibility.
+    return { start: noteStart, end: Math.max(noteStart, contentEnd) };
+  };
+  const intersects = (index: number): boolean => {
+    const range = rangeOf(index);
+    return range.start < end && range.end > start;
+  };
+
+  const safeCursor = Math.max(0, Math.min(noteCount - 1, currentCursor));
+  if (intersects(safeCursor)) return safeCursor;
+
+  const visible: number[] = [];
+  for (let index = 0; index < noteCount; index += 1) {
+    if (intersects(index)) visible.push(index);
+  }
+  if (visible.length > 0) {
+    // Scroll down shows newer rows: first visible note.
+    // Scroll up shows older rows: last visible note.
+    return delta > 0 ? visible[0]! : visible[visible.length - 1]!;
+  }
+  if (delta > 0) {
+    for (let index = 0; index < noteCount; index += 1) {
+      if ((noteStarts[index] ?? 0) >= start) return index;
+    }
+    return noteCount - 1;
+  }
+  for (let index = noteCount - 1; index >= 0; index -= 1) {
+    if (rangeOf(index).end <= end) return index;
+  }
+  return 0;
+}

--- a/tui/src/aside-placement-model.ts
+++ b/tui/src/aside-placement-model.ts
@@ -1,0 +1,139 @@
+/**
+ * Pure Placement stop model. Free of story-adoption and mutation I/O so
+ * adoption can rebase stops without an import cycle.
+ */
+import type { StoryNode, StoryPayload } from "../../shared/types.js";
+
+export type PlacementStop =
+  | {
+      kind: "take";
+      partId: string;
+      partNumber: number;
+      parentId: string | null;
+    }
+  | {
+      kind: "leaf-gap";
+      leafId: string;
+      partNumber: number;
+    };
+
+export interface PlacementStopSelection {
+  stops: PlacementStop[];
+  cursor: number;
+}
+
+/**
+ * Identity of one Placement createNode submission.
+ * Retained after an uncertain failure so same-story recovery can settle.
+ */
+export interface PlacementPendingSubmission {
+  /** Node ids known when createNode was submitted. */
+  knownNodeIds: ReadonlySet<string>;
+  parentId: string | null;
+  instruction: string;
+  text: string;
+  partNumber: number;
+}
+
+/**
+ * Story-bound unresolved Placement create after an uncertain outcome.
+ * Survives Esc back to Aside until recovery settles it or a definite failure
+ * proves the write did not commit.
+ */
+export interface UnresolvedPlacementSubmission {
+  storyId: string;
+  submission: PlacementPendingSubmission;
+}
+
+/**
+ * Match an uncertain Placement submission against an authoritative payload.
+ * Requires exact active-path text and instruction. Off-path stubs only carry
+ * preview/word-count/instruction-presence and must not clear the guard.
+ */
+export function findSubmittedPlacementNode(
+  payload: StoryPayload,
+  submission: PlacementPendingSubmission
+): StoryNode | undefined {
+  return payload.path.find((node) =>
+    !submission.knownNodeIds.has(node.id)
+    && node.parentId === submission.parentId
+    && node.instruction === submission.instruction
+    && node.text === submission.text
+  );
+}
+
+export function buildPlacementStops(payload: StoryPayload): PlacementStop[] {
+  const stops: PlacementStop[] = payload.path.map((node, pathIndex) => ({
+    kind: "take" as const,
+    partId: node.id,
+    partNumber: pathIndex + 1,
+    parentId: node.parentId
+  }));
+  const leaf = payload.path.at(-1);
+  if (leaf !== undefined) {
+    stops.push({
+      kind: "leaf-gap",
+      leafId: leaf.id,
+      partNumber: payload.path.length + 1
+    });
+  }
+  return stops;
+}
+
+export function initialPlacementCursor(
+  stops: readonly PlacementStop[],
+  openingPartId: string | null
+): number {
+  if (stops.length === 0) return 0;
+  if (openingPartId !== null) {
+    const match = stops.findIndex(
+      (stop) => stop.kind === "take" && stop.partId === openingPartId
+    );
+    if (match >= 0) return match;
+  }
+  // Prefer the active leaf's Take stop when the opening Part is gone.
+  const lastTake = stops.findLastIndex((stop) => stop.kind === "take");
+  return lastTake >= 0 ? lastTake : 0;
+}
+
+/**
+ * Rebase Placement stops onto a newer same-story payload.
+ * - Selected Take: keep by node id when present.
+ * - Selected trailing gap: follow the new active leaf.
+ * - Missing Take: fall back to the active leaf's Take stop.
+ */
+export function rebasePlacementStops(
+  selection: PlacementStopSelection,
+  payload: StoryPayload
+): void {
+  const previous = selection.stops[selection.cursor];
+  const stops = buildPlacementStops(payload);
+  selection.stops = stops;
+  if (stops.length === 0) {
+    selection.cursor = 0;
+    return;
+  }
+  if (previous === undefined) {
+    selection.cursor = initialPlacementCursor(stops, null);
+    return;
+  }
+  if (previous.kind === "take") {
+    const match = stops.findIndex(
+      (stop) => stop.kind === "take" && stop.partId === previous.partId
+    );
+    selection.cursor = match >= 0
+      ? match
+      : initialPlacementCursor(stops, null);
+    return;
+  }
+  const gap = stops.findIndex((stop) => stop.kind === "leaf-gap");
+  selection.cursor = gap >= 0 ? gap : initialPlacementCursor(stops, null);
+}
+
+/** Shared answer preview for status labels and story destination markers. */
+export function firstWords(text: string, count: number): string {
+  const words = text.trim().split(/\s+/u).filter((word) => word.length > 0);
+  if (words.length === 0) return "";
+  const slice = words.slice(0, count).join(" ");
+  return words.length > count ? `${slice}…` : slice;
+}

--- a/tui/src/aside-placement-settle.ts
+++ b/tui/src/aside-placement-settle.ts
@@ -1,0 +1,98 @@
+/**
+ * Placement settlement against an authoritative same-story payload.
+ * Free of story-adoption imports so recovery and createNode share one path.
+ */
+import type { StoryPayload } from "../../shared/types.js";
+import { findSubmittedPlacementNode } from "./aside-placement-model.js";
+import {
+  createStoryViewModel,
+  rowIndexForNode,
+  rowPart
+} from "./model.js";
+import type { RuntimeState } from "./state.js";
+import { followStoryViewport } from "./viewport-intent.js";
+
+/**
+ * Active Placement success: close Placement, land focus, go to NAV.
+ * Used only while the writer is still in PLACE owning the submission.
+ */
+export function completePlacementLanding(
+  state: RuntimeState,
+  payload: StoryPayload,
+  landedId: string | null,
+  partNumber: number
+): void {
+  state.placement = null;
+  state.unresolvedPlacement = null;
+  state.mode = "NAV";
+  reportPlacedPart(state, payload, landedId, partNumber, true);
+}
+
+/**
+ * Detached guard success: clear only the mutation guard and report placement.
+ * Preserve the current mode and every owned surface/draft (COMPOSE, ASIDE,
+ * SETTINGS, LIBRARY, …). Do not steal focus behind an active modal.
+ */
+export function completeDetachedPlacementSettlement(
+  state: RuntimeState,
+  payload: StoryPayload,
+  landedId: string | null,
+  partNumber: number
+): void {
+  state.unresolvedPlacement = null;
+  reportPlacedPart(state, payload, landedId, partNumber, false);
+}
+
+function reportPlacedPart(
+  state: RuntimeState,
+  payload: StoryPayload,
+  landedId: string | null,
+  partNumber: number,
+  moveFocus: boolean
+): void {
+  if (landedId === null) {
+    state.toast = `placed as Part ${partNumber}`;
+    return;
+  }
+  const view = createStoryViewModel(payload);
+  const index = rowIndexForNode(view, landedId);
+  if (moveFocus && index >= 0) {
+    state.focusIndex = index;
+    followStoryViewport(state);
+  }
+  state.freshLandedAt = new Map(state.freshLandedAt).set(landedId, Date.now());
+  const number = index >= 0
+    ? rowPart(view, index)?.number ?? partNumber
+    : partNumber;
+  state.toast = `placed as Part ${number}`;
+}
+
+/**
+ * When the singular unresolved guard matches an authoritative same-story node
+ * (exact path identity), settle active Placement or a detached guard.
+ * Returns true when settlement ran.
+ */
+export function trySettlePlacementFromPayload(
+  state: RuntimeState,
+  payload: StoryPayload
+): boolean {
+  if (payload.id !== state.payload.id) return false;
+  const guard = state.unresolvedPlacement;
+  if (guard === null || guard.storyId !== payload.id) return false;
+  const candidate = guard.submission;
+  // Uncertain recovery: exact path text + instruction only (no stub approx).
+  const landed = findSubmittedPlacementNode(payload, candidate);
+  if (landed === undefined) return false;
+  const activePlacement = state.mode === "PLACE" && state.placement !== null;
+  if (activePlacement) {
+    completePlacementLanding(state, payload, landed.id, candidate.partNumber);
+  } else {
+    completeDetachedPlacementSettlement(
+      state,
+      payload,
+      landed.id,
+      candidate.partNumber
+    );
+  }
+  return true;
+}

--- a/tui/src/aside-placement.ts
+++ b/tui/src/aside-placement.ts
@@ -1,0 +1,388 @@
+/**
+ * Placement mode: put a complete Side Note answer into the active story line.
+ * Stage 2: Take stops for each Part, plus one gap after the active leaf.
+ */
+import type { ActionContext } from "./action-context.js";
+import {
+  ApiError,
+  ApiHttpError,
+  apiErrorCode,
+  isExplicitMutationUnsent
+} from "./api-error.js";
+import type { AppSource } from "./app.js";
+import type { AsideSurfaceState } from "./aside-surface.js";
+import {
+  buildPlacementStops,
+  firstWords,
+  initialPlacementCursor,
+  type PlacementPendingSubmission,
+  type PlacementStop
+} from "./aside-placement-model.js";
+import { completePlacementLanding } from "./aside-placement-settle.js";
+import { findCreatedTake } from "./created-take.js";
+import { generationBusy } from "./generation-action.js";
+import {
+  createStoryViewModel,
+  rowIndexForNode
+} from "./model.js";
+import { rememberFocus } from "./reading-position-persist.js";
+import { adoptSameStoryPayload } from "./story-adoption.js";
+import type { RuntimeState } from "./state.js";
+import { followStoryViewport } from "./viewport-intent.js";
+import { WorkerApiError } from "./worker-error.js";
+
+export {
+  buildPlacementStops,
+  firstWords,
+  initialPlacementCursor,
+  rebasePlacementStops,
+  type PlacementPendingSubmission,
+  type PlacementStop,
+  type UnresolvedPlacementSubmission
+} from "./aside-placement-model.js";
+
+export { trySettlePlacementFromPayload } from "./aside-placement-settle.js";
+
+export const FROM_ASIDE_INSTRUCTION = "» from aside";
+
+/**
+ * Failure codes that explicitly mean the write may have committed.
+ * Do not invent codes; only those declared on the failure envelope.
+ */
+const UNCERTAIN_PLACEMENT_FAILURE_CODES: ReadonlySet<string> = new Set([
+  "mutation_outcome_unknown",
+  "operation_unknown"
+]);
+
+export interface PlacementState {
+  /** Complete Side Note answer to place. */
+  answer: string;
+  stops: PlacementStop[];
+  cursor: number;
+  /**
+   * Exact Aside surface restored on cancel, including focus, note cursor, and
+   * open use menu. openPlacementFromAside does not mutate this retained surface.
+   */
+  returnAside: AsideSurfaceState;
+  /**
+   * Backend task id for this Placement's in-flight createNode.
+   * Null when no createNode from this Placement is running.
+   * Unresolved submission identity lives only on RuntimeState.unresolvedPlacement.
+   */
+  placingTaskId: number | null;
+  /**
+   * Use-menu session copied at open. Enter-place hits bind to it so a queued
+   * click from Placement A cannot createNode after cancel + open Placement B
+   * at the same stop. Survives repaint; new menu open → new Placement id.
+   */
+  interactionId: string;
+}
+
+export function placementBlockedReason(
+  state: Pick<RuntimeState, "stream" | "abort" | "backendTask" | "aside">
+): string | null {
+  if (generationBusy(state)) return "stream running · esc stops it first";
+  if (state.backendTask !== null) {
+    return `busy · ${state.backendTask.label} still running`;
+  }
+  if (state.aside?.busy === true) {
+    return state.aside.inflightQuestion !== null
+      ? "Aside is answering · wait or stop first"
+      : "Aside is clearing · wait first";
+  }
+  return null;
+}
+
+/**
+ * True only while this Placement owns its createNode task.
+ * Unrelated backend work (reconnect/recovery) must not lock Placement.
+ */
+export function placementInputLocked(
+  state: Pick<RuntimeState, "backendTask" | "mode" | "placement">
+): boolean {
+  const placement = state.placement;
+  if (state.mode !== "PLACE" || placement === null) return false;
+  const taskId = placement.placingTaskId;
+  if (taskId === null) return false;
+  return state.backendTask?.id === taskId;
+}
+
+/**
+ * True after an uncertain createNode error while Placement is open: the
+ * singular story-bound guard remains and placingTaskId is null, so Enter is
+ * blocked until recovery settles or a definite failure clears the guard.
+ */
+export function placementOutcomeUnknown(
+  state: Pick<RuntimeState, "payload" | "placement" | "unresolvedPlacement">
+): boolean {
+  const placement = state.placement;
+  if (placement === null || placement.placingTaskId !== null) return false;
+  return state.unresolvedPlacement?.storyId === state.payload.id;
+}
+
+/**
+ * True when any unresolved Placement create blocks a new mutation.
+ * The singular story-bound guard blocks placement for every story until
+ * recovery settles it or a definite failure proves absence.
+ * In-flight createNode is owned by placementInputLocked instead.
+ */
+export function storyPlacementMutationBlocked(
+  state: Pick<RuntimeState, "placement" | "unresolvedPlacement">
+): boolean {
+  if (state.placement !== null && state.placement.placingTaskId !== null) {
+    return false;
+  }
+  return state.unresolvedPlacement !== null;
+}
+
+/**
+ * Authoritative application failure or provably unsent failure.
+ * Worker transport settlement owns mutation truth when present. Explicit
+ * uncertain HTTP codes (mutation_outcome_unknown, operation_unknown) win over
+ * requestSent=false — those codes mean the write may still have committed.
+ * Explicit-unsent is orthogonal to ApiError vs transport Error class.
+ */
+export function isDefinitePlacementFailure(error: unknown): boolean {
+  // Marker proves the mutation never left the client (app or transport).
+  if (isExplicitMutationUnsent(error)) return true;
+  if (!(error instanceof ApiError)) return false;
+  // Transport-owned settlement outcome is authoritative for worker mutations.
+  if (error instanceof WorkerApiError) {
+    if (error.mutationOutcome === "uncertain") return false;
+    if (error.mutationOutcome === "terminal") return true;
+    // Legacy/synthetic WorkerApiError without settlement: keep the guard.
+    // Do not guess definite absence from failure codes alone.
+    return false;
+  }
+  const code = apiErrorCode(error);
+  // Explicit uncertain outcome codes always keep the submission identity.
+  if (code !== null && UNCERTAIN_PLACEMENT_FAILURE_CODES.has(code)) return false;
+  // Other ApiHttpError with request never sent: provably did not commit.
+  // ApiRecoveryRequiredError and other authoritative ApiErrors stay definite.
+  if (error instanceof ApiHttpError && !error.requestSent) return true;
+  return true;
+}
+
+function retainUnresolvedPlacement(
+  state: RuntimeState,
+  storyId: string,
+  submission: PlacementPendingSubmission
+): void {
+  state.unresolvedPlacement = { storyId, submission };
+}
+
+function clearUnresolvedPlacement(
+  state: RuntimeState,
+  storyId: string
+): void {
+  if (state.unresolvedPlacement?.storyId === storyId) {
+    state.unresolvedPlacement = null;
+  }
+}
+
+/**
+ * Close Aside and open Placement over the active story line.
+ * Refuses while generation, Aside work, or another backend task is active.
+ */
+export function openPlacementFromAside(state: RuntimeState): boolean {
+  const surface = state.aside;
+  if (surface === null || surface.useMenu === null) return false;
+  const blocked = placementBlockedReason(state);
+  if (blocked !== null) {
+    state.toast = blocked;
+    return false;
+  }
+  // A guard for another story blocks every new Placement until recovery settles it.
+  const guard = state.unresolvedPlacement;
+  if (guard !== null && guard.storyId !== state.payload.id) {
+    state.toast = PLACEMENT_UNCERTAIN_TOAST;
+    return false;
+  }
+  const note = surface.notes[surface.useMenu.noteIndex];
+  if (note === undefined || note.answer.trim().length === 0) {
+    state.toast = "this Side Note has no answer to place";
+    return false;
+  }
+  const stops = buildPlacementStops(state.payload);
+  if (stops.length === 0) {
+    state.toast = "no story line to place into";
+    return false;
+  }
+  // Keep returnAside intact (focus, noteCursor, useMenu). Esc reattaches it.
+  // Uncertain state is derived from the singular guard — no copy onto Placement.
+  const sameStoryGuard = guard !== null && guard.storyId === state.payload.id;
+  const placement: PlacementState = {
+    answer: note.answer,
+    stops,
+    cursor: initialPlacementCursor(stops, surface.openingPartId),
+    returnAside: surface,
+    placingTaskId: null,
+    // Bind Enter-place to this menu open, not only the destination stop.
+    interactionId: surface.useMenu.sessionId
+  };
+  state.aside = null;
+  state.placement = placement;
+  state.mode = "PLACE";
+  focusPlacementStop(state, placement);
+  state.toast = sameStoryGuard ? PLACEMENT_UNCERTAIN_TOAST : null;
+  return true;
+}
+
+export function cancelPlacement(state: RuntimeState): void {
+  if (placementInputLocked(state)) return;
+  const placement = state.placement;
+  if (placement === null) return;
+  // Esc reattaches the retained surface as-is. Submission identity stays on
+  // unresolvedPlacement only; Esc does not invent focus or menu state.
+  state.placement = null;
+  state.aside = placement.returnAside;
+  state.mode = "ASIDE";
+  state.toast = null;
+}
+
+export function movePlacementCursor(state: RuntimeState, delta: number): void {
+  if (placementInputLocked(state)) return;
+  const placement = state.placement;
+  if (placement === null || placement.stops.length === 0) return;
+  placement.cursor = Math.max(
+    0,
+    Math.min(placement.stops.length - 1, placement.cursor + delta)
+  );
+  focusPlacementStop(state, placement);
+}
+
+export function focusPlacementStop(
+  state: Pick<RuntimeState, "payload" | "stream" | "focusIndex" | "viewScroll" | "viewScrollDelta">,
+  placement: PlacementState
+): void {
+  const stop = placement.stops[placement.cursor];
+  if (stop === undefined) return;
+  const view = createStoryViewModel(state.payload, state.stream);
+  const partId = stop.kind === "take" ? stop.partId : stop.leafId;
+  const index = rowIndexForNode(view, partId);
+  if (index >= 0) {
+    state.focusIndex = index;
+    followStoryViewport(state);
+  }
+}
+
+export function placementStopLabel(
+  stop: PlacementStop,
+  answer: string
+): string {
+  if (stop.kind === "take") {
+    return `new take on ¶ ${stop.partNumber}`;
+  }
+  const preview = firstWords(answer, 8);
+  return preview.length === 0
+    ? `new Part after ¶ ${stop.partNumber - 1}`
+    : `after leaf · ${preview}`;
+}
+
+export async function confirmPlacement(
+  state: RuntimeState,
+  source: AppSource,
+  context: ActionContext
+): Promise<void> {
+  const placement = state.placement;
+  if (placement === null) return;
+  if (placementInputLocked(state)) return;
+  // Refuse before any submission identity is created or createNode is called.
+  if (state.connection.down) {
+    state.toast = "offline · reading still works";
+    return;
+  }
+  // Singular guard blocks retry until recovery settles or a definite failure.
+  if (storyPlacementMutationBlocked(state)) {
+    state.toast = PLACEMENT_UNCERTAIN_TOAST;
+    return;
+  }
+  const blocked = placementBlockedReason(state);
+  if (blocked !== null) {
+    state.toast = blocked;
+    return;
+  }
+  const stop = placement.stops[placement.cursor];
+  if (stop === undefined) return;
+  const answer = placement.answer;
+  const parentId = stop.kind === "take" ? stop.parentId : stop.leafId;
+  const partNumber = stop.partNumber;
+  const knownNodeIds = new Set(state.payload.nodes.map(({ id }) => id));
+  const submission: PlacementPendingSubmission = {
+    knownNodeIds,
+    parentId,
+    instruction: FROM_ASIDE_INSTRUCTION,
+    text: answer.trim(),
+    partNumber
+  };
+  await context.backend.run("placing Side Note", async (task) => {
+    if (state.placement !== placement) return;
+    // Guard or concurrent placing task must not be overwritten.
+    if (storyPlacementMutationBlocked(state) || placement.placingTaskId !== null) {
+      return;
+    }
+    // Singular guard + placing ownership before createNode.
+    retainUnresolvedPlacement(state, task.storyId, submission);
+    placement.placingTaskId = task.id;
+    try {
+      const payload = await source.api.createNode(task.storyId, {
+        parentId,
+        text: answer,
+        instruction: FROM_ASIDE_INSTRUCTION
+      });
+      // Committed create: drop the singular guard even if Placement/story
+      // ownership was lost mid-flight so later placements are not blocked.
+      if (!task.storyCurrent()) {
+        clearUnresolvedPlacement(state, task.storyId);
+        return;
+      }
+      // Adopt and land only while this task still owns the current story.
+      adoptSameStoryPayload(state, payload, context.cache);
+      // Adoption settles when the singular guard matches the payload.
+      if (state.placement !== placement) {
+        rememberFocus(state, source);
+        return;
+      }
+      const landed = findCreatedTake(
+        payload,
+        knownNodeIds,
+        parentId,
+        FROM_ASIDE_INSTRUCTION,
+        answer.trim()
+      );
+      const landedId = landed?.id ?? payload.path.at(-1)?.id ?? null;
+      completePlacementLanding(state, payload, landedId, partNumber);
+      if (landedId !== null) rememberFocus(state, source);
+    } catch (error) {
+      // Definite failures clear the singular guard even when Placement ownership
+      // was lost mid-flight so later placements are not permanently blocked.
+      if (isDefinitePlacementFailure(error)) {
+        clearUnresolvedPlacement(state, task.storyId);
+      }
+      // Current-story UI/toast stay ownership-gated.
+      if (!task.storyCurrent() || state.placement !== placement) return;
+      if (isDefinitePlacementFailure(error)) {
+        state.toast = error instanceof Error ? error.message : String(error);
+        return;
+      }
+      // Uncertain outcome: guard remains; placingTaskId clears in finally.
+      const detail = error instanceof Error ? error.message : String(error);
+      state.toast = `${detail} · ${PLACEMENT_UNCERTAIN_TOAST}`;
+    } finally {
+      if (state.placement === placement && placement.placingTaskId === task.id) {
+        placement.placingTaskId = null;
+      }
+    }
+  });
+}
+
+export const PLACEMENT_STATUS_TEXT = "nothing is written until Enter";
+export const PLACEMENT_KEYLINE = "Up/Down where · Enter place · Esc back to Aside";
+/** Status while Placement owns the placing backend task. */
+export const PLACEMENT_PLACING_STATUS = "placing Side Note · wait";
+/** Keyline while input is locked; no Esc/arrow/Enter hints. */
+export const PLACEMENT_PLACING_KEYLINE = "placing…";
+/** Status after an uncertain createNode outcome. */
+export const PLACEMENT_UNCERTAIN_STATUS = "outcome unknown · wait for recovery";
+/** Toast when Enter is blocked on an unresolved uncertain submission. */
+export const PLACEMENT_UNCERTAIN_TOAST = "outcome unknown · wait for recovery";

--- a/tui/src/aside-surface.ts
+++ b/tui/src/aside-surface.ts
@@ -9,6 +9,22 @@ export interface AsideNoteView {
   readonly answer: string;
 }
 
+export type AsideFocus = "composer" | "notes";
+
+/** Use menu for one complete saved Side Note answer. */
+export interface AsideUseMenuState {
+  noteIndex: number;
+  /** Index into the stage's use-menu action list. */
+  cursor: number;
+  /**
+   * Fresh identity for this menu open. Hit reconciliation binds list/apply
+   * clicks to it so a queued click for note A cannot run after the writer
+   * opens note B. Survives repaint and Placement Esc restoration; changes on
+   * every openAsideUseMenu.
+   */
+  sessionId: string;
+}
+
 export interface AsideSurfaceState {
   readonly storyId: string;
   storyTitle: string;
@@ -24,13 +40,25 @@ export interface AsideSurfaceState {
   busy: boolean;
   /** Seed question from `/aside <question>` after the surface opens. */
   pendingAsk: string | null;
+  /** Keyboard focus: the Aside composer or the Side Note list. */
+  focus: AsideFocus;
+  /** Index of the focused complete Side Note when focus is notes. */
+  noteCursor: number;
+  /** Use menu for one complete saved answer, or null when closed. */
+  useMenu: AsideUseMenuState | null;
+  /**
+   * Story Part id focused when Aside opened. Placement starts here when the
+   * Part still exists. Anchors are not used in this stage.
+   */
+  openingPartId: string | null;
 }
 
 export function createAsideSurface(
   storyId: string,
   storyTitle: string,
   notes: readonly AsideNoteView[] = [],
-  pendingAsk: string | null = null
+  pendingAsk: string | null = null,
+  openingPartId: string | null = null
 ): AsideSurfaceState {
   return {
     storyId,
@@ -42,7 +70,11 @@ export function createAsideSurface(
     scrollTop: null,
     confirmClear: false,
     busy: false,
-    pendingAsk
+    pendingAsk,
+    focus: "composer",
+    noteCursor: Math.max(0, notes.length - 1),
+    useMenu: null,
+    openingPartId
   };
 }
 

--- a/tui/src/aside-use.ts
+++ b/tui/src/aside-use.ts
@@ -1,0 +1,180 @@
+/**
+ * Aside use menu and local backcopy actions.
+ * Stage 1: insert into compose. Stage 2: insert into story… (Placement).
+ */
+import { countWords } from "../../shared/story-text.js";
+import { closeAside } from "./aside-actions.js";
+import { openPlacementFromAside } from "./aside-placement.js";
+import { insertComposerText } from "./composer-model.js";
+import { openDirectComposer } from "./composer-ownership.js";
+import { disarmAsideClear, type AsideSurfaceState } from "./aside-surface.js";
+import type { RuntimeState } from "./state.js";
+
+export type AsideUseActionId = "insert-into-compose" | "insert-into-story";
+
+export interface AsideUseAction {
+  readonly id: AsideUseActionId;
+  readonly name: string;
+  readonly description: string;
+}
+
+/** Current-stage actions only. Do not list future actions as disabled rows. */
+export const ASIDE_USE_ACTIONS: readonly AsideUseAction[] = [
+  {
+    id: "insert-into-compose",
+    name: "insert into compose",
+    description: "insert at the composer cursor"
+  },
+  {
+    id: "insert-into-story",
+    name: "insert into story…",
+    description: "select a position, then confirm"
+  }
+];
+
+/** Hit-map / selection identity for one use-menu action in one menu session. */
+export function asideUseRowId(
+  sessionId: string,
+  actionId: AsideUseActionId
+): string {
+  return `aside-use:${sessionId}:${actionId}`;
+}
+
+/** Resolve a session-bound use-menu row id to its action index, or -1. */
+export function asideUseActionIndexFromRowId(
+  rowId: string,
+  sessionId: string
+): number {
+  const prefix = `aside-use:${sessionId}:`;
+  if (!rowId.startsWith(prefix)) return -1;
+  const actionId = rowId.slice(prefix.length);
+  return ASIDE_USE_ACTIONS.findIndex((entry) => entry.id === actionId);
+}
+
+export function asideUseMenuTitle(answer: string): string {
+  const words = countWords(answer);
+  const label = words === 1 ? "1 word" : `${words.toLocaleString("en-US")} words`;
+  return `use answer · ${label}`;
+}
+
+export function openAsideUseMenu(
+  surface: AsideSurfaceState,
+  noteIndex: number,
+  cursor = 0
+): boolean {
+  if (surface.busy) return false;
+  if (noteIndex < 0 || noteIndex >= surface.notes.length) return false;
+  disarmAsideClear(surface);
+  surface.focus = "notes";
+  surface.noteCursor = noteIndex;
+  surface.useMenu = {
+    noteIndex,
+    cursor: Math.max(0, Math.min(ASIDE_USE_ACTIONS.length - 1, cursor)),
+    // New id every open so A→B menu clicks cannot reconcile on action alone.
+    sessionId: crypto.randomUUID()
+  };
+  return true;
+}
+
+export function closeAsideUseMenu(surface: AsideSurfaceState): void {
+  surface.useMenu = null;
+}
+
+export function moveAsideUseMenuCursor(
+  surface: AsideSurfaceState,
+  delta: number
+): void {
+  const menu = surface.useMenu;
+  if (menu === null) return;
+  menu.cursor = Math.max(
+    0,
+    Math.min(ASIDE_USE_ACTIONS.length - 1, menu.cursor + delta)
+  );
+}
+
+/** Absolute use-menu row from a mouse focus-index hit. */
+export function focusAsideUseMenuIndex(
+  surface: AsideSurfaceState,
+  index: number
+): void {
+  const menu = surface.useMenu;
+  if (menu === null) return;
+  menu.cursor = Math.max(0, Math.min(ASIDE_USE_ACTIONS.length - 1, index));
+}
+
+/**
+ * Tab moves focus between the Aside composer and the Side Note list.
+ * Busy Ask/Clear keeps the composer so Esc can still stop an Ask.
+ */
+export function cycleAsideFocus(surface: AsideSurfaceState): boolean {
+  if (surface.busy || surface.useMenu !== null) return false;
+  if (surface.notes.length === 0) return false;
+  if (surface.focus === "composer") {
+    disarmAsideClear(surface);
+    surface.focus = "notes";
+    surface.noteCursor = Math.max(
+      0,
+      Math.min(surface.notes.length - 1, surface.noteCursor)
+    );
+    return true;
+  }
+  surface.focus = "composer";
+  return true;
+}
+
+export function moveAsideNoteFocus(
+  surface: AsideSurfaceState,
+  delta: number
+): void {
+  if (surface.busy || surface.notes.length === 0) return;
+  const next = Math.max(
+    0,
+    Math.min(surface.notes.length - 1, surface.noteCursor + delta)
+  );
+  surface.noteCursor = next;
+  surface.focus = "notes";
+}
+
+/**
+ * Insert the complete Side Note answer at the persistent Direct composer
+ * cursor, close Aside, and open Compose. Preserves the Direct draft and
+ * selection/cursor semantics via insertComposerText.
+ */
+export function insertAsideAnswerIntoCompose(
+  state: RuntimeState,
+  noteIndex: number
+): boolean {
+  const surface = state.aside;
+  if (surface === null) return false;
+  const note = surface.notes[noteIndex];
+  if (note === undefined) return false;
+  if (state.stream !== null) {
+    state.toast = "stream running · esc stops it first";
+    return false;
+  }
+  const answer = note.answer;
+  closeAside(state);
+  if (!openDirectComposer(state)) {
+    state.toast = "stream running · esc stops it first";
+    return false;
+  }
+  insertComposerText(state.composer, answer);
+  return true;
+}
+
+/** Apply the focused use-menu action. Returns which path ran, or false. */
+export function applyAsideUseMenu(
+  state: RuntimeState
+): "compose" | "placement" | false {
+  const surface = state.aside;
+  if (surface === null || surface.useMenu === null) return false;
+  const action = ASIDE_USE_ACTIONS[surface.useMenu.cursor];
+  if (action === undefined) return false;
+  const noteIndex = surface.useMenu.noteIndex;
+  if (action.id === "insert-into-compose") {
+    closeAsideUseMenu(surface);
+    return insertAsideAnswerIntoCompose(state, noteIndex) ? "compose" : false;
+  }
+  // Placement owns closing the menu and Aside surface.
+  return openPlacementFromAside(state) ? "placement" : false;
+}

--- a/tui/src/hit.ts
+++ b/tui/src/hit.ts
@@ -27,7 +27,12 @@ export type HitTarget =
   | { kind: "settings-row"; row: SettingsRowId; profilePurpose?: SettingsRoutePurpose }
   | { kind: "action"; action: KeyAction; index?: number }
   /** Row control whose non-left clicks deliberately fall through to its row. */
-  | { kind: "inline-action"; action: KeyAction }
+  | {
+      kind: "inline-action";
+      action: KeyAction;
+      /** Stable identity for a painted control (for example Placement stop). */
+      rowId?: string;
+    }
   /** A rendered part prompt; left-click toggles its inline expansion. */
   | { kind: "prompt"; index: number; rowId: string }
   /** A part's thought waymark or unfolded block; left-click toggles its fold

--- a/tui/src/keys.ts
+++ b/tui/src/keys.ts
@@ -34,7 +34,7 @@ import { resolveRequestViewerKey } from "./request-viewer-actions.js";
 import { resolveTokenProbabilitiesKey } from "./token-probabilities-actions.js";
 import { resolveGenerationRecordKey } from "./generation-record-actions.js";
 import { resolveLogKey } from "./notice-log.js";
-import { disarmAsideClear } from "./aside-surface.js";
+import { disarmAsideClear, type AsideSurfaceState } from "./aside-surface.js";
 
 export type KeyAction =
   | "focus-next" | "focus-previous" | "take-next" | "take-previous" | "take-at"
@@ -70,7 +70,7 @@ export type KeyAction =
 export type AppMode = "NAV" | "COMPOSE" | "EDITOR" | "MAP" | "KEYS" | "TAG"
   | "LIBRARY" | "FACTS" | "COMMANDS" | "SUMMARY" | "SETTINGS" | "ACTIONS" | "CHAPTERS"
   | "SEARCH" | "REQUEST" | "CARD" | "ARCHIVE" | "IMAGE" | "LOG" | "PROBS" | "RECORD"
-  | "ASIDE";
+  | "ASIDE" | "PLACE";
 
 export interface ResolvedKey {
   action: KeyAction;
@@ -254,7 +254,7 @@ export function pasteInto(
     pendingGenerationDraft: PendingGenerationDraft | null;
     composerClaimEpoch: number;
     stream: RuntimeState["stream"];
-    aside?: { composer: ComposerState; confirmClear: boolean } | null;
+    aside?: Pick<AsideSurfaceState, "composer" | "confirmClear" | "focus" | "useMenu"> | null;
   },
   raw: string
 ): boolean {
@@ -275,6 +275,7 @@ export function pasteInto(
     return true;
   }
   if (state.mode === "ASIDE" && state.aside !== null && state.aside !== undefined) {
+    if (asideKeyboardLayer(state.aside) !== "composer") return false;
     disarmAsideClear(state.aside);
     insertComposerText(state.aside.composer, clean);
     return true;
@@ -394,8 +395,16 @@ export interface ResolveOptions {
   authorsNoteEditor?: boolean;
   /** The editor context menu owns all keys until it closes. */
   textActionsOpen?: boolean;
+  /**
+   * Aside keyboard layer. One explicit state so composer, notes, and use-menu
+   * cannot combine incorrectly.
+   */
+  asideLayer?: AsideKeyboardLayer;
   mapView?: MapView;
 }
+
+/** Mutually exclusive Aside keyboard ownership while mode is ASIDE. */
+export type AsideKeyboardLayer = "composer" | "notes" | "use-menu";
 
 type OverlayTextInputState = Pick<
   RuntimeState,
@@ -423,11 +432,24 @@ export function overlayTextInputActive(state: OverlayTextInputState): boolean {
 export function textOwnsKeyboard(mode: AppMode, options: ResolveOptions = {}): boolean {
   // Search refines live, so its query field owns every plain letter. Its own
   // verbs are arrows and chords for exactly that reason.
-  return mode === "COMPOSE" || mode === "EDITOR" || mode === "SEARCH" || mode === "ASIDE"
+  // Aside owns text only on the composer layer.
+  const asideOwnsText = mode === "ASIDE"
+    && (options.asideLayer === undefined || options.asideLayer === "composer");
+  return mode === "COMPOSE" || mode === "EDITOR" || mode === "SEARCH" || asideOwnsText
     || options.overlayTyping === true
     || mode === "COMMANDS" && options.commandsTags !== true
     || mode === "TAG" && options.tagChoosingStatus !== true
     || mode === "CARD" || mode === "ARCHIVE" || mode === "IMAGE";
+}
+
+/** Derive the exclusive Aside keyboard layer from surface state. */
+export function asideKeyboardLayer(
+  surface: Pick<AsideSurfaceState, "focus" | "useMenu"> | null | undefined
+): AsideKeyboardLayer {
+  if (surface === null || surface === undefined) return "composer";
+  if (surface.useMenu !== null) return "use-menu";
+  if (surface.focus === "notes") return "notes";
+  return "composer";
 }
 
 export function resolveKey(key: KeyEvent, mode: AppMode, options: ResolveOptions = {}): ResolvedKey {
@@ -436,6 +458,7 @@ export function resolveKey(key: KeyEvent, mode: AppMode, options: ResolveOptions
     factEditor = false, authorsNoteEditor = false, settingsPicker = false,
     settingsProfileTransfer = null,
     textActionsOpen = false,
+    asideLayer = "composer",
     libraryRenaming = false,
     mapView = "path" } = options;
   const globalReference = resolveReferenceBinding("global", key, mode, mapView);
@@ -449,12 +472,25 @@ export function resolveKey(key: KeyEvent, mode: AppMode, options: ResolveOptions
     return { action: "none" };
   }
   const ownsText = textOwnsKeyboard(mode, {
-    overlayTyping, commandsTags, tagChoosingStatus
+    overlayTyping, commandsTags, tagChoosingStatus, asideLayer
   });
   // The banner's capital-R shortcut is page/list chrome, never a text-field
   // override. Writers must still be able to type R while working offline.
+  // Resolved before modal list filters so use-menu and PLACE still retry offline.
   if (!key.ctrl && !key.meta && connectionDown && !ownsText && shiftedLetter(key, "r")) {
     return { action: "retry" };
+  }
+  if (mode === "ASIDE" && asideLayer === "use-menu") {
+    if (key.name === "down") return { action: "focus-next" };
+    if (key.name === "up") return { action: "focus-previous" };
+    if (key.name === "return") return { action: "apply" };
+    return { action: "none" };
+  }
+  if (mode === "PLACE") {
+    if (key.name === "down") return { action: "focus-next" };
+    if (key.name === "up") return { action: "focus-previous" };
+    if (key.name === "return") return { action: "apply" };
+    return { action: "none" };
   }
   if (confirmingPrune) {
     return { action: key.name === "d" && !key.ctrl && !key.meta && !key.shift ? "prune" : "none" };
@@ -465,14 +501,26 @@ export function resolveKey(key: KeyEvent, mode: AppMode, options: ResolveOptions
   if (mode === "LOG") return resolveLogKey(key);
   if (mode === "ASIDE") {
     if (key.name === "escape") return { action: "cancel" };
-    if (key.name === "return" && key.shift) return { action: "newline" };
-    if (key.name === "return") return { action: "send" };
     const name = key.name.toLowerCase();
+    if (name === "tab") return { action: "cycle" };
     if (name === "pageup") return { action: "scroll-up" };
     if (name === "pagedown") return { action: "scroll-down" };
     if ((name === "up" || name === "down")
+      && !key.ctrl && !key.meta && !key.option && !key.super
+      && key.shift) {
+      return { action: name === "up" ? "scroll-line-up" : "scroll-line-down" };
+    }
+    if (asideLayer === "notes") {
+      if (name === "up") return { action: "focus-previous" };
+      if (name === "down") return { action: "focus-next" };
+      if (key.name === "return") return { action: "open-selected" };
+      if ((key.ctrl || key.super) && name === "v") return { action: "none" };
+      return { action: "none" };
+    }
+    if (key.name === "return" && key.shift) return { action: "newline" };
+    if (key.name === "return") return { action: "send" };
+    if ((name === "up" || name === "down")
       && !key.ctrl && !key.meta && !key.option && !key.super) {
-      if (key.shift) return { action: name === "up" ? "scroll-line-up" : "scroll-line-down" };
       return { action: name === "up" ? "cursor-up" : "cursor-down" };
     }
     if ((key.ctrl || key.super) && name === "v") return { action: "paste-clipboard" };

--- a/tui/src/library-actions.ts
+++ b/tui/src/library-actions.ts
@@ -252,6 +252,12 @@ async function deleteStory(
     await source.api.deleteStory(target.id);
     if (!task.owns()) return;
     forgetStoryReadingPosition(state, source, target.id);
+    // Successful delete proves the story is gone. Drop its Placement guard so
+    // adoptStoryState of a fallback story cannot leave it blocking survivors.
+    // Ordinary cross-story navigation still keeps the guard (no delete proof).
+    if (state.unresolvedPlacement?.storyId === target.id) {
+      state.unresolvedPlacement = null;
+    }
     let stories = await source.api.listStories();
     if (!task.owns()) return;
     if (deletedOpenStory && task.storyCurrent()) {

--- a/tui/src/mouse-actions.ts
+++ b/tui/src/mouse-actions.ts
@@ -21,6 +21,7 @@ export type MouseActionState = Pick<RuntimeState,
   | "actions" | "textActions" | "library" | "facts" | "commands" | "chapters" | "settings"
   | "search"
   | "request"
+  | "aside"
 > & {
   /** Derived exactly as the panel renderer derives it, since the palette's
    *  rows — and therefore their indexes — depend on it. Optional so live
@@ -227,7 +228,11 @@ export function captureMouseActionState(state: RuntimeState): MouseActionState {
     },
     settings: state.settings === null ? null : captureSettingsOverlay(state.settings),
     search: state.search === null ? null : { ...state.search },
-    request: state.request === null ? null : { ...state.request }
+    request: state.request === null ? null : { ...state.request },
+    aside: state.aside === null ? null : {
+      ...state.aside,
+      useMenu: state.aside.useMenu === null ? null : { ...state.aside.useMenu }
+    }
   };
 }
 
@@ -290,7 +295,8 @@ export function mouseToAction(
   if (event.type === "scroll") {
     const down = event.scroll?.direction === "down";
     if (state.mode === "REQUEST"
-      || state.mode === "ASIDE" && state.textActions === null) {
+      || state.mode === "ASIDE" && state.textActions === null
+        && (state.aside?.useMenu === null || state.aside?.useMenu === undefined)) {
       return { action: down ? "scroll-line-down" : "scroll-line-up" };
     }
     // The Fact editor owns several header rows above a scrollable body. Wheel
@@ -357,6 +363,20 @@ export function mouseToAction(
     if (state.mode === "NAV" || state.mode === "COMPOSE" && target.action === "open-request") {
       return { action: target.action };
     }
+    // Placement keyline: apply and destination focus only (cancel already above).
+    // Apply carries the painted stop identity so reconciliation can drop a
+    // stale click after a queued Up/Down moved the destination.
+    if (state.mode === "PLACE"
+      && (target.action === "apply"
+        || target.action === "focus-next"
+        || target.action === "focus-previous")) {
+      return {
+        action: target.action,
+        ...(target.action === "apply" && target.rowId !== undefined
+          ? { rowId: target.rowId }
+          : {})
+      };
+    }
   }
   if (target.kind === "fact" && event.button === 0 && state.mode === "NAV") {
     return { action: "open-facts", index: target.index };
@@ -419,6 +439,10 @@ function listCursor(state: MouseActionState): number | null {
   if (state.chapters !== null) return state.chapters.cursor;
   if (state.settings !== null) return state.settings.cursor;
   if (state.search !== null) return state.search.cursor;
+  if (state.mode === "ASIDE" && state.aside?.useMenu !== null
+    && state.aside?.useMenu !== undefined) {
+    return state.aside.useMenu.cursor;
+  }
   // The map has no cursor index of its own; read it off the rendered rows
   // so the click and the frame always agree.
   if (state.mode === "MAP" && state.map !== null) {

--- a/tui/src/overlay-actions.ts
+++ b/tui/src/overlay-actions.ts
@@ -34,10 +34,26 @@ import {
   clearAsideSurface,
   closeAside,
   openAside,
+  revealAsideFocusedNote,
   scrollAside,
   sendAsideQuestion,
   stopAsideAsk
 } from "./aside-actions.js";
+import {
+  applyAsideUseMenu,
+  cycleAsideFocus,
+  focusAsideUseMenuIndex,
+  moveAsideNoteFocus,
+  moveAsideUseMenuCursor,
+  openAsideUseMenu,
+  closeAsideUseMenu
+} from "./aside-use.js";
+import {
+  cancelPlacement,
+  confirmPlacement,
+  movePlacementCursor,
+  placementInputLocked
+} from "./aside-placement.js";
 import { insertComposerText, setComposerText } from "./composer-model.js";
 import { composerMotion } from "./composer-motion.js";
 import { directComposerWrapWidth } from "./composer-geometry.js";
@@ -138,6 +154,10 @@ export async function handleOverlayAction(
   }
   if (state.mode === "ASIDE" && state.aside !== null) {
     await asideKeyAction(resolved, state, source, context);
+    return true;
+  }
+  if (state.mode === "PLACE" && state.placement !== null) {
+    await placementKeyAction(resolved, state, source, context);
     return true;
   }
   if (resolved.action === "open-log") {
@@ -704,6 +724,45 @@ async function reconnect(state: RuntimeState, source: AppSource, context: Overla
   });
 }
 
+function asideViewportBodyRows(
+  surface: NonNullable<RuntimeState["aside"]>,
+  context: OverlayActionContext
+): { width: number; bodyRows: number } {
+  const width = context.renderer?.width ?? 80;
+  const height = context.renderer?.height ?? 24;
+  const composerRows = asideComposerRows(height);
+  return {
+    width,
+    bodyRows: asideBodyHeight(surface, width, height, composerRows)
+  };
+}
+
+async function placementKeyAction(
+  resolved: ResolvedKey,
+  state: RuntimeState,
+  source: AppSource,
+  context: OverlayActionContext
+): Promise<void> {
+  if (state.placement === null) return;
+  // Lock only while this Placement owns createNode — not reconnect/recovery.
+  if (placementInputLocked(state)) return;
+  if (resolved.action === "cancel") {
+    cancelPlacement(state);
+    return;
+  }
+  if (resolved.action === "focus-next") {
+    movePlacementCursor(state, 1);
+    return;
+  }
+  if (resolved.action === "focus-previous") {
+    movePlacementCursor(state, -1);
+    return;
+  }
+  if (resolved.action === "apply" || resolved.action === "open-selected") {
+    await confirmPlacement(state, source, context);
+  }
+}
+
 async function asideKeyAction(
   resolved: ResolvedKey,
   state: RuntimeState,
@@ -713,6 +772,15 @@ async function asideKeyAction(
   const surface = state.aside;
   if (surface === null) return;
   if (resolved.action === "cancel") {
+    if (surface.useMenu !== null) {
+      closeAsideUseMenu(surface);
+      surface.focus = "notes";
+      return;
+    }
+    if (surface.focus === "notes") {
+      surface.focus = "composer";
+      return;
+    }
     if (surface.confirmClear) {
       surface.confirmClear = false;
       return;
@@ -729,6 +797,35 @@ async function asideKeyAction(
     closeAside(state);
     return;
   }
+  if (surface.useMenu !== null) {
+    if (resolved.action === "focus-next") {
+      moveAsideUseMenuCursor(surface, 1);
+      return;
+    }
+    if (resolved.action === "focus-previous") {
+      moveAsideUseMenuCursor(surface, -1);
+      return;
+    }
+    if (resolved.action === "focus-index") {
+      focusAsideUseMenuIndex(surface, resolved.index ?? surface.useMenu.cursor);
+      return;
+    }
+    if (resolved.action === "apply" || resolved.action === "open-selected") {
+      applyAsideUseMenu(state);
+      return;
+    }
+    // Use menu owns the surface: scrim/cancel stay authoritative; compose does
+    // not steal focus from under the modal.
+    return;
+  }
+
+  if (resolved.action === "cycle") {
+    if (cycleAsideFocus(surface) && surface.focus === "notes") {
+      const { width, bodyRows } = asideViewportBodyRows(surface, context);
+      revealAsideFocusedNote(surface, width, bodyRows);
+    }
+    return;
+  }
   if (resolved.action === "scroll-line-down" || resolved.action === "scroll-line-up"
     || resolved.action === "scroll-down" || resolved.action === "scroll-up") {
     const width = context.renderer?.width ?? 80;
@@ -739,6 +836,29 @@ async function asideKeyAction(
       ? resolved.action === "scroll-down" ? page : 1
       : resolved.action === "scroll-up" ? -page : -1;
     scrollAside(surface, delta, width, height, composerRows);
+    return;
+  }
+  if (surface.focus === "notes") {
+    // Left-click on the visible prompt claims composer focus so paste/text
+    // target it. Use menu already returned above.
+    if (resolved.action === "compose") {
+      surface.focus = "composer";
+      return;
+    }
+    if (resolved.action === "focus-next" || resolved.action === "focus-previous") {
+      moveAsideNoteFocus(surface, resolved.action === "focus-next" ? 1 : -1);
+      const { width, bodyRows } = asideViewportBodyRows(surface, context);
+      revealAsideFocusedNote(surface, width, bodyRows);
+      return;
+    }
+    if (resolved.action === "open-selected" || resolved.action === "apply") {
+      // Re-anchor under the current terminal size: a stale scrollTop from a
+      // prior width/header layout can hide noteCursor while Enter still uses it.
+      const { width, bodyRows } = asideViewportBodyRows(surface, context);
+      revealAsideFocusedNote(surface, width, bodyRows);
+      openAsideUseMenu(surface, surface.noteCursor);
+      return;
+    }
     return;
   }
   const width = context.renderer?.width ?? 80;

--- a/tui/src/overlay-publication.ts
+++ b/tui/src/overlay-publication.ts
@@ -14,13 +14,20 @@ interface SettingsViewSource {
 }
 
 /** Publish a catalog refresh to the cache and whichever Library surface is
- * live now, preserving its selected story rather than its numeric row. */
+ * live now, preserving its selected story rather than its numeric row.
+ * An authoritative catalog that omits the singular Placement guard's story
+ * proves that story is gone: clear the guard. Single-story payloads and plain
+ * navigation do not pass through this boundary. */
 export function publishStories(
   state: RuntimeState,
   source: StoryCatalogSource,
   stories: StorySummary[]
 ): void {
   source.stories = stories;
+  const guard = state.unresolvedPlacement;
+  if (guard !== null && !stories.some(({ id }) => id === guard.storyId)) {
+    state.unresolvedPlacement = null;
+  }
   const overlay = state.library;
   if (overlay === null) return;
   const query = overlay.query;

--- a/tui/src/presented-mouse-action.ts
+++ b/tui/src/presented-mouse-action.ts
@@ -21,6 +21,11 @@ import {
   type MouseGesture
 } from "./mouse-actions.js";
 import type { RuntimeState } from "./state.js";
+import {
+  ASIDE_USE_ACTIONS,
+  asideUseActionIndexFromRowId,
+  asideUseRowId
+} from "./aside-use.js";
 import { availableTextActions } from "./text-actions.js";
 
 export interface PresentedInteraction {
@@ -131,6 +136,15 @@ function rebaseByStableIdentity(
     return index < 0 ? null : { ...action, index };
   }
   if (action.action === "focus-index" && action.rowId !== undefined && state.mode !== "REQUEST") {
+    if (state.mode === "ASIDE" && state.aside?.useMenu !== null
+      && state.aside?.useMenu !== undefined) {
+      // Session-bound row id: same action on a later menu open does not match.
+      const index = asideUseActionIndexFromRowId(
+        action.rowId,
+        state.aside.useMenu.sessionId
+      );
+      return index < 0 ? null : { ...action, index };
+    }
     const index = createStoryViewModel(state.payload, state.stream).rows
       .findIndex((row) => row.id === action.rowId);
     return index < 0 ? null : { ...action, index };
@@ -231,6 +245,13 @@ function mapRowId(state: MouseActionState, index: number | undefined): string | 
 function listRowIdentity(state: MouseActionState, index: number | undefined): string | null {
   if (index === undefined) return null;
   if (state.textActions !== null) return availableTextActions(state.textActions)[index]?.id ?? null;
+  if (state.mode === "ASIDE" && state.aside?.useMenu !== null
+    && state.aside?.useMenu !== undefined) {
+    const entry = ASIDE_USE_ACTIONS[index];
+    return entry === undefined
+      ? null
+      : asideUseRowId(state.aside.useMenu.sessionId, entry.id);
+  }
   if (state.request !== null) return requestRowIdentity(state, index);
   if (state.mode === "MAP" && state.map !== null) return mapRowId(state, index);
   if (state.search !== null) {
@@ -305,13 +326,22 @@ const NO_SELECTION = "none";
 function selectableRowsOpen(state: MouseActionState): boolean {
   return state.map !== null || state.actions !== null || state.textActions !== null || state.library !== null
     || state.facts !== null || state.commands !== null || state.chapters !== null
-    || state.settings !== null || state.search !== null || state.request !== null;
+    || state.settings !== null || state.search !== null || state.request !== null
+    || state.mode === "ASIDE" && state.aside?.useMenu !== null
+      && state.aside?.useMenu !== undefined;
 }
 
 function selectedListIdentity(state: MouseActionState): string | null {
   if (state.textActions !== null) {
     const entry = availableTextActions(state.textActions)[state.textActions.cursor];
     return entry === undefined ? null : `text-actions:${entry.id}`;
+  }
+  if (state.mode === "ASIDE" && state.aside?.useMenu !== null
+    && state.aside?.useMenu !== undefined) {
+    const entry = ASIDE_USE_ACTIONS[state.aside.useMenu.cursor];
+    return entry === undefined
+      ? null
+      : asideUseRowId(state.aside.useMenu.sessionId, entry.id);
   }
   if (state.request !== null) return requestRowIdentity(state, state.request.cursor);
   if (state.search !== null) {

--- a/tui/src/reading-position-persist.ts
+++ b/tui/src/reading-position-persist.ts
@@ -35,7 +35,12 @@ export function rememberFocus(state: RuntimeState, source: FocusSource): void {
     state.focusIndex,
     state.stream
   );
-  if (next === state.readingPositions) return;
+  if (next === state.readingPositions) {
+    // Adoption may have already persisted via rememberFocus(state, state).
+    // Still sync a lagging AppSource map onto the current positions.
+    source.readingPositions = next;
+    return;
+  }
   state.readingPositions = next;
   source.readingPositions = next;
   const partId = next[state.payload.id];

--- a/tui/src/screens/connection-banner.ts
+++ b/tui/src/screens/connection-banner.ts
@@ -1,9 +1,17 @@
 import { retrySeconds } from "../connection.js";
 import type { FrameDeadlineCollector } from "../animation-deadline.js";
 import { addHit } from "../hit.js";
-import { overlayTextInputActive, textOwnsKeyboard } from "../keys.js";
+import {
+  asideKeyboardLayer,
+  overlayTextInputActive,
+  textOwnsKeyboard
+} from "../keys.js";
 import type { OverlayState, StoryScreenState } from "../state.js";
 import { fitLine, visibleWidth, type FrameLine } from "./story/frame.js";
+
+type ConnectionBannerState = OverlayState
+  & Pick<StoryScreenState, "mode" | "tag">
+  & { now: number; aside?: StoryScreenState["aside"] };
 
 /** The banner's own sentence, without the countdown that changes every second.
  *  C-29 and C-37 have to say the same thing, so they read it from here — the
@@ -18,7 +26,7 @@ export function connectionNoticeText(
 
 export function renderConnectionBanner(
   base: FrameLine[],
-  state: OverlayState & Pick<StoryScreenState, "mode" | "tag"> & { now: number },
+  state: ConnectionBannerState,
   width: number,
   deadlines?: FrameDeadlineCollector
 ): FrameLine[] {
@@ -30,7 +38,10 @@ export function renderConnectionBanner(
   const ownsText = textOwnsKeyboard(state.mode, {
     overlayTyping: overlayTextInputActive(state),
     commandsTags: state.commands?.view === "tags",
-    tagChoosingStatus: state.tag?.choosingStatus ?? false
+    tagChoosingStatus: state.tag?.choosingStatus ?? false,
+    asideLayer: state.mode === "ASIDE"
+      ? asideKeyboardLayer(state.aside ?? null)
+      : undefined
   });
   const retry = ownsText ? "retry now" : "R retries now";
   const attempts = `(attempt ${state.connection.attempt}/5)`;

--- a/tui/src/screens/story.ts
+++ b/tui/src/screens/story.ts
@@ -45,17 +45,10 @@ import { renderRequestViewerScreen } from "./request-viewer.js";
 import { renderTokenProbabilitiesScreen } from "./token-probabilities.js";
 import { renderGenerationRecordViewerScreen } from "./generation-record-viewer.js";
 import { renderLogScreen } from "./log.js";
-import {
-  asideComposerRows,
-  asideFooterHint,
-  asideHeaderWindow,
-  asideHistoryWindow
-} from "../aside-actions.js";
-import type { AsideSurfaceState } from "../aside-surface.js";
-import { ASIDE_INPUT_PLACEHOLDER } from "../aside-surface.js";
 import { wrapFeedback } from "./feedback-wrap.js";
 import { renderPanels, renderTextActionsPanel } from "./panels.js";
 import { renderConnectionBanner } from "./connection-banner.js";
+import { renderAsideScreen } from "./story/aside-screen.js";
 import {
   fitLine,
   hintItem,
@@ -87,6 +80,17 @@ import { storyProseMeasure, STORY_GUTTER } from "../composer-geometry.js";
 import type { ComposerStatus as ComposerChromeStatus } from "./story/composer-chrome.js";
 import { renderStatus as renderCanonicalStatus } from "./story/status.js";
 import { viewportLines, type ViewportBlock } from "./story/viewport.js";
+import {
+  PLACEMENT_PLACING_KEYLINE,
+  placementInputLocked,
+  placementOutcomeUnknown
+} from "../aside-placement.js";
+import {
+  placementEnterPlaceRowId,
+  placementFocusBlockId,
+  placementLeafGapBlock,
+  placementMarkerAfterRow
+} from "./story/placement-marker.js";
 import {
   buildComposerSelectionProjection,
   buildStorySelectionProjection,
@@ -228,7 +232,17 @@ export function renderStoryScreen(state: StoryScreenState, options: StoryScreenO
       height: layout.height + 1,
       render: () => [...layout.render(), []]
     });
+    const placementMarker = placementMarkerAfterRow(
+      state.placement,
+      row,
+      view,
+      measure
+    );
+    if (placementMarker !== null) blocks.push(placementMarker);
   }
+  // After chapter summary/divider rows that follow the active leaf.
+  const leafGapMarker = placementLeafGapBlock(state.placement, view, measure);
+  if (leafGapMarker !== null) blocks.push(leafGapMarker);
 
   const composer = renderPageComposer(state, view, width, measure, narrow, height);
   const composerLines = composer.lines;
@@ -237,7 +251,16 @@ export function renderStoryScreen(state: StoryScreenState, options: StoryScreenO
   // Generation moves focus to its target when the stream opens. Later user
   // navigation owns the same semantic focus, so rendering needs no second
   // auto-follow flag that can drift from the reducer state.
-  const focusId = options.viewportAnchorId ?? rows[state.focusIndex]?.id ?? rows[0]?.id ?? null;
+  // Placement keeps the selected destination marker in view by focusing its
+  // synthetic block id rather than only the related Part.
+  const placementFocus = state.mode === "PLACE" && state.placement !== null
+    ? placementFocusBlockId(state.placement)
+    : null;
+  const focusId = options.viewportAnchorId
+    ?? placementFocus
+    ?? rows[state.focusIndex]?.id
+    ?? rows[0]?.id
+    ?? null;
   const focusAtStarterIntro = options.viewportAnchorId === undefined
     && state.focusIndex === 0
     && rowPart(view, state.focusIndex)?.node.text.startsWith(`${STARTER_LOGO_TEXT}\n\n`) === true;
@@ -612,6 +635,27 @@ function navHint(
       ...suffix
     ];
   }
+  if (state.mode === "PLACE" && state.placement !== null) {
+    // Esc/arrows/Enter are ignored only while this Placement owns createNode.
+    if (placementInputLocked(state)) {
+      return fitLine([segment(` ${PLACEMENT_PLACING_KEYLINE}`, "chrome")], budget);
+    }
+    // Uncertain outcome: no Enter place until recovery settles the first node.
+    if (placementOutcomeUnknown(state)) {
+      return joinHints([
+        hintItem([actionHint("Up/Down where", "focus-next")]),
+        hintItem([actionHint("Esc back to Aside", "cancel")], 1)
+      ], budget);
+    }
+    // Stamp Enter place with session + stop so a queued Up/Down or a later
+    // Placement open at the same stop cannot createNode against the wrong work.
+    const placeStopId = placementEnterPlaceRowId(state.placement) ?? undefined;
+    return joinHints([
+      hintItem([actionHint("Up/Down where", "focus-next")]),
+      hintItem([actionHint("Enter place", "apply", "chrome", placeStopId)]),
+      hintItem([actionHint("Esc back to Aside", "cancel")], 1)
+    ], budget);
+  }
   return joinHints(navHintItems(state, view), budget);
 }
 
@@ -911,67 +955,15 @@ function renderStoryStatus(
   return [{ ...modeBlock, text: modeBlock.text.replace("COMPOSE", label) }, ...rest];
 }
 
-function actionHint(text: string, action: KeyAction, role: DisplayRole = "chrome"): FrameSegment {
-  return segment(text, role, { kind: "inline-action", action });
-}
-
-function renderAsideScreen(
-  state: StoryScreenState,
-  surface: AsideSurfaceState,
-  width: number,
-  height: number,
-  deadlines?: FrameDeadlineCollector
-): StoryScreenFrame {
-  const composerHeight = asideComposerRows(height);
-  const clearing = surface.busy && surface.inflightQuestion === null;
-  const composer = renderComposerLayout({
-    composer: surface.composer,
-    fullscreen: true,
-    terminalWidth: width,
-    terminalHeight: composerHeight + 1,
-    measure: width,
-    title: "aside · prompt",
-    caret: clearing ? "none" : surface.busy ? "streaming" : "focused",
-    footerNotice: surface.busy ? null : state.toast,
-    footerHints: asideFooterHint(surface),
-    placeholder: ASIDE_INPUT_PLACEHOLDER,
-    narrow: width < 100,
-    softWrap: true
+function actionHint(
+  text: string,
+  action: KeyAction,
+  role: DisplayRole = "chrome",
+  rowId?: string
+): FrameSegment {
+  return segment(text, role, {
+    kind: "inline-action",
+    action,
+    ...(rowId === undefined ? {} : { rowId })
   });
-  const header = asideHeaderWindow(surface, width, height - composer.lines.length);
-  const historyRows = Math.max(0, height - header.length - composer.lines.length);
-  const lines: FrameLine[] = [
-    ...header.map((text) => [segment(text, "prose")]),
-    ...asideHistoryWindow(surface, width, historyRows)
-      .map((text) => [segment(text, "prose")]),
-    ...composer.lines
-  ];
-  const composerStart = header.length + historyRows;
-  while (lines.length < height) lines.push([]);
-  const visibleLines = lines.slice(0, height).map((line) => fitLine(line, width));
-  const hitRows: HitRows = Array.from({ length: height }, (_, row) => {
-    if (row < composerStart || row >= composerStart + composer.lines.length) return null;
-    return { target: composerHitTarget(visibleLines[row]), left: 0, right: width };
-  });
-  const renderedLines = state.connection.down
-    ? renderConnectionBanner(visibleLines, { ...state, hitRows }, width, deadlines)
-    : visibleLines;
-  return {
-    lines: renderedLines,
-    selectable: null,
-    derived: {
-      hitRows,
-      viewScroll: null,
-      viewScrollDelta: 0,
-      lastViewportStart: 0,
-      composerScrollTop: composer.scrollTop,
-      editorScrollTop: 0,
-      keysScrollTop: 0,
-      composerSelectionProjection: buildComposerSelectionProjection(renderedLines, width),
-      storySelectionProjection: null,
-      map: null,
-      request: null,
-      record: null
-    }
-  };
 }

--- a/tui/src/screens/story/aside-screen.ts
+++ b/tui/src/screens/story/aside-screen.ts
@@ -1,0 +1,177 @@
+/**
+ * Full-screen Aside surface: header, Side Notes, composer, and use menu.
+ */
+import type { FrameDeadlineCollector } from "../../animation-deadline.js";
+import {
+  asideComposerRows,
+  asideFooterHint,
+  asideHeaderWindow,
+  asideHistoryWindow
+} from "../../aside-actions.js";
+import type { AsideSurfaceState } from "../../aside-surface.js";
+import { ASIDE_INPUT_PLACEHOLDER } from "../../aside-surface.js";
+import {
+  ASIDE_USE_ACTIONS,
+  asideUseMenuTitle,
+  asideUseRowId
+} from "../../aside-use.js";
+import type { HitRows, HitTarget } from "../../hit.js";
+import {
+  buildComposerSelectionProjection
+} from "../../selection-projection.js";
+import type { StoryScreenState } from "../../state.js";
+import { renderConnectionBanner } from "../connection-banner.js";
+import { dimPage, panelHorizontalGeometry, placePanel, raisedSegment } from "../overlay.js";
+import { cellPad } from "../panel-table-layout.js";
+import {
+  fitLine,
+  segment,
+  truncate,
+  visibleWidth,
+  type FrameLine
+} from "./frame.js";
+import { renderComposerLayout } from "./composer.js";
+import type { StoryScreenFrame } from "../story.js";
+
+function composerHitTarget(line: FrameLine | undefined): HitTarget {
+  const sources = new Map<string, boolean>();
+  for (const part of line ?? []) {
+    if (part.composerHitSource !== undefined) {
+      sources.set(part.composerHitSource.id, part.composerHitSource.editable);
+    }
+  }
+  if (sources.size !== 1) return { kind: "composer" };
+  const source = sources.entries().next().value;
+  if (source === undefined) return { kind: "composer" };
+  return {
+    kind: "composer",
+    composerSourceId: source[0],
+    composerEditable: source[1]
+  };
+}
+
+function renderAsideUseMenu(
+  base: FrameLine[],
+  surface: AsideSurfaceState,
+  width: number,
+  height: number,
+  hitRows: HitRows
+): FrameLine[] {
+  const menu = surface.useMenu;
+  if (menu === null) return base;
+  const note = surface.notes[menu.noteIndex];
+  if (note === undefined) return base;
+  const actions = ASIDE_USE_ACTIONS;
+  const contentWidth = panelHorizontalGeometry(width, 56).contentWidth;
+  const leadWidth = Math.min(4, contentWidth);
+  const widestName = Math.max(...actions.map((action) => visibleWidth(action.name)));
+  const nameWidth = Math.min(widestName + 2, Math.max(0, contentWidth - leadWidth));
+  const descriptionWidth = Math.max(0, contentWidth - leadWidth - nameWidth);
+  const content: FrameLine[] = actions.map((action, index): FrameLine => [
+    raisedSegment(cellPad(index === menu.cursor ? "  ▸ " : "", leadWidth),
+      index === menu.cursor ? "focus / accent" : "chrome"),
+    raisedSegment(cellPad(truncate(action.name, nameWidth), nameWidth),
+      index === menu.cursor ? "prose" : "prose · dim"),
+    raisedSegment(truncate(action.description, descriptionWidth), "chrome")
+  ]);
+  // Keep ↵ and esc complete at 20–21 columns; drop secondary words first.
+  const footer = panelHorizontalGeometry(width, 56).footerWidth < visibleWidth("↑↓ · ↵ · esc notes")
+    ? "↵ · esc"
+    : "↑↓ · ↵ · esc notes";
+  return placePanel(
+    dimPage(base),
+    asideUseMenuTitle(note.answer),
+    content,
+    footer,
+    width,
+    height,
+    56,
+    {
+      rows: hitRows,
+      targets: actions.map((action, index): HitTarget => ({
+        kind: "list",
+        index,
+        rowId: asideUseRowId(menu.sessionId, action.id),
+        selected: index === menu.cursor
+      })),
+      footerActions: [
+        { token: "↵", action: "apply" },
+        { token: "esc", action: "cancel" }
+      ]
+    }
+  ).lines;
+}
+
+export function renderAsideScreen(
+  state: StoryScreenState,
+  surface: AsideSurfaceState,
+  width: number,
+  height: number,
+  deadlines?: FrameDeadlineCollector
+): StoryScreenFrame {
+  const composerHeight = asideComposerRows(height);
+  const clearing = surface.busy && surface.inflightQuestion === null;
+  const notesFocus = surface.focus === "notes" || surface.useMenu !== null;
+  const composer = renderComposerLayout({
+    composer: surface.composer,
+    fullscreen: true,
+    terminalWidth: width,
+    terminalHeight: composerHeight + 1,
+    measure: width,
+    title: "aside · prompt",
+    caret: clearing || notesFocus ? "none" : surface.busy ? "streaming" : "focused",
+    footerNotice: surface.busy ? null : state.toast,
+    footerHints: asideFooterHint(surface),
+    placeholder: ASIDE_INPUT_PLACEHOLDER,
+    narrow: width < 100,
+    softWrap: true
+  });
+  const header = asideHeaderWindow(surface, width, height - composer.lines.length);
+  const historyRows = Math.max(0, height - header.length - composer.lines.length);
+  const history = asideHistoryWindow(surface, width, historyRows);
+  const lines: FrameLine[] = [
+    ...header.map((text) => [segment(text, "prose")]),
+    ...history.map((text) => {
+      const focused = text.startsWith("▸ ");
+      return [segment(text, focused ? "focus / accent" : "prose")];
+    }),
+    ...composer.lines
+  ];
+  const composerStart = header.length + historyRows;
+  while (lines.length < height) lines.push([]);
+  const visibleLines = lines.slice(0, height).map((line) => fitLine(line, width));
+  const hitRows: HitRows = Array.from({ length: height }, (_, row) => {
+    if (row < composerStart || row >= composerStart + composer.lines.length) return null;
+    return { target: composerHitTarget(visibleLines[row]), left: 0, right: width };
+  });
+  // Menu first (owns scrim), connection banner last so its retry hit stays live.
+  let renderedLines = visibleLines;
+  if (surface.useMenu !== null) {
+    renderedLines = renderAsideUseMenu(renderedLines, surface, width, height, hitRows);
+  }
+  if (state.connection.down) {
+    renderedLines = renderConnectionBanner(
+      renderedLines, { ...state, hitRows }, width, deadlines
+    );
+  }
+  return {
+    lines: renderedLines,
+    selectable: null,
+    derived: {
+      hitRows,
+      viewScroll: null,
+      viewScrollDelta: 0,
+      lastViewportStart: 0,
+      composerScrollTop: composer.scrollTop,
+      editorScrollTop: 0,
+      keysScrollTop: 0,
+      composerSelectionProjection: notesFocus
+        ? null
+        : buildComposerSelectionProjection(renderedLines, width),
+      storySelectionProjection: null,
+      map: null,
+      request: null,
+      record: null
+    }
+  };
+}

--- a/tui/src/screens/story/placement-marker.ts
+++ b/tui/src/screens/story/placement-marker.ts
@@ -1,0 +1,106 @@
+/**
+ * Visible Placement destination markers on the story surface.
+ * Only the selected stop is painted; Up/Down moves it with the stop.
+ */
+import type { PlacementState } from "../../aside-placement.js";
+import {
+  firstWords,
+  type PlacementStop
+} from "../../aside-placement-model.js";
+import type { StoryPart, StoryRow, StoryViewModel } from "../../model.js";
+import { segment, truncate, type FrameLine } from "./frame.js";
+import type { ViewportBlock } from "./viewport.js";
+
+/** Viewport / marker block id for the selected stop (not session-bound). */
+export function placementFocusBlockId(placement: PlacementState): string | null {
+  const stop = placement.stops[placement.cursor];
+  if (stop === undefined) return null;
+  return placementStopBlockId(stop);
+}
+
+export function placementStopBlockId(stop: PlacementStop): string {
+  return stop.kind === "take"
+    ? `placement:take:${stop.partId}`
+    : `placement:leaf-gap:${stop.leafId}`;
+}
+
+/**
+ * Enter-place hit identity: interaction session + destination stop.
+ * Separate from viewport marker ids so session binding cannot hide markers.
+ */
+export function placementEnterPlaceRowId(placement: PlacementState): string | null {
+  const stop = placement.stops[placement.cursor];
+  if (stop === undefined) return null;
+  return stop.kind === "take"
+    ? `placement:${placement.interactionId}:take:${stop.partId}`
+    : `placement:${placement.interactionId}:leaf-gap:${stop.leafId}`;
+}
+
+/**
+ * Marker after a story row when that row owns the selected Take stop.
+ * Leaf-gap markers use {@link placementLeafGapBlock} so they trail any chapter
+ * summary/divider rows that follow the active leaf.
+ */
+export function placementMarkerAfterRow(
+  placement: PlacementState | null | undefined,
+  row: StoryRow,
+  view: StoryViewModel,
+  measure: number
+): ViewportBlock | null {
+  if (placement === null || placement === undefined) return null;
+  const stop = placement.stops[placement.cursor];
+  if (stop === undefined || stop.kind !== "take") return null;
+  if (row.kind !== "part" || stop.partId !== row.id) return null;
+  return takeMarkerBlock(stop, row, measure);
+}
+
+/**
+ * Trailing leaf-gap destination. Call after every story row has been pushed so
+ * the marker sits after chapter summary/divider chrome that follows the leaf.
+ */
+export function placementLeafGapBlock(
+  placement: PlacementState | null | undefined,
+  view: StoryViewModel,
+  measure: number
+): ViewportBlock | null {
+  if (placement === null || placement === undefined) return null;
+  const stop = placement.stops[placement.cursor];
+  if (stop === undefined || stop.kind !== "leaf-gap") return null;
+  const leaf = view.parts.at(-1);
+  if (leaf === undefined || leaf.id !== stop.leafId) return null;
+  return leafGapMarkerBlock(stop, placement.answer, measure);
+}
+
+function takeMarkerBlock(
+  stop: Extract<PlacementStop, { kind: "take" }>,
+  part: StoryPart,
+  measure: number
+): ViewportBlock {
+  const nextTake = part.siblingCount + 1;
+  const label = `take on ¶ ${stop.partNumber} · take ${nextTake}/${nextTake}`;
+  return markerBlock(placementStopBlockId(stop), label, measure);
+}
+
+function leafGapMarkerBlock(
+  stop: Extract<PlacementStop, { kind: "leaf-gap" }>,
+  answer: string,
+  measure: number
+): ViewportBlock {
+  const preview = firstWords(answer, 8);
+  const label = preview.length === 0
+    ? "here · new Part"
+    : `here · new Part · ${preview}`;
+  return markerBlock(placementStopBlockId(stop), label, measure);
+}
+
+function markerBlock(partId: string, label: string, measure: number): ViewportBlock {
+  const painted: FrameLine = [
+    segment(truncate(`▸ ${label}`, Math.max(1, measure)), "focus / accent")
+  ];
+  return {
+    partId,
+    partIndex: -1,
+    height: 2,
+    render: () => [painted, []]
+  };
+}

--- a/tui/src/screens/story/status.ts
+++ b/tui/src/screens/story/status.ts
@@ -7,6 +7,14 @@ import { samplingListPanelStatusLabel } from "../../sampling-panel-spec.js";
 import { isPlainNavigation } from "../../keys.js";
 import { contextSeverity, formatTokensScaled, formatTokensEstimate, requestWindow } from "../../rail.js";
 import type { NextRequestEstimate } from "../../request-projection.js";
+import {
+  PLACEMENT_PLACING_STATUS,
+  PLACEMENT_STATUS_TEXT,
+  PLACEMENT_UNCERTAIN_STATUS,
+  placementInputLocked,
+  placementOutcomeUnknown,
+  placementStopLabel
+} from "../../aside-placement.js";
 import type { StoryScreenState } from "../../state.js";
 import {
   fitLine,
@@ -47,6 +55,25 @@ export function renderStatus(
   };
   if (state.prune !== null) {
     return renderPruneStatus(modeBlock, pruneConfirmText(state.prune), width);
+  }
+  if (state.mode === "PLACE" && state.placement !== null) {
+    if (placementInputLocked(state)) {
+      // In-flight place is normal work, not a destructive prune.
+      return renderPlacementStatus(modeBlock, PLACEMENT_PLACING_STATUS, width, "chrome");
+    }
+    if (placementOutcomeUnknown(state)) {
+      return renderPlacementStatus(
+        modeBlock,
+        PLACEMENT_UNCERTAIN_STATUS,
+        width,
+        "context warning"
+      );
+    }
+    const stop = state.placement.stops[state.placement.cursor];
+    const where = stop === undefined
+      ? PLACEMENT_STATUS_TEXT
+      : `${placementStopLabel(stop, state.placement.answer)} · ${PLACEMENT_STATUS_TEXT}`;
+    return renderPlacementStatus(modeBlock, where, width, "chrome");
   }
   const left: FrameLine = [modeBlock];
   left.push(segment(`  ${title} · `, "chrome"));
@@ -170,6 +197,35 @@ function renderPruneStatus(block: FrameSegment, text: string, width: number): Fr
     segment("  ", "danger text"),
     segment(truncate(body, bodyWidth), "danger text"),
     segment(suffix, "danger text")
+  ], width);
+}
+
+/**
+ * PLACE status: keep the assurance suffix when destination labels run long,
+ * and use normal chrome (not prune danger) unless the role is a warning.
+ */
+function renderPlacementStatus(
+  block: FrameSegment,
+  text: string,
+  width: number,
+  role: DisplayRole
+): FrameLine {
+  const suffix = ` · ${PLACEMENT_STATUS_TEXT}`;
+  const available = Math.max(0, width - visibleWidth(block.text) - 2);
+  if (visibleWidth(text) <= available || !text.endsWith(suffix)) {
+    return fitLine([block, segment(`  ${text}`, role)], width);
+  }
+  const body = text.slice(0, -suffix.length);
+  const bodyWidth = available - visibleWidth(suffix);
+  if (bodyWidth <= 0) {
+    // Prefer the required assurance over the destination label.
+    return fitLine([block, segment(`  ${PLACEMENT_STATUS_TEXT}`, role)], width);
+  }
+  return fitLine([
+    block,
+    segment("  ", role),
+    segment(truncate(body, bodyWidth), role),
+    segment(suffix, role)
   ], width);
 }
 

--- a/tui/src/state.ts
+++ b/tui/src/state.ts
@@ -650,6 +650,14 @@ export interface StoryScreenState extends OverlayState {
   record: GenerationRecordViewerState | null;
   /** Full-screen Aside surface, or null when it is closed. */
   aside: import("./aside-surface.js").AsideSurfaceState | null;
+  /** Placement mode for inserting a Side Note into the story line. */
+  placement: import("./aside-placement.js").PlacementState | null;
+  /**
+   * Story-bound unresolved Placement createNode after an uncertain outcome.
+   * Survives Esc back to Aside until recovery settles it or a definite failure
+   * proves the write did not commit.
+   */
+  unresolvedPlacement: import("./aside-placement-model.js").UnresolvedPlacementSubmission | null;
   toast: string | null;
   /** C-37: every notice the session has shown, so a capped channel never
    *  loses a message for good. `!` opens it. */

--- a/tui/src/story-adoption.ts
+++ b/tui/src/story-adoption.ts
@@ -1,4 +1,6 @@
 import type { StoryPayload } from "../../shared/types.js";
+import { rebasePlacementStops } from "./aside-placement-model.js";
+import { trySettlePlacementFromPayload } from "./aside-placement-settle.js";
 import { createComposer } from "./composer-model.js";
 import { capturePendingDirectDraft } from "./composer-ownership.js";
 import {
@@ -11,7 +13,10 @@ import { boundedFactSelection, factRows } from "./facts-model.js";
 import { createStoryViewModel, rowIndexForNode } from "./model.js";
 import { createPrunePlan, createUnusedTakesPrunePlan } from "./prune-model.js";
 import { applyOpeningFocus } from "./reading-position.js";
-import { flushReadingPositionPersist } from "./reading-position-persist.js";
+import {
+  flushReadingPositionPersist,
+  rememberFocus
+} from "./reading-position-persist.js";
 import { abortPendingSearch, retireSearch } from "./search-request.js";
 import type { RuntimeState } from "./state.js";
 import { followStoryViewport } from "./viewport-intent.js";
@@ -69,11 +74,18 @@ export function adoptSameStoryPayload(
     : chapterRows[Math.max(0, Math.min(chapterRows.length - 1, chapters.cursor))] ?? null;
 
   reconcileWrapCache(cache, state.payload, payload);
-  if (state.aside?.storyId === payload.id) {
-    state.aside.storyTitle = payload.title;
+  // Active Aside, or the surface Placement retains while it owns the screen.
+  const retainedAside = state.aside?.storyId === payload.id
+    ? state.aside
+    : state.placement?.returnAside.storyId === payload.id
+      ? state.placement.returnAside
+      : null;
+  if (retainedAside !== null) {
+    retainedAside.storyTitle = payload.title;
   }
   state.payload = payload;
   const view = restoreStoryFocus(state, focus);
+  reconcilePlacementStops(state, view);
 
   if (facts !== null && state.facts === facts) {
     Object.assign(facts, boundedFactSelection(payload.facts, facts, facts.query));
@@ -131,6 +143,34 @@ export function reconcileStoryActions(
   if (rowIndexForNode(view, actions.partId) >= 0) return;
   state.actions = null;
   if (state.mode === "ACTIONS") state.mode = "NAV";
+}
+
+/** Rebase Placement destinations onto the newly adopted same-story payload.
+ * When the singular unresolved createNode guard matches an authoritative node,
+ * settle Placement (or a detached guard) instead of admitting a duplicate write. */
+function reconcilePlacementStops(
+  state: RuntimeState,
+  view: ReturnType<typeof createStoryViewModel>
+): void {
+  // Active Placement settlement moves focus onto the created Part. Persist
+  // that landing once here (adoption owns recovery settlement I/O; the pure
+  // settle helper does not). Detached guard settlement does not move focus.
+  const activePlacement = state.mode === "PLACE" && state.placement !== null;
+  if (trySettlePlacementFromPayload(state, state.payload)) {
+    if (activePlacement) rememberFocus(state, state);
+    return;
+  }
+  const placement = state.placement;
+  if (placement === null || state.mode !== "PLACE") return;
+  rebasePlacementStops(placement, state.payload);
+  const stop = placement.stops[placement.cursor];
+  if (stop === undefined) return;
+  const partId = stop.kind === "take" ? stop.partId : stop.leafId;
+  const index = rowIndexForNode(view, partId);
+  if (index >= 0) {
+    state.focusIndex = index;
+    followStoryViewport(state);
+  }
 }
 
 /** Keep story-bound navigation and inspection ids aligned with rendered nodes. */
@@ -401,6 +441,10 @@ export function adoptStoryState(state: RuntimeState, payload: StoryPayload, cach
   state.settings = null;
   state.summary = null;
   state.chapterSummary = null;
+  // Active Placement is UI-bound: drop it with the other interaction freezes.
+  // unresolvedPlacement is a singular story-bound mutation guard: navigation
+  // must not discard it. Settlement runs only when this payload is that story.
+  state.placement = null;
   if (changingStory) state.aside = null;
   state.hitRows = [];
   followStoryViewport(state);
@@ -409,4 +453,6 @@ export function adoptStoryState(state: RuntimeState, payload: StoryPayload, cach
   state.editorScrollTop = 0;
   state.editorScrollDetached = false;
   state.quitArmed = false;
+  // Returning to the guarded story with an authoritative payload may settle it.
+  trySettlePlacementFromPayload(state, payload);
 }

--- a/tui/src/text-actions.ts
+++ b/tui/src/text-actions.ts
@@ -32,7 +32,15 @@ type TextOwnerState = Pick<RuntimeState, "mode" | "composer" | "editor" | "setti
 /** Find the composer-backed field that currently owns text input. */
 export function activeTextComposer(state: TextOwnerState): ComposerState | null {
   if (state.mode === "COMPOSE") return state.composer;
-  if (state.mode === "ASIDE") return state.aside?.composer ?? null;
+  if (state.mode === "ASIDE") {
+    const surface = state.aside;
+    // Aside composer owns text only while focus is composer and no use menu
+    // owns the surface. Notes focus and the use-menu modal both refuse it.
+    if (surface == null || surface.useMenu !== null || surface.focus !== "composer") {
+      return null;
+    }
+    return surface.composer;
+  }
   if (state.mode === "EDITOR" && state.editor !== null) {
     return state.editor.kind === "fact"
       ? factEditorActiveTextComposer(state.editor)

--- a/tui/src/worker-error.ts
+++ b/tui/src/worker-error.ts
@@ -52,15 +52,30 @@ export function exitForBackendRestart(
   }
 }
 
+/** Authoritative mutation settlement from the worker transport. */
+export type WorkerMutationOutcome = "terminal" | "uncertain";
+
 export class WorkerApiError extends ApiFailureError<CompatibleHttpFailureEnvelope> {
-  constructor(failure: CompatibleHttpFailureEnvelope) {
+  /**
+   * Transport-owned mutation settlement outcome when this error rejects a
+   * mutation call. Null for non-mutation failures and legacy/synthetic errors
+   * that never settled through the transport.
+   */
+  readonly mutationOutcome: WorkerMutationOutcome | null;
+
+  constructor(
+    failure: CompatibleHttpFailureEnvelope,
+    mutationOutcome: WorkerMutationOutcome | null = null
+  ) {
     super(failure);
     this.name = "WorkerApiError";
+    this.mutationOutcome = mutationOutcome;
   }
 }
 
 export function workerApiErrorFromFailure(
-  failure: FailureEnvelope
+  failure: FailureEnvelope,
+  mutationOutcome: WorkerMutationOutcome | null = null
 ): WorkerApiError {
-  return new WorkerApiError(failure);
+  return new WorkerApiError(failure, mutationOutcome);
 }

--- a/tui/src/worker-story-api.ts
+++ b/tui/src/worker-story-api.ts
@@ -5,7 +5,13 @@ import type {
 } from "../../shared/worker-protocol.js";
 import type { StoryAggregateVersion } from "../../shared/story-aggregate-version.js";
 import type { ProviderRecoveryContext } from "../../shared/provider-recovery.js";
-import { textHash, type StoryApi, type StreamCallbacks, type SummaryStreamCallbacks } from "./api.js";
+import {
+  textHash,
+  type StoryApi,
+  type StreamCallbacks,
+  type SummaryStreamCallbacks
+} from "./api.js";
+import { explicitMutationUnsentFromCause } from "./api-error.js";
 import type { StoryPayload, StorySummary } from "../../shared/types.js";
 import { normalizeMarkdownDefaultTitle } from "../../shared/import-markdown-wire.js";
 
@@ -220,11 +226,27 @@ export function storyApiFromWorkerTransport(transport: StoryWorkerTransport): St
         { expectedAggregateVersion: await expectedVersion(storyId) }
       )
     ),
-    createNode: async (storyId, body) => rememberPayload(await transport.call(
-      "createNode",
-      { storyId, body },
-      { expectedAggregateVersion: await expectedVersion(storyId) }
-    )),
+    // createNode only: cold-cache version preflight is adapter-owned and runs
+    // before any createNode worker post or mutation id. Failures here are
+    // definitely unsent. Do not widen this to other mutations; post-send
+    // WorkerApiError with null outcome stays conservatively uncertain.
+    createNode: async (storyId, body) => {
+      let expectedAggregateVersion: StoryAggregateVersion;
+      try {
+        expectedAggregateVersion = await expectedVersion(storyId);
+      } catch (error) {
+        throw explicitMutationUnsentFromCause(
+          error,
+          "createNode was not sent",
+          "createNode was not sent; story version preflight failed."
+        );
+      }
+      return rememberPayload(await transport.call(
+        "createNode",
+        { storyId, body },
+        { expectedAggregateVersion }
+      ));
+    },
     editNode: async (storyId, node, patch) => rememberPayload(await transport.call(
       "editNode",
       {

--- a/tui/src/worker-terminal.ts
+++ b/tui/src/worker-terminal.ts
@@ -11,7 +11,8 @@ import {
 } from "../../server/mutation-outbox.js";
 import {
   WorkerApiError,
-  workerApiErrorFromFailure
+  workerApiErrorFromFailure,
+  type WorkerMutationOutcome
 } from "./worker-error.js";
 import type { SerializedWorkerOutbox } from "./worker-outbox.js";
 import type { PendingCall, PendingRequestRegistry } from "./worker-pending.js";
@@ -63,10 +64,17 @@ async function settleOwnedWorkerTerminal(
   pending.settling = true;
   pending.cleanup();
   deliverStreamTail(pending, message);
+  const mutationOwned = pending.mutationId !== undefined
+    || isServiceOwnedSettingsMutation(pending.method);
   const uncertainMutation = message.type === "error"
-    && (pending.mutationId !== undefined
-      || isServiceOwnedSettingsMutation(pending.method))
+    && mutationOwned
     && message.mutationOutcome !== "terminal";
+  // Authoritative settlement for mutation rejects only. Non-mutation errors
+  // leave mutationOutcome null so callers do not invent wire truth.
+  const mutationOutcome: WorkerMutationOutcome | null = message.type === "error"
+    && mutationOwned
+    ? uncertainMutation ? "uncertain" : "terminal"
+    : null;
   let replayResolution: RecoveryWarning<WorkerApiError>["resolution"] | null = null;
   let warningStoryId: string | null = null;
   let providerRecovery: ProviderRecoveryContext | undefined;
@@ -97,7 +105,7 @@ async function settleOwnedWorkerTerminal(
     && pending.mutationId !== undefined) {
     pendingRequests.discard(message.id);
     context.acknowledge();
-    const error = workerError(message);
+    const error = workerError(message, mutationOutcome);
     const replayRecord = recovery.recordFor(pending.mutationId);
     recovery.warn({
       mutationId: pending.mutationId,
@@ -120,7 +128,7 @@ async function settleOwnedWorkerTerminal(
     && pending.mutationId !== undefined) {
     pendingRequests.discard(message.id);
     context.acknowledge();
-    const error = workerError(message);
+    const error = workerError(message, mutationOutcome);
     recovery.warn({
       mutationId: pending.mutationId,
       method: pending.method,
@@ -137,14 +145,14 @@ async function settleOwnedWorkerTerminal(
   if (uncertainMutation && message.type === "error") {
     pendingRequests.discard(message.id);
     context.acknowledge();
-    pending.reject(workerError(message));
+    pending.reject(workerError(message, mutationOutcome));
     return;
   }
   if (!pendingRequests.isCurrent(pending)) return;
   pendingRequests.discard(message.id);
   context.acknowledge();
   if (message.type === "error") {
-    pending.reject(workerError(message));
+    pending.reject(workerError(message, mutationOutcome));
     return;
   }
   pending.resolve(message.value);
@@ -177,7 +185,8 @@ function deliverStreamTail(
 }
 
 function workerError(
-  message: Extract<WorkerToMainMessage, { type: "error" }>
+  message: Extract<WorkerToMainMessage, { type: "error" }>,
+  mutationOutcome: WorkerMutationOutcome | null
 ): WorkerApiError {
-  return workerApiErrorFromFailure(message.failure);
+  return workerApiErrorFromFailure(message.failure, mutationOutcome);
 }

--- a/tui/src/worker-transport.ts
+++ b/tui/src/worker-transport.ts
@@ -42,6 +42,10 @@ import { PendingRequestRegistry } from "./worker-pending.js";
 import { loadWorkerRecoveryOutbox, OutboxRecoveryCoordinator } from "./worker-recovery.js";
 import { preparePendingWorkerShutdown } from "./worker-shutdown.js";
 import {
+  ApiRecoveryRequiredError,
+  markExplicitMutationUnsent
+} from "./api-error.js";
+import {
   BackendRestartRequiredError,
   WorkerApiError,
   workerApiErrorFromFailure
@@ -217,26 +221,48 @@ export class WorkerTransport {
       expectedAggregateVersion?: StoryAggregateVersion;
     }
   ): Promise<WorkerOutput<M>> {
-    if (!this.lifecycle.acceptingRequests) return Promise.reject(new Error("Embedded backend is not running"));
-    if (isAborted(options.signal)) return Promise.resolve(null as WorkerOutput<M>);
     const mutating = isWorkerMutationMethod(method);
+    // Pre-post lifecycle exits: transport has not allocated a request id or
+    // posted yet. Mutations are explicit-unsent and remain non-ApiError
+    // connection failures; reads keep an ordinary Error.
+    if (!this.lifecycle.acceptingRequests) {
+      return Promise.reject(prePostLifecycleError(
+        mutating,
+        "Embedded backend is not running"
+      ));
+    }
+    if (isAborted(options.signal)) return Promise.resolve(null as WorkerOutput<M>);
+    // Pre-send recovery fence: no request id, mutation id, or post yet.
+    // Use ApiRecoveryRequiredError (not an uncertain mutation code) so callers
+    // can clear singular guards that never settled on the wire.
     if (mutating
       && this.recoveryCoordinator.warnings.length > 0
       && this.options.onRecoveryWarnings?.(
         this.recoveryCoordinator.warnings
       ) === true) {
-      throw workerApiErrorFromFailure(createFailureEnvelope({
-        code: "mutation_outcome_unknown",
-        message: "1667 is reloading saved state. Try again when the reload is complete.",
-        status: 409
-      }));
+      throw new ApiRecoveryRequiredError(
+        "1667 is reloading saved state. Try again when the reload is complete."
+      );
     }
     // Reads may proceed while startup recovery reconciles authoritative state,
     // but a new write must not overtake an older retained intent. In particular,
     // a delete racing replay could otherwise make deterministic absence look
     // like an unsent create and resurrect the deleted entity.
-    if (mutating && this.recoveryCoordinator.blocksMutations) await this.recoveryCoordinator.recovery;
-    if (!this.lifecycle.acceptingRequests) throw new Error("Embedded backend is not running");
+    if (mutating && this.recoveryCoordinator.blocksMutations) {
+      try {
+        await this.recoveryCoordinator.recovery;
+      } catch (error) {
+        // Backend already not accepting: this call never posted. Reclassify as
+        // explicit-unsent instead of propagating recovery's plain Error.
+        if (!this.lifecycle.acceptingRequests) {
+          throw prePostLifecycleError(true, "Embedded backend is not running");
+        }
+        throw error;
+      }
+    }
+    if (!this.lifecycle.acceptingRequests) {
+      throw prePostLifecycleError(mutating, "Embedded backend is not running");
+    }
     if (isAborted(options.signal)) return null as WorkerOutput<M>;
     try {
       validateWorkerRequestSize(method, input, WORKER_PROTOCOL_VERSION);
@@ -287,8 +313,13 @@ export class WorkerTransport {
           return null as WorkerOutput<M>;
         }
         if (!this.lifecycle.acceptingRequests) {
+          // Cancel first: cancellation failure keeps restart/uncertainty
+          // semantics and must not be reclassified as unsent.
           await intent?.cancel();
-          throw new Error("Embedded backend stopped before the mutation was sent");
+          throw prePostLifecycleError(
+            true,
+            "Embedded backend stopped before the mutation was sent"
+          );
         }
       }
       const stream = STREAM_METHODS.has(method);
@@ -682,3 +713,13 @@ function createDefaultWorker(): Worker {
   );
 }
 function isAborted(signal: AbortSignal | undefined): boolean { return signal?.aborted === true; }
+
+/**
+ * Pre-post lifecycle exit. Mutations: explicit-unsent + plain Error so the
+ * connection monitor goes down. Recovery-warning fences stay ApiError online.
+ * Reads: ordinary Error.
+ */
+function prePostLifecycleError(mutating: boolean, message: string): Error {
+  if (!mutating) return new Error(message);
+  return markExplicitMutationUnsent(new Error(message));
+}

--- a/tui/test/aside-layout.test.ts
+++ b/tui/test/aside-layout.test.ts
@@ -81,6 +81,48 @@ test("shows a submitted Aside question before the first provider delta", () => {
   expect(text).not.toContain("(no Side Notes yet)");
 });
 
+test("streaming-to-saved Side Note keeps one left edge and wrap width", () => {
+  const source = demoAppSource();
+  const state = initialState(source, false);
+  state.mode = "ASIDE";
+  // Long enough to soft-wrap at 40 columns under a five-cell "  Q: "/"  A: " pad.
+  const question = "Why does the wrap edge stay fixed when the answer lands?";
+  const answer = "The answer keeps the same five-cell prefix so soft wraps do not jump when the stream becomes a saved Side Note.";
+  const surface = createAsideSurface(state.payload.id, state.payload.title);
+  state.aside = surface;
+  surface.busy = true;
+  surface.inflightQuestion = question;
+  surface.streamText = answer;
+  const width = 40;
+  const height = 24;
+  const streamingLines = renderStoryScreen(state, { width, height }).lines.map(plainLine);
+
+  surface.busy = false;
+  surface.inflightQuestion = null;
+  surface.streamText = "";
+  surface.notes = [{ question, answer }];
+  surface.noteCursor = 0;
+  surface.focus = "notes";
+  const savedLines = renderStoryScreen(state, { width, height }).lines.map(plainLine);
+
+  const contentLines = (lines: string[]) => lines.filter((line) =>
+    line.includes("Q:") || line.includes("A:") || /^\s+\S/.test(line)
+  );
+  const streamContent = contentLines(streamingLines);
+  const savedContent = contentLines(savedLines);
+  // Same soft-wrap geometry: each content row's text after the pad matches.
+  expect(streamContent.length).toBeGreaterThan(1);
+  expect(savedContent.length).toBe(streamContent.length);
+  for (let index = 0; index < streamContent.length; index += 1) {
+    const stream = streamContent[index]!;
+    const saved = savedContent[index]!;
+    // Focus marker may replace the first pad cell on the first saved row.
+    const streamBody = stream.replace(/^▸/, " ").trimEnd();
+    const savedBody = saved.replace(/^▸/, " ").trimEnd();
+    expect(savedBody).toBe(streamBody);
+  }
+});
+
 test("Aside arrow motion follows the painted fullscreen soft-wrap", async () => {
   const source = demoAppSource();
   const state = initialState(source, false);

--- a/tui/test/aside-note-wrap-focus.test.ts
+++ b/tui/test/aside-note-wrap-focus.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Stable Side Note wrap widths when focus moves after history scroll.
+ */
+import { describe, expect, test } from "bun:test";
+import { createAsideSurface } from "../src/aside-surface.js";
+import { demoAppSource } from "../src/demo.js";
+import { initialState } from "../src/app.js";
+import { handleOverlayAction } from "../src/overlay-actions.js";
+import { ActionRuntime } from "../src/action-runtime.js";
+import { createWrapCache, type ProseStyle } from "../src/wrap.js";
+import { renderStoryScreen } from "../src/screens/story.js";
+
+function overlayContext(
+  state: ReturnType<typeof initialState>,
+  width: number,
+  height: number
+) {
+  return {
+    backend: new ActionRuntime(state, () => undefined),
+    cache: createWrapCache<ProseStyle>(),
+    repaint: () => undefined,
+    renderer: { width, height } as never,
+    applyTheme: () => undefined,
+    previewTheme: () => undefined
+  };
+}
+
+describe("Aside note wrap stability under focus change", () => {
+  test("PageDown/wheel keeps focused marker and Enter target visible after wrap", async () => {
+    // Long answers reflow when prefix width changes; equal-width prefixes
+    // keep the newly focused note on-screen after scroll moves selection.
+    const long = (label: string) =>
+      `${label} ${"wrapword ".repeat(40)}end-${label}`;
+    const notes = Array.from({ length: 8 }, (_, index) => ({
+      question: `wrap-q-${index} ${"q ".repeat(20)}`,
+      answer: long(`wrap-a-${index}`)
+    }));
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const surface = createAsideSurface(state.payload.id, state.payload.title, notes);
+    state.aside = surface;
+    state.mode = "ASIDE";
+    const width = 36;
+    const height = 14;
+    const context = overlayContext(state, width, height);
+    const frameText = () => renderStoryScreen(state, { width, height })
+      .lines.map((line) => line.map((part) => part.text).join("")).join("\n");
+
+    await handleOverlayAction({ action: "cycle" }, state, source, context);
+    expect(surface.focus).toBe("notes");
+    expect(surface.noteCursor).toBe(notes.length - 1);
+
+    // Page toward older notes: each focus change must keep ▸ Q: and Enter target
+    // identical and on-screen (stable wrap + reveal after cursor move).
+    let previousCursor = surface.noteCursor;
+    for (let page = 0; page < 5; page += 1) {
+      await handleOverlayAction({ action: "scroll-up" }, state, source, context);
+      if (surface.noteCursor === previousCursor) continue;
+      previousCursor = surface.noteCursor;
+      const frame = frameText();
+      expect(frame).toContain("▸ Q:");
+      expect(frame).toContain(`wrap-q-${surface.noteCursor}`);
+      expect(frame).toContain(`wrap-a-${surface.noteCursor}`);
+    }
+    expect(surface.noteCursor).toBeLessThan(notes.length - 1);
+
+    // Wheel/line down that changes selection must also keep the marker visible.
+    previousCursor = surface.noteCursor;
+    for (let step = 0; step < 20; step += 1) {
+      await handleOverlayAction({ action: "scroll-line-down" }, state, source, context);
+      if (surface.noteCursor !== previousCursor) break;
+    }
+    expect(surface.noteCursor).not.toBe(previousCursor);
+    const frameAfterFocusChange = frameText();
+    expect(frameAfterFocusChange).toContain("▸ Q:");
+    expect(frameAfterFocusChange).toContain(`wrap-q-${surface.noteCursor}`);
+
+    const beforeEnter = surface.noteCursor;
+    await handleOverlayAction({ action: "open-selected" }, state, source, context);
+    expect(surface.useMenu).not.toBeNull();
+    expect(surface.useMenu!.noteIndex).toBe(beforeEnter);
+    expect(surface.notes[surface.useMenu!.noteIndex]!.question)
+      .toBe(notes[beforeEnter]!.question);
+  });
+
+  test("one tall note marks a wrap continuation after Q and first A scroll away", async () => {
+    // One paragraph so later rows are wrap continuations (pad spaces), not "A:".
+    const answer = Array.from(
+      { length: 80 },
+      (_, index) => `wrapword${index}`
+    ).join(" ");
+    const notes = [{
+      question: "tall-note-question that may wrap once",
+      answer
+    }];
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const surface = createAsideSurface(state.payload.id, state.payload.title, notes);
+    state.aside = surface;
+    state.mode = "ASIDE";
+    const width = 36;
+    const height = 12;
+    const context = overlayContext(state, width, height);
+    const frameText = () => renderStoryScreen(state, { width, height })
+      .lines.map((line) => line.map((part) => part.text).join("")).join("\n");
+
+    await handleOverlayAction({ action: "cycle" }, state, source, context);
+    expect(surface.focus).toBe("notes");
+    expect(surface.noteCursor).toBe(0);
+    // Labelled first content row still gets ▸ Q: when it is first visible.
+    expect(frameText()).toContain("▸ Q:");
+
+    // Scroll past the question and the paragraph's first "  A:" labelled row.
+    for (let step = 0; step < 40; step += 1) {
+      await handleOverlayAction({ action: "scroll-line-down" }, state, source, context);
+    }
+    expect(surface.noteCursor).toBe(0);
+    const frame = frameText();
+    expect(frame).not.toContain("tall-note-question");
+    expect(frame).not.toContain("▸ Q:");
+    expect(frame).not.toContain("▸ A:");
+    // First visible owned row is a wrap continuation: still shows ▸.
+    expect(frame).toContain("▸");
+    expect(frame).toMatch(/wrapword\d+/);
+
+    await handleOverlayAction({ action: "open-selected" }, state, source, context);
+    expect(surface.useMenu).not.toBeNull();
+    expect(surface.useMenu!.noteIndex).toBe(0);
+    expect(surface.notes[0]!.question).toContain("tall-note-question");
+  });
+});

--- a/tui/test/aside-open-race.test.ts
+++ b/tui/test/aside-open-race.test.ts
@@ -12,13 +12,20 @@ import { ActionRuntime } from "../src/action-runtime.js";
 import { setComposerText } from "../src/composer-model.js";
 import { handleOverlayAction } from "../src/overlay-actions.js";
 import { openAside } from "../src/aside-actions.js";
+import { createStoryViewModel, rowIndexForNode, rowPart } from "../src/model.js";
 
-function context(state: ReturnType<typeof initialState>) {
+function context(
+  state: ReturnType<typeof initialState>,
+  width?: number,
+  height?: number
+) {
   return {
     backend: new ActionRuntime(state, () => undefined),
     cache: createWrapCache<ProseStyle>(),
     repaint: () => undefined,
-    renderer: null,
+    renderer: width === undefined || height === undefined
+      ? null
+      : { width, height } as never,
     applyTheme: () => undefined,
     previewTheme: () => undefined
   };
@@ -65,6 +72,34 @@ describe("Aside open ownership", () => {
 
     expect(await opening).toBeTrue();
     expect(state.aside?.storyTitle).toBe("Current title");
+  });
+
+  test("openingPartId is captured before a deferred getAside settles", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    expect(state.payload.path.length).toBeGreaterThan(1);
+    const openingPart = state.payload.path[0]!;
+    const otherPart = state.payload.path.at(-1)!;
+    state.focusIndex = rowIndexForNode(createStoryViewModel(state.payload), openingPart.id);
+
+    let resolveAside!: (document: { notes: readonly { question: string; answer: string }[] }) => void;
+    const pendingAside = new Promise<{ notes: readonly { question: string; answer: string }[] }>(
+      (resolve) => { resolveAside = resolve; }
+    );
+    const api: StoryApi = {
+      ...source.api,
+      getAside: async () => pendingAside
+    };
+    const opening = openAside(state, api, { entryPointsOpen: true });
+    await Promise.resolve();
+
+    // Writer moves focus while the Aside document is still loading.
+    state.focusIndex = rowIndexForNode(createStoryViewModel(state.payload), otherPart.id);
+    resolveAside({ notes: [] });
+
+    expect(await opening).toBeTrue();
+    expect(state.aside?.openingPartId).toBe(openingPart.id);
+    expect(state.aside?.openingPartId).not.toBe(otherPart.id);
   });
 
   test("discards an A response after recovery adopts B and keeps the Direct draft", async () => {
@@ -212,5 +247,84 @@ describe("Aside open ownership", () => {
     expect(state.payload.title).toBe("B story");
     expect(clearStoryIds).toEqual([storyAId]);
     clearContext.backend.dispose();
+  });
+
+  test("Placement initial Take follows chapter-summary via openAside", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const view = createStoryViewModel(state.payload);
+    const summaryIndex = view.rows.findIndex((row) => row.kind === "chapter-summary");
+    expect(summaryIndex).toBeGreaterThan(-1);
+    const summary = view.rows[summaryIndex]!;
+    expect(summary.kind).toBe("chapter-summary");
+    // Summary maps to the closed chapter's last Part (demo chapter 1 → p5).
+    const expectedPartId = summary.kind === "chapter-summary"
+      ? summary.chapter.parts.at(-1)!.id
+      : null;
+    expect(expectedPartId).toBe("p5");
+    expect(rowPart(view, summaryIndex)).toBeNull();
+    state.focusIndex = summaryIndex;
+
+    const api: StoryApi = {
+      ...source.api,
+      getAside: async () => ({
+        notes: [{ question: "from summary?", answer: "summary placement prose" }]
+      })
+    };
+    await openAside(state, api, { entryPointsOpen: true });
+    expect(state.aside?.openingPartId).toBe(expectedPartId);
+
+    const openContext = context(state, 80, 24);
+    await handleOverlayAction({ action: "cycle" }, state, source, openContext);
+    await handleOverlayAction({ action: "open-selected" }, state, source, openContext);
+    await handleOverlayAction({ action: "focus-next" }, state, source, openContext);
+    await handleOverlayAction({ action: "apply" }, state, source, openContext);
+
+    expect(state.mode).toBe("PLACE");
+    const stop = state.placement!.stops[state.placement!.cursor]!;
+    expect(stop.kind).toBe("take");
+    if (stop.kind === "take") expect(stop.partId).toBe(expectedPartId);
+    // Without the summary mapping, cursor would fall back to the active leaf.
+    const leafId = state.payload.path.at(-1)!.id;
+    expect(expectedPartId).not.toBe(leafId);
+  });
+
+  test("Placement initial Take follows chapter-divider via openAside", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const view = createStoryViewModel(state.payload);
+    const dividerIndex = view.rows.findIndex((row) => row.kind === "chapter-divider");
+    expect(dividerIndex).toBeGreaterThan(-1);
+    const divider = view.rows[dividerIndex]!;
+    expect(divider.kind).toBe("chapter-divider");
+    // Divider maps to the opening chapter's first Part (demo chapter 2 → p6).
+    const expectedPartId = divider.kind === "chapter-divider"
+      ? divider.openingChapter.parts[0]!.id
+      : null;
+    expect(expectedPartId).toBe("p6");
+    expect(rowPart(view, dividerIndex)).toBeNull();
+    state.focusIndex = dividerIndex;
+
+    const api: StoryApi = {
+      ...source.api,
+      getAside: async () => ({
+        notes: [{ question: "from divider?", answer: "divider placement prose" }]
+      })
+    };
+    await openAside(state, api, { entryPointsOpen: true });
+    expect(state.aside?.openingPartId).toBe(expectedPartId);
+
+    const openContext = context(state, 80, 24);
+    await handleOverlayAction({ action: "cycle" }, state, source, openContext);
+    await handleOverlayAction({ action: "open-selected" }, state, source, openContext);
+    await handleOverlayAction({ action: "focus-next" }, state, source, openContext);
+    await handleOverlayAction({ action: "apply" }, state, source, openContext);
+
+    expect(state.mode).toBe("PLACE");
+    const stop = state.placement!.stops[state.placement!.cursor]!;
+    expect(stop.kind).toBe("take");
+    if (stop.kind === "take") expect(stop.partId).toBe(expectedPartId);
+    const leafId = state.payload.path.at(-1)!.id;
+    expect(expectedPartId).not.toBe(leafId);
   });
 });

--- a/tui/test/aside-placement-detached.test.ts
+++ b/tui/test/aside-placement-detached.test.ts
@@ -1,0 +1,233 @@
+/**
+ * Detached Placement guard settlement ownership and exact-path identity.
+ */
+import { describe, expect, test } from "bun:test";
+import { createAsideSurface } from "../src/aside-surface.js";
+import { FROM_ASIDE_INSTRUCTION } from "../src/aside-placement.js";
+import { findSubmittedPlacementNode } from "../src/aside-placement-model.js";
+import { demoAppSource } from "../src/demo.js";
+import { initialState } from "../src/app.js";
+import { handleOverlayAction } from "../src/overlay-actions.js";
+import type { StoryApi } from "../src/api.js";
+import { ActionRuntime } from "../src/action-runtime.js";
+import { createWrapCache, type ProseStyle } from "../src/wrap.js";
+import { adoptSameStoryPayload } from "../src/story-adoption.js";
+import { openDirectComposer } from "../src/composer-ownership.js";
+import { setComposerText } from "../src/composer-model.js";
+import { initialSettingsOverlay } from "../src/settings-overlay-model.js";
+import { findCreatedTake } from "../src/created-take.js";
+import { countWords } from "../../shared/story-text.js";
+import { nodeStubPreviewText } from "../../shared/node-stub.js";
+import type { StoryPayload } from "../../shared/types.js";
+
+function overlayContext(
+  state: ReturnType<typeof initialState>,
+  width?: number,
+  height?: number
+) {
+  return {
+    backend: new ActionRuntime(state, () => undefined),
+    cache: createWrapCache<ProseStyle>(),
+    repaint: () => undefined,
+    renderer: width === undefined || height === undefined
+      ? null
+      : { width, height } as never,
+    applyTheme: () => undefined,
+    previewTheme: () => undefined
+  };
+}
+
+async function openPlacementOnStoryAction(
+  state: ReturnType<typeof initialState>,
+  source: ReturnType<typeof demoAppSource>,
+  context: ReturnType<typeof overlayContext>
+): Promise<void> {
+  await handleOverlayAction({ action: "cycle" }, state, source, context);
+  await handleOverlayAction({ action: "open-selected" }, state, source, context);
+  await handleOverlayAction({ action: "focus-next" }, state, source, context);
+  await handleOverlayAction({ action: "apply" }, state, source, context);
+  expect(state.mode).toBe("PLACE");
+}
+
+describe("Aside Placement detached settlement", () => {
+  test("detached guard settlement preserves COMPOSE draft", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const answer = "detached settle compose draft";
+    const surface = createAsideSurface(
+      state.payload.id,
+      state.payload.title,
+      [{ question: "Q?", answer }],
+      null,
+      state.payload.path.at(-1)!.id
+    );
+    state.aside = surface;
+    state.mode = "ASIDE";
+    let committed: typeof state.payload | null = null;
+    const api: StoryApi = {
+      ...source.api,
+      createNode: async (storyId, body) => {
+        committed = await source.api.createNode(storyId, body);
+        throw new Error("response lost");
+      }
+    };
+    const uncertain = { ...source, api };
+    const context = overlayContext(state, 80, 24);
+    await openPlacementOnStoryAction(state, uncertain, context);
+    await handleOverlayAction({ action: "apply" }, state, uncertain, context);
+    await context.backend.whenIdle();
+    expect(committed).not.toBeNull();
+
+    // Leave Placement and Aside, open Compose with a draft.
+    await handleOverlayAction({ action: "cancel" }, state, uncertain, context);
+    while (state.mode === "ASIDE") {
+      await handleOverlayAction({ action: "cancel" }, state, uncertain, context);
+    }
+    expect(openDirectComposer(state)).toBeTrue();
+    setComposerText(state.composer, "keep this compose draft");
+    const focusBefore = state.focusIndex;
+
+    adoptSameStoryPayload(state, committed!, context.cache);
+    expect(state.unresolvedPlacement).toBeNull();
+    expect(state.mode).toBe("COMPOSE");
+    expect(state.composer.text).toBe("keep this compose draft");
+    expect(state.focusIndex).toBe(focusBefore);
+    expect(state.toast).toMatch(/^placed as Part \d+$/);
+  });
+
+  test("detached guard settlement preserves SETTINGS overlay", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const answer = "detached settle settings surface";
+    const surface = createAsideSurface(
+      state.payload.id,
+      state.payload.title,
+      [{ question: "Q?", answer }],
+      null,
+      state.payload.path.at(-1)!.id
+    );
+    state.aside = surface;
+    state.mode = "ASIDE";
+    let committed: typeof state.payload | null = null;
+    const api: StoryApi = {
+      ...source.api,
+      createNode: async (storyId, body) => {
+        committed = await source.api.createNode(storyId, body);
+        throw new Error("response lost");
+      }
+    };
+    const uncertain = { ...source, api };
+    const context = overlayContext(state, 80, 24);
+    await openPlacementOnStoryAction(state, uncertain, context);
+    await handleOverlayAction({ action: "apply" }, state, uncertain, context);
+    await context.backend.whenIdle();
+    expect(committed).not.toBeNull();
+
+    await handleOverlayAction({ action: "cancel" }, state, uncertain, context);
+    while (state.mode === "ASIDE") {
+      await handleOverlayAction({ action: "cancel" }, state, uncertain, context);
+    }
+    state.settings = initialSettingsOverlay(source.settingsView, state.config);
+    state.mode = "SETTINGS";
+    const settings = state.settings;
+    const focusBefore = state.focusIndex;
+
+    adoptSameStoryPayload(state, committed!, context.cache);
+    expect(state.unresolvedPlacement).toBeNull();
+    expect(state.mode).toBe("SETTINGS");
+    expect(state.settings).toBe(settings);
+    expect(state.focusIndex).toBe(focusBefore);
+    expect(state.toast).toMatch(/^placed as Part \d+$/);
+  });
+
+  test("uncertain settlement requires exact path text and instruction", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const answer = "exact path identity for guard settlement";
+    const surface = createAsideSurface(
+      state.payload.id,
+      state.payload.title,
+      [{ question: "Q?", answer }],
+      null,
+      state.payload.path.at(-1)!.id
+    );
+    state.aside = surface;
+    state.mode = "ASIDE";
+    const api: StoryApi = {
+      ...source.api,
+      createNode: async () => {
+        throw new Error("response lost");
+      }
+    };
+    const uncertain = { ...source, api };
+    const context = overlayContext(state, 80, 24);
+    await openPlacementOnStoryAction(state, uncertain, context);
+    await handleOverlayAction({ action: "apply" }, state, uncertain, context);
+    await context.backend.whenIdle();
+    const submission = state.unresolvedPlacement!.submission;
+
+    // Off-path stub collides on parent/preview/words/instruction-presence only.
+    const collidingStub = {
+      id: "colliding-stub-id",
+      parentId: submission.parentId,
+      preview: nodeStubPreviewText(submission.text),
+      words: countWords(submission.text),
+      hasInstruction: true,
+      lastTouched: new Date().toISOString(),
+      activeChildId: null as string | null,
+      human: true as const
+    };
+    const ambiguous = {
+      ...state.payload,
+      // Path keeps no exact match; only an approximate stub exists.
+      nodes: [...state.payload.nodes, collidingStub]
+    } as StoryPayload;
+    expect(findCreatedTake(
+      ambiguous,
+      submission.knownNodeIds,
+      submission.parentId,
+      submission.instruction,
+      submission.text
+    )?.id).toBe("colliding-stub-id");
+    expect(findSubmittedPlacementNode(ambiguous, submission)).toBe(undefined);
+
+    adoptSameStoryPayload(state, ambiguous, context.cache);
+    // Approximate stub must not clear the guard.
+    expect(state.unresolvedPlacement).not.toBeNull();
+    expect(state.unresolvedPlacement!.submission.text).toBe(answer.trim());
+
+    // Exact active-path identity settles.
+    const exactNode = {
+      id: "exact-path-place-id",
+      parentId: submission.parentId,
+      instruction: submission.instruction,
+      text: submission.text,
+      model: "human",
+      createdAt: new Date().toISOString(),
+      activeChildId: null as string | null,
+      human: true as const
+    };
+    const exactPayload = {
+      ...state.payload,
+      path: [...state.payload.path, exactNode],
+      nodes: [
+        ...state.payload.nodes,
+        {
+          id: exactNode.id,
+          parentId: exactNode.parentId,
+          preview: nodeStubPreviewText(exactNode.text),
+          words: countWords(exactNode.text),
+          hasInstruction: true,
+          lastTouched: exactNode.createdAt,
+          activeChildId: null,
+          human: true as const
+        }
+      ]
+    } as StoryPayload;
+    expect(findSubmittedPlacementNode(exactPayload, submission)?.id)
+      .toBe("exact-path-place-id");
+    adoptSameStoryPayload(state, exactPayload, context.cache);
+    expect(state.unresolvedPlacement).toBeNull();
+    expect(state.toast).toMatch(/^placed as Part \d+$/);
+  });
+});

--- a/tui/test/aside-placement-mouse.test.ts
+++ b/tui/test/aside-placement-mouse.test.ts
@@ -1,0 +1,472 @@
+/**
+ * Placement keyline mouse hits: apply, destination focus, and presented
+ * frame reconciliation.
+ */
+import { describe, expect, test } from "bun:test";
+import { createAsideSurface } from "../src/aside-surface.js";
+import { FROM_ASIDE_INSTRUCTION } from "../src/aside-placement.js";
+import { openAsideUseMenu } from "../src/aside-use.js";
+import { demoAppSource } from "../src/demo.js";
+import { initialState } from "../src/app.js";
+import { handleOverlayAction } from "../src/overlay-actions.js";
+import { ActionRuntime } from "../src/action-runtime.js";
+import { createWrapCache, type ProseStyle } from "../src/wrap.js";
+import { renderStoryScreen } from "../src/screens/story.js";
+import { createStoryViewModel, rowPart } from "../src/model.js";
+import {
+  captureMouseActionState,
+  mouseToAction
+} from "../src/mouse-actions.js";
+import {
+  reconcilePresentedMouseAction,
+  type FrozenMouseEvent,
+  type PresentedInteraction
+} from "../src/presented-mouse-action.js";
+import { plainLine } from "../src/screens/story/frame.js";
+
+function overlayContext(
+  state: ReturnType<typeof initialState>,
+  width = 80,
+  height = 24
+) {
+  return {
+    backend: new ActionRuntime(state, () => undefined),
+    cache: createWrapCache<ProseStyle>(),
+    repaint: () => undefined,
+    renderer: { width, height } as never,
+    applyTheme: () => undefined,
+    previewTheme: () => undefined
+  };
+}
+
+async function openPlacement(
+  state: ReturnType<typeof initialState>,
+  source: ReturnType<typeof demoAppSource>,
+  context: ReturnType<typeof overlayContext>
+): Promise<void> {
+  await handleOverlayAction({ action: "cycle" }, state, source, context);
+  await handleOverlayAction({ action: "open-selected" }, state, source, context);
+  await handleOverlayAction({ action: "focus-next" }, state, source, context);
+  await handleOverlayAction({ action: "apply" }, state, source, context);
+  expect(state.mode).toBe("PLACE");
+}
+
+function findInlineHit(
+  state: ReturnType<typeof initialState>,
+  action: string,
+  width = 80,
+  height = 24
+): { x: number; y: number } | null {
+  const frame = renderStoryScreen(state, { width, height });
+  state.hitRows = frame.derived.hitRows;
+  for (let y = 0; y < frame.lines.length; y += 1) {
+    const line = plainLine(frame.lines[y] ?? []);
+    // Prefer the labeled glyph region when present.
+    const label = action === "apply"
+      ? (line.includes("Enter place") ? "Enter place" : "Enter")
+      : action === "focus-next"
+        ? (line.includes("Up/Down where") ? "Up/Down where" : "Up/Down")
+        : action === "cancel"
+          ? (line.includes("Esc back") ? "Esc back" : "Esc")
+          : null;
+    if (label === null || !line.includes(label)) continue;
+    const x = Math.min(width - 1, Math.max(0, line.indexOf(label) + 1));
+    const hit = mouseToAction({
+      type: "down",
+      button: 0,
+      x,
+      y,
+      modifiers: { shift: false, alt: false, ctrl: false }
+    }, state);
+    if (hit?.action === action) return { x, y };
+    // Scan the rest of the keyline for the inline hit.
+    for (let scanX = 0; scanX < width; scanX += 1) {
+      const scanned = mouseToAction({
+        type: "down",
+        button: 0,
+        x: scanX,
+        y,
+        modifiers: { shift: false, alt: false, ctrl: false }
+      }, state);
+      if (scanned?.action === action) return { x: scanX, y };
+    }
+  }
+  return null;
+}
+
+describe("Aside Placement keyline mouse hits", () => {
+  test("Enter place hit commits Placement; Up/Down where moves destination", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const answer = "mouse place commit answer";
+    const surface = createAsideSurface(
+      state.payload.id,
+      state.payload.title,
+      [{ question: "Q?", answer }],
+      null,
+      state.payload.path.at(-1)!.id
+    );
+    state.aside = surface;
+    state.mode = "ASIDE";
+    const context = overlayContext(state);
+    await openPlacement(state, source, context);
+    const startCursor = state.placement!.cursor;
+    const nodesBefore = state.payload.nodes.length;
+
+    const focusHit = findInlineHit(state, "focus-next");
+    expect(focusHit).not.toBeNull();
+    const focusClick: FrozenMouseEvent = {
+      type: "down",
+      button: 0,
+      x: focusHit!.x,
+      y: focusHit!.y,
+      modifiers: { shift: false, alt: false, ctrl: false }
+    };
+    const focusAction = mouseToAction(focusClick, state);
+    expect(focusAction).toEqual({ action: "focus-next" });
+
+    // Presented-frame reconciliation keeps the same inline action.
+    const captured: PresentedInteraction = {
+      version: 1,
+      frameToken: 1,
+      interactive: true,
+      storyId: state.payload.id,
+      state: captureMouseActionState(state)
+    };
+    state.hitRows = renderStoryScreen(state, { width: 80, height: 24 }).derived.hitRows;
+    const presented: PresentedInteraction = {
+      version: 2,
+      frameToken: 2,
+      interactive: true,
+      storyId: state.payload.id,
+      state: captureMouseActionState(state)
+    };
+    const reconciledFocus = reconcilePresentedMouseAction({
+      action: focusAction!,
+      event: focusClick,
+      captured,
+      presented,
+      state
+    });
+    expect(reconciledFocus).toEqual({ action: "focus-next" });
+    await handleOverlayAction(reconciledFocus!, state, source, context);
+    expect(state.placement!.cursor).not.toBe(startCursor);
+
+    // Move back if possible so place lands on a known stop; then click Enter place.
+    await handleOverlayAction({ action: "focus-previous" }, state, source, context);
+    const applyHit = findInlineHit(state, "apply");
+    expect(applyHit).not.toBeNull();
+    const applyClick: FrozenMouseEvent = {
+      type: "down",
+      button: 0,
+      x: applyHit!.x,
+      y: applyHit!.y,
+      modifiers: { shift: false, alt: false, ctrl: false }
+    };
+    const applyAction = mouseToAction(applyClick, state);
+    expect(applyAction?.action).toBe("apply");
+    expect(applyAction?.rowId).toBeDefined();
+    state.hitRows = renderStoryScreen(state, { width: 80, height: 24 }).derived.hitRows;
+    const presentedApply: PresentedInteraction = {
+      version: 3,
+      frameToken: 3,
+      interactive: true,
+      storyId: state.payload.id,
+      state: captureMouseActionState(state)
+    };
+    const reconciledApply = reconcilePresentedMouseAction({
+      action: applyAction!,
+      event: applyClick,
+      captured: {
+        version: 2,
+        frameToken: 2,
+        interactive: true,
+        storyId: state.payload.id,
+        state: captureMouseActionState(state)
+      },
+      presented: presentedApply,
+      state
+    });
+    expect(reconciledApply?.action).toBe("apply");
+    expect(reconciledApply?.rowId).toBe(applyAction!.rowId);
+    await handleOverlayAction(reconciledApply!, state, source, context);
+    await context.backend.whenIdle();
+    expect(state.mode).toBe("NAV");
+    expect(state.placement).toBeNull();
+    expect(state.payload.nodes.length).toBe(nodesBefore + 1);
+    const placed = rowPart(createStoryViewModel(state.payload), state.focusIndex);
+    expect(placed?.node.text).toBe(answer);
+    expect(placed?.node.instruction).toBe(FROM_ASIDE_INSTRUCTION);
+  });
+
+  test("stale Enter place after leaf Take → leaf gap is dropped; same-stop click still places", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const answer = "stale place click must not commit";
+    const leaf = state.payload.path.at(-1)!;
+    const surface = createAsideSurface(
+      state.payload.id,
+      state.payload.title,
+      [{ question: "Q?", answer }],
+      null,
+      leaf.id
+    );
+    state.aside = surface;
+    state.mode = "ASIDE";
+    let createCalls = 0;
+    const api = {
+      ...source.api,
+      createNode: async (...args: Parameters<typeof source.api.createNode>) => {
+        createCalls += 1;
+        return source.api.createNode(...args);
+      }
+    };
+    const tracked = { ...source, api };
+    const context = overlayContext(state);
+    await openPlacement(state, tracked, context);
+    // Opening on the leaf Take stop; one Down reaches the trailing leaf gap.
+    expect(state.placement!.stops[state.placement!.cursor]?.kind).toBe("take");
+    expect(
+      state.placement!.stops[state.placement!.cursor]
+    ).toMatchObject({ partId: leaf.id });
+
+    const applyHit = findInlineHit(state, "apply");
+    expect(applyHit).not.toBeNull();
+    const applyClick: FrozenMouseEvent = {
+      type: "down",
+      button: 0,
+      x: applyHit!.x,
+      y: applyHit!.y,
+      modifiers: { shift: false, alt: false, ctrl: false }
+    };
+    const interactionId = state.placement!.interactionId;
+    const takeApply = mouseToAction(applyClick, state);
+    expect(takeApply).toEqual({
+      action: "apply",
+      rowId: `placement:${interactionId}:take:${leaf.id}`
+    });
+    const capturedTake: PresentedInteraction = {
+      version: 1,
+      frameToken: 1,
+      interactive: true,
+      storyId: state.payload.id,
+      state: captureMouseActionState(state)
+    };
+
+    // Queued Down moves destination to the leaf gap before the click runs.
+    await handleOverlayAction({ action: "focus-next" }, state, tracked, context);
+    expect(state.placement!.stops[state.placement!.cursor]?.kind).toBe("leaf-gap");
+    state.hitRows = renderStoryScreen(state, { width: 80, height: 24 }).derived.hitRows;
+    const presentedGap: PresentedInteraction = {
+      version: 2,
+      frameToken: 2,
+      interactive: true,
+      storyId: state.payload.id,
+      state: captureMouseActionState(state)
+    };
+    const stale = reconcilePresentedMouseAction({
+      action: takeApply!,
+      event: applyClick,
+      captured: capturedTake,
+      presented: presentedGap,
+      state
+    });
+    expect(stale).toBeNull();
+    expect(createCalls).toBe(0);
+    expect(state.mode).toBe("PLACE");
+
+    // Fresh click on the current stop still commits.
+    const gapHit = findInlineHit(state, "apply");
+    expect(gapHit).not.toBeNull();
+    const gapClick: FrozenMouseEvent = {
+      type: "down",
+      button: 0,
+      x: gapHit!.x,
+      y: gapHit!.y,
+      modifiers: { shift: false, alt: false, ctrl: false }
+    };
+    const gapApply = mouseToAction(gapClick, state);
+    expect(gapApply).toEqual({
+      action: "apply",
+      rowId: `placement:${interactionId}:leaf-gap:${leaf.id}`
+    });
+    const capturedGap: PresentedInteraction = {
+      version: 3,
+      frameToken: 3,
+      interactive: true,
+      storyId: state.payload.id,
+      state: captureMouseActionState(state)
+    };
+    state.hitRows = renderStoryScreen(state, { width: 80, height: 24 }).derived.hitRows;
+    const presentedSame: PresentedInteraction = {
+      version: 4,
+      frameToken: 4,
+      interactive: true,
+      storyId: state.payload.id,
+      state: captureMouseActionState(state)
+    };
+    const fresh = reconcilePresentedMouseAction({
+      action: gapApply!,
+      event: gapClick,
+      captured: capturedGap,
+      presented: presentedSame,
+      state
+    });
+    expect(fresh?.action).toBe("apply");
+    expect(fresh?.rowId).toBe(`placement:${interactionId}:leaf-gap:${leaf.id}`);
+    // Relative Up/Down stays relative — no absolute rowId stamp.
+    const focusHit = findInlineHit(state, "focus-next");
+    expect(focusHit).not.toBeNull();
+    const focusAction = mouseToAction({
+      type: "down",
+      button: 0,
+      x: focusHit!.x,
+      y: focusHit!.y,
+      modifiers: { shift: false, alt: false, ctrl: false }
+    }, state);
+    expect(focusAction).toEqual({ action: "focus-next" });
+    expect("rowId" in (focusAction ?? {})).toBe(false);
+
+    await handleOverlayAction(fresh!, state, tracked, context);
+    await context.backend.whenIdle();
+    expect(createCalls).toBe(1);
+    expect(state.mode).toBe("NAV");
+    expect(state.placement).toBeNull();
+  });
+
+  test("stale Enter place from Placement A is dropped after cancel + Placement B at same stop", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const leaf = state.payload.path.at(-1)!;
+    const surface = createAsideSurface(
+      state.payload.id,
+      state.payload.title,
+      [
+        { question: "A?", answer: "placement A answer must not create" },
+        { question: "B?", answer: "placement B answer stays open" }
+      ],
+      null,
+      leaf.id
+    );
+    state.aside = surface;
+    state.mode = "ASIDE";
+    let createCalls = 0;
+    let lastText: string | null = null;
+    const api = {
+      ...source.api,
+      createNode: async (
+        storyId: string,
+        body: Parameters<typeof source.api.createNode>[1]
+      ) => {
+        createCalls += 1;
+        lastText = body.text;
+        return source.api.createNode(storyId, body);
+      }
+    };
+    const tracked = { ...source, api };
+    const context = overlayContext(state);
+
+    // Placement A from note 0, cursor on insert-into-story.
+    expect(openAsideUseMenu(surface, 0, 1)).toBeTrue();
+    await handleOverlayAction({ action: "apply" }, state, tracked, context);
+    expect(state.mode).toBe("PLACE");
+    expect(state.placement!.answer).toBe("placement A answer must not create");
+    const interactionA = state.placement!.interactionId;
+    expect(state.placement!.stops[state.placement!.cursor]).toMatchObject({
+      kind: "take",
+      partId: leaf.id
+    });
+
+    const applyHit = findInlineHit(state, "apply");
+    expect(applyHit).not.toBeNull();
+    const applyClick: FrozenMouseEvent = {
+      type: "down",
+      button: 0,
+      x: applyHit!.x,
+      y: applyHit!.y,
+      modifiers: { shift: false, alt: false, ctrl: false }
+    };
+    const applyA = mouseToAction(applyClick, state);
+    expect(applyA).toEqual({
+      action: "apply",
+      rowId: `placement:${interactionA}:take:${leaf.id}`
+    });
+    const capturedA: PresentedInteraction = {
+      version: 1,
+      frameToken: 1,
+      interactive: true,
+      storyId: state.payload.id,
+      state: captureMouseActionState(state)
+    };
+
+    // Cancel A, open Placement B from note 1 at the same leaf Take stop.
+    await handleOverlayAction({ action: "cancel" }, state, tracked, context);
+    expect(state.mode).toBe("ASIDE");
+    expect(state.aside).toBe(surface);
+    // Esc restores the same menu; close it and open a new session on note B.
+    await handleOverlayAction({ action: "cancel" }, state, tracked, context);
+    expect(surface.useMenu).toBeNull();
+    expect(openAsideUseMenu(surface, 1, 1)).toBeTrue();
+    await handleOverlayAction({ action: "apply" }, state, tracked, context);
+    expect(state.mode).toBe("PLACE");
+    expect(state.placement!.answer).toBe("placement B answer stays open");
+    const interactionB = state.placement!.interactionId;
+    expect(interactionB).not.toBe(interactionA);
+    expect(state.placement!.stops[state.placement!.cursor]).toMatchObject({
+      kind: "take",
+      partId: leaf.id
+    });
+
+    state.hitRows = renderStoryScreen(state, { width: 80, height: 24 }).derived.hitRows;
+    const presentedB: PresentedInteraction = {
+      version: 2,
+      frameToken: 2,
+      interactive: true,
+      storyId: state.payload.id,
+      state: captureMouseActionState(state)
+    };
+    const stale = reconcilePresentedMouseAction({
+      action: applyA!,
+      event: applyClick,
+      captured: capturedA,
+      presented: presentedB,
+      state
+    });
+    expect(stale).toBeNull();
+    expect(createCalls).toBe(0);
+    expect(lastText).toBeNull();
+    expect(state.mode).toBe("PLACE");
+    expect(state.placement!.answer).toBe("placement B answer stays open");
+    expect(state.placement!.interactionId).toBe(interactionB);
+  });
+
+  test("PLACE does not admit unrelated modal inline actions", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const surface = createAsideSurface(
+      state.payload.id,
+      state.payload.title,
+      [{ question: "Q?", answer: "mouse place" }],
+      null,
+      state.payload.path.at(-1)!.id
+    );
+    state.aside = surface;
+    state.mode = "ASIDE";
+    const context = overlayContext(state);
+    await openPlacement(state, source, context);
+    // Fabricate a non-PLACE inline hit; PLACE must ignore it.
+    state.hitRows = [{
+      target: { kind: "inline-action", action: "open-request" },
+      left: 0,
+      right: 80
+    }];
+    const action = mouseToAction({
+      type: "down",
+      button: 0,
+      x: 10,
+      y: 0,
+      modifiers: { shift: false, alt: false, ctrl: false }
+    }, state);
+    expect(action).toBeNull();
+  });
+});

--- a/tui/test/aside-placement-ownership.test.ts
+++ b/tui/test/aside-placement-ownership.test.ts
@@ -1,0 +1,602 @@
+/**
+ * Placement ownership: in-flight createNode, same-story rebase, and retained
+ * use-menu identity through Placement Esc.
+ */
+import { describe, expect, test } from "bun:test";
+import { createAsideSurface } from "../src/aside-surface.js";
+import {
+  FROM_ASIDE_INSTRUCTION,
+  placementInputLocked,
+  storyPlacementMutationBlocked
+} from "../src/aside-placement.js";
+import { openAsideUseMenu } from "../src/aside-use.js";
+import { ApiError } from "../src/api-error.js";
+import { demoAppSource } from "../src/demo.js";
+import { initialState } from "../src/app.js";
+import { handleOverlayAction } from "../src/overlay-actions.js";
+import type { StoryApi } from "../src/api.js";
+import { ActionRuntime } from "../src/action-runtime.js";
+import { createWrapCache, type ProseStyle } from "../src/wrap.js";
+import { renderStoryScreen } from "../src/screens/story.js";
+import { createStoryViewModel, rowPart } from "../src/model.js";
+import {
+  adoptSameStoryPayload,
+  adoptStoryState
+} from "../src/story-adoption.js";
+
+function overlayContext(
+  state: ReturnType<typeof initialState>,
+  width?: number,
+  height?: number
+) {
+  return {
+    backend: new ActionRuntime(state, () => undefined),
+    cache: createWrapCache<ProseStyle>(),
+    repaint: () => undefined,
+    renderer: width === undefined || height === undefined
+      ? null
+      : { width, height } as never,
+    applyTheme: () => undefined,
+    previewTheme: () => undefined
+  };
+}
+
+async function openPlacementOnStoryAction(
+  state: ReturnType<typeof initialState>,
+  source: ReturnType<typeof demoAppSource>,
+  context: ReturnType<typeof overlayContext>
+): Promise<void> {
+  await handleOverlayAction({ action: "cycle" }, state, source, context);
+  await handleOverlayAction({ action: "open-selected" }, state, source, context);
+  await handleOverlayAction({ action: "focus-next" }, state, source, context);
+  await handleOverlayAction({ action: "apply" }, state, source, context);
+  expect(state.mode).toBe("PLACE");
+}
+
+describe("Aside Placement ownership", () => {
+  test("Placement locks input during createNode and still adopts the commit", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const answer = "deferred placement prose";
+    const leaf = state.payload.path.at(-1)!;
+    const surface = createAsideSurface(
+      state.payload.id,
+      state.payload.title,
+      [{ question: "Q?", answer }],
+      null,
+      leaf.id
+    );
+    state.aside = surface;
+    state.mode = "ASIDE";
+    let resolveCreate!: (payload: typeof state.payload) => void;
+    const pendingCreate = new Promise<typeof state.payload>((resolve) => {
+      resolveCreate = resolve;
+    });
+    let createCalls = 0;
+    const api: StoryApi = {
+      ...source.api,
+      createNode: async (_storyId, body) => {
+        createCalls += 1;
+        return pendingCreate;
+      }
+    };
+    const delayedSource = { ...source, api };
+    const context = overlayContext(state, 80, 24);
+
+    await openPlacementOnStoryAction(state, delayedSource, context);
+    const stopCursor = state.placement!.cursor;
+    const stop = state.placement!.stops[stopCursor]!;
+    expect(stop.kind).toBe("take");
+
+    const placing = handleOverlayAction(
+      { action: "apply" },
+      state,
+      delayedSource,
+      context
+    );
+    await Promise.resolve();
+    expect(state.backendTask?.label).toBe("placing Side Note");
+    expect(createCalls).toBe(1);
+
+    await handleOverlayAction({ action: "cancel" }, state, delayedSource, context);
+    await handleOverlayAction({ action: "focus-next" }, state, delayedSource, context);
+    await handleOverlayAction({ action: "apply" }, state, delayedSource, context);
+    expect(state.mode).toBe("PLACE");
+    expect(state.placement!.cursor).toBe(stopCursor);
+    expect(createCalls).toBe(1);
+
+    const knownBefore = new Set(state.payload.nodes.map(({ id }) => id));
+    const committed = await source.api.createNode(state.payload.id, {
+      parentId: stop.kind === "take" ? stop.parentId : stop.leafId,
+      text: answer,
+      instruction: FROM_ASIDE_INSTRUCTION
+    });
+    resolveCreate(committed);
+    await placing;
+    await context.backend.whenIdle();
+
+    expect(createCalls).toBe(1);
+    expect(state.mode).toBe("NAV");
+    expect(state.placement).toBeNull();
+    expect(state.backendTask).toBeNull();
+    const placed = rowPart(createStoryViewModel(state.payload), state.focusIndex);
+    expect(placed).not.toBeNull();
+    expect(knownBefore.has(placed!.id)).toBeFalse();
+    expect(placed!.node.text).toBe(answer);
+    expect(placed!.node.instruction).toBe(FROM_ASIDE_INSTRUCTION);
+    expect(state.toast).toMatch(/^placed as Part \d+$/);
+  });
+
+  test("unrelated reconnect task does not lock Placement or show placing UI", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const surface = createAsideSurface(
+      state.payload.id,
+      state.payload.title,
+      [{ question: "Q?", answer: "reconnect while placing" }],
+      null,
+      state.payload.path.at(-1)!.id
+    );
+    state.aside = surface;
+    state.mode = "ASIDE";
+    const context = overlayContext(state, 80, 24);
+    await openPlacementOnStoryAction(state, source, context);
+    const cursor = state.placement!.cursor;
+
+    // Simulate Shift+R reconnect while still in PLACE.
+    let releaseReconnect!: () => void;
+    const reconnectGate = new Promise<void>((resolve) => {
+      releaseReconnect = resolve;
+    });
+    const reconnecting = context.backend.run("reconnecting", async () => {
+      await reconnectGate;
+    }, { kind: "explicit-retry" });
+    await Promise.resolve();
+    expect(state.backendTask?.label).toBe("reconnecting");
+    expect(state.backendTask?.kind).toBe("explicit-retry");
+    expect(state.placement!.placingTaskId).toBeNull();
+    expect(placementInputLocked(state)).toBeFalse();
+
+    const frame = renderStoryScreen(state, { width: 80, height: 24 })
+      .lines.map((line) => line.map((part) => part.text).join("")).join("\n");
+    expect(frame).not.toContain("placing Side Note · wait");
+    expect(frame).not.toContain("placing…");
+    expect(frame).toContain("Enter place");
+    expect(frame).toContain("Esc back to Aside");
+
+    // Esc/arrows remain available during unrelated backend work.
+    await handleOverlayAction({ action: "focus-next" }, state, source, context);
+    expect(state.placement!.cursor).not.toBe(cursor);
+    await handleOverlayAction({ action: "focus-previous" }, state, source, context);
+    expect(state.placement!.cursor).toBe(cursor);
+
+    releaseReconnect();
+    await reconnecting;
+    await context.backend.whenIdle();
+    expect(state.backendTask).toBeNull();
+    expect(state.mode).toBe("PLACE");
+  });
+
+  test("createNode still locks Placement via placing task identity", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const answer = "lock by task id";
+    const surface = createAsideSurface(
+      state.payload.id,
+      state.payload.title,
+      [{ question: "Q?", answer }],
+      null,
+      state.payload.path.at(-1)!.id
+    );
+    state.aside = surface;
+    state.mode = "ASIDE";
+    let resolveCreate!: (payload: typeof state.payload) => void;
+    const pendingCreate = new Promise<typeof state.payload>((resolve) => {
+      resolveCreate = resolve;
+    });
+    const api: StoryApi = {
+      ...source.api,
+      createNode: async () => pendingCreate
+    };
+    const delayed = { ...source, api };
+    const context = overlayContext(state, 80, 24);
+    await openPlacementOnStoryAction(state, delayed, context);
+
+    const placing = handleOverlayAction({ action: "apply" }, state, delayed, context);
+    await Promise.resolve();
+    expect(state.backendTask?.label).toBe("placing Side Note");
+    expect(state.placement!.placingTaskId).toBe(state.backendTask!.id);
+    expect(placementInputLocked(state)).toBeTrue();
+
+    const locked = renderStoryScreen(state, { width: 80, height: 24 })
+      .lines.map((line) => line.map((part) => part.text).join("")).join("\n");
+    expect(locked).toContain("placing Side Note · wait");
+    expect(locked).toContain("placing…");
+    expect(locked).not.toContain("Enter place");
+
+    resolveCreate(await source.api.createNode(state.payload.id, {
+      parentId: state.payload.path.at(-1)!.parentId,
+      text: answer,
+      instruction: FROM_ASIDE_INSTRUCTION
+    }));
+    await placing;
+    await context.backend.whenIdle();
+    expect(state.mode).toBe("NAV");
+  });
+
+  test("Placement rebases a selected Take after same-story adoption", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const opening = state.payload.path[Math.max(0, state.payload.path.length - 2)]!;
+    const surface = createAsideSurface(
+      state.payload.id,
+      state.payload.title,
+      [{ question: "Q?", answer: "rebased take prose" }],
+      null,
+      opening.id
+    );
+    state.aside = surface;
+    state.mode = "ASIDE";
+    const context = overlayContext(state, 80, 24);
+    await openPlacementOnStoryAction(state, source, context);
+    const selected = state.placement!.stops[state.placement!.cursor]!;
+    expect(selected.kind).toBe("take");
+    expect(selected.kind === "take" && selected.partId).toBe(opening.id);
+
+    const appended = await source.api.createNode(state.payload.id, {
+      parentId: state.payload.path.at(-1)!.id,
+      text: "appended while placing",
+      instruction: "» continue"
+    });
+    adoptSameStoryPayload(state, appended, context.cache);
+
+    expect(state.mode).toBe("PLACE");
+    const rebased = state.placement!.stops[state.placement!.cursor]!;
+    expect(rebased.kind).toBe("take");
+    expect(rebased.kind === "take" && rebased.partId).toBe(opening.id);
+    const frame = renderStoryScreen(state, { width: 80, height: 24 })
+      .lines.map((line) => line.map((part) => part.text).join("")).join("\n");
+    expect(frame).toContain(`take on ¶ ${rebased.partNumber}`);
+
+    await handleOverlayAction({ action: "apply" }, state, source, context);
+    await context.backend.whenIdle();
+    const placed = rowPart(createStoryViewModel(state.payload), state.focusIndex);
+    expect(placed!.node.parentId).toBe(opening.parentId);
+    expect(placed!.node.text).toBe("rebased take prose");
+  });
+
+  test("Placement rebases a trailing gap to the new active leaf", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const surface = createAsideSurface(
+      state.payload.id,
+      state.payload.title,
+      [{ question: "Q?", answer: "gap after append" }],
+      null,
+      state.payload.path.at(-1)!.id
+    );
+    state.aside = surface;
+    state.mode = "ASIDE";
+    const context = overlayContext(state, 80, 24);
+    await openPlacementOnStoryAction(state, source, context);
+    while (state.placement!.stops[state.placement!.cursor]?.kind !== "leaf-gap") {
+      await handleOverlayAction({ action: "focus-next" }, state, source, context);
+    }
+    const oldLeaf = state.payload.path.at(-1)!.id;
+
+    const appended = await source.api.createNode(state.payload.id, {
+      parentId: oldLeaf,
+      text: "new active leaf",
+      instruction: "» continue"
+    });
+    adoptSameStoryPayload(state, appended, context.cache);
+
+    const stop = state.placement!.stops[state.placement!.cursor]!;
+    expect(stop.kind).toBe("leaf-gap");
+    const newLeaf = state.payload.path.at(-1)!.id;
+    expect(newLeaf).not.toBe(oldLeaf);
+    expect(stop.kind === "leaf-gap" && stop.leafId).toBe(newLeaf);
+    const frame = renderStoryScreen(state, { width: 80, height: 24 })
+      .lines.map((line) => line.map((part) => part.text).join("")).join("\n");
+    expect(frame).toContain("here · new Part");
+    expect(frame).toContain("gap after append");
+
+    await handleOverlayAction({ action: "apply" }, state, source, context);
+    await context.backend.whenIdle();
+    const placed = rowPart(createStoryViewModel(state.payload), state.focusIndex);
+    expect(placed!.node.parentId).toBe(newLeaf);
+    expect(placed!.node.text).toBe("gap after append");
+  });
+
+  test("when a selected Take leaves the path, Placement falls back to the leaf Take", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const mid = state.payload.path[Math.max(0, state.payload.path.length - 2)]!;
+    const surface = createAsideSurface(
+      state.payload.id,
+      state.payload.title,
+      [{ question: "Q?", answer: "fallback leaf take" }],
+      null,
+      mid.id
+    );
+    state.aside = surface;
+    state.mode = "ASIDE";
+    const context = overlayContext(state, 80, 24);
+    await openPlacementOnStoryAction(state, source, context);
+    const before = state.placement!.stops[state.placement!.cursor]!;
+    expect(before.kind).toBe("take");
+    if (before.kind !== "take") throw new Error("expected take stop");
+    expect(before.partId).toBe(mid.id);
+
+    // Sibling take under the same parent replaces mid on the active path.
+    const switched = await source.api.createNode(state.payload.id, {
+      parentId: mid.parentId,
+      text: "sibling take steals the path",
+      instruction: "» retake"
+    });
+    expect(switched.path.some(({ id }) => id === mid.id)).toBeFalse();
+    adoptSameStoryPayload(state, switched, context.cache);
+
+    expect(state.mode).toBe("PLACE");
+    const stop = state.placement!.stops[state.placement!.cursor]!;
+    expect(stop.kind).toBe("take");
+    if (stop.kind !== "take") throw new Error("expected take stop");
+    const leafId = state.payload.path.at(-1)!.id;
+    expect(stop.partId).toBe(leafId);
+    const frame = renderStoryScreen(state, { width: 80, height: 24 })
+      .lines.map((line) => line.map((part) => part.text).join("")).join("\n");
+    expect(frame).toContain(`take on ¶ ${stop.partNumber}`);
+    expect(frame).not.toContain("here · new Part");
+  });
+
+  test("whole-story replacement clears Placement and its destination marker", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const surface = createAsideSurface(
+      state.payload.id,
+      state.payload.title,
+      [{ question: "Q?", answer: "must not survive story replace" }],
+      null,
+      state.payload.path.at(-1)!.id
+    );
+    state.aside = surface;
+    state.mode = "ASIDE";
+    const context = overlayContext(state, 80, 24);
+    await openPlacementOnStoryAction(state, source, context);
+    expect(state.mode).toBe("PLACE");
+    const beforeFrame = renderStoryScreen(state, { width: 80, height: 24 })
+      .lines.map((line) => line.map((part) => part.text).join("")).join("\n");
+    expect(beforeFrame).toContain("take on ¶");
+
+    const other = (await source.api.listStories()).find((story) => story.id !== state.payload.id);
+    expect(other).toBeDefined();
+    const next = await source.api.loadStory(other!.id);
+    adoptStoryState(state, next, context.cache);
+
+    expect(state.placement).toBeNull();
+    const modeAfter = state.mode as string;
+    expect(modeAfter === "NAV" || modeAfter === "COMPOSE").toBeTrue();
+    expect(state.payload.id).toBe(other!.id);
+    const afterFrame = renderStoryScreen(state, { width: 80, height: 24 })
+      .lines.map((line) => line.map((part) => part.text).join("")).join("\n");
+    expect(afterFrame).not.toContain("must not survive story replace");
+    expect(afterFrame).not.toContain("here · new Part");
+    expect(afterFrame.includes("PLACE")).toBeFalse();
+  });
+
+  test("definite createNode failure clears guard after Placement ownership is lost", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const originId = state.payload.id;
+    const answer = "place after lost ownership definite fail";
+    const surface = createAsideSurface(
+      state.payload.id,
+      state.payload.title,
+      [{ question: "Q?", answer }],
+      null,
+      state.payload.path.at(-1)!.id
+    );
+    state.aside = surface;
+    state.mode = "ASIDE";
+    let rejectCreate!: (error: Error) => void;
+    const pendingCreate = new Promise<typeof state.payload>((_resolve, reject) => {
+      rejectCreate = reject;
+    });
+    let createCalls = 0;
+    const api: StoryApi = {
+      ...source.api,
+      createNode: async (storyId, body) => {
+        createCalls += 1;
+        if (createCalls === 1) return pendingCreate;
+        return source.api.createNode(storyId, body);
+      }
+    };
+    const delayed = { ...source, api };
+    const context = overlayContext(state, 80, 24);
+    await openPlacementOnStoryAction(state, delayed, context);
+
+    const placing = handleOverlayAction({ action: "apply" }, state, delayed, context);
+    await Promise.resolve();
+    expect(createCalls).toBe(1);
+    // Guard is installed before createNode; in-flight placing does not block
+    // storyPlacementMutationBlocked, but the singular identity is retained.
+    expect(state.unresolvedPlacement?.storyId).toBe(originId);
+    expect(state.placement?.placingTaskId).not.toBeNull();
+
+    // Lose Placement ownership mid-flight via whole-story adoption.
+    const other = (await source.api.listStories()).find((story) => story.id !== originId);
+    expect(other).toBeDefined();
+    const next = await source.api.loadStory(other!.id);
+    adoptStoryState(state, next, context.cache);
+    expect(state.payload.id).toBe(other!.id);
+    expect(state.placement).toBeNull();
+    // Without the fix, the origin guard would still block later placement.
+    expect(state.unresolvedPlacement?.storyId).toBe(originId);
+
+    // Definite terminal outcome after ownership loss must still clear the guard.
+    rejectCreate(new ApiError("provider unavailable after recovery"));
+    await placing;
+    await context.backend.whenIdle();
+    expect(state.unresolvedPlacement).toBeNull();
+    expect(storyPlacementMutationBlocked(state)).toBeFalse();
+    // Ownership-gated toast must not attach to the adopted story surface.
+    expect(state.toast).not.toBe("provider unavailable after recovery");
+    // Later Placement on the adopted story is not permanently blocked.
+    const surfaceB = createAsideSurface(
+      state.payload.id,
+      state.payload.title,
+      [{ question: "B?", answer: "retry place after cleared guard" }],
+      null,
+      state.payload.path.at(-1)!.id
+    );
+    state.aside = surfaceB;
+    state.mode = "ASIDE";
+    await openPlacementOnStoryAction(state, delayed, context);
+    await handleOverlayAction({ action: "apply" }, state, delayed, context);
+    await context.backend.whenIdle();
+    expect(createCalls).toBe(2);
+    expect(state.mode).toBe("NAV");
+    expect(state.placement).toBeNull();
+    expect(state.unresolvedPlacement).toBeNull();
+    expect(state.toast).toMatch(/^placed as Part \d+$/);
+  });
+
+  test("successful createNode clears guard after Placement ownership is lost", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const originId = state.payload.id;
+    const answer = "place after lost ownership commit success";
+    const surface = createAsideSurface(
+      state.payload.id,
+      state.payload.title,
+      [{ question: "Q?", answer }],
+      null,
+      state.payload.path.at(-1)!.id
+    );
+    state.aside = surface;
+    state.mode = "ASIDE";
+    let resolveCreate!: (payload: typeof state.payload) => void;
+    const pendingCreate = new Promise<typeof state.payload>((resolve) => {
+      resolveCreate = resolve;
+    });
+    let createCalls = 0;
+    const api: StoryApi = {
+      ...source.api,
+      createNode: async (storyId, body) => {
+        createCalls += 1;
+        if (createCalls === 1) return pendingCreate;
+        return source.api.createNode(storyId, body);
+      }
+    };
+    const delayed = { ...source, api };
+    const context = overlayContext(state, 80, 24);
+    await openPlacementOnStoryAction(state, delayed, context);
+    const stop = state.placement!.stops[state.placement!.cursor]!;
+    const parentId = stop.kind === "take" ? stop.parentId : stop.leafId;
+
+    const placing = handleOverlayAction({ action: "apply" }, state, delayed, context);
+    await Promise.resolve();
+    expect(createCalls).toBe(1);
+    expect(state.unresolvedPlacement?.storyId).toBe(originId);
+    expect(state.placement?.placingTaskId).not.toBeNull();
+
+    // Lose Placement ownership mid-flight via whole-story adoption.
+    const other = (await source.api.listStories()).find((story) => story.id !== originId);
+    expect(other).toBeDefined();
+    const next = await source.api.loadStory(other!.id);
+    adoptStoryState(state, next, context.cache);
+    expect(state.payload.id).toBe(other!.id);
+    expect(state.placement).toBeNull();
+    expect(state.unresolvedPlacement?.storyId).toBe(originId);
+
+    // Committed payload for story A must clear the singular guard without
+    // adopting onto B or writing place toast/focus for the adopted story.
+    const committed = await source.api.createNode(originId, {
+      parentId,
+      text: answer,
+      instruction: FROM_ASIDE_INSTRUCTION
+    });
+    resolveCreate(committed);
+    await placing;
+    await context.backend.whenIdle();
+    expect(state.unresolvedPlacement).toBeNull();
+    expect(storyPlacementMutationBlocked(state)).toBeFalse();
+    expect(state.payload.id).toBe(other!.id);
+    // Ownership-gated: no place toast on the adopted story surface.
+    expect(state.toast).toBeNull();
+
+    // Later Placement on the adopted story is admitted.
+    const surfaceB = createAsideSurface(
+      state.payload.id,
+      state.payload.title,
+      [{ question: "B?", answer: "retry place after successful orphan commit" }],
+      null,
+      state.payload.path.at(-1)!.id
+    );
+    state.aside = surfaceB;
+    state.mode = "ASIDE";
+    await openPlacementOnStoryAction(state, delayed, context);
+    await handleOverlayAction({ action: "apply" }, state, delayed, context);
+    await context.backend.whenIdle();
+    expect(createCalls).toBe(2);
+    expect(state.mode).toBe("NAV");
+    expect(state.placement).toBeNull();
+    expect(state.unresolvedPlacement).toBeNull();
+    expect(state.toast).toMatch(/^placed as Part \d+$/);
+  });
+
+  test("opening Placement retains surface focus, note cursor, and use-menu identity", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const surface = createAsideSurface(
+      state.payload.id,
+      state.payload.title,
+      [
+        { question: "First?", answer: "first answer" },
+        { question: "Second?", answer: "second answer to place" }
+      ],
+      null,
+      state.payload.path.at(-1)!.id
+    );
+    state.aside = surface;
+    state.mode = "ASIDE";
+    const context = overlayContext(state, 80, 24);
+    expect(openAsideUseMenu(surface, 1, 0)).toBeTrue();
+    const menuBefore = surface.useMenu!;
+    const sessionId = menuBefore.sessionId;
+
+    // Move use menu to the story action, then open Placement.
+    await handleOverlayAction({ action: "focus-next" }, state, source, context);
+    expect(surface.useMenu).toBe(menuBefore);
+    expect(menuBefore.cursor).toBe(1);
+    const focusBefore = surface.focus;
+    const noteCursorBefore = surface.noteCursor;
+
+    await handleOverlayAction({ action: "apply" }, state, source, context);
+    expect(state.mode).toBe("PLACE");
+    expect(state.aside).toBeNull();
+    expect(state.placement!.returnAside).toBe(surface);
+    expect(state.placement!.interactionId).toBe(sessionId);
+    expect(surface.focus).toBe(focusBefore);
+    expect(surface.noteCursor).toBe(noteCursorBefore);
+    expect(surface.useMenu).toBe(menuBefore);
+    expect(surface.useMenu).toEqual({
+      noteIndex: 1,
+      cursor: 1,
+      sessionId
+    });
+
+    await handleOverlayAction({ action: "cancel" }, state, source, context);
+    expect(state.mode).toBe("ASIDE");
+    expect(state.aside).toBe(surface);
+    expect(state.placement).toBeNull();
+    expect(surface.focus).toBe(focusBefore);
+    expect(surface.noteCursor).toBe(noteCursorBefore);
+    expect(surface.useMenu).toBe(menuBefore);
+    expect(surface.useMenu).toEqual({
+      noteIndex: 1,
+      cursor: 1,
+      sessionId
+    });
+  });
+});

--- a/tui/test/aside-placement-recovery.test.ts
+++ b/tui/test/aside-placement-recovery.test.ts
@@ -1,0 +1,587 @@
+/**
+ * Uncertain createNode settlement while Placement is open: preserve submission,
+ * block retry, settle on recovery; definite ApiError restores retry.
+ */
+import { describe, expect, test } from "bun:test";
+import { createAsideSurface } from "../src/aside-surface.js";
+import {
+  FROM_ASIDE_INSTRUCTION,
+  PLACEMENT_UNCERTAIN_STATUS,
+  PLACEMENT_UNCERTAIN_TOAST,
+  isDefinitePlacementFailure,
+  placementInputLocked,
+  placementOutcomeUnknown
+} from "../src/aside-placement.js";
+import { ApiError, ApiRecoveryRequiredError } from "../src/api-error.js";
+import { createFailureEnvelope } from "../../shared/failure-envelope.js";
+import { demoAppSource } from "../src/demo.js";
+import { initialState } from "../src/app.js";
+import { handleOverlayAction } from "../src/overlay-actions.js";
+import type { StoryApi } from "../src/api.js";
+import { ActionRuntime } from "../src/action-runtime.js";
+import { createWrapCache, type ProseStyle } from "../src/wrap.js";
+import { createStoryViewModel, rowPart } from "../src/model.js";
+import { adoptSameStoryPayload } from "../src/story-adoption.js";
+import { renderStoryScreen } from "../src/screens/story.js";
+import { WorkerApiError } from "../src/worker-error.js";
+
+function overlayContext(
+  state: ReturnType<typeof initialState>,
+  width?: number,
+  height?: number
+) {
+  return {
+    backend: new ActionRuntime(state, () => undefined),
+    cache: createWrapCache<ProseStyle>(),
+    repaint: () => undefined,
+    renderer: width === undefined || height === undefined
+      ? null
+      : { width, height } as never,
+    applyTheme: () => undefined,
+    previewTheme: () => undefined
+  };
+}
+
+async function openPlacementOnStoryAction(
+  state: ReturnType<typeof initialState>,
+  source: ReturnType<typeof demoAppSource>,
+  context: ReturnType<typeof overlayContext>
+): Promise<void> {
+  await handleOverlayAction({ action: "cycle" }, state, source, context);
+  await handleOverlayAction({ action: "open-selected" }, state, source, context);
+  await handleOverlayAction({ action: "focus-next" }, state, source, context);
+  await handleOverlayAction({ action: "apply" }, state, source, context);
+  expect(state.mode).toBe("PLACE");
+}
+
+function frameText(
+  state: ReturnType<typeof initialState>,
+  width = 80,
+  height = 24
+): string {
+  return renderStoryScreen(state, { width, height })
+    .lines.map((line) => line.map((part) => part.text).join("")).join("\n");
+}
+
+describe("Aside Placement uncertain recovery", () => {
+  test("first uncertain submission is preserved; second Enter does not createNode", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const answer = "first uncertain place answer";
+    const opening = state.payload.path[Math.max(0, state.payload.path.length - 2)]!;
+    const surface = createAsideSurface(
+      state.payload.id,
+      state.payload.title,
+      [{ question: "Q?", answer }],
+      null,
+      opening.id
+    );
+    state.aside = surface;
+    state.mode = "ASIDE";
+    let createCalls = 0;
+    let firstBody: { parentId: string | null; text: string } | null = null;
+    const api: StoryApi = {
+      ...source.api,
+      createNode: async (_storyId, body) => {
+        createCalls += 1;
+        if (firstBody === null) {
+          firstBody = { parentId: body.parentId ?? null, text: body.text };
+        }
+        throw new Error("response lost");
+      }
+    };
+    const uncertain = { ...source, api };
+    const context = overlayContext(state, 80, 24);
+    await openPlacementOnStoryAction(state, uncertain, context);
+    const firstStop = state.placement!.stops[state.placement!.cursor]!;
+    expect(firstStop.kind).toBe("take");
+    if (firstStop.kind !== "take") throw new Error("expected take stop");
+
+    await handleOverlayAction({ action: "apply" }, state, uncertain, context);
+    await context.backend.whenIdle();
+    expect(createCalls).toBe(1);
+    expect(state.mode).toBe("PLACE");
+    expect(placementOutcomeUnknown(state)).toBeTrue();
+    expect(state.placement!.placingTaskId).toBeNull();
+    const pending = state.unresolvedPlacement!;
+    expect(pending.storyId).toBe(state.payload.id);
+    expect(pending.submission.parentId).toBe(firstStop.parentId);
+    expect(pending.submission.text).toBe(answer.trim());
+    expect(state.toast).toContain("response lost");
+    expect(state.toast).toContain(PLACEMENT_UNCERTAIN_TOAST);
+
+    // Status shows uncertain guidance; toast briefly owns the keyline slot.
+    expect(frameText(state)).toContain(PLACEMENT_UNCERTAIN_STATUS);
+    state.toast = null;
+    const uncertainFrame = frameText(state);
+    expect(uncertainFrame).toContain(PLACEMENT_UNCERTAIN_STATUS);
+    expect(uncertainFrame).toContain("Up/Down where");
+    expect(uncertainFrame).toContain("Esc back to Aside");
+    expect(uncertainFrame).not.toContain("Enter place");
+
+    // Move to another stop; first submission must stay authoritative.
+    await handleOverlayAction({ action: "focus-next" }, state, uncertain, context);
+    const movedCursor = state.placement!.cursor;
+    expect(movedCursor).not.toBe(
+      state.placement!.stops.findIndex(
+        (stop) => stop.kind === "take" && stop.partId === firstStop.partId
+      )
+    );
+
+    await handleOverlayAction({ action: "apply" }, state, uncertain, context);
+    await context.backend.whenIdle();
+    expect(createCalls).toBe(1);
+    expect(state.unresolvedPlacement).toBe(pending);
+    expect(state.unresolvedPlacement!.submission.parentId).toBe(firstStop.parentId);
+    expect(state.unresolvedPlacement!.submission.text).toBe(answer.trim());
+    expect(state.toast).toBe(PLACEMENT_UNCERTAIN_TOAST);
+    expect(firstBody).toEqual({
+      parentId: firstStop.parentId,
+      text: answer
+    });
+  });
+
+  test("uncertain Take create settles Placement when recovery finds the node", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const answer = "uncertain take recovery prose";
+    const opening = state.payload.path[Math.max(0, state.payload.path.length - 2)]!;
+    const surface = createAsideSurface(
+      state.payload.id,
+      state.payload.title,
+      [{ question: "Q?", answer }],
+      null,
+      opening.id
+    );
+    state.aside = surface;
+    state.mode = "ASIDE";
+    let committed: typeof state.payload | null = null;
+    let createCalls = 0;
+    const api: StoryApi = {
+      ...source.api,
+      createNode: async (storyId, body) => {
+        createCalls += 1;
+        // Commit, then lose the terminal response (uncertain outcome).
+        committed = await source.api.createNode(storyId, body);
+        throw new Error("response lost");
+      }
+    };
+    const uncertain = { ...source, api };
+    const context = overlayContext(state, 80, 24);
+    await openPlacementOnStoryAction(state, uncertain, context);
+    const stop = state.placement!.stops[state.placement!.cursor]!;
+    expect(stop.kind).toBe("take");
+    if (stop.kind !== "take") throw new Error("expected take stop");
+    expect(stop.partId).toBe(opening.id);
+
+    await handleOverlayAction({ action: "apply" }, state, uncertain, context);
+    await context.backend.whenIdle();
+    expect(createCalls).toBe(1);
+    expect(state.mode).toBe("PLACE");
+    expect(state.unresolvedPlacement).not.toBeNull();
+    expect(placementOutcomeUnknown(state)).toBeTrue();
+    expect(committed).not.toBeNull();
+
+    // Second Enter must not fire another create before recovery.
+    await handleOverlayAction({ action: "apply" }, state, uncertain, context);
+    await context.backend.whenIdle();
+    expect(createCalls).toBe(1);
+
+    // Authoritative same-story recovery carries the committed Take.
+    adoptSameStoryPayload(state, committed!, context.cache);
+    expect(state.mode).toBe("NAV");
+    expect(state.placement).toBeNull();
+    const placed = rowPart(createStoryViewModel(state.payload), state.focusIndex);
+    expect(placed).not.toBeNull();
+    expect(placed!.node.text).toBe(answer);
+    expect(placed!.node.instruction).toBe(FROM_ASIDE_INSTRUCTION);
+    expect(placed!.node.parentId).toBe(opening.parentId);
+    expect(state.toast).toMatch(/^placed as Part \d+$/);
+    expect(state.backendTask).toBeNull();
+  });
+
+  test("active recovery settlement persists the landed reading position", async () => {
+    const source = demoAppSource();
+    // Non-demo so rememberFocus writes the reading-position map.
+    source.demo = false;
+    source.readingPositions = {};
+    const state = initialState(source, false);
+    state.demo = false;
+    state.readingPositions = {};
+    const answer = "recovery settle persist focus";
+    const opening = state.payload.path[Math.max(0, state.payload.path.length - 2)]!;
+    const storyId = state.payload.id;
+    const surface = createAsideSurface(
+      storyId,
+      state.payload.title,
+      [{ question: "Q?", answer }],
+      null,
+      opening.id
+    );
+    state.aside = surface;
+    state.mode = "ASIDE";
+    let committed: typeof state.payload | null = null;
+    const api: StoryApi = {
+      ...source.api,
+      createNode: async (id, body) => {
+        committed = await source.api.createNode(id, body);
+        throw new Error("response lost");
+      }
+    };
+    const uncertain = { ...source, api, demo: false, readingPositions: state.readingPositions };
+    const context = overlayContext(state, 80, 24);
+    await openPlacementOnStoryAction(state, uncertain, context);
+    await handleOverlayAction({ action: "apply" }, state, uncertain, context);
+    await context.backend.whenIdle();
+    expect(state.mode).toBe("PLACE");
+    expect(committed).not.toBeNull();
+    expect(state.readingPositions[storyId]).toBe(undefined);
+
+    // Recovery adoption settles active Placement and must persist focus.
+    adoptSameStoryPayload(state, committed!, context.cache);
+    expect(state.mode).toBe("NAV");
+    expect(state.placement).toBeNull();
+    const placed = rowPart(createStoryViewModel(state.payload), state.focusIndex);
+    expect(placed).not.toBeNull();
+    expect(placed!.node.text).toBe(answer);
+    expect(placed!.node.instruction).toBe(FROM_ASIDE_INSTRUCTION);
+    expect(state.readingPositions[storyId]).toBe(placed!.node.id);
+    expect(state.focusIndex).toBe(
+      createStoryViewModel(state.payload).rows.findIndex((row) => row.id === placed!.node.id)
+    );
+  });
+
+  test("uncertain leaf-gap create settles Placement when recovery finds the node", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const answer = "uncertain leaf gap recovery";
+    const leaf = state.payload.path.at(-1)!;
+    const surface = createAsideSurface(
+      state.payload.id,
+      state.payload.title,
+      [{ question: "Q?", answer }],
+      null,
+      leaf.id
+    );
+    state.aside = surface;
+    state.mode = "ASIDE";
+    let committed: typeof state.payload | null = null;
+    const api: StoryApi = {
+      ...source.api,
+      createNode: async (storyId, body) => {
+        committed = await source.api.createNode(storyId, body);
+        throw new Error("response lost");
+      }
+    };
+    const uncertain = { ...source, api };
+    const context = overlayContext(state, 80, 24);
+    await openPlacementOnStoryAction(state, uncertain, context);
+    while (state.placement!.stops[state.placement!.cursor]?.kind !== "leaf-gap") {
+      await handleOverlayAction({ action: "focus-next" }, state, uncertain, context);
+    }
+
+    await handleOverlayAction({ action: "apply" }, state, uncertain, context);
+    await context.backend.whenIdle();
+    expect(state.mode).toBe("PLACE");
+    expect(state.unresolvedPlacement?.submission.parentId).toBe(leaf.id);
+    expect(committed).not.toBeNull();
+
+    adoptSameStoryPayload(state, committed!, context.cache);
+    expect(state.mode).toBe("NAV");
+    expect(state.placement).toBeNull();
+    const placed = rowPart(createStoryViewModel(state.payload), state.focusIndex);
+    expect(placed).not.toBeNull();
+    expect(placed!.node.parentId).toBe(leaf.id);
+    expect(placed!.node.text).toBe(answer);
+    expect(placed!.node.instruction).toBe(FROM_ASIDE_INSTRUCTION);
+    expect(state.toast).toMatch(/^placed as Part \d+$/);
+  });
+
+  test("recovery does not settle Placement without a matching submitted node", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const answer = "pending place answer";
+    const surface = createAsideSurface(
+      state.payload.id,
+      state.payload.title,
+      [{ question: "Q?", answer }],
+      null,
+      state.payload.path.at(-1)!.id
+    );
+    state.aside = surface;
+    state.mode = "ASIDE";
+    const api: StoryApi = {
+      ...source.api,
+      createNode: async () => {
+        throw new Error("response lost");
+      }
+    };
+    const uncertain = { ...source, api };
+    const context = overlayContext(state, 80, 24);
+    await openPlacementOnStoryAction(state, uncertain, context);
+    await handleOverlayAction({ action: "apply" }, state, uncertain, context);
+    await context.backend.whenIdle();
+    expect(state.mode).toBe("PLACE");
+    expect(state.unresolvedPlacement).not.toBeNull();
+
+    // Authoritative payload gains an unrelated node — not the submission.
+    const unrelated = await source.api.createNode(state.payload.id, {
+      parentId: state.payload.path.at(-1)!.id,
+      text: "unrelated recovery prose",
+      instruction: "» continue"
+    });
+    adoptSameStoryPayload(state, unrelated, context.cache);
+    expect(state.mode).toBe("PLACE");
+    expect(state.placement).not.toBeNull();
+    expect(state.unresolvedPlacement).not.toBeNull();
+    expect(state.unresolvedPlacement!.submission.text).toBe(answer.trim());
+  });
+
+  test("definite ApiError clears pending and restores normal placement retry", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const surface = createAsideSurface(
+      state.payload.id,
+      state.payload.title,
+      [{ question: "Q?", answer: "retry after definite failure" }],
+      null,
+      state.payload.path.at(-1)!.id
+    );
+    state.aside = surface;
+    state.mode = "ASIDE";
+    let createCalls = 0;
+    const api: StoryApi = {
+      ...source.api,
+      createNode: async () => {
+        createCalls += 1;
+        if (createCalls === 1) throw new ApiError("provider unavailable");
+        return source.api.createNode(state.payload.id, {
+          parentId: state.payload.path.at(-1)!.parentId,
+          text: "retry after definite failure",
+          instruction: FROM_ASIDE_INSTRUCTION
+        });
+      }
+    };
+    const failing = { ...source, api };
+    const context = overlayContext(state, 80, 24);
+    await openPlacementOnStoryAction(state, failing, context);
+    const cursor = state.placement!.cursor;
+
+    await handleOverlayAction({ action: "apply" }, state, failing, context);
+    await context.backend.whenIdle();
+    expect(createCalls).toBe(1);
+    expect(state.mode).toBe("PLACE");
+    expect(state.unresolvedPlacement).toBeNull();
+    expect(placementOutcomeUnknown(state)).toBeFalse();
+    expect(placementInputLocked(state)).toBeFalse();
+    expect(state.toast).toBe("provider unavailable");
+
+    state.toast = null;
+    const restored = frameText(state);
+    expect(restored).toContain("nothing is written until Enter");
+    expect(restored).toContain("Enter place");
+    expect(restored).not.toContain(PLACEMENT_UNCERTAIN_STATUS);
+
+    await handleOverlayAction({ action: "focus-next" }, state, failing, context);
+    expect(state.placement!.cursor).not.toBe(cursor);
+    // Return to original stop and retry successfully.
+    await handleOverlayAction({ action: "focus-previous" }, state, failing, context);
+    await handleOverlayAction({ action: "apply" }, state, failing, context);
+    await context.backend.whenIdle();
+    expect(createCalls).toBe(2);
+    expect(state.mode).toBe("NAV");
+    expect(state.placement).toBeNull();
+  });
+
+  test("pre-send ApiRecoveryRequiredError clears guard, stays in PLACE, and permits Enter retry", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const answer = "retry after pre-send recovery fence";
+    const surface = createAsideSurface(
+      state.payload.id,
+      state.payload.title,
+      [{ question: "Q?", answer }],
+      null,
+      state.payload.path.at(-1)!.id
+    );
+    state.aside = surface;
+    state.mode = "ASIDE";
+    let createCalls = 0;
+    const fenceMessage =
+      "1667 is reloading saved state. Try again when the reload is complete.";
+    const api: StoryApi = {
+      ...source.api,
+      createNode: async (storyId, body) => {
+        createCalls += 1;
+        if (createCalls === 1) {
+          throw new ApiRecoveryRequiredError(fenceMessage);
+        }
+        return source.api.createNode(storyId, body);
+      }
+    };
+    const recovering = { ...source, api };
+    const context = overlayContext(state, 80, 24);
+    await openPlacementOnStoryAction(state, recovering, context);
+
+    await handleOverlayAction({ action: "apply" }, state, recovering, context);
+    await context.backend.whenIdle();
+    expect(createCalls).toBe(1);
+    expect(state.mode).toBe("PLACE");
+    expect(state.placement).not.toBeNull();
+    expect(state.unresolvedPlacement).toBeNull();
+    expect(placementOutcomeUnknown(state)).toBeFalse();
+    expect(placementInputLocked(state)).toBeFalse();
+    expect(state.toast).toBe(fenceMessage);
+
+    state.toast = null;
+    const restored = frameText(state);
+    expect(restored).toContain("nothing is written until Enter");
+    expect(restored).toContain("Enter place");
+    expect(restored).not.toContain(PLACEMENT_UNCERTAIN_STATUS);
+
+    await handleOverlayAction({ action: "apply" }, state, recovering, context);
+    await context.backend.whenIdle();
+    expect(createCalls).toBe(2);
+    expect(state.mode).toBe("NAV");
+    expect(state.placement).toBeNull();
+    expect(state.unresolvedPlacement).toBeNull();
+    expect(state.toast).toMatch(/^placed as Part \d+$/);
+  });
+
+  test("WorkerApiError internal + uncertain keeps Placement blocked", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const answer = "internal uncertain keeps guard";
+    const surface = createAsideSurface(
+      state.payload.id,
+      state.payload.title,
+      [{ question: "Q?", answer }],
+      null,
+      state.payload.path.at(-1)!.id
+    );
+    state.aside = surface;
+    state.mode = "ASIDE";
+    let createCalls = 0;
+    const failure = new WorkerApiError(createFailureEnvelope({
+      code: "internal",
+      message: "worker failed after possible commit",
+      status: 500
+    }), "uncertain");
+    expect(isDefinitePlacementFailure(failure)).toBeFalse();
+    const api: StoryApi = {
+      ...source.api,
+      createNode: async () => {
+        createCalls += 1;
+        throw failure;
+      }
+    };
+    const uncertain = { ...source, api };
+    const context = overlayContext(state, 80, 24);
+    await openPlacementOnStoryAction(state, uncertain, context);
+    await handleOverlayAction({ action: "apply" }, state, uncertain, context);
+    await context.backend.whenIdle();
+    expect(createCalls).toBe(1);
+    expect(state.unresolvedPlacement?.storyId).toBe(state.payload.id);
+    expect(placementOutcomeUnknown(state)).toBeTrue();
+    await handleOverlayAction({ action: "apply" }, state, uncertain, context);
+    await context.backend.whenIdle();
+    expect(createCalls).toBe(1);
+  });
+
+  test("WorkerApiError internal + terminal clears guard and permits retry", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const answer = "internal terminal permits retry";
+    const surface = createAsideSurface(
+      state.payload.id,
+      state.payload.title,
+      [{ question: "Q?", answer }],
+      null,
+      state.payload.path.at(-1)!.id
+    );
+    state.aside = surface;
+    state.mode = "ASIDE";
+    let createCalls = 0;
+    const failure = new WorkerApiError(createFailureEnvelope({
+      code: "internal",
+      message: "worker failed without commit",
+      status: 500
+    }), "terminal");
+    expect(isDefinitePlacementFailure(failure)).toBeTrue();
+    const api: StoryApi = {
+      ...source.api,
+      createNode: async (storyId, body) => {
+        createCalls += 1;
+        if (createCalls === 1) throw failure;
+        return source.api.createNode(storyId, body);
+      }
+    };
+    const terminal = { ...source, api };
+    const context = overlayContext(state, 80, 24);
+    await openPlacementOnStoryAction(state, terminal, context);
+    await handleOverlayAction({ action: "apply" }, state, terminal, context);
+    await context.backend.whenIdle();
+    expect(createCalls).toBe(1);
+    expect(state.unresolvedPlacement).toBeNull();
+    expect(placementOutcomeUnknown(state)).toBeFalse();
+    expect(state.mode).toBe("PLACE");
+    await handleOverlayAction({ action: "apply" }, state, terminal, context);
+    await context.backend.whenIdle();
+    expect(createCalls).toBe(2);
+    expect(state.mode).toBe("NAV");
+    expect(state.placement).toBeNull();
+  });
+
+  test("legacy WorkerApiError without settlement outcome keeps the guard", async () => {
+    const failure = new WorkerApiError(createFailureEnvelope({
+      code: "internal",
+      message: "synthetic without transport outcome",
+      status: 500
+    }));
+    expect(failure.mutationOutcome).toBeNull();
+    expect(isDefinitePlacementFailure(failure)).toBeFalse();
+  });
+
+  test("same-story title adoption refreshes Placement returnAside; Esc shows new title", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const answer = "title adoption while placing";
+    const opening = state.payload.path.at(-1)!;
+    const surface = createAsideSurface(
+      state.payload.id,
+      "Old title",
+      [{ question: "Q?", answer }],
+      null,
+      opening.id
+    );
+    state.aside = surface;
+    state.mode = "ASIDE";
+    const context = overlayContext(state, 80, 24);
+    await openPlacementOnStoryAction(state, source, context);
+    expect(state.mode).toBe("PLACE");
+    expect(state.aside).toBeNull();
+    expect(state.placement!.returnAside).toBe(surface);
+    expect(surface.storyTitle).toBe("Old title");
+
+    // Same-story rename while Placement owns the retained Aside surface.
+    adoptSameStoryPayload(
+      state,
+      { ...state.payload, title: "Renamed while placing" },
+      context.cache
+    );
+    expect(state.payload.title).toBe("Renamed while placing");
+    expect(state.mode).toBe("PLACE");
+    expect(state.placement).not.toBeNull();
+    expect(state.placement!.returnAside.storyTitle).toBe("Renamed while placing");
+    expect(surface.storyTitle).toBe("Renamed while placing");
+
+    // Esc restores the same menu/note with the updated title on the header.
+    await handleOverlayAction({ action: "cancel" }, state, source, context);
+    expect(state.mode).toBe("ASIDE");
+    expect(state.aside).toBe(surface);
+    expect(state.aside!.storyTitle).toBe("Renamed while placing");
+    expect(surface.useMenu).toMatchObject({ noteIndex: 0, cursor: 1 });
+    expect(typeof surface.useMenu?.sessionId).toBe("string");
+    expect(frameText(state)).toContain("ASIDE · Renamed while placing · non-canon");
+  });
+});

--- a/tui/test/aside-placement-render.test.ts
+++ b/tui/test/aside-placement-render.test.ts
@@ -1,0 +1,465 @@
+/**
+ * Placement/Aside render and key edge cases: narrow use-menu footer, offline
+ * retry ownership, and leaf-gap markers around chapter chrome.
+ */
+import { describe, expect, test } from "bun:test";
+import type { KeyEvent } from "@opentui/core";
+import { createAsideSurface } from "../src/aside-surface.js";
+import {
+  FROM_ASIDE_INSTRUCTION,
+  PLACEMENT_PLACING_KEYLINE,
+  PLACEMENT_PLACING_STATUS,
+  PLACEMENT_STATUS_TEXT,
+  PLACEMENT_UNCERTAIN_STATUS
+} from "../src/aside-placement.js";
+import { openAsideUseMenu } from "../src/aside-use.js";
+import { ApiError } from "../src/api-error.js";
+import { demoAppSource } from "../src/demo.js";
+import { initialState } from "../src/app.js";
+import { handleOverlayAction } from "../src/overlay-actions.js";
+import type { StoryApi } from "../src/api.js";
+import { ActionRuntime } from "../src/action-runtime.js";
+import { createWrapCache, type ProseStyle } from "../src/wrap.js";
+import { renderStoryScreen } from "../src/screens/story.js";
+import { createStoryViewModel, rowPart } from "../src/model.js";
+import { adoptSameStoryPayload } from "../src/story-adoption.js";
+import { mouseToAction } from "../src/mouse-actions.js";
+import { resolveKey } from "../src/keys.js";
+import { plainLine } from "../src/screens/story/frame.js";
+
+function key(
+  name: string,
+  options: { shift?: boolean; ctrl?: boolean } = {}
+): KeyEvent {
+  return {
+    name,
+    sequence: name.length === 1 ? name : name,
+    shift: options.shift ?? false,
+    ctrl: options.ctrl ?? false,
+    meta: false,
+    option: false,
+    super: false
+  } as KeyEvent;
+}
+
+function overlayContext(
+  state: ReturnType<typeof initialState>,
+  width = 80,
+  height = 24
+) {
+  return {
+    backend: new ActionRuntime(state, () => undefined),
+    cache: createWrapCache<ProseStyle>(),
+    repaint: () => undefined,
+    renderer: { width, height } as never,
+    applyTheme: () => undefined,
+    previewTheme: () => undefined
+  };
+}
+
+function frameText(
+  state: ReturnType<typeof initialState>,
+  width: number,
+  height = 24
+): string {
+  return renderStoryScreen(state, { width, height }).lines.map(plainLine).join("\n");
+}
+
+describe("Aside placement render and offline keys", () => {
+  test("use-menu footer keeps ↵ and esc complete at 20 and 21 columns", () => {
+    for (const width of [20, 21] as const) {
+      const source = demoAppSource();
+      const state = initialState(source, false);
+      state.mode = "ASIDE";
+      state.aside = createAsideSurface(state.payload.id, "Lantern", [{
+        question: "Q?",
+        answer: "a few answer words"
+      }]);
+      expect(openAsideUseMenu(state.aside, 0, 0)).toBeTrue();
+      const text = frameText(state, width);
+      expect(text).toContain("↵");
+      expect(text).toContain("esc");
+      // Action names may truncate; the declared footer tokens must not.
+      expect(text).toContain("insert");
+    }
+  });
+
+  test("Shift+R retries offline in use-menu and PLACE; composer still types R", () => {
+    const offline = { connectionDown: true as const };
+    expect(resolveKey(key("r", { shift: true }), "ASIDE", {
+      ...offline,
+      asideLayer: "use-menu"
+    }).action).toBe("retry");
+    expect(resolveKey(key("r", { shift: true }), "PLACE", offline).action).toBe("retry");
+    // Active Aside composer is a text owner: capital R is input, not retry.
+    expect(resolveKey(key("r", { shift: true }), "ASIDE", {
+      ...offline,
+      asideLayer: "composer"
+    }).action).not.toBe("retry");
+    expect(resolveKey(key("R"), "ASIDE", {
+      ...offline,
+      asideLayer: "composer"
+    }).action).not.toBe("retry");
+  });
+
+  test("offline PLACE Enter makes no createNode and creates no guard", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const surface = createAsideSurface(
+      state.payload.id,
+      state.payload.title,
+      [{ question: "Q?", answer: "offline place answer" }],
+      null,
+      state.payload.path.at(-1)!.id
+    );
+    state.aside = surface;
+    state.mode = "ASIDE";
+    let createCalls = 0;
+    const api: StoryApi = {
+      ...source.api,
+      createNode: async () => {
+        createCalls += 1;
+        throw new Error("should not run offline");
+      }
+    };
+    const offlineSource = { ...source, api };
+    const context = overlayContext(state, 80, 24);
+    await handleOverlayAction({ action: "cycle" }, state, offlineSource, context);
+    await handleOverlayAction({ action: "open-selected" }, state, offlineSource, context);
+    await handleOverlayAction({ action: "focus-next" }, state, offlineSource, context);
+    await handleOverlayAction({ action: "apply" }, state, offlineSource, context);
+    expect(state.mode).toBe("PLACE");
+
+    state.connection = {
+      down: true,
+      attempt: 1,
+      nextRetryAt: state.now + 5_000,
+      error: null
+    };
+    const cursor = state.placement!.cursor;
+    await handleOverlayAction({ action: "apply" }, state, offlineSource, context);
+    await context.backend.whenIdle();
+
+    expect(createCalls).toBe(0);
+    expect(state.mode).toBe("PLACE");
+    expect(state.placement).not.toBeNull();
+    expect(state.placement!.cursor).toBe(cursor);
+    expect(state.placement!.placingTaskId).toBeNull();
+    expect(state.unresolvedPlacement).toBeNull();
+    expect(state.toast).toBe("offline · reading still works");
+    // Shift+R still routes as retry while PLACE is offline.
+    expect(resolveKey(key("r", { shift: true }), "PLACE", {
+      connectionDown: true
+    }).action).toBe("retry");
+  });
+
+  test("offline banner retry hit stays above the use-menu scrim", () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    state.mode = "ASIDE";
+    state.connection = {
+      down: true,
+      attempt: 1,
+      nextRetryAt: state.now + 5_000,
+      error: null
+    };
+    state.aside = createAsideSurface(state.payload.id, state.payload.title, [{
+      question: "Q?",
+      answer: "offline answer"
+    }]);
+    expect(openAsideUseMenu(state.aside, 0, 0)).toBeTrue();
+    const frame = renderStoryScreen(state, { width: 80, height: 24 });
+    state.hitRows = frame.derived.hitRows;
+    const banner = plainLine(frame.lines[0] ?? []);
+    expect(banner).toContain("connection lost");
+    // Prefer the labeled retry affordance when present.
+    const retryLabel = banner.includes("R retries now") ? "R retries now" : "retry now";
+    expect(banner).toContain(retryLabel);
+    const retryX = Math.min(79, Math.max(0, banner.indexOf(retryLabel) + 1));
+    const action = mouseToAction({
+      type: "down",
+      button: 0,
+      x: retryX,
+      y: 0,
+      modifiers: { shift: false, alt: false, ctrl: false }
+    }, state);
+    expect(action).toEqual({ action: "retry" });
+    expect(action?.action).not.toBe("cancel");
+  });
+
+  test("locked Placement shows placing status and hides key hints", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const surface = createAsideSurface(
+      state.payload.id,
+      state.payload.title,
+      [{ question: "Q?", answer: "locked place prose" }],
+      null,
+      state.payload.path.at(-1)!.id
+    );
+    state.aside = surface;
+    state.mode = "ASIDE";
+    let resolveCreate!: (payload: typeof state.payload) => void;
+    const pendingCreate = new Promise<typeof state.payload>((resolve) => {
+      resolveCreate = resolve;
+    });
+    const api: StoryApi = {
+      ...source.api,
+      createNode: async () => pendingCreate
+    };
+    const delayed = { ...source, api };
+    const context = overlayContext(state, 80, 24);
+
+    await handleOverlayAction({ action: "cycle" }, state, delayed, context);
+    await handleOverlayAction({ action: "open-selected" }, state, delayed, context);
+    await handleOverlayAction({ action: "focus-next" }, state, delayed, context);
+    await handleOverlayAction({ action: "apply" }, state, delayed, context);
+    expect(state.mode).toBe("PLACE");
+
+    const placing = handleOverlayAction({ action: "apply" }, state, delayed, context);
+    await Promise.resolve();
+    expect(state.backendTask?.label).toBe("placing Side Note");
+
+    const locked = frameText(state, 80);
+    expect(locked).toContain(PLACEMENT_PLACING_STATUS);
+    expect(locked).toContain(PLACEMENT_PLACING_KEYLINE);
+    expect(locked).not.toContain(PLACEMENT_STATUS_TEXT);
+    expect(locked).not.toContain("Up/Down where");
+    expect(locked).not.toContain("Enter place");
+    expect(locked).not.toContain("Esc back to Aside");
+
+    resolveCreate(await source.api.createNode(state.payload.id, {
+      parentId: state.payload.path.at(-1)!.parentId,
+      text: "locked place prose",
+      instruction: FROM_ASIDE_INSTRUCTION
+    }));
+    await placing;
+    await context.backend.whenIdle();
+    expect(state.mode).toBe("NAV");
+  });
+
+  test("failed place restores Placement status and keyline", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const surface = createAsideSurface(
+      state.payload.id,
+      state.payload.title,
+      [{ question: "Q?", answer: "restore keyline prose" }],
+      null,
+      state.payload.path.at(-1)!.id
+    );
+    state.aside = surface;
+    state.mode = "ASIDE";
+    const api: StoryApi = {
+      ...source.api,
+      createNode: async () => {
+        // Definite application outcome: pending clears and input restores.
+        throw new ApiError("provider unavailable");
+      }
+    };
+    const failing = { ...source, api };
+    const context = overlayContext(state, 80, 24);
+
+    await handleOverlayAction({ action: "cycle" }, state, failing, context);
+    await handleOverlayAction({ action: "open-selected" }, state, failing, context);
+    await handleOverlayAction({ action: "focus-next" }, state, failing, context);
+    await handleOverlayAction({ action: "apply" }, state, failing, context);
+    expect(state.mode).toBe("PLACE");
+
+    await handleOverlayAction({ action: "apply" }, state, failing, context);
+    await context.backend.whenIdle();
+    expect(state.mode).toBe("PLACE");
+    expect(state.backendTask).toBeNull();
+    expect(state.placement!.placingTaskId).toBeNull();
+    expect(state.unresolvedPlacement).toBeNull();
+    expect(state.toast).toBe("provider unavailable");
+
+    // Status restores immediately; toast briefly owns the keyline slot.
+    const withToast = frameText(state, 80);
+    expect(withToast).toContain(PLACEMENT_STATUS_TEXT);
+    expect(withToast).not.toContain(PLACEMENT_PLACING_STATUS);
+    expect(withToast).not.toContain(PLACEMENT_PLACING_KEYLINE);
+
+    state.toast = null;
+    const restored = frameText(state, 80);
+    expect(restored).toContain(PLACEMENT_STATUS_TEXT);
+    expect(restored).toContain("Up/Down where");
+    expect(restored).toContain("Enter place");
+    expect(restored).toContain("Esc back to Aside");
+    expect(restored).not.toContain(PLACEMENT_PLACING_STATUS);
+    expect(restored).not.toContain(PLACEMENT_PLACING_KEYLINE);
+  });
+
+  test("leaf-gap marker trails chapter divider after the active leaf", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const leaf = state.payload.path.at(-1)!;
+    const created = await source.api.createChapterBreak(
+      state.payload.id,
+      leaf.id,
+      "After leaf"
+    );
+    adoptSameStoryPayload(state, created.payload, createWrapCache<ProseStyle>());
+    const viewBefore = createStoryViewModel(state.payload);
+    const leafIndex = viewBefore.rows.findIndex(
+      (row) => row.kind === "part" && row.id === leaf.id
+    );
+    expect(leafIndex).toBeGreaterThan(-1);
+    const trailing = viewBefore.rows.slice(leafIndex + 1);
+    expect(trailing.some((row) => row.kind === "chapter-divider")).toBeTrue();
+
+    const surface = createAsideSurface(
+      state.payload.id,
+      state.payload.title,
+      [{ question: "Where?", answer: "part after the boundary" }],
+      null,
+      leaf.id
+    );
+    state.aside = surface;
+    state.mode = "ASIDE";
+    const context = overlayContext(state, 80, 24);
+    await handleOverlayAction({ action: "cycle" }, state, source, context);
+    await handleOverlayAction({ action: "open-selected" }, state, source, context);
+    await handleOverlayAction({ action: "focus-next" }, state, source, context);
+    await handleOverlayAction({ action: "apply" }, state, source, context);
+    expect(state.mode).toBe("PLACE");
+    while (state.placement!.stops[state.placement!.cursor]?.kind !== "leaf-gap") {
+      await handleOverlayAction({ action: "focus-next" }, state, source, context);
+    }
+
+    const lines = renderStoryScreen(state, { width: 80, height: 36 }).lines.map(plainLine);
+    const leafLine = lines.findIndex((line) => line.includes(leaf.text.slice(0, 12)));
+    const dividerLine = lines.findIndex((line) =>
+      line.toLowerCase().includes("chapter") || line.includes("After leaf")
+    );
+    const markerLine = lines.findIndex((line) => line.includes("here · new Part"));
+    expect(markerLine).toBeGreaterThan(-1);
+    expect(leafLine).toBeGreaterThan(-1);
+    // Marker is below the leaf and, when the divider paints, below the divider.
+    expect(markerLine).toBeGreaterThan(leafLine);
+    if (dividerLine >= 0) expect(markerLine).toBeGreaterThan(dividerLine);
+    expect(lines[markerLine]).toContain("part after the boundary");
+
+    const pathBefore = state.payload.path.length;
+    await handleOverlayAction({ action: "apply" }, state, source, context);
+    await context.backend.whenIdle();
+    expect(state.mode).toBe("NAV");
+    expect(state.payload.path.length).toBe(pathBefore + 1);
+    const placed = rowPart(createStoryViewModel(state.payload), state.focusIndex);
+    expect(placed).not.toBeNull();
+    expect(placed!.node.parentId).toBe(leaf.id);
+    expect(placed!.node.instruction).toBe(FROM_ASIDE_INSTRUCTION);
+    expect(placed!.node.text).toBe("part after the boundary");
+    // New Part is the first path node after the leaf that closed the chapter.
+    const path = state.payload.path;
+    const leafPathIndex = path.findIndex(({ id }) => id === leaf.id);
+    expect(path[leafPathIndex + 1]?.id).toBe(placed!.id);
+  });
+
+  test("PLACE status keeps Enter assurance at 80 and narrow with a long leaf-gap answer", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    // Eight-plus words: leaf-gap label previews eight words then ellipsis.
+    const answer = "alpha bravo charlie delta echo foxtrot golf hotel india juliet";
+    const surface = createAsideSurface(
+      state.payload.id,
+      state.payload.title,
+      [{ question: "Where?", answer }],
+      null,
+      state.payload.path.at(-1)!.id
+    );
+    state.aside = surface;
+    state.mode = "ASIDE";
+    const context = overlayContext(state, 80, 24);
+    await handleOverlayAction({ action: "cycle" }, state, source, context);
+    await handleOverlayAction({ action: "open-selected" }, state, source, context);
+    await handleOverlayAction({ action: "focus-next" }, state, source, context);
+    await handleOverlayAction({ action: "apply" }, state, source, context);
+    expect(state.mode).toBe("PLACE");
+    while (state.placement!.stops[state.placement!.cursor]?.kind !== "leaf-gap") {
+      await handleOverlayAction({ action: "focus-next" }, state, source, context);
+    }
+
+    for (const width of [80, 48] as const) {
+      const text = frameText(state, width);
+      expect(text).toContain(PLACEMENT_STATUS_TEXT);
+      // Destination label may clip; the required assurance must not.
+      expect(text).toContain("nothing is written until Enter");
+    }
+  });
+
+  test("PLACE status uses chrome for normal and placing; warning only when uncertain", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const answer = "status role prose for placement browsing";
+    const surface = createAsideSurface(
+      state.payload.id,
+      state.payload.title,
+      [{ question: "Q?", answer }],
+      null,
+      state.payload.path.at(-1)!.id
+    );
+    state.aside = surface;
+    state.mode = "ASIDE";
+    const context = overlayContext(state, 80, 24);
+    await handleOverlayAction({ action: "cycle" }, state, source, context);
+    await handleOverlayAction({ action: "open-selected" }, state, source, context);
+    await handleOverlayAction({ action: "focus-next" }, state, source, context);
+    await handleOverlayAction({ action: "apply" }, state, source, context);
+    expect(state.mode).toBe("PLACE");
+
+    const statusRoles = (width = 80) => {
+      const frame = renderStoryScreen(state, { width, height: 24 });
+      const line = frame.lines.find((parts) =>
+        plainLine(parts).includes("PLACE")
+      );
+      expect(line).toBeDefined();
+      return line!.filter((part) => part.text.trim().length > 0).map((part) => part.role);
+    };
+
+    // Normal browsing: no danger text on the status line body.
+    const browsing = statusRoles();
+    expect(browsing).toContain("chrome");
+    expect(browsing.includes("danger text")).toBeFalse();
+
+    // In-flight place keeps normal chrome, not prune danger.
+    state.placement!.placingTaskId = 42;
+    state.backendTask = {
+      id: 42,
+      kind: "action",
+      label: "placing Side Note",
+      storyId: state.payload.id
+    };
+    const placing = statusRoles();
+    expect(plainLine(
+      renderStoryScreen(state, { width: 80, height: 24 }).lines.find((parts) =>
+        plainLine(parts).includes("PLACE")
+      )!
+    )).toContain(PLACEMENT_PLACING_STATUS);
+    expect(placing).toContain("chrome");
+    expect(placing.includes("danger text")).toBeFalse();
+
+    // Uncertain outcome may warn; still not prune danger.
+    state.placement!.placingTaskId = null;
+    state.backendTask = null;
+    state.unresolvedPlacement = {
+      storyId: state.payload.id,
+      submission: {
+        knownNodeIds: new Set(state.payload.nodes.map((node) => node.id)),
+        parentId: state.payload.path.at(-1)!.id,
+        text: answer,
+        instruction: FROM_ASIDE_INSTRUCTION,
+        partNumber: state.payload.path.length + 1
+      }
+    };
+    const uncertainLine = renderStoryScreen(state, { width: 80, height: 24 }).lines.find(
+      (parts) => plainLine(parts).includes("PLACE")
+    )!;
+    expect(plainLine(uncertainLine)).toContain(PLACEMENT_UNCERTAIN_STATUS);
+    const uncertainRoles = uncertainLine
+      .filter((part) => part.text.trim().length > 0)
+      .map((part) => part.role);
+    expect(uncertainRoles).toContain("context warning");
+    expect(uncertainRoles.includes("danger text")).toBeFalse();
+  });
+});

--- a/tui/test/aside-placement-unresolved.test.ts
+++ b/tui/test/aside-placement-unresolved.test.ts
@@ -1,0 +1,598 @@
+/**
+ * Unresolved Placement identity: uncertainty-coded failures, Esc survival,
+ * and recovery after leaving active Placement.
+ */
+import { describe, expect, test } from "bun:test";
+import { createFailureEnvelope } from "../../shared/failure-envelope.js";
+import { createAsideSurface } from "../src/aside-surface.js";
+import {
+  FROM_ASIDE_INSTRUCTION,
+  PLACEMENT_UNCERTAIN_TOAST,
+  isDefinitePlacementFailure
+} from "../src/aside-placement.js";
+import { ApiHttpError } from "../src/api-error.js";
+import { WorkerApiError } from "../src/worker-error.js";
+import { demoAppSource } from "../src/demo.js";
+import { initialState } from "../src/app.js";
+import { handleOverlayAction } from "../src/overlay-actions.js";
+import type { StoryApi } from "../src/api.js";
+import { ActionRuntime } from "../src/action-runtime.js";
+import { createWrapCache, type ProseStyle } from "../src/wrap.js";
+import { createStoryViewModel, rowPart } from "../src/model.js";
+import {
+  adoptSameStoryPayload,
+  adoptStoryState
+} from "../src/story-adoption.js";
+import { libraryAction } from "../src/library-actions.js";
+
+function overlayContext(
+  state: ReturnType<typeof initialState>,
+  width?: number,
+  height?: number
+) {
+  return {
+    backend: new ActionRuntime(state, () => undefined),
+    cache: createWrapCache<ProseStyle>(),
+    repaint: () => undefined,
+    renderer: width === undefined || height === undefined
+      ? null
+      : { width, height } as never,
+    applyTheme: () => undefined,
+    previewTheme: () => undefined
+  };
+}
+
+async function openPlacementOnStoryAction(
+  state: ReturnType<typeof initialState>,
+  source: ReturnType<typeof demoAppSource>,
+  context: ReturnType<typeof overlayContext>
+): Promise<void> {
+  await handleOverlayAction({ action: "cycle" }, state, source, context);
+  await handleOverlayAction({ action: "open-selected" }, state, source, context);
+  await handleOverlayAction({ action: "focus-next" }, state, source, context);
+  await handleOverlayAction({ action: "apply" }, state, source, context);
+  expect(state.mode).toBe("PLACE");
+}
+
+describe("Aside Placement unresolved identity", () => {
+  test("WorkerApiError mutation_outcome_unknown retains the unresolved guard", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const answer = "worker uncertain place";
+    const surface = createAsideSurface(
+      state.payload.id,
+      state.payload.title,
+      [{ question: "Q?", answer }],
+      null,
+      state.payload.path.at(-1)!.id
+    );
+    state.aside = surface;
+    state.mode = "ASIDE";
+    let createCalls = 0;
+    const api: StoryApi = {
+      ...source.api,
+      createNode: async () => {
+        createCalls += 1;
+        throw new WorkerApiError(createFailureEnvelope({
+          code: "mutation_outcome_unknown",
+          message: "outcome unknown after possible commit",
+          status: 409
+        }));
+      }
+    };
+    const uncertain = { ...source, api };
+    const context = overlayContext(state, 80, 24);
+    await openPlacementOnStoryAction(state, uncertain, context);
+    await handleOverlayAction({ action: "apply" }, state, uncertain, context);
+    await context.backend.whenIdle();
+    expect(createCalls).toBe(1);
+    expect(isDefinitePlacementFailure(new WorkerApiError(createFailureEnvelope({
+      code: "mutation_outcome_unknown",
+      message: "x",
+      status: 409
+    })))).toBeFalse();
+    expect(state.placement!.placingTaskId).toBeNull();
+    expect(state.unresolvedPlacement?.storyId).toBe(state.payload.id);
+    expect(state.unresolvedPlacement?.submission.text).toBe(answer.trim());
+
+    await handleOverlayAction({ action: "apply" }, state, uncertain, context);
+    await context.backend.whenIdle();
+    expect(createCalls).toBe(1);
+  });
+
+  test("ApiHttpError operation_unknown retains the unresolved guard", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const answer = "http uncertain place";
+    const surface = createAsideSurface(
+      state.payload.id,
+      state.payload.title,
+      [{ question: "Q?", answer }],
+      null,
+      state.payload.path.at(-1)!.id
+    );
+    state.aside = surface;
+    state.mode = "ASIDE";
+    let createCalls = 0;
+    const api: StoryApi = {
+      ...source.api,
+      createNode: async () => {
+        createCalls += 1;
+        throw new ApiHttpError(createFailureEnvelope({
+          code: "operation_unknown",
+          message: "Something interrupted the last change. You can try again.",
+          status: 410
+        }), true);
+      }
+    };
+    const uncertain = { ...source, api };
+    const context = overlayContext(state, 80, 24);
+    await openPlacementOnStoryAction(state, uncertain, context);
+    await handleOverlayAction({ action: "apply" }, state, uncertain, context);
+    await context.backend.whenIdle();
+    expect(createCalls).toBe(1);
+    expect(isDefinitePlacementFailure(new ApiHttpError(createFailureEnvelope({
+      code: "operation_unknown",
+      message: "x",
+      status: 410
+    }), true))).toBeFalse();
+    expect(state.placement!.placingTaskId).toBeNull();
+    expect(state.unresolvedPlacement?.submission.text).toBe(answer.trim());
+
+    await handleOverlayAction({ action: "apply" }, state, uncertain, context);
+    await context.backend.whenIdle();
+    expect(createCalls).toBe(1);
+  });
+
+  test("operation_unknown with requestSent=false stays uncertain and keeps the guard", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const answer = "operation unknown unsent flag";
+    const surface = createAsideSurface(
+      state.payload.id,
+      state.payload.title,
+      [{ question: "Q?", answer }],
+      null,
+      state.payload.path.at(-1)!.id
+    );
+    state.aside = surface;
+    state.mode = "ASIDE";
+    let createCalls = 0;
+    const failure = new ApiHttpError(createFailureEnvelope({
+      code: "operation_unknown",
+      message: "interrupted after possible commit",
+      status: 410
+    }), false);
+    expect(isDefinitePlacementFailure(failure)).toBeFalse();
+    const api: StoryApi = {
+      ...source.api,
+      createNode: async () => {
+        createCalls += 1;
+        throw failure;
+      }
+    };
+    const uncertain = { ...source, api };
+    const context = overlayContext(state, 80, 24);
+    await openPlacementOnStoryAction(state, uncertain, context);
+    await handleOverlayAction({ action: "apply" }, state, uncertain, context);
+    await context.backend.whenIdle();
+    expect(createCalls).toBe(1);
+    expect(state.placement!.placingTaskId).toBeNull();
+    expect(state.unresolvedPlacement?.storyId).toBe(state.payload.id);
+    expect(state.unresolvedPlacement?.submission.text).toBe(answer.trim());
+
+    await handleOverlayAction({ action: "apply" }, state, uncertain, context);
+    await context.backend.whenIdle();
+    expect(createCalls).toBe(1);
+  });
+
+  test("provably unsent ApiHttpError clears the guard and permits retry", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const surface = createAsideSurface(
+      state.payload.id,
+      state.payload.title,
+      [{ question: "Q?", answer: "unsent then retry" }],
+      null,
+      state.payload.path.at(-1)!.id
+    );
+    state.aside = surface;
+    state.mode = "ASIDE";
+    let createCalls = 0;
+    const api: StoryApi = {
+      ...source.api,
+      createNode: async () => {
+        createCalls += 1;
+        if (createCalls === 1) {
+          throw new ApiHttpError(createFailureEnvelope({
+            code: "invalid_request",
+            message: "request never left",
+            status: 400
+          }), false);
+        }
+        return source.api.createNode(state.payload.id, {
+          parentId: state.payload.path.at(-1)!.parentId,
+          text: "unsent then retry",
+          instruction: FROM_ASIDE_INSTRUCTION
+        });
+      }
+    };
+    const failing = { ...source, api };
+    const context = overlayContext(state, 80, 24);
+    await openPlacementOnStoryAction(state, failing, context);
+    await handleOverlayAction({ action: "apply" }, state, failing, context);
+    await context.backend.whenIdle();
+    expect(createCalls).toBe(1);
+    expect(state.placement!.placingTaskId).toBeNull();
+    expect(state.unresolvedPlacement).toBeNull();
+    await handleOverlayAction({ action: "apply" }, state, failing, context);
+    await context.backend.whenIdle();
+    expect(createCalls).toBe(2);
+    expect(state.mode).toBe("NAV");
+  });
+
+  test("uncertain submission survives Esc; reopen cannot createNode again", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const answer = "esc retain place answer";
+    const surface = createAsideSurface(
+      state.payload.id,
+      state.payload.title,
+      [{ question: "Q?", answer }],
+      null,
+      state.payload.path.at(-1)!.id
+    );
+    state.aside = surface;
+    state.mode = "ASIDE";
+    let createCalls = 0;
+    let firstParent: string | null | undefined;
+    const api: StoryApi = {
+      ...source.api,
+      createNode: async (_storyId, body) => {
+        createCalls += 1;
+        if (firstParent === undefined) firstParent = body.parentId ?? null;
+        throw new Error("response lost");
+      }
+    };
+    const uncertain = { ...source, api };
+    const context = overlayContext(state, 80, 24);
+    await openPlacementOnStoryAction(state, uncertain, context);
+    const stop = state.placement!.stops[state.placement!.cursor]!;
+    const expectedParent = stop.kind === "take" ? stop.parentId : stop.leafId;
+
+    await handleOverlayAction({ action: "apply" }, state, uncertain, context);
+    await context.backend.whenIdle();
+    expect(createCalls).toBe(1);
+    const pending = state.unresolvedPlacement!;
+    expect(pending.submission.text).toBe(answer.trim());
+
+    // Esc restores Aside + use menu; guard identity is not copied.
+    await handleOverlayAction({ action: "cancel" }, state, uncertain, context);
+    expect(state.mode).toBe("ASIDE");
+    expect(state.placement).toBeNull();
+    expect(state.aside).toBe(surface);
+    expect(surface.useMenu).toMatchObject({ noteIndex: 0, cursor: 1 });
+    expect(typeof surface.useMenu?.sessionId).toBe("string");
+    expect(state.unresolvedPlacement).toBe(pending);
+
+    // Closing the use menu and reopening must not drop the guard.
+    await handleOverlayAction({ action: "cancel" }, state, uncertain, context);
+    expect(surface.useMenu).toBeNull();
+    expect(state.unresolvedPlacement).not.toBeNull();
+    await handleOverlayAction({ action: "open-selected" }, state, uncertain, context);
+    expect(surface.useMenu?.cursor).toBe(0);
+    await handleOverlayAction({ action: "focus-next" }, state, uncertain, context);
+    await handleOverlayAction({ action: "apply" }, state, uncertain, context);
+    expect(state.mode).toBe("PLACE");
+    expect(state.unresolvedPlacement).toBe(pending);
+    expect(state.toast).toBe(PLACEMENT_UNCERTAIN_TOAST);
+
+    await handleOverlayAction({ action: "apply" }, state, uncertain, context);
+    await context.backend.whenIdle();
+    expect(createCalls).toBe(1);
+    expect(firstParent).toBe(expectedParent);
+    expect(state.toast).toBe(PLACEMENT_UNCERTAIN_TOAST);
+  });
+
+  test("same-story adoption after Esc settles the first committed node", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const answer = "esc then recovery place";
+    const leaf = state.payload.path.at(-1)!;
+    const surface = createAsideSurface(
+      state.payload.id,
+      state.payload.title,
+      [{ question: "Q?", answer }],
+      null,
+      leaf.id
+    );
+    state.aside = surface;
+    state.mode = "ASIDE";
+    let committed: typeof state.payload | null = null;
+    const api: StoryApi = {
+      ...source.api,
+      createNode: async (storyId, body) => {
+        committed = await source.api.createNode(storyId, body);
+        throw new WorkerApiError(createFailureEnvelope({
+          code: "mutation_outcome_unknown",
+          message: "response lost after commit",
+          status: 409
+        }));
+      }
+    };
+    const uncertain = { ...source, api };
+    const context = overlayContext(state, 80, 24);
+    await openPlacementOnStoryAction(state, uncertain, context);
+    await handleOverlayAction({ action: "apply" }, state, uncertain, context);
+    await context.backend.whenIdle();
+    expect(committed).not.toBeNull();
+
+    await handleOverlayAction({ action: "cancel" }, state, uncertain, context);
+    expect(state.mode).toBe("ASIDE");
+    expect(state.unresolvedPlacement).not.toBeNull();
+
+    // Close use menu; guard must still settle on adoption.
+    await handleOverlayAction({ action: "cancel" }, state, uncertain, context);
+    expect(surface.useMenu).toBeNull();
+
+    adoptSameStoryPayload(state, committed!, context.cache);
+    // Detached guard settlement keeps ASIDE ownership; only the guard clears.
+    expect(state.unresolvedPlacement).toBeNull();
+    expect(state.placement).toBeNull();
+    expect(state.aside).toBe(surface);
+    expect(state.mode).toBe("ASIDE");
+    expect(state.toast).toMatch(/^placed as Part \d+$/);
+    expect(state.freshLandedAt.size).toBeGreaterThan(0);
+  });
+
+  test("normal Esc ladder is unchanged when no unresolved submission exists", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const surface = createAsideSurface(
+      state.payload.id,
+      state.payload.title,
+      [{ question: "Q?", answer: "clean cancel ladder" }],
+      null,
+      state.payload.path.at(-1)!.id
+    );
+    state.aside = surface;
+    state.mode = "ASIDE";
+    const context = overlayContext(state, 80, 24);
+    await openPlacementOnStoryAction(state, source, context);
+    expect(state.unresolvedPlacement).toBeNull();
+    expect(state.placement!.placingTaskId).toBeNull();
+
+    await handleOverlayAction({ action: "cancel" }, state, source, context);
+    expect(state.mode).toBe("ASIDE");
+    expect(state.placement).toBeNull();
+    expect(state.unresolvedPlacement).toBeNull();
+    expect(state.aside).toBe(surface);
+    expect(surface.useMenu).toMatchObject({ noteIndex: 0, cursor: 1 });
+    expect(typeof surface.useMenu?.sessionId).toBe("string");
+
+    await handleOverlayAction({ action: "cancel" }, state, source, context);
+    expect(surface.useMenu).toBeNull();
+    expect(surface.focus).toBe("notes");
+    await handleOverlayAction({ action: "cancel" }, state, source, context);
+    expect(surface.focus).toBe("composer");
+    await handleOverlayAction({ action: "cancel" }, state, source, context);
+    expect(state.mode).toBe("NAV");
+    expect(state.aside).toBeNull();
+    expect(state.unresolvedPlacement).toBeNull();
+  });
+
+  test("adoptStoryState away preserves the guard; return settles an exact node", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const originStoryId = state.payload.id;
+    const answer = "navigate away then settle";
+    const surface = createAsideSurface(
+      originStoryId,
+      state.payload.title,
+      [{ question: "Q?", answer }],
+      null,
+      state.payload.path.at(-1)!.id
+    );
+    state.aside = surface;
+    state.mode = "ASIDE";
+    let committed: typeof state.payload | null = null;
+    const api: StoryApi = {
+      ...source.api,
+      createNode: async (storyId, body) => {
+        committed = await source.api.createNode(storyId, body);
+        throw new WorkerApiError(createFailureEnvelope({
+          code: "mutation_outcome_unknown",
+          message: "response lost after commit",
+          status: 409
+        }));
+      }
+    };
+    const uncertain = { ...source, api };
+    const context = overlayContext(state, 80, 24);
+    await openPlacementOnStoryAction(state, uncertain, context);
+    await handleOverlayAction({ action: "apply" }, state, uncertain, context);
+    await context.backend.whenIdle();
+    expect(committed).not.toBeNull();
+    expect(state.unresolvedPlacement?.storyId).toBe(originStoryId);
+
+    // Navigate to another story before recovery proves the outcome.
+    const other = (await source.api.listStories()).find((story) => story.id !== originStoryId);
+    expect(other).toBeDefined();
+    const otherPayload = await source.api.loadStory(other!.id);
+    adoptStoryState(state, otherPayload, context.cache);
+    expect(state.payload.id).toBe(other!.id);
+    expect(state.placement).toBeNull();
+    expect(state.unresolvedPlacement?.storyId).toBe(originStoryId);
+    expect(state.unresolvedPlacement?.submission.text).toBe(answer.trim());
+
+    // Placement on the other story is refused while the origin guard stands.
+    const otherSurface = createAsideSurface(
+      other!.id,
+      otherPayload.title,
+      [{ question: "Q?", answer: "must not place while other guard" }],
+      null,
+      otherPayload.path.at(-1)?.id ?? null
+    );
+    state.aside = otherSurface;
+    state.mode = "ASIDE";
+    await handleOverlayAction({ action: "cycle" }, state, uncertain, context);
+    await handleOverlayAction({ action: "open-selected" }, state, uncertain, context);
+    await handleOverlayAction({ action: "focus-next" }, state, uncertain, context);
+    await handleOverlayAction({ action: "apply" }, state, uncertain, context);
+    expect(state.mode).toBe("ASIDE");
+    expect(state.placement).toBeNull();
+    expect(state.toast).toBe(PLACEMENT_UNCERTAIN_TOAST);
+    expect(state.unresolvedPlacement?.storyId).toBe(originStoryId);
+
+    // Return to the origin story with the committed node: settle exactly.
+    adoptStoryState(state, committed!, context.cache);
+    expect(state.payload.id).toBe(originStoryId);
+    expect(state.unresolvedPlacement).toBeNull();
+    expect(state.placement).toBeNull();
+    expect(state.mode).toBe("NAV");
+    const placed = rowPart(createStoryViewModel(state.payload), state.focusIndex);
+    expect(placed).not.toBeNull();
+    expect(placed!.node.text).toBe(answer);
+    expect(placed!.node.instruction).toBe(FROM_ASIDE_INSTRUCTION);
+    expect(state.toast).toMatch(/^placed as Part \d+$/);
+  });
+
+  test("adoptStoryState return without the node does not false-settle", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const originStoryId = state.payload.id;
+    const answer = "navigate without match";
+    // Snapshot the origin payload before navigation; create never committed.
+    const originSnapshot = state.payload;
+    expect(originSnapshot.path.every((node) => node.text !== answer)).toBeTrue();
+    const surface = createAsideSurface(
+      originStoryId,
+      state.payload.title,
+      [{ question: "Q?", answer }],
+      null,
+      state.payload.path.at(-1)!.id
+    );
+    state.aside = surface;
+    state.mode = "ASIDE";
+    const api: StoryApi = {
+      ...source.api,
+      createNode: async () => {
+        throw new Error("response lost");
+      }
+    };
+    const uncertain = { ...source, api };
+    const context = overlayContext(state, 80, 24);
+    await openPlacementOnStoryAction(state, uncertain, context);
+    await handleOverlayAction({ action: "apply" }, state, uncertain, context);
+    await context.backend.whenIdle();
+    const pendingText = state.unresolvedPlacement!.submission.text;
+
+    const other = (await source.api.listStories()).find((story) => story.id !== originStoryId);
+    expect(other).toBeDefined();
+    adoptStoryState(state, await source.api.loadStory(other!.id), context.cache);
+    expect(state.unresolvedPlacement?.storyId).toBe(originStoryId);
+
+    // Return to origin without the submitted node: no false settle.
+    adoptStoryState(state, originSnapshot, context.cache);
+    expect(state.payload.id).toBe(originStoryId);
+    expect(state.unresolvedPlacement).not.toBeNull();
+    expect(state.unresolvedPlacement!.storyId).toBe(originStoryId);
+    expect(state.unresolvedPlacement!.submission.text).toBe(pendingText);
+    const mode = state.mode as string;
+    expect(mode === "NAV" || mode === "COMPOSE").toBeTrue();
+    expect(state.toast === null || !/^placed as Part /.test(state.toast)).toBeTrue();
+  });
+
+  test("deleting the guarded story clears the unresolved Placement guard", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const originStoryId = state.payload.id;
+    const originSummary = source.stories.find((story) => story.id === originStoryId)!;
+    const answer = "delete guarded story place";
+    const surface = createAsideSurface(
+      originStoryId,
+      state.payload.title,
+      [{ question: "Q?", answer }],
+      null,
+      state.payload.path.at(-1)!.id
+    );
+    state.aside = surface;
+    state.mode = "ASIDE";
+    const api: StoryApi = {
+      ...source.api,
+      createNode: async () => {
+        throw new Error("response lost");
+      }
+    };
+    const uncertain = { ...source, api };
+    const context = overlayContext(state, 80, 24);
+    await openPlacementOnStoryAction(state, uncertain, context);
+    await handleOverlayAction({ action: "apply" }, state, uncertain, context);
+    await context.backend.whenIdle();
+    expect(state.unresolvedPlacement?.storyId).toBe(originStoryId);
+
+    // Ordinary navigation preserves the guard.
+    const survivor = {
+      ...originSummary,
+      id: "survivor-story",
+      title: "survivor story"
+    };
+    const survivorPayload = {
+      ...state.payload,
+      id: survivor.id,
+      title: survivor.title,
+      path: state.payload.path.map((node) => ({ ...node })),
+      nodes: state.payload.nodes.map((node) => ({ ...node }))
+    };
+    adoptStoryState(state, survivorPayload, context.cache);
+    expect(state.unresolvedPlacement?.storyId).toBe(originStoryId);
+    expect(state.payload.id).toBe(survivor.id);
+
+    // Successful library delete of the guarded story proves it is gone.
+    let deleted = false;
+    source.stories = [originSummary, survivor];
+    source.api.deleteStory = async (storyId) => {
+      expect(storyId).toBe(originStoryId);
+      deleted = true;
+      return { ok: true };
+    };
+    source.api.listStories = async () => deleted ? [survivor] : [originSummary, survivor];
+    source.api.loadStory = async (storyId) => {
+      if (storyId === survivor.id) return survivorPayload;
+      throw new Error(`unexpected loadStory ${storyId}`);
+    };
+    state.library = {
+      stories: source.stories,
+      cursor: 0,
+      query: "",
+      prompt: {
+        kind: "delete",
+        value: originSummary.title,
+        targetId: originStoryId
+      }
+    };
+    state.mode = "LIBRARY";
+    await libraryAction({ action: "open-selected" }, state, source, context);
+    await context.backend.whenIdle();
+    expect(deleted).toBeTrue();
+    expect(state.unresolvedPlacement).toBeNull();
+
+    // Placement on the survivor is no longer blocked by a dead-story guard.
+    const survivorSurface = createAsideSurface(
+      survivor.id,
+      survivor.title,
+      [{ question: "Q?", answer: "place on survivor after delete" }],
+      null,
+      survivorPayload.path.at(-1)?.id ?? null
+    );
+    state.aside = survivorSurface;
+    state.mode = "ASIDE";
+    await handleOverlayAction({ action: "cycle" }, state, source, context);
+    await handleOverlayAction({ action: "open-selected" }, state, source, context);
+    await handleOverlayAction({ action: "focus-next" }, state, source, context);
+    await handleOverlayAction({ action: "apply" }, state, source, context);
+    expect(state.mode).toBe("PLACE");
+    expect(state.placement).not.toBeNull();
+    expect(state.unresolvedPlacement).toBeNull();
+  });
+});

--- a/tui/test/aside-use-menu-mouse.test.ts
+++ b/tui/test/aside-use-menu-mouse.test.ts
@@ -1,0 +1,257 @@
+/**
+ * Aside use-menu mouse hits and presented-frame reconciliation.
+ */
+import { describe, expect, test } from "bun:test";
+import { createAsideSurface } from "../src/aside-surface.js";
+import { demoAppSource } from "../src/demo.js";
+import { initialState } from "../src/app.js";
+import { handleOverlayAction } from "../src/overlay-actions.js";
+import { ActionRuntime } from "../src/action-runtime.js";
+import { createWrapCache, type ProseStyle } from "../src/wrap.js";
+import { renderStoryScreen } from "../src/screens/story.js";
+import {
+  captureMouseActionState,
+  mouseToAction
+} from "../src/mouse-actions.js";
+import {
+  reconcilePresentedMouseAction,
+  type FrozenMouseEvent,
+  type PresentedInteraction
+} from "../src/presented-mouse-action.js";
+
+function overlayContext(
+  state: ReturnType<typeof initialState>,
+  width?: number,
+  height?: number
+) {
+  return {
+    backend: new ActionRuntime(state, () => undefined),
+    cache: createWrapCache<ProseStyle>(),
+    repaint: () => undefined,
+    renderer: width === undefined || height === undefined
+      ? null
+      : { width, height } as never,
+    applyTheme: () => undefined,
+    previewTheme: () => undefined
+  };
+}
+
+describe("Aside use-menu mouse", () => {
+  test("use-menu mouse click selects insert into story then opens Placement", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const surface = createAsideSurface(
+      state.payload.id,
+      state.payload.title,
+      [{ question: "Q?", answer: "from mouse menu" }]
+    );
+    state.aside = surface;
+    state.mode = "ASIDE";
+    const context = overlayContext(state, 80, 24);
+    await handleOverlayAction({ action: "cycle" }, state, source, context);
+    await handleOverlayAction({ action: "open-selected" }, state, source, context);
+    expect(surface.useMenu?.cursor).toBe(0);
+
+    const frame = renderStoryScreen(state, { width: 80, height: 24 });
+    state.hitRows = frame.derived.hitRows;
+    let storyY = -1;
+    const storyX = 40;
+    for (let y = 0; y < frame.derived.hitRows.length; y += 1) {
+      const action = mouseToAction({
+        type: "down",
+        button: 0,
+        x: storyX,
+        y,
+        modifiers: { shift: false, alt: false, ctrl: false }
+      }, state);
+      if (action?.action === "focus-index"
+        && action.rowId !== undefined
+        && action.rowId.endsWith(":insert-into-story")) {
+        storyY = y;
+        break;
+      }
+    }
+    expect(storyY).toBeGreaterThan(-1);
+    const click: FrozenMouseEvent = {
+      type: "down",
+      button: 0,
+      x: storyX,
+      y: storyY,
+      modifiers: { shift: false, alt: false, ctrl: false }
+    };
+    const sessionId = surface.useMenu!.sessionId;
+    const storyRowId = `aside-use:${sessionId}:insert-into-story`;
+
+    // Captured at cursor 0; presented after a paint-only cursor change so
+    // reconciliation must re-resolve by stable session+action id, not index.
+    const capturedFocus: PresentedInteraction = {
+      version: 1,
+      frameToken: 1,
+      interactive: true,
+      storyId: state.payload.id,
+      state: captureMouseActionState(state)
+    };
+    expect(capturedFocus.state.aside?.useMenu?.cursor).toBe(0);
+    const first = mouseToAction(click, state);
+    expect(first).toEqual({
+      action: "focus-index",
+      index: 1,
+      rowId: storyRowId
+    });
+    // Present a different frame identity with the same hits/story, as if a
+    // repaint reordered nothing but is a new presented snapshot.
+    state.hitRows = renderStoryScreen(state, { width: 80, height: 24 }).derived.hitRows;
+    const presentedFocus: PresentedInteraction = {
+      version: 2,
+      frameToken: 2,
+      interactive: true,
+      storyId: state.payload.id,
+      state: captureMouseActionState(state)
+    };
+    expect(presentedFocus).not.toBe(capturedFocus);
+    const reconciledFocus = reconcilePresentedMouseAction({
+      action: first!,
+      event: click,
+      captured: capturedFocus,
+      presented: presentedFocus,
+      state
+    });
+    expect(reconciledFocus).toEqual({
+      action: "focus-index",
+      index: 1,
+      rowId: storyRowId
+    });
+    await handleOverlayAction(reconciledFocus!, state, source, context);
+    expect(surface.useMenu?.cursor).toBe(1);
+
+    // Second click: captured before selection; presented after selection so
+    // open-selected survives via selected session+action identity.
+    const afterFocusFrame = renderStoryScreen(state, { width: 80, height: 24 });
+    state.hitRows = afterFocusFrame.derived.hitRows;
+    const capturedOpen: PresentedInteraction = {
+      version: 3,
+      frameToken: 3,
+      interactive: true,
+      storyId: state.payload.id,
+      state: captureMouseActionState(state)
+    };
+    expect(capturedOpen.state.aside?.useMenu?.cursor).toBe(1);
+    const second = mouseToAction(click, state);
+    expect(second?.action).toBe("open-selected");
+    expect(second?.rowId).toBe(storyRowId);
+    state.hitRows = renderStoryScreen(state, { width: 80, height: 24 }).derived.hitRows;
+    const presentedOpen: PresentedInteraction = {
+      version: 4,
+      frameToken: 4,
+      interactive: true,
+      storyId: state.payload.id,
+      state: captureMouseActionState(state)
+    };
+    expect(presentedOpen).not.toBe(capturedOpen);
+    const reconciledOpen = reconcilePresentedMouseAction({
+      action: second!,
+      event: click,
+      captured: capturedOpen,
+      presented: presentedOpen,
+      state
+    });
+    expect(reconciledOpen?.action).toBe("open-selected");
+    await handleOverlayAction(reconciledOpen!, state, source, context);
+    expect(state.mode).toBe("PLACE");
+    expect(state.aside).toBeNull();
+    expect(state.placement?.answer).toBe("from mouse menu");
+    expect(state.placement?.interactionId).toBe(sessionId);
+  });
+
+  test("stale use-menu click for note A is dropped after menu reopens on note B", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const surface = createAsideSurface(
+      state.payload.id,
+      state.payload.title,
+      [
+        { question: "A?", answer: "answer A must not run" },
+        { question: "B?", answer: "answer B stays selected" }
+      ]
+    );
+    state.aside = surface;
+    state.mode = "ASIDE";
+    const context = overlayContext(state, 80, 24);
+    await handleOverlayAction({ action: "cycle" }, state, source, context);
+    // Open menu on note A (index 0).
+    surface.noteCursor = 0;
+    await handleOverlayAction({ action: "open-selected" }, state, source, context);
+    expect(surface.useMenu?.noteIndex).toBe(0);
+    const sessionA = surface.useMenu!.sessionId;
+
+    const frame = renderStoryScreen(state, { width: 80, height: 24 });
+    state.hitRows = frame.derived.hitRows;
+    let storyY = -1;
+    const storyX = 40;
+    for (let y = 0; y < frame.derived.hitRows.length; y += 1) {
+      const action = mouseToAction({
+        type: "down",
+        button: 0,
+        x: storyX,
+        y,
+        modifiers: { shift: false, alt: false, ctrl: false }
+      }, state);
+      if (action?.action === "focus-index"
+        && action.rowId === `aside-use:${sessionA}:insert-into-story`) {
+        storyY = y;
+        break;
+      }
+    }
+    expect(storyY).toBeGreaterThan(-1);
+    const click: FrozenMouseEvent = {
+      type: "down",
+      button: 0,
+      x: storyX,
+      y: storyY,
+      modifiers: { shift: false, alt: false, ctrl: false }
+    };
+    const capturedA: PresentedInteraction = {
+      version: 1,
+      frameToken: 1,
+      interactive: true,
+      storyId: state.payload.id,
+      state: captureMouseActionState(state)
+    };
+    const actionA = mouseToAction(click, state);
+    expect(actionA).toEqual({
+      action: "focus-index",
+      index: 1,
+      rowId: `aside-use:${sessionA}:insert-into-story`
+    });
+
+    // Keyboard closes A and opens the same action on note B.
+    await handleOverlayAction({ action: "cancel" }, state, source, context);
+    expect(surface.useMenu).toBeNull();
+    surface.noteCursor = 1;
+    await handleOverlayAction({ action: "open-selected" }, state, source, context);
+    await handleOverlayAction({ action: "focus-next" }, state, source, context);
+    expect(surface.useMenu?.noteIndex).toBe(1);
+    expect(surface.useMenu?.cursor).toBe(1);
+    expect(surface.useMenu!.sessionId).not.toBe(sessionA);
+
+    state.hitRows = renderStoryScreen(state, { width: 80, height: 24 }).derived.hitRows;
+    const presentedB: PresentedInteraction = {
+      version: 2,
+      frameToken: 2,
+      interactive: true,
+      storyId: state.payload.id,
+      state: captureMouseActionState(state)
+    };
+    const stale = reconcilePresentedMouseAction({
+      action: actionA!,
+      event: click,
+      captured: capturedA,
+      presented: presentedB,
+      state
+    });
+    expect(stale).toBeNull();
+    expect(surface.useMenu?.noteIndex).toBe(1);
+    expect(surface.useMenu?.cursor).toBe(1);
+    expect(state.mode).toBe("ASIDE");
+  });
+});

--- a/tui/test/aside-use-placement.test.ts
+++ b/tui/test/aside-use-placement.test.ts
@@ -1,0 +1,588 @@
+/**
+ * Stage 1/2 Side Note focus, use menu, and Placement behavior.
+ */
+import { describe, expect, test } from "bun:test";
+import type { KeyEvent } from "@opentui/core";
+import { createAsideSurface } from "../src/aside-surface.js";
+import {
+  openAside,
+  sendAsideQuestion
+} from "../src/aside-actions.js";
+import {
+  buildPlacementStops,
+  initialPlacementCursor,
+  FROM_ASIDE_INSTRUCTION,
+  PLACEMENT_STATUS_TEXT
+} from "../src/aside-placement.js";
+import { noteCursorAfterHistoryScroll } from "../src/aside-note-scroll.js";
+import { pasteInto, resolveKey } from "../src/keys.js";
+import { demoAppSource } from "../src/demo.js";
+import { initialState } from "../src/app.js";
+import { handleOverlayAction } from "../src/overlay-actions.js";
+import type { StoryApi } from "../src/api.js";
+import { ActionRuntime } from "../src/action-runtime.js";
+import { createWrapCache, type ProseStyle } from "../src/wrap.js";
+import { openDirectComposer } from "../src/composer-ownership.js";
+import { moveComposerTo, setComposerText } from "../src/composer-model.js";
+import { renderStoryScreen } from "../src/screens/story.js";
+import { createStoryViewModel, rowIndexForNode, rowPart } from "../src/model.js";
+
+function key(
+  name: string,
+  options: { shift?: boolean; ctrl?: boolean; super?: boolean } = {}
+): KeyEvent {
+  return {
+    name,
+    sequence: name,
+    shift: options.shift ?? false,
+    ctrl: options.ctrl ?? false,
+    meta: false,
+    option: false,
+    super: options.super ?? false
+  } as KeyEvent;
+}
+
+function overlayContext(
+  state: ReturnType<typeof initialState>,
+  width?: number,
+  height?: number
+) {
+  return {
+    backend: new ActionRuntime(state, () => undefined),
+    cache: createWrapCache<ProseStyle>(),
+    repaint: () => undefined,
+    renderer: width === undefined || height === undefined
+      ? null
+      : { width, height } as never,
+    applyTheme: () => undefined,
+    previewTheme: () => undefined
+  };
+}
+
+describe("Aside use menu and Placement", () => {
+  test("focus, use-menu, and PLACE key layers", () => {
+    expect(resolveKey(key("tab"), "ASIDE", { asideLayer: "composer" }).action).toBe("cycle");
+    expect(resolveKey(key("return"), "ASIDE", { asideLayer: "notes" }).action)
+      .toBe("open-selected");
+    expect(resolveKey(key("up"), "ASIDE", { asideLayer: "notes" }).action)
+      .toBe("focus-previous");
+    expect(resolveKey(key("return"), "ASIDE", { asideLayer: "use-menu" }).action)
+      .toBe("apply");
+    expect(resolveKey(key("up"), "ASIDE", { asideLayer: "use-menu" }).action)
+      .toBe("focus-previous");
+    expect(resolveKey(key("down"), "PLACE").action).toBe("focus-next");
+    expect(resolveKey(key("return"), "PLACE").action).toBe("apply");
+    expect(resolveKey(key("escape"), "PLACE").action).toBe("cancel");
+  });
+
+  test("Side Note use menu inserts complete answer into Direct compose", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    expect(openDirectComposer(state)).toBeTrue();
+    setComposerText(state.composer, "draft replace right");
+    const selectionStart = "draft ".length;
+    moveComposerTo(state.composer, "draft replace".length);
+    state.composer.anchor = selectionStart;
+    const answer = "complete Side Note answer";
+    const surface = createAsideSurface(state.payload.id, state.payload.title, [
+      { question: "first?", answer: "older answer" },
+      { question: "Why the lantern?", answer }
+    ]);
+    state.aside = surface;
+    state.mode = "ASIDE";
+    const context = overlayContext(state, 80, 24);
+
+    await handleOverlayAction({ action: "cycle" }, state, source, context);
+    expect(surface.focus).toBe("notes");
+    expect(surface.noteCursor).toBe(1);
+    const notesFrame = renderStoryScreen(state, { width: 80, height: 24 })
+      .lines.map((line) => line.map((part) => part.text).join("")).join("\n");
+    expect(notesFrame).toContain("▸ Q: Why the lantern?");
+    expect(notesFrame).toContain("Tab ask");
+    expect(notesFrame).toContain("Enter use");
+    expect(pasteInto(state, "hidden paste")).toBeFalse();
+    expect(surface.composer.text).toBe("");
+    expect(state.composer.text).toBe("draft replace right");
+
+    await handleOverlayAction({ action: "focus-previous" }, state, source, context);
+    expect(surface.noteCursor).toBe(0);
+    await handleOverlayAction({ action: "focus-next" }, state, source, context);
+    expect(surface.noteCursor).toBe(1);
+
+    await handleOverlayAction({ action: "open-selected" }, state, source, context);
+    expect(surface.useMenu).toMatchObject({ noteIndex: 1, cursor: 0 });
+    expect(typeof surface.useMenu?.sessionId).toBe("string");
+    const menuFrame = renderStoryScreen(state, { width: 80, height: 24 })
+      .lines.map((line) => line.map((part) => part.text).join("")).join("\n");
+    expect(menuFrame).toContain("use answer ·");
+    expect(menuFrame).toContain("insert into compose");
+    expect(menuFrame).toContain("insert into story…");
+    expect(menuFrame).toContain("insert at the composer cur");
+    expect(menuFrame).toContain("select a position");
+    expect(menuFrame).not.toContain("new fact");
+    expect(menuFrame).not.toContain("delete note");
+    expect(menuFrame).not.toContain("author's note");
+
+    await handleOverlayAction({ action: "cancel" }, state, source, context);
+    expect(surface.useMenu).toBeNull();
+    expect(surface.focus).toBe("notes");
+    expect(surface.noteCursor).toBe(1);
+
+    await handleOverlayAction({ action: "open-selected" }, state, source, context);
+    await handleOverlayAction({ action: "apply" }, state, source, context);
+
+    expect(state.mode).toBe("COMPOSE");
+    expect(state.aside).toBeNull();
+    expect(state.composer.text).toBe(`draft ${answer} right`);
+    expect(state.composer.cursor).toBe(selectionStart + answer.length);
+    expect(state.composer.anchor).toBeNull();
+
+    // Esc ladder: use menu → notes → composer → leave Aside.
+    state.aside = createAsideSurface(state.payload.id, state.payload.title, [
+      { question: "Q?", answer: "A." }
+    ]);
+    state.mode = "ASIDE";
+    const again = state.aside;
+    await handleOverlayAction({ action: "cycle" }, state, source, context);
+    await handleOverlayAction({ action: "open-selected" }, state, source, context);
+    expect(again.useMenu).not.toBeNull();
+    await handleOverlayAction({ action: "cancel" }, state, source, context);
+    expect(again.focus).toBe("notes");
+    await handleOverlayAction({ action: "cancel" }, state, source, context);
+    expect(again.focus).toBe("composer");
+    await handleOverlayAction({ action: "cancel" }, state, source, context);
+    expect(state.mode).toBe("NAV");
+    expect(state.aside).toBeNull();
+  });
+
+  test("Tab stays on the composer while Ask is busy; Esc still stops", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => { release = resolve; });
+    const api: StoryApi = {
+      ...source.api,
+      getAside: async () => ({
+        notes: [{ question: "saved?", answer: "yes" }]
+      }),
+      askAside: async (_id, _q, _onDelta, signal) => {
+        await gate;
+        if (signal.aborted) return null;
+        return { notes: [{ question: "saved?", answer: "yes" }] };
+      },
+      clearAside: async () => state.payload
+    };
+    await openAside(state, api, { entryPointsOpen: true });
+    const context = overlayContext(state, 80, 24);
+    const pending = sendAsideQuestion(state, api, "In flight?");
+    await Promise.resolve();
+    expect(state.aside!.busy).toBeTrue();
+    expect(state.aside!.focus).toBe("composer");
+
+    await handleOverlayAction({ action: "cycle" }, state, source, context);
+    expect(state.aside!.focus).toBe("composer");
+    expect(state.aside!.useMenu).toBeNull();
+
+    await handleOverlayAction({ action: "cancel" }, state, source, context);
+    release();
+    await pending;
+    expect(state.mode).toBe("ASIDE");
+    expect(state.aside!.busy).toBeFalse();
+    expect(state.aside!.composer.text).toBe("In flight?");
+    expect(state.aside!.notes).toHaveLength(1);
+  });
+
+  test("leaving the composer for Side Notes disarms Clear confirmation", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const surface = createAsideSurface(state.payload.id, state.payload.title, [
+      { question: "Q?", answer: "A." }
+    ]);
+    state.aside = surface;
+    state.mode = "ASIDE";
+    surface.confirmClear = true;
+    const context = overlayContext(state, 80, 24);
+
+    await handleOverlayAction({ action: "cycle" }, state, source, context);
+    expect(surface.focus).toBe("notes");
+    expect(surface.confirmClear).toBeFalse();
+  });
+
+  test("Up/Down keeps the focused Side Note inside the history viewport", async () => {
+    const notes = Array.from({ length: 12 }, (_, index) => ({
+      question: `note-q-${index}`,
+      answer: index === 6 ? "tall answer\n".repeat(20) : `note-a-${index}`
+    }));
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const surface = createAsideSurface(state.payload.id, state.payload.title, notes);
+    state.aside = surface;
+    state.mode = "ASIDE";
+    const width = 40;
+    const height = 12;
+    const context = overlayContext(state, width, height);
+    const frameText = () => renderStoryScreen(state, { width, height })
+      .lines.map((line) => line.map((part) => part.text).join("")).join("\n");
+
+    await handleOverlayAction({ action: "cycle" }, state, source, context);
+    expect(surface.focus).toBe("notes");
+    // Newest note after open; scroll to the oldest through Up.
+    for (let step = 0; step < notes.length; step += 1) {
+      await handleOverlayAction({ action: "focus-previous" }, state, source, context);
+    }
+    expect(surface.noteCursor).toBe(0);
+    let frame = frameText();
+    expect(frame).toContain("note-q-0");
+    expect(frame).toContain("▸ Q:");
+
+    for (let step = 0; step < notes.length - 1; step += 1) {
+      await handleOverlayAction({ action: "focus-next" }, state, source, context);
+      frame = frameText();
+      expect(frame).toContain(`note-q-${surface.noteCursor}`);
+      expect(frame).toContain("▸ Q:");
+    }
+    expect(surface.noteCursor).toBe(notes.length - 1);
+    expect(frame).toContain(`note-q-${notes.length - 1}`);
+  });
+
+  test("PageUp/PageDown and line scroll keep notes-focused selection visible", async () => {
+    const notes = Array.from({ length: 14 }, (_, index) => ({
+      question: `scroll-q-${index}`,
+      answer: `scroll-a-${index} with a few extra words for wrap`
+    }));
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const surface = createAsideSurface(state.payload.id, state.payload.title, notes);
+    state.aside = surface;
+    state.mode = "ASIDE";
+    const width = 40;
+    const height = 12;
+    const context = overlayContext(state, width, height);
+    const frameText = () => renderStoryScreen(state, { width, height })
+      .lines.map((line) => line.map((part) => part.text).join("")).join("\n");
+
+    await handleOverlayAction({ action: "cycle" }, state, source, context);
+    expect(surface.focus).toBe("notes");
+    expect(surface.noteCursor).toBe(notes.length - 1);
+
+    // Page toward older history while notes own focus.
+    for (let page = 0; page < 6; page += 1) {
+      await handleOverlayAction({ action: "scroll-up" }, state, source, context);
+      const frame = frameText();
+      expect(frame).toContain(`scroll-q-${surface.noteCursor}`);
+      expect(frame).toContain("▸ Q:");
+    }
+    expect(surface.noteCursor).toBeLessThan(notes.length - 1);
+    const afterPageUp = surface.noteCursor;
+
+    // Line/wheel scroll further toward older notes.
+    for (let step = 0; step < 8; step += 1) {
+      await handleOverlayAction({ action: "scroll-line-up" }, state, source, context);
+    }
+    const afterLineUp = surface.noteCursor;
+    expect(afterLineUp <= afterPageUp).toBeTrue();
+    let frame = frameText();
+    expect(frame).toContain(`scroll-q-${surface.noteCursor}`);
+    expect(frame).toContain("▸ Q:");
+
+    // Enter opens the use menu for the visible focused note.
+    await handleOverlayAction({ action: "open-selected" }, state, source, context);
+    expect(surface.useMenu).not.toBeNull();
+    expect(surface.useMenu!.noteIndex).toBe(surface.noteCursor);
+    expect(surface.notes[surface.useMenu!.noteIndex]!.question)
+      .toBe(`scroll-q-${surface.noteCursor}`);
+    await handleOverlayAction({ action: "cancel" }, state, source, context);
+    expect(surface.useMenu).toBeNull();
+
+    // Page/line down toward newer notes keeps selection visible.
+    for (let page = 0; page < 6; page += 1) {
+      await handleOverlayAction({ action: "scroll-down" }, state, source, context);
+      frame = frameText();
+      expect(frame).toContain(`scroll-q-${surface.noteCursor}`);
+      expect(frame).toContain("▸ Q:");
+    }
+    for (let step = 0; step < 8; step += 1) {
+      await handleOverlayAction({ action: "scroll-line-down" }, state, source, context);
+    }
+    frame = frameText();
+    expect(frame).toContain(`scroll-q-${surface.noteCursor}`);
+    expect(frame).toContain("▸ Q:");
+    await handleOverlayAction({ action: "open-selected" }, state, source, context);
+    expect(surface.useMenu!.noteIndex).toBe(surface.noteCursor);
+
+    // Composer focus: history scroll must not steal noteCursor for Enter later.
+    await handleOverlayAction({ action: "cancel" }, state, source, context);
+    await handleOverlayAction({ action: "cycle" }, state, source, context);
+    expect(surface.focus).toBe("composer");
+    const cursorWhileComposer = surface.noteCursor;
+    await handleOverlayAction({ action: "scroll-up" }, state, source, context);
+    await handleOverlayAction({ action: "scroll-line-up" }, state, source, context);
+    expect(surface.focus).toBe("composer");
+    expect(surface.noteCursor).toBe(cursorWhileComposer);
+  });
+
+  test("separator-only rows do not keep an invisible note focused", async () => {
+    // note0 content [0,4), separator at 4; note1 content [5,8)
+    const noteStarts = [0, 5];
+    const noteContentEnds = [4, 8];
+    const bodyLength = 9;
+    // Viewport shows only row 4 — the separator blank of note 0.
+    const cursor = noteCursorAfterHistoryScroll(
+      2,
+      noteStarts,
+      noteContentEnds,
+      bodyLength,
+      4,
+      1,
+      0,
+      1
+    );
+    expect(cursor).not.toBe(0);
+
+    // Integration: after line scroll, Enter menu matches the visible ▸ note.
+    const notes = [
+      { question: "old-q", answer: "line-a\nline-b\nline-c\nline-d\nline-e\nline-f" },
+      { question: "new-q", answer: "visible newer answer" }
+    ];
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const surface = createAsideSurface(state.payload.id, state.payload.title, notes);
+    state.aside = surface;
+    state.mode = "ASIDE";
+    const width = 40;
+    const height = 10;
+    const context = overlayContext(state, width, height);
+    const frameText = () => renderStoryScreen(state, { width, height })
+      .lines.map((line) => line.map((part) => part.text).join("")).join("\n");
+
+    await handleOverlayAction({ action: "cycle" }, state, source, context);
+    expect(surface.focus).toBe("notes");
+    for (let step = 0; step < 40; step += 1) {
+      await handleOverlayAction({ action: "scroll-line-up" }, state, source, context);
+    }
+    const frame = frameText();
+    expect(frame).toContain("▸ Q:");
+    const focusedQuestion = notes[surface.noteCursor]!.question;
+    expect(frame).toContain(focusedQuestion);
+    await handleOverlayAction({ action: "open-selected" }, state, source, context);
+    expect(surface.useMenu!.noteIndex).toBe(surface.noteCursor);
+    expect(surface.notes[surface.useMenu!.noteIndex]!.question).toBe(focusedQuestion);
+  });
+
+  test("Enter re-anchors a note hidden by stale scrollTop after reflow before use menu", async () => {
+    const notes = Array.from({ length: 16 }, (_, index) => ({
+      question: `anchor-q-${index}`,
+      answer: `anchor-a-${index} ${"word ".repeat(12)}`
+    }));
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const surface = createAsideSurface(state.payload.id, state.payload.title, notes);
+    state.aside = surface;
+    state.mode = "ASIDE";
+    // Wide layout first: focus an older note and establish a real scroll offset.
+    const wide = overlayContext(state, 80, 24);
+    await handleOverlayAction({ action: "cycle" }, state, source, wide);
+    expect(surface.focus).toBe("notes");
+    for (let step = 0; step < notes.length; step += 1) {
+      await handleOverlayAction({ action: "focus-previous" }, state, source, wide);
+    }
+    expect(surface.noteCursor).toBe(0);
+    expect(surface.scrollTop === null || surface.scrollTop === 0).toBeTrue();
+
+    // Stale offset as if the terminal reflowed under a narrower width.
+    surface.scrollTop = 40;
+    // Header-height reflow: a longer title changes chrome rows vs bodyRows.
+    surface.storyTitle = "Reflow title that wraps ".repeat(3);
+    const narrowW = 40;
+    const narrowH = 16;
+    const hidden = renderStoryScreen(state, { width: narrowW, height: narrowH })
+      .lines.map((line) => line.map((part) => part.text).join("")).join("\n");
+    expect(hidden).not.toContain("anchor-q-0");
+
+    // Enter uses noteCursor 0; re-anchor must run before the menu owns the surface.
+    const narrow = overlayContext(state, narrowW, narrowH);
+    await handleOverlayAction({ action: "open-selected" }, state, source, narrow);
+    expect(surface.useMenu).not.toBeNull();
+    expect(surface.useMenu!.noteIndex).toBe(0);
+    expect(surface.noteCursor).toBe(0);
+    expect(surface.notes[surface.useMenu!.noteIndex]!.question).toBe("anchor-q-0");
+    // Re-anchor ran under the new viewport: note start is on-screen again.
+    expect(surface.scrollTop === null || surface.scrollTop === 0).toBeTrue();
+
+    // Menu closes with Esc; history stays on the re-anchored note under new size.
+    await handleOverlayAction({ action: "cancel" }, state, source, narrow);
+    expect(surface.useMenu).toBeNull();
+    expect(surface.focus).toBe("notes");
+    const shown = renderStoryScreen(state, { width: narrowW, height: narrowH })
+      .lines.map((line) => line.map((part) => part.text).join("")).join("\n");
+    expect(shown).toContain("anchor-q-0");
+    expect(shown).toContain("▸");
+  });
+
+  test("Placement: initial stop, Take place, leaf gap, cancel restore, busy reject", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const pathLen = state.payload.path.length;
+    expect(pathLen).toBeGreaterThan(1);
+    // Focus a mid-line Part so the opening stop is not the leaf.
+    const openingPathIndex = Math.max(0, pathLen - 2);
+    const openingPart = state.payload.path[openingPathIndex]!;
+    state.focusIndex = rowIndexForNode(
+      createStoryViewModel(state.payload),
+      openingPart.id
+    );
+    const answer = "prose placed from a Side Note";
+    const surface = createAsideSurface(
+      state.payload.id,
+      state.payload.title,
+      [{ question: "Where?", answer }],
+      null,
+      openingPart.id
+    );
+    state.aside = surface;
+    state.mode = "ASIDE";
+    const context = overlayContext(state, 80, 24);
+
+    const stops = buildPlacementStops(state.payload);
+    expect(stops.some((stop) => stop.kind === "take")).toBeTrue();
+    expect(stops.at(-1)?.kind).toBe("leaf-gap");
+    expect(stops.filter((stop) => stop.kind === "leaf-gap")).toHaveLength(1);
+    expect(initialPlacementCursor(stops, openingPart.id)).toBe(
+      stops.findIndex((stop) => stop.kind === "take" && stop.partId === openingPart.id)
+    );
+    expect(initialPlacementCursor(stops, "missing-part-id")).toBe(
+      stops.findLastIndex((stop) => stop.kind === "take")
+    );
+
+    await handleOverlayAction({ action: "cycle" }, state, source, context);
+    await handleOverlayAction({ action: "open-selected" }, state, source, context);
+    expect(surface.useMenu?.cursor).toBe(0);
+    await handleOverlayAction({ action: "focus-next" }, state, source, context);
+    expect(surface.useMenu?.cursor).toBe(1);
+
+    // Busy generation refuses Placement without leaving Aside.
+    state.stream = {
+      nodeId: "virtual",
+      parentId: null,
+      instruction: "",
+      text: "…",
+      startedAt: new Date().toISOString(),
+      retakeNodeId: undefined
+    } as never;
+    await handleOverlayAction({ action: "apply" }, state, source, context);
+    expect(state.mode).toBe("ASIDE");
+    expect(state.placement).toBeNull();
+    expect(state.toast).toContain("stream running");
+    state.stream = null;
+    state.toast = null;
+
+    await handleOverlayAction({ action: "apply" }, state, source, context);
+    expect(state.mode).toBe("PLACE");
+    expect(state.aside).toBeNull();
+    expect(state.placement).not.toBeNull();
+    expect(state.placement!.cursor).toBe(
+      stops.findIndex((stop) => stop.kind === "take" && stop.partId === openingPart.id)
+    );
+    expect(state.placement!.returnAside).toBe(surface);
+    const frameText = () => renderStoryScreen(state, { width: 80, height: 24 })
+      .lines.map((line) => line.map((part) => part.text).join("")).join("\n");
+    const placeFrame = frameText();
+    expect(placeFrame).toContain("PLACE");
+    expect(placeFrame).toContain(PLACEMENT_STATUS_TEXT);
+    expect(placeFrame).toContain("Up/Down where");
+    expect(placeFrame).toContain("Enter place");
+    expect(placeFrame).toContain("Esc back to Aside");
+    // Destination marker is painted on the story surface at the Take stop.
+    const openingPartView = rowPart(
+      createStoryViewModel(state.payload),
+      rowIndexForNode(createStoryViewModel(state.payload), openingPart.id)
+    )!;
+    const takeLabel = `take on ¶ ${openingPartView.number}`;
+    const takePosition = `take ${openingPartView.siblingCount + 1}/${openingPartView.siblingCount + 1}`;
+    expect(placeFrame).toContain(takeLabel);
+    expect(placeFrame).toContain(takePosition);
+    expect(placeFrame).not.toContain("here · new Part");
+
+    // Up/Down moves the marker; the previous destination is gone.
+    await handleOverlayAction({ action: "focus-next" }, state, source, context);
+    const movedFrame = frameText();
+    const movedStop = state.placement!.stops[state.placement!.cursor]!;
+    if (movedStop.kind === "take") {
+      expect(movedFrame).toContain(`take on ¶ ${movedStop.partNumber}`);
+      expect(movedFrame).not.toContain(takeLabel);
+    } else {
+      expect(movedFrame).toContain("here · new Part");
+      expect(movedFrame).toContain("prose placed");
+      expect(movedFrame).not.toContain(takeLabel);
+    }
+    // Return to the opening Take stop for the rest of the flow.
+    while (state.placement!.stops[state.placement!.cursor]?.kind !== "take"
+      || (state.placement!.stops[state.placement!.cursor] as { partId?: string }).partId
+        !== openingPart.id) {
+      await handleOverlayAction({ action: "focus-previous" }, state, source, context);
+    }
+
+    // Esc restores the exact Aside surface with the use menu open.
+    await handleOverlayAction({ action: "cancel" }, state, source, context);
+    expect(state.mode).toBe("ASIDE");
+    expect(state.aside).toBe(surface);
+    expect(state.placement).toBeNull();
+    expect(surface.focus).toBe("notes");
+    expect(surface.useMenu).toMatchObject({ noteIndex: 0, cursor: 1 });
+    expect(typeof surface.useMenu?.sessionId).toBe("string");
+
+    // Take placement: sibling under the opening Part's parent.
+    await handleOverlayAction({ action: "apply" }, state, source, context);
+    expect(state.mode).toBe("PLACE");
+    const beforeNodes = state.payload.nodes.length;
+    await handleOverlayAction({ action: "apply" }, state, source, context);
+    await context.backend.whenIdle();
+    expect(state.mode).toBe("NAV");
+    expect(state.placement).toBeNull();
+    expect(state.payload.nodes.length).toBe(beforeNodes + 1);
+    expect(state.toast).toMatch(/^placed as Part \d+$/);
+    const focused = rowPart(createStoryViewModel(state.payload), state.focusIndex);
+    expect(focused).not.toBeNull();
+    expect(focused!.node.instruction).toBe(FROM_ASIDE_INSTRUCTION);
+    expect(focused!.node.text).toBe(answer);
+    expect(focused!.node.parentId).toBe(openingPart.parentId);
+    expect(state.freshLandedAt.has(focused!.id)).toBeTrue();
+
+    // Leaf-gap placement: child of the active leaf.
+    const surface2 = createAsideSurface(
+      state.payload.id,
+      state.payload.title,
+      [{ question: "gap?", answer: "leaf gap prose" }],
+      null,
+      state.payload.path.at(-1)!.id
+    );
+    state.aside = surface2;
+    state.mode = "ASIDE";
+    await handleOverlayAction({ action: "cycle" }, state, source, context);
+    await handleOverlayAction({ action: "open-selected" }, state, source, context);
+    await handleOverlayAction({ action: "focus-next" }, state, source, context);
+    await handleOverlayAction({ action: "apply" }, state, source, context);
+    expect(state.mode).toBe("PLACE");
+    // Move to the trailing leaf gap.
+    while (state.placement!.stops[state.placement!.cursor]?.kind !== "leaf-gap") {
+      await handleOverlayAction({ action: "focus-next" }, state, source, context);
+    }
+    const gapFrame = renderStoryScreen(state, { width: 80, height: 24 })
+      .lines.map((line) => line.map((part) => part.text).join("")).join("\n");
+    expect(gapFrame).toContain("here · new Part");
+    expect(gapFrame).toContain("leaf gap prose");
+    expect(gapFrame.includes("take on ¶")).toBeFalse();
+    const leafId = state.payload.path.at(-1)!.id;
+    const pathBefore = state.payload.path.length;
+    await handleOverlayAction({ action: "apply" }, state, source, context);
+    await context.backend.whenIdle();
+    expect(state.mode).toBe("NAV");
+    expect(state.payload.path.length).toBe(pathBefore + 1);
+    const leafPlaced = rowPart(createStoryViewModel(state.payload), state.focusIndex);
+    expect(leafPlaced).not.toBeNull();
+    expect(leafPlaced!.node.parentId).toBe(leafId);
+    expect(leafPlaced!.node.instruction).toBe(FROM_ASIDE_INSTRUCTION);
+    expect(leafPlaced!.node.text).toBe("leaf gap prose");
+    expect(state.toast).toBe(`placed as Part ${leafPlaced!.number}`);
+  });
+});

--- a/tui/test/aside.test.ts
+++ b/tui/test/aside.test.ts
@@ -328,6 +328,81 @@ describe("Aside TUI contract", () => {
       && part.composerStart === 5)).toBeTrue();
   });
 
+  test("notes focus withholds Aside composer ownership until a prompt click", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const surface = createAsideSurface(
+      state.payload.id,
+      state.payload.title,
+      [{ question: "Why?", answer: "Because." }]
+    );
+    surface.focus = "notes";
+    surface.noteCursor = 0;
+    state.aside = surface;
+    state.mode = "ASIDE";
+    const context = overlayContext(state, 80, 24);
+
+    // Before the prompt click, text ownership is null and right-click refuses.
+    expect(activeTextComposer(state)).toBeNull();
+    const notesFrame = renderStoryScreen(state, { width: 80, height: 24 });
+    state.hitRows = notesFrame.derived.hitRows;
+    let composerHit: { x: number; y: number } | null = null;
+    for (let y = 0; y < state.hitRows.length; y += 1) {
+      const row = state.hitRows[y];
+      if (row?.target.kind !== "composer") continue;
+      composerHit = { x: Math.min(40, Math.max(0, row.right - 1)), y };
+      break;
+    }
+    expect(composerHit).not.toBeNull();
+    const rightClick = mouseToAction({
+      type: "down",
+      button: 2,
+      x: composerHit!.x,
+      y: composerHit!.y,
+      modifiers: { shift: false, alt: false, ctrl: false }
+    }, state);
+    expect(rightClick).toBeNull();
+    openTextActions(state);
+    expect(state.textActions).toBeNull();
+
+    // Left-click on the visible prompt claims composer focus.
+    const compose = mouseToAction({
+      type: "down",
+      button: 0,
+      x: composerHit!.x,
+      y: composerHit!.y,
+      modifiers: { shift: false, alt: false, ctrl: false }
+    }, state);
+    expect(compose).toEqual({ action: "compose" });
+    await handleOverlayAction(compose!, state, source, context);
+    expect(surface.focus).toBe("composer");
+    expect(activeTextComposer(state)).toBe(surface.composer);
+
+    // Subsequent text and paste target the Aside composer.
+    await handleOverlayAction({ action: "input", text: "typed " }, state, source, context);
+    expect(surface.composer.text).toBe("typed ");
+    expect(pasteInto(state, "paste")).toBeTrue();
+    expect(surface.composer.text).toBe("typed paste");
+
+    // Esc/Tab ladder still moves notes → composer → leave.
+    await handleOverlayAction({ action: "cycle" }, state, source, context);
+    expect(surface.focus).toBe("notes");
+    expect(activeTextComposer(state)).toBeNull();
+    await handleOverlayAction({ action: "cancel" }, state, source, context);
+    expect(surface.focus).toBe("composer");
+    expect(activeTextComposer(state)).toBe(surface.composer);
+
+    // Use menu owns the surface: compose click does not steal focus.
+    await handleOverlayAction({ action: "cycle" }, state, source, context);
+    await handleOverlayAction({ action: "open-selected" }, state, source, context);
+    expect(surface.useMenu).not.toBeNull();
+    expect(activeTextComposer(state)).toBeNull();
+    await handleOverlayAction({ action: "compose" }, state, source, context);
+    expect(surface.useMenu).not.toBeNull();
+    expect(surface.focus).toBe("notes");
+    expect(activeTextComposer(state)).toBeNull();
+  });
+
   test("failed ask restores the question; successful ask appends a Side Note", async () => {
     const source = demoAppSource();
     const state = initialState(source, false);

--- a/tui/test/create-node-preflight.test.ts
+++ b/tui/test/create-node-preflight.test.ts
@@ -1,0 +1,237 @@
+/**
+ * createNode version-preflight failures are adapter-owned and definitely
+ * unsent. No node mutation, mutation id, or createNode worker post leaves
+ * the client when expectedVersion fails on a cold cache.
+ *
+ * Explicit-unsent is orthogonal to connection class: application ApiError
+ * stays online; transport/plain Error marks the connection down.
+ */
+import { afterEach, expect, test } from "bun:test";
+import { createFailureEnvelope } from "../../shared/failure-envelope.js";
+import {
+  ApiError,
+  ApiRecoveryRequiredError,
+  isExplicitMutationUnsent
+} from "../src/api.js";
+import { isDefinitePlacementFailure } from "../src/aside-placement.js";
+import { createConnectionMonitor } from "../src/connection.js";
+import { demoAppSource } from "../src/demo.js";
+import { WorkerApiError } from "../src/worker-error.js";
+import { storyApiFromWorkerTransport } from "../src/worker-story-api.js";
+import {
+  createTestApi as createApi,
+  testHttpMetadata as metadata,
+  testStoryPayload as storyPayload
+} from "./http-api-fixture.js";
+
+const originalFetch = globalThis.fetch;
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+async function rejection(promise: Promise<unknown>): Promise<unknown> {
+  try {
+    await promise;
+    return undefined;
+  } catch (error) {
+    return error;
+  }
+}
+
+test("HTTP createNode cold version preflight failure is explicit-unsent and posts no node mutation", async () => {
+  const paths: string[] = [];
+  globalThis.fetch = (async (input, init) => {
+    const path = new URL(String(input)).pathname;
+    paths.push(`${init?.method ?? "GET"} ${path}`);
+    if (path === "/api/health") return Response.json(metadata());
+    if (path === "/api/stories/story") {
+      return Response.json(
+        createFailureEnvelope({
+          code: "not_found",
+          message: "version preflight load failed",
+          status: 404
+        }),
+        { status: 404 }
+      );
+    }
+    throw new Error(`Unexpected API path: ${path}`);
+  }) as typeof fetch;
+
+  const api = createApi("http://127.0.0.1:7373");
+  const error = await rejection(api.createNode("story", {
+    parentId: null,
+    text: "must not post"
+  }));
+
+  expect(isExplicitMutationUnsent(error)).toBeTrue();
+  expect(error instanceof ApiRecoveryRequiredError).toBeTrue();
+  expect((error as Error).message).toContain("createNode was not sent");
+  expect((error as Error).message).toContain("version preflight load failed");
+  expect(isDefinitePlacementFailure(error)).toBeTrue();
+  expect(paths.some((entry) => entry.includes("/nodes"))).toBeFalse();
+  expect(paths).toContain("GET /api/stories/story");
+});
+
+test("HTTP cold preflight application failure stays online, unsent, and posts no nodes", async () => {
+  const paths: string[] = [];
+  globalThis.fetch = (async (input, init) => {
+    const path = new URL(String(input)).pathname;
+    paths.push(`${init?.method ?? "GET"} ${path}`);
+    if (path === "/api/health") return Response.json(metadata());
+    if (path === "/api/stories/story") {
+      return Response.json(
+        createFailureEnvelope({
+          code: "not_found",
+          message: "story missing for version preflight",
+          status: 404
+        }),
+        { status: 404 }
+      );
+    }
+    throw new Error(`Unexpected API path: ${path}`);
+  }) as typeof fetch;
+
+  const monitor = createConnectionMonitor(createApi("http://127.0.0.1:7373"));
+  const error = await rejection(monitor.api.createNode("story", {
+    parentId: null,
+    text: "must not post"
+  }));
+
+  expect(isExplicitMutationUnsent(error)).toBeTrue();
+  expect(error instanceof ApiError).toBeTrue();
+  expect(isDefinitePlacementFailure(error)).toBeTrue();
+  expect(monitor.state().down).toBeFalse();
+  expect(paths.some((entry) => entry.includes("/nodes"))).toBeFalse();
+});
+
+test("HTTP cold preflight transport failure goes down, unsent, and posts no nodes", async () => {
+  const paths: string[] = [];
+  globalThis.fetch = (async (input, init) => {
+    const path = new URL(String(input)).pathname;
+    paths.push(`${init?.method ?? "GET"} ${path}`);
+    if (path === "/api/health") return Response.json(metadata());
+    if (path === "/api/stories/story") {
+      throw new TypeError("fetch failed: connection refused");
+    }
+    throw new Error(`Unexpected API path: ${path}`);
+  }) as typeof fetch;
+
+  const monitor = createConnectionMonitor(createApi("http://127.0.0.1:7373"));
+  const error = await rejection(monitor.api.createNode("story", {
+    parentId: null,
+    text: "must not post"
+  }));
+
+  expect(isExplicitMutationUnsent(error)).toBeTrue();
+  expect(error instanceof ApiError).toBeFalse();
+  expect((error as Error).message).toContain("createNode was not sent");
+  expect((error as Error).message).toContain("connection refused");
+  expect((error as Error).cause instanceof TypeError).toBeTrue();
+  expect(isDefinitePlacementFailure(error)).toBeTrue();
+  expect(monitor.state().down).toBeTrue();
+  expect(paths.some((entry) => entry.includes("/nodes"))).toBeFalse();
+  expect(paths).toContain("GET /api/stories/story");
+});
+
+test("HTTP createNode still mutates after a successful cold version preflight", async () => {
+  const paths: string[] = [];
+  globalThis.fetch = (async (input, init) => {
+    const path = new URL(String(input)).pathname;
+    paths.push(`${init?.method ?? "GET"} ${path}`);
+    if (path === "/api/health") return Response.json(metadata());
+    // Empty path/nodes is a valid cold story for version metadata only.
+    if (path === "/api/stories/story" || path === "/api/stories/story/nodes") {
+      return Response.json(storyPayload("story"));
+    }
+    throw new Error(`Unexpected API path: ${path}`);
+  }) as typeof fetch;
+
+  const api = createApi("http://127.0.0.1:7373");
+  const payload = await api.createNode("story", {
+    parentId: null,
+    text: "placed"
+  });
+
+  expect(payload.id).toBe("story");
+  expect(paths).toContain("GET /api/stories/story");
+  expect(paths).toContain("POST /api/stories/story/nodes");
+});
+
+test("embedded createNode cold loadStory preflight failure is explicit-unsent and posts no createNode", async () => {
+  const methods: string[] = [];
+  const api = storyApiFromWorkerTransport({
+    call: async (method: string) => {
+      methods.push(method);
+      if (method === "loadStory") {
+        throw new WorkerApiError(createFailureEnvelope({
+          code: "not_found",
+          message: "loadStory preflight failed",
+          status: 404
+        }));
+      }
+      throw new Error(`Unexpected method: ${method}`);
+    }
+  } as never);
+
+  const error = await rejection(api.createNode("story", {
+    parentId: null,
+    text: "must not create"
+  }));
+
+  expect(isExplicitMutationUnsent(error)).toBeTrue();
+  expect(error instanceof ApiRecoveryRequiredError).toBeTrue();
+  expect((error as Error).message).toContain("createNode was not sent");
+  expect((error as Error).message).toContain("loadStory preflight failed");
+  expect(isDefinitePlacementFailure(error)).toBeTrue();
+  expect(methods).toEqual(["loadStory"]);
+});
+
+test("embedded createNode cold preflight transport failure is unsent and not ApiError", async () => {
+  const methods: string[] = [];
+  const api = storyApiFromWorkerTransport({
+    call: async (method: string) => {
+      methods.push(method);
+      if (method === "loadStory") {
+        throw new Error("Embedded backend is not running");
+      }
+      throw new Error(`Unexpected method: ${method}`);
+    }
+  } as never);
+
+  const error = await rejection(api.createNode("story", {
+    parentId: null,
+    text: "must not create"
+  }));
+
+  expect(isExplicitMutationUnsent(error)).toBeTrue();
+  expect(error instanceof ApiError).toBeFalse();
+  expect(isDefinitePlacementFailure(error)).toBeTrue();
+  expect(methods).toEqual(["loadStory"]);
+});
+
+test("embedded createNode after a warm version cache posts createNode only", async () => {
+  const methods: string[] = [];
+  const source = demoAppSource();
+  const versioned = {
+    ...structuredClone(source.payload),
+    id: "story",
+    aggregateVersion: {
+      kind: "v6" as const,
+      revision: "00000000000000000001" as const
+    }
+  };
+  const api = storyApiFromWorkerTransport({
+    call: async (method: string) => {
+      methods.push(method);
+      if (method === "loadStory") return versioned;
+      if (method === "createNode") return versioned;
+      throw new Error(`Unexpected method: ${method}`);
+    }
+  } as never);
+
+  await api.loadStory("story");
+  methods.length = 0;
+  await api.createNode("story", { parentId: null, text: "ok" });
+
+  expect(methods).toEqual(["createNode"]);
+});

--- a/tui/test/generation-deadline-recovery.test.ts
+++ b/tui/test/generation-deadline-recovery.test.ts
@@ -9,6 +9,7 @@ import { normalizeUserConfig } from "../src/config.js";
 import { DEMO_SETTINGS_VIEW } from "../src/demo.js";
 import { generate } from "../src/generation-action.js";
 import { RecoveryWarningFeed } from "../src/recovery-warning-feed.js";
+import { ApiRecoveryRequiredError } from "../src/api-error.js";
 import { createWorkerStoryApi, WorkerApiError } from "../src/worker-api.js";
 import { createWrapCache, type ProseStyle } from "../src/wrap.js";
 import { initialState } from "../src/app.js";
@@ -96,9 +97,12 @@ describe("deadline recovery through the real worker transport", () => {
         text: arrivedText,
         genId
       }));
-      expect(blocked instanceof WorkerApiError).toBeTrue();
-      expect((blocked as unknown as WorkerApiError).status).toBe(409);
-      expect(blocked.message).toContain("reloading saved state");
+      // Pre-send recovery fence: no request was posted; not an uncertain code.
+      expect(blocked instanceof ApiRecoveryRequiredError).toBeTrue();
+      expect(blocked instanceof WorkerApiError).toBeFalse();
+      expect(blocked.message).toBe(
+        "1667 is reloading saved state. Try again when the reload is complete."
+      );
 
       // A recovery listener standing in for recovery-orchestration.ts's
       // refreshAfterRecovery: it must not resolve (adopt the warning) until

--- a/tui/test/placement-catalog-lifecycle.test.ts
+++ b/tui/test/placement-catalog-lifecycle.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Authoritative catalog publication clears a Placement guard only when the
+ * catalog proves the guarded story is gone. Ordinary navigation does not.
+ */
+import { describe, expect, test } from "bun:test";
+import type { StorySummary } from "../../shared/types.js";
+import { ActionRuntime } from "../src/action-runtime.js";
+import { initialState } from "../src/app.js";
+import { createAsideSurface } from "../src/aside-surface.js";
+import {
+  FROM_ASIDE_INSTRUCTION,
+  openPlacementFromAside
+} from "../src/aside-placement.js";
+import { openAsideUseMenu } from "../src/aside-use.js";
+import {
+  connectionSucceeded,
+  type ConnectionMonitor
+} from "../src/connection.js";
+import { demoAppSource } from "../src/demo.js";
+import { handleOverlayAction } from "../src/overlay-actions.js";
+import { publishStories } from "../src/overlay-publication.js";
+import { startRecoveryOrchestration } from "../src/recovery-orchestration.js";
+import { adoptStoryState } from "../src/story-adoption.js";
+import { createWrapCache, type ProseStyle } from "../src/wrap.js";
+
+function overlayContext(
+  state: ReturnType<typeof initialState>,
+  width = 80,
+  height = 24
+) {
+  return {
+    backend: new ActionRuntime(state, () => undefined),
+    cache: createWrapCache<ProseStyle>(),
+    repaint: () => undefined,
+    renderer: { width, height } as never,
+    applyTheme: () => undefined,
+    previewTheme: () => undefined
+  };
+}
+
+function seedUnresolvedGuard(
+  state: ReturnType<typeof initialState>,
+  storyId: string,
+  text = "guarded placement text"
+): void {
+  state.unresolvedPlacement = {
+    storyId,
+    submission: {
+      knownNodeIds: new Set(state.payload.nodes.map(({ id }) => id)),
+      parentId: state.payload.path.at(-1)?.parentId ?? null,
+      instruction: FROM_ASIDE_INSTRUCTION,
+      text,
+      partNumber: state.payload.path.length + 1
+    }
+  };
+}
+
+function onlineMonitor(
+  api: ReturnType<typeof demoAppSource>["api"],
+  retryNow: () => Promise<boolean>
+): ConnectionMonitor {
+  return {
+    api,
+    state: connectionSucceeded,
+    retryNow,
+    subscribe: () => () => undefined,
+    dispose: () => undefined
+  };
+}
+
+describe("Placement guard catalog lifecycle", () => {
+  test("authoritative catalog that omits the guarded story clears the guard and permits Placement on a survivor", async () => {
+    const source = demoAppSource();
+    const originId = source.payload.id;
+    const survivorSummary = source.stories.find((story) => story.id !== originId)!;
+    const survivorPayload = {
+      ...structuredClone(source.payload),
+      id: survivorSummary.id,
+      title: survivorSummary.title
+    };
+    source.api.listStories = async () => [survivorSummary];
+    source.api.loadStory = async (storyId) => {
+      expect(storyId).toBe(survivorSummary.id);
+      return survivorPayload;
+    };
+    source.api.getSettings = async () => source.settingsView;
+    source.connection = onlineMonitor(source.api, async () => true);
+
+    const state = initialState(source, false);
+    seedUnresolvedGuard(state, originId);
+    expect(state.unresolvedPlacement?.storyId).toBe(originId);
+
+    const cache = createWrapCache<ProseStyle>();
+    const backend = new ActionRuntime(state, () => undefined);
+    const stop = startRecoveryOrchestration({
+      state,
+      source,
+      backend,
+      cache,
+      repaint: () => undefined
+    });
+
+    await handleOverlayAction({ action: "retry" }, state, source, {
+      backend,
+      cache,
+      repaint: () => undefined,
+      renderer: null,
+      applyTheme: () => undefined,
+      previewTheme: () => undefined
+    });
+    await backend.whenIdle();
+
+    expect(state.payload.id).toBe(survivorSummary.id);
+    expect(source.stories).toEqual([survivorSummary]);
+    expect(state.unresolvedPlacement).toBeNull();
+
+    const surface = createAsideSurface(
+      survivorSummary.id,
+      survivorPayload.title,
+      [{ question: "Q?", answer: "place on survivor after catalog omit" }],
+      null,
+      survivorPayload.path.at(-1)?.id ?? null
+    );
+    expect(openAsideUseMenu(surface, 0, 0)).toBeTrue();
+    state.aside = surface;
+    state.mode = "ASIDE";
+    expect(openPlacementFromAside(state)).toBeTrue();
+    expect(state.mode).toBe("PLACE");
+    expect(state.placement).not.toBeNull();
+    expect(state.unresolvedPlacement).toBeNull();
+    stop();
+  });
+
+  test("ordinary A→B navigation without catalog publication preserves the guard", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const originId = state.payload.id;
+    seedUnresolvedGuard(state, originId);
+    const context = overlayContext(state);
+
+    const other = source.stories.find((story) => story.id !== originId);
+    expect(other).toBeDefined();
+    const otherPayload = await source.api.loadStory(other!.id);
+    adoptStoryState(state, otherPayload, context.cache);
+
+    expect(state.payload.id).toBe(other!.id);
+    expect(state.unresolvedPlacement?.storyId).toBe(originId);
+    expect(state.placement).toBeNull();
+  });
+
+  test("authoritative catalog that still contains the guarded story preserves the guard", () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const originId = state.payload.id;
+    seedUnresolvedGuard(state, originId);
+    state.library = {
+      stories: source.stories,
+      cursor: 0,
+      query: "",
+      prompt: null
+    };
+
+    const catalog: StorySummary[] = source.stories.map((story) => ({ ...story }));
+    expect(catalog.some(({ id }) => id === originId)).toBeTrue();
+    publishStories(state, source, catalog);
+
+    expect(state.unresolvedPlacement?.storyId).toBe(originId);
+    expect(source.stories).toBe(catalog);
+  });
+
+  test("publishStories clears the guard even when Library is closed", () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const originId = state.payload.id;
+    seedUnresolvedGuard(state, originId);
+    expect(state.library).toBeNull();
+
+    const survivor = source.stories.find((story) => story.id !== originId)!;
+    publishStories(state, source, [survivor]);
+
+    expect(state.unresolvedPlacement).toBeNull();
+    expect(source.stories).toEqual([survivor]);
+  });
+});

--- a/tui/test/worker-api.test.ts
+++ b/tui/test/worker-api.test.ts
@@ -27,6 +27,12 @@ import {
   type MainToWorkerMessage,
   type WorkerToMainMessage
 } from "../../shared/worker-protocol.js";
+import {
+  ApiError,
+  ApiRecoveryRequiredError,
+  isExplicitMutationUnsent
+} from "../src/api-error.js";
+import { isDefinitePlacementFailure } from "../src/aside-placement.js";
 import { textHash, type StoryApi } from "../src/api.js";
 import {
   BackendRestartRequiredError,
@@ -1126,6 +1132,7 @@ describe("embedded backend worker", () => {
     const worker = new FakeWorker(true);
     const outbox = new DeferredEnqueueOutbox();
     const backend = await createWorkerStoryApi({ worker, outbox, readyTimeoutMs: 100 });
+    const requestsBefore = worker.messages.filter(({ type }) => type === "request").length;
     const mutation = backend.api.createStory("drain before unlock");
     await outbox.started;
     let disposed = false;
@@ -1134,9 +1141,87 @@ describe("embedded backend worker", () => {
     await Promise.resolve();
     expect(disposed).toBeFalse();
     outbox.finishEnqueue();
-    expect((await rejection(mutation)).message).toContain("stopped before the mutation was sent");
+    const error = await rejection(mutation);
+    // Durable intent cancelled successfully: pre-post exit is explicit-unsent
+    // and a connection-class failure (not ApiError / not online).
+    expect(isExplicitMutationUnsent(error)).toBeTrue();
+    expect(error instanceof ApiError).toBeFalse();
+    expect(isDefinitePlacementFailure(error)).toBeTrue();
+    expect(error.message).toContain("stopped before the mutation was sent");
+    expect(worker.messages.filter(({ type }) => type === "request"))
+      .toHaveLength(requestsBefore);
     await disposal;
     expect(outbox.cancellations).toBe(1);
+  });
+
+  test("mutation after dispose is explicit-unsent; read stays ordinary Error", async () => {
+    const worker = new FakeWorker(true);
+    const backend = await createWorkerStoryApi({ worker, readyTimeoutMs: 100 });
+    await backend.dispose();
+    const requestsBefore = worker.messages.filter(({ type }) => type === "request").length;
+
+    const mutError = await rejection(backend.api.createStory("after stop"));
+    expect(isExplicitMutationUnsent(mutError)).toBeTrue();
+    expect(mutError instanceof ApiError).toBeFalse();
+    expect(isDefinitePlacementFailure(mutError)).toBeTrue();
+    expect(mutError.message).toContain("not running");
+    expect(worker.messages.filter(({ type }) => type === "request"))
+      .toHaveLength(requestsBefore);
+
+    const readError = await rejection(backend.api.listStories());
+    expect(isExplicitMutationUnsent(readError)).toBeFalse();
+    expect(readError instanceof ApiError).toBeFalse();
+    expect(readError instanceof Error).toBeTrue();
+    expect(readError.message).toContain("not running");
+    expect(worker.messages.filter(({ type }) => type === "request"))
+      .toHaveLength(requestsBefore);
+  });
+
+  test("mutation parked behind startup recovery is explicit-unsent when backend stops", async () => {
+    const dataDir = await mkdtemp(path.join(
+      tmpdir(),
+      "1667-worker-recovery-prepost-"
+    ));
+    const outbox = new MutationOutbox(path.join(dataDir, "mutation-outbox"));
+    await outbox.init();
+    await outbox.enqueue(
+      `m1-${Date.now().toString(36)}-${"c".padStart(32, "0")}`,
+      "createStory",
+      { title: "retained for recovery" }
+    );
+    const worker = new FakeWorker(true);
+    const backend = await createWorkerStoryApi({
+      worker,
+      outbox,
+      readyTimeoutMs: 100
+    });
+    try {
+      const recoveryRequest = await waitForRequest(worker, "createStory");
+      const requestsBefore = worker.messages.filter(({ type }) => type === "request").length;
+      const parked = backend.api.createStory("queued behind recovery");
+      // Yield so beginCall parks on recovery before dispose flips accepting.
+      await Promise.resolve();
+      await Promise.resolve();
+
+      // Dispose stops accepting; recovery's in-flight replay is rejected. The
+      // parked call never posts. Graceful FakeWorker stop can complete dispose.
+      const disposal = backend.dispose();
+      const mutError = await rejection(parked);
+      expect(isExplicitMutationUnsent(mutError)).toBeTrue();
+      expect(mutError instanceof ApiError).toBeFalse();
+      expect(isDefinitePlacementFailure(mutError)).toBeTrue();
+      expect(mutError.message).toContain("not running");
+      // Only the recovery replay was posted; the parked create never was.
+      expect(worker.messages.filter(
+        (message) => message.type === "request" && message.method === "createStory"
+      )).toHaveLength(1);
+      expect(worker.messages.filter(({ type }) => type === "request"))
+        .toHaveLength(requestsBefore);
+      expect(recoveryRequest.method).toBe("createStory");
+      await disposal;
+    } finally {
+      await rm(dataDir, { recursive: true, force: true });
+    }
   });
 
   test("pre-delivery cancellation failure owns concurrent disposal", async () => {
@@ -1207,9 +1292,16 @@ describe("embedded backend worker", () => {
       const requestsBeforeBlockedRetry = worker.messages.filter(
         ({ type }) => type === "request"
       ).length;
-      expect((await rejection(
+      const blocked = await rejection(
         backend.api.createStory("blocked during reload")
-      )).message).toBe(
+      );
+      // Recovery-warning fence: application ApiError stays online; unsent to
+      // Placement via ApiError definite path (not a connection failure).
+      expect(blocked instanceof ApiRecoveryRequiredError).toBeTrue();
+      expect(blocked instanceof ApiError).toBeTrue();
+      expect(blocked instanceof WorkerApiError).toBeFalse();
+      expect(isDefinitePlacementFailure(blocked)).toBeTrue();
+      expect(blocked.message).toBe(
         "1667 is reloading saved state. Try again when the reload is complete."
       );
       expect(worker.messages.filter(

--- a/tui/test/worker-error-log.test.ts
+++ b/tui/test/worker-error-log.test.ts
@@ -285,7 +285,10 @@ test("uncertain terminal failures retain diagnostics without stopping the worker
   const pendingError = await rejection(pending);
   expect(pendingError instanceof WorkerApiError).toBeTrue();
   expect(pendingError).toMatchObject({
-    diagnosticRef: "err_deadbeefdeadbeefdeadbeef"
+    diagnosticRef: "err_deadbeefdeadbeefdeadbeef",
+    // Settlement exposes the transport-owned mutation outcome.
+    mutationOutcome: "uncertain",
+    code: "internal"
   });
   expect(worker.terminateCalls).toBe(0);
   expect(await Promise.race([
@@ -294,6 +297,36 @@ test("uncertain terminal failures retain diagnostics without stopping the worker
       setTimeout(() => resolve("running"), 10)
     )
   ])).toBe("running");
+  await backend.dispose();
+});
+
+test("terminal mutation settlement stamps WorkerApiError.mutationOutcome terminal", async () => {
+  const worker = new FakeWorker(true);
+  const backend = await createWorkerStoryApi({
+    worker,
+    readyTimeoutMs: 100
+  });
+  const pending = backend.api.createStory("terminal internal failure");
+  const request = await waitForRequest(worker, "createStory");
+  worker.message({
+    type: "error",
+    id: request.id,
+    failure: createFailureEnvelope({
+      code: "internal",
+      message: "Internal server error",
+      status: 500
+    }, "err_deadbeefdeadbeefdeadbeef"),
+    mutationOutcome: "terminal"
+  });
+
+  const pendingError = await rejection(pending);
+  expect(pendingError instanceof WorkerApiError).toBeTrue();
+  expect(pendingError).toMatchObject({
+    code: "internal",
+    mutationOutcome: "terminal",
+    diagnosticRef: "err_deadbeefdeadbeefdeadbeef"
+  });
+  expect(worker.terminateCalls).toBe(0);
   await backend.dispose();
 });
 


### PR DESCRIPTION
Closes #229

## Outcome

Side Notes can insert a saved answer into Direct or into the story. The release metadata prepares beta candidate 0.9.6-rc.1.

## Changes

- Add the Side Note use menu and story Placement mode.
- Insert an answer at the Direct cursor without replacing the draft.
- Add an answer as a new Take or as a new Part.
- Preserve story ownership across reload, recovery, and transport boundaries.
- Add keyboard, mouse, narrow-layout, recovery, and integration coverage.
- Set the workspace and TUI versions to 0.9.6-rc.1.
- Add and generate the 0.9.6-rc.1 release notes.

## Verification

- `npm run build`
- `npm test` on Node 22.22.0: 2,495 passed; 226 skipped
- `bun run typecheck`
- `bun test --timeout 30000`: 1,992 passed; 2 platform tests skipped
- `bun bench/perf.ts`
- `bun run build:standalone`
- `npm run notes:check-version -- 0.9.6-rc.1`
- Structured code, maintainability, and UI/UX reviews: clean

## Risk and limitations

- Side Notes stay scoped to one story.
- Placement creates a new Take or a new Part. It does not edit existing prose.
- The release remains a beta candidate until the hosted publication workflow completes.