### PR TITLE
chore(release): prepare 0.9.6-rc.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -260,6 +260,12 @@ This file records notable changes to 1667. Product terms use the definitions in
   command accepts one or more JSON or PNG files. It adds their Facts to the
   story that `--story` names.
 
+## 0.9.6-rc.3 - 2026-08-15
+
+- **The PowerShell Installer shows the command that starts 1667.** After the
+  installation, the Installer shows the exact executable path. This command
+  works when the Install Root is not in `PATH`.
+
 ## 0.9.6-rc.2 - 2026-08-15
 
 - **Aside and the Author's Note have new navigation keys.** Press `a` to open

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "1667-workspace",
-  "version": "0.9.6-rc.2",
+  "version": "0.9.6-rc.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "1667-workspace",
-      "version": "0.9.6-rc.2",
+      "version": "0.9.6-rc.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@silvia-odwyer/photon-node": "0.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667-workspace",
-  "version": "0.9.6-rc.2",
+  "version": "0.9.6-rc.3",
   "private": true,
   "description": "Source workspace for the 1667 terminal writing environment",
   "license": "Apache-2.0",

--- a/shared/release-notes.ts
+++ b/shared/release-notes.ts
@@ -11,6 +11,11 @@ export interface ReleaseNote {
  *  a release, and is not included. */
 export const RELEASE_NOTES: readonly ReleaseNote[] = [
   {
+    version: "0.9.6-rc.3",
+    date: "2026-08-15",
+    body: "- **The PowerShell Installer shows the command that starts 1667.** After the\n  installation, the Installer shows the exact executable path. This command\n  works when the Install Root is not in `PATH`."
+  },
+  {
     version: "0.9.6-rc.2",
     date: "2026-08-15",
     body: "- **Aside and the Author's Note have new navigation keys.** Press `a` to open\n  Aside. Press `n` to edit the Author's Note. To create a story, press `o` to\n  open Library, and then press `n`."

--- a/tui/package.json
+++ b/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667",
-  "version": "0.9.6-rc.2",
+  "version": "0.9.6-rc.3",
   "private": true,
   "description": "A terminal environment for writing fiction with language models",
   "license": "Apache-2.0",


### PR DESCRIPTION
Prepare the final 0.9.6 release candidate. This candidate includes the PowerShell Installer command hint that landed after rc.2.

Changes:
- Set the workspace and TUI versions to 0.9.6-rc.3.
- Add the candidate release note.
- Regenerate the embedded release notes.

Verification:
- npm run build
- npm test: 2,495 passed; 226 skipped
- bun run typecheck
- bun test: 1,993 passed; 2 skipped
- bun bench/perf.ts
- bun run build:standalone

Risk: Version and release-note metadata only. The product change has its own regression test.

Closes #235