### PR TITLE
fix(installer): show PowerShell executable command

### DIFF
--- a/scripts/release-install-powershell-body.ts
+++ b/scripts/release-install-powershell-body.ts
@@ -454,7 +454,9 @@ function Main {
     if ($null -ne $lock) { $lock.Dispose() }
   }
   Write-Output "Installed 1667 $ProductVersion ($InstallChannel) for $ArtifactTarget to $active"
-  Write-Output 'Open a new PowerShell window, then run: 1667'
+  Write-Output 'PowerShell treats 1667 as a number.'
+  Write-Output 'Open a new PowerShell window.'
+  Write-Output 'Then run: 1667.exe'
 }
 
 Main

--- a/test/release-install-powershell.test.ts
+++ b/test/release-install-powershell.test.ts
@@ -76,6 +76,10 @@ test("PowerShell Installer handles install, repeat, and upgrade cases", async (t
 
   const fresh = await runInstaller(v1.url, installRoot);
   assert.match(fresh.stdout, /Installed 1667 1\.2\.3 \(stable\)/u);
+  assert.match(
+    fresh.stdout,
+    /PowerShell treats 1667 as a number\.\r?\nOpen a new PowerShell window\.\r?\nThen run: 1667\.exe/u
+  );
   assert.equal(await installedVersion(installRoot), "1.2.3");
   assert.equal(await accessRulesAreProtected(installRoot), false);
   const firstRecord = await ownershipRecord(installRoot);


### PR DESCRIPTION
## Summary

- Tell PowerShell users to run `1667.exe`.
- Explain that PowerShell treats bare `1667` as a number.
- Check the final message in the PowerShell Installer integration test.

## Why

PowerShell parses bare `1667` as a numeric expression. The old success message did not start the installed executable.

## Test

- `node --import tsx --import ./test/setup.ts --test --test-name-pattern="PowerShell Installer handles install, repeat, and upgrade cases" test/release-install-powershell.test.ts`

Closes #234
