### PR TITLE
fix(aside): keep stopped answers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -260,7 +260,7 @@ This file records notable changes to 1667. Product terms use the definitions in
   command accepts one or more JSON or PNG files. It adds their Facts to the
   story that `--story` names.
 
-## 0.9.6-rc.3 - 2026-08-15
+## 0.9.6 - 2026-08-15
 
 - **The PowerShell Installer shows the command that starts 1667.** After the
   installation, the Installer shows the exact executable path. This command

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -260,7 +260,11 @@ This file records notable changes to 1667. Product terms use the definitions in
   command accepts one or more JSON or PNG files. It adds their Facts to the
   story that `--story` names.
 
-## 0.9.6 - 2026-08-15
+## 0.9.6-rc.4 - 2026-08-15
+
+- **Stopping an Aside answer keeps the text that arrived.** Press `Esc` after
+  answer text appears to save that text as a Side Note. If no answer text
+  appears, 1667 restores the question.
 
 - **The PowerShell Installer shows the command that starts 1667.** After the
   installation, the Installer shows the exact executable path. This command

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "1667-workspace",
-  "version": "0.9.6-rc.3",
+  "version": "0.9.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "1667-workspace",
-      "version": "0.9.6-rc.3",
+      "version": "0.9.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@silvia-odwyer/photon-node": "0.3.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "1667-workspace",
-  "version": "0.9.6",
+  "version": "0.9.6-rc.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "1667-workspace",
-      "version": "0.9.6",
+      "version": "0.9.6-rc.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@silvia-odwyer/photon-node": "0.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667-workspace",
-  "version": "0.9.6",
+  "version": "0.9.6-rc.4",
   "private": true,
   "description": "Source workspace for the 1667 terminal writing environment",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667-workspace",
-  "version": "0.9.6-rc.3",
+  "version": "0.9.6",
   "private": true,
   "description": "Source workspace for the 1667 terminal writing environment",
   "license": "Apache-2.0",

--- a/server/aside-http.ts
+++ b/server/aside-http.ts
@@ -28,6 +28,10 @@ import {
   GenerationResultError,
   ServiceError as HttpError
 } from "./errors.js";
+import {
+  classifyProviderAbort,
+  providerAbortForError
+} from "./provider-abort.js";
 import type { DeltaConsumer } from "./generation-stream.js";
 import type { GenerationStreamHooks } from "./generation-http.js";
 import { streamCompletion } from "./providers.js";
@@ -56,13 +60,16 @@ export function viewAsideDocument(document: AsideDocument | null): AsideDocument
 
 export interface AskAsideHooks extends GenerationStreamHooks {
   readonly entryPointsOpen?: boolean;
+  /** Mutable cancellation authority owned by the active transport operation. */
+  readonly canCommitStoppedAside?: () => boolean;
   /** Load the current Aside document for the admitted story snapshot. */
   readonly loadDocument: (story: Story) => Promise<AsideDocument | null>;
 }
 
 /**
  * Stream one Aside question. On success, commits one replacement Aside
- * document via the provider effect. On failure or stop, saves nothing.
+ * document via the provider effect. A user Stop after output commits the text
+ * that already streamed. Other cancellation sources and failures save nothing.
  *
  * Uses the `utility` Generation Profile (falls back to `default` when the
  * utility route is unset — `selectSettingsRoute`).
@@ -77,7 +84,12 @@ export async function askAside(
   signal: AbortSignal,
   hooks: AskAsideHooks
 ): Promise<AsideDocumentView | null> {
-  const { bindIntent, providerStarted = () => {}, loadDocument } = hooks;
+  const {
+    bindIntent,
+    canCommitStoppedAside,
+    providerStarted = () => {},
+    loadDocument
+  } = hooks;
   if (!asideEntryPointsOpen(hooks.entryPointsOpen)) {
     throw new HttpError(400, "Aside is not available in this release.", "aside_not_supported");
   }
@@ -185,10 +197,20 @@ export async function askAside(
       await onDelta(delta);
     }
   } catch (error) {
-    if (signal.aborted) return null;
-    throw error;
+    const abort = providerAbortForError(signal, error);
+    const userStopped = abort.kind === "terminal" && abort.userInitiated;
+    if (!signal.aborted) throw error;
+    if (!userStopped
+      || canCommitStoppedAside?.() !== true
+      || raw.trim().length === 0) return null;
   }
-  if (signal.aborted) return null;
+  if (signal.aborted) {
+    const abort = classifyProviderAbort(signal);
+    if (abort.kind !== "terminal"
+      || !abort.userInitiated
+      || canCommitStoppedAside?.() !== true
+      || raw.trim().length === 0) return null;
+  }
 
   const answer = raw.trim();
   if (answer.length === 0) {
@@ -209,7 +231,8 @@ export async function askAside(
     kind: "aside",
     expectedAsideDocumentId: story.asideDocumentId,
     document: nextDocument,
-    cancelled: signal
+    cancelled: signal,
+    canCommitStoppedAside
   });
   // The provider runtime has now prepared the durable effect. A Stop that
   // arrives after this point must not turn a committed answer into a null

--- a/server/http-operation-mutation.ts
+++ b/server/http-operation-mutation.ts
@@ -28,7 +28,8 @@ export async function runHttpOperationMutation<
   transportOperationId: string,
   expectedAggregateVersion: StoryAggregateVersion,
   onDelta: (text: string) => void | Promise<void> = () => {},
-  onReasoning: (delta: ReasoningStreamDelta) => void | Promise<void> = () => {}
+  onReasoning: (delta: ReasoningStreamDelta) => void | Promise<void> = () => {},
+  canCommitStoppedAside?: () => boolean
 ): Promise<WorkerOutput<M>> {
   const protocolVersion = await acceptedHttpMutationProtocolVersion(
     service,
@@ -71,6 +72,9 @@ export async function runHttpOperationMutation<
         onDelta,
         onReasoning,
         signal,
+        ...(canCommitStoppedAside === undefined
+          ? {}
+          : { canCommitStoppedAside }),
         storyMutationRequest
       });
     },

--- a/server/http-router.ts
+++ b/server/http-router.ts
@@ -238,7 +238,8 @@ async function handleApi(
     input: unknown,
     onDelta?: (text: string) => void | Promise<void>,
     signal = operation.signal,
-    onReasoning?: (delta: ReasoningStreamDelta) => void | Promise<void>
+    onReasoning?: (delta: ReasoningStreamDelta) => void | Promise<void>,
+    canCommitStoppedAside?: () => boolean
   ) => {
     if (operation.mutationId === null) {
       throw new ServiceError(
@@ -261,7 +262,8 @@ async function handleApi(
       ticket,
       operation.expectedAggregateVersion,
       onDelta,
-      onReasoning
+      onReasoning,
+      canCommitStoppedAside
     );
   };
   if (head === "settings" && id === undefined) {
@@ -698,10 +700,18 @@ async function handleApi(
   if (head === "stories" && id !== undefined && sub === "aside" && subId === "ask" && method === "POST") {
     const body = await jsonBody();
     return await streamResponse(request, response,
-      (onDelta, signal) => mutate("askAside", {
-        storyId: id,
-        question: requireString(body.question, "question")
-      }, onDelta, signal),
+      (onDelta, signal, _onReasoning, transportConnected) => mutate(
+        "askAside",
+        {
+          storyId: id,
+          question: requireString(body.question, "question")
+        },
+        onDelta,
+        signal,
+        undefined,
+        () => operation.isUserCancellationAuthoritative()
+          && transportConnected()
+      ),
       (result) => ({ type: "done", aside: result }),
       operation.signal,
       context.errorReporter,

--- a/server/mutation-plan.ts
+++ b/server/mutation-plan.ts
@@ -122,6 +122,8 @@ export function mutationPreflightPlan<M extends MutatingWorkerMethod>(
 export interface MutationHandlerContext {
   readonly onDelta: (text: string) => void | Promise<void>;
   readonly signal: AbortSignal;
+  /** Mutable authority for an Aside answer stopped by the user. */
+  readonly canCommitStoppedAside?: () => boolean;
   /** Parsed again by the canonical coordinator at the service boundary. */
   readonly storyMutationRequest?: unknown;
   /** Reasoning ("thinking") text, kept apart from `onDelta`'s story prose.

--- a/server/story-provider-effect.ts
+++ b/server/story-provider-effect.ts
@@ -152,6 +152,17 @@ export interface AsideStoryEffect {
   readonly expectedAsideDocumentId: Story["asideDocumentId"];
   readonly document: AsideDocument;
   readonly cancelled?: AbortSignal;
+  /** True only while user Stop remains the authoritative cancellation source. */
+  readonly canCommitStoppedAside?: () => boolean;
+}
+
+/** A user Stop can save the Side Note text that already streamed. Other
+ * cancellation sources keep authority and must prevent the commit. */
+export function asideCanCommitStoppedAnswer(
+  effect: Pick<AsideStoryEffect, "cancelled" | "canCommitStoppedAside">
+): boolean {
+  return effect.cancelled?.aborted === true
+    && effect.canCommitStoppedAside?.() === true;
 }
 
 export type ProviderStoryEffect =
@@ -235,7 +246,8 @@ function applyAside(
   story: Story,
   effect: AsideStoryEffect
 ): AppliedProviderStoryEffect<Story> {
-  if (effect.cancelled?.aborted === true) {
+  if (effect.cancelled?.aborted === true
+    && !asideCanCommitStoppedAnswer(effect)) {
     throw new GenerationStoppedError("Aside was cancelled before it could be saved.");
   }
   if (story.asideDocumentId !== effect.expectedAsideDocumentId) {

--- a/server/story-provider-preparation.ts
+++ b/server/story-provider-preparation.ts
@@ -8,6 +8,7 @@ import type {
   RewriteNodeEffect,
   SummaryTakeEffect
 } from "./story-provider-effect.js";
+import { asideCanCommitStoppedAnswer } from "./story-provider-effect.js";
 
 export type PreparedProviderStoryEffect<
   Effect extends ProviderStoryEffect = ProviderStoryEffect
@@ -28,7 +29,9 @@ export type PreparedProviderStoryEffect<
         }
       : Effect extends RewriteNodeEffect
         ? Omit<Effect, "cancelled" | "takeId"> & { readonly takeId: string }
-        : Omit<Effect, "cancelled">;
+        : Effect extends AsideStoryEffect
+          ? Omit<Effect, "cancelled" | "canCommitStoppedAside">
+          : Omit<Effect, "cancelled">;
 
 /** Freeze all IDs, timestamps, and cancellation checks before an effect can
  * cross the provider/terminal phase boundary. The returned effect is safe to
@@ -87,7 +90,11 @@ export function prepareProviderStoryEffect(
     case "autoname":
       return { ...effect };
     case "aside": {
-      const { cancelled: _cancelled, ...rest } = effect as AsideStoryEffect;
+      const {
+        cancelled: _cancelled,
+        canCommitStoppedAside: _canCommitStoppedAside,
+        ...rest
+      } = effect as AsideStoryEffect;
       return rest;
     }
     default: {
@@ -99,6 +106,7 @@ export function prepareProviderStoryEffect(
 
 function requireEffectActive(effect: ProviderStoryEffect): void {
   if (!("cancelled" in effect) || effect.cancelled?.aborted !== true) return;
+  if (effect.kind === "aside" && asideCanCommitStoppedAnswer(effect)) return;
   const message = effect.kind === "continue"
     ? "Story writing was cancelled"
     : effect.kind === "rewrite"

--- a/server/story-service-generation.ts
+++ b/server/story-service-generation.ts
@@ -40,6 +40,8 @@ import {
  *  identity), which no lower layer ever reads. */
 export interface GenerationMutationHooks extends GenerationStreamHooks {
   mutationRequest?: unknown;
+  /** Mutable authority for an Aside answer stopped by the user. */
+  canCommitStoppedAside?: () => boolean;
 }
 
 export interface StoryServiceGenerationDependencies {

--- a/server/stream-response.ts
+++ b/server/stream-response.ts
@@ -21,7 +21,11 @@ export async function streamResponse<T>(
     /** Reasoning ("thinking") text, kept apart from `onDelta`'s story prose:
      *  it reaches the client only through its own `"reasoning"` SSE frame,
      *  never through a `"delta"` frame. */
-    onReasoning: (delta: ReasoningStreamDelta) => Promise<void>
+    onReasoning: (delta: ReasoningStreamDelta) => Promise<void>,
+    /** True while the request transport can still authorize a stopped
+     * provider result. A disconnect changes this value even when another
+     * signal source aborted first. */
+    transportConnected: () => boolean
   ) => Promise<T | null>,
   done: (value: T) => Record<string, unknown>,
   operationSignal?: AbortSignal,
@@ -84,7 +88,8 @@ export async function streamResponse<T>(
       (delta) => {
         reasoningTokenCount = delta.tokenCount;
         return reasoningDeltas.push(delta.text);
-      }
+      },
+      () => !abort.signal.aborted
     );
     // A pending batch must reach the client before "done" or "error" — never
     // delayed behind it, and never reordered around it — so every exit path

--- a/server/worker-mutations.ts
+++ b/server/worker-mutations.ts
@@ -1007,7 +1007,12 @@ const MUTATIONS: MutationRegistry = {
         { question: input.question },
         context.onDelta,
         context.signal,
-        generationHooks(plan, {}, context.storyMutationRequest)
+        generationHooks(
+          plan,
+          {},
+          context.storyMutationRequest,
+          context.canCommitStoppedAside
+        )
       )
   }),
   clearAside: define<"clearAside">({
@@ -1073,12 +1078,14 @@ function generationHooks<M extends
   "autonameStory" | "continueStory" | "rewriteNode" | "createSummaryTake" | "summarizeChapter" | "askAside">(
   plan: MutationPlan<M>,
   options: Record<string, string> = {},
-  mutationRequest?: unknown
+  mutationRequest?: unknown,
+  canCommitStoppedAside?: () => boolean
 ) {
   return {
     providerStarted: () => plan.providerStarted(),
     bindIntent: plan.bindGenerationIntent,
     ...(mutationRequest === undefined ? {} : { mutationRequest }),
+    ...(canCommitStoppedAside === undefined ? {} : { canCommitStoppedAside }),
     ...options
   };
 }

--- a/server/worker-request-executor.ts
+++ b/server/worker-request-executor.ts
@@ -236,7 +236,8 @@ async function executeMutation(
   message: WorkerRequest,
   onDelta: (text: string) => void,
   onReasoning: (delta: ReasoningStreamDelta) => void,
-  signal: AbortSignal
+  signal: AbortSignal,
+  canCommitStoppedAside?: () => boolean
 ): Promise<unknown> {
   const method = message.method;
   if (!isMutatingWorkerMethod(method)) {
@@ -298,6 +299,9 @@ async function executeMutation(
         onDelta,
         onReasoning,
         signal,
+        ...(canCommitStoppedAside === undefined
+          ? {}
+          : { canCommitStoppedAside }),
         ...(storyMutationRequest === undefined
           ? {}
           : { storyMutationRequest })
@@ -495,7 +499,14 @@ async function executeWorkerMutationWithRetry(
 ): Promise<unknown> {
   for (;;) {
     try {
-      return await executeMutation(service, message, onDelta, onReasoning, cancellation.signal);
+      return await executeMutation(
+        service,
+        message,
+        onDelta,
+        onReasoning,
+        cancellation.signal,
+        () => cancellation.userCancellationRequested
+      );
     } catch (error) {
       if (message.method !== "commitPartialRewrite"
         || !isRetryablePartialSettlementFailure(error)

--- a/shared/release-notes.ts
+++ b/shared/release-notes.ts
@@ -11,7 +11,7 @@ export interface ReleaseNote {
  *  a release, and is not included. */
 export const RELEASE_NOTES: readonly ReleaseNote[] = [
   {
-    version: "0.9.6-rc.3",
+    version: "0.9.6",
     date: "2026-08-15",
     body: "- **The PowerShell Installer shows the command that starts 1667.** After the\n  installation, the Installer shows the exact executable path. This command\n  works when the Install Root is not in `PATH`."
   },

--- a/shared/release-notes.ts
+++ b/shared/release-notes.ts
@@ -11,9 +11,9 @@ export interface ReleaseNote {
  *  a release, and is not included. */
 export const RELEASE_NOTES: readonly ReleaseNote[] = [
   {
-    version: "0.9.6",
+    version: "0.9.6-rc.4",
     date: "2026-08-15",
-    body: "- **The PowerShell Installer shows the command that starts 1667.** After the\n  installation, the Installer shows the exact executable path. This command\n  works when the Install Root is not in `PATH`."
+    body: "- **Stopping an Aside answer keeps the text that arrived.** Press `Esc` after\n  answer text appears to save that text as a Side Note. If no answer text\n  appears, 1667 restores the question.\n\n- **The PowerShell Installer shows the command that starts 1667.** After the\n  installation, the Installer shows the exact executable path. This command\n  works when the Install Root is not in `PATH`."
   },
   {
     version: "0.9.6-rc.2",

--- a/shared/worker-protocol.ts
+++ b/shared/worker-protocol.ts
@@ -313,7 +313,7 @@ export interface WorkerMethodContract {
     input: { storyId: string };
     output: { notes: readonly { question: string; answer: string }[] };
   };
-  /** Stream one Aside question. Null means cancelled before save. */
+  /** Stream one Aside question. Null means no answer text was saved. */
   askAside: {
     input: { storyId: string; question: string };
     output: { notes: readonly { question: string; answer: string }[] } | null;

--- a/test/aside-service.integration.test.ts
+++ b/test/aside-service.integration.test.ts
@@ -12,8 +12,12 @@ import {
 } from "../shared/aside.js";
 import { hasUnpairedSurrogate } from "../shared/unicode.js";
 import { isSealed } from "../shared/vault-cipher.js";
-import { ServiceError } from "../server/errors.js";
+import {
+  GenerationCancelledError,
+  ServiceError
+} from "../server/errors.js";
 import { StoryService } from "../server/story-service.js";
+import { WorkerRequestCancellation } from "../server/worker-request-cancellation.js";
 import {
   STORY_REAP_RETENTION_MS,
   StoryReaper
@@ -284,7 +288,7 @@ test("dry-run Aside keeps a scalar-safe question prefix at an emoji boundary", a
   assert.match(answer, /😀/u, "the complete boundary scalar stays in the dry-run answer");
 });
 
-test("started Aside stop and stream failure save no partial Side Note", async (t) => {
+test("started Aside stop saves streamed text; stream failure saves nothing", async (t) => {
   const { service } = await openService(t);
   const created = await service.createStory("Aside cancellation");
   await service.createNode(created.id, {
@@ -294,19 +298,38 @@ test("started Aside stop and stream failure save no partial Side Note", async (t
   });
 
   const stopped = new AbortController();
-  let stoppedDeltas = 0;
+  let stoppedText = "";
   const stoppedResult = await service.askAside(
     created.id,
     { question: "Stop after output." },
     async (delta) => {
-      stoppedDeltas += delta.length;
-      stopped.abort();
+      stoppedText += delta;
+      stopped.abort(new GenerationCancelledError());
     },
-    stopped.signal
+    stopped.signal,
+    { canCommitStoppedAside: () => true }
   );
-  assert.equal(stoppedResult, null);
-  assert.ok(stoppedDeltas > 0, "the provider must have streamed before Stop");
-  assert.equal((await service.getAside(created.id)).notes.length, 0);
+  assert.ok(stoppedResult !== null, "Stop after output must save a Side Note");
+  assert.ok(stoppedText.length > 0, "the provider must have streamed before Stop");
+  assert.equal(stoppedResult.notes[0]!.answer, stoppedText.trim());
+  assert.deepEqual(await service.getAside(created.id), stoppedResult);
+
+  const superseded = new WorkerRequestCancellation(
+    true,
+    "00000000-0000-7000-8000-000000000001"
+  );
+  const supersededResult = await service.askAside(
+    created.id,
+    { question: "Do not save after shutdown supersedes Stop." },
+    async () => {
+      superseded.cancel("user");
+      superseded.cancel("shutdown");
+    },
+    superseded.signal,
+    { canCommitStoppedAside: () => superseded.userCancellationRequested }
+  );
+  assert.equal(supersededResult, null);
+  assert.equal((await service.getAside(created.id)).notes.length, 1);
 
   let failedDeltas = 0;
   await assert.rejects(
@@ -322,7 +345,7 @@ test("started Aside stop and stream failure save no partial Side Note", async (t
     /consumer failed after Aside output/u
   );
   assert.ok(failedDeltas > 0, "the provider must have streamed before failure");
-  assert.equal((await service.getAside(created.id)).notes.length, 0);
+  assert.equal((await service.getAside(created.id)).notes.length, 1);
 });
 
 test("export omits Side Notes with the exact notice; payload has presence only", async (t) => {

--- a/test/aside-transport.integration.test.ts
+++ b/test/aside-transport.integration.test.ts
@@ -23,6 +23,7 @@ import { WorkerRequestCancellation } from "../server/worker-request-cancellation
 import type { WorkerRequestFailureResponder } from "../server/worker-request-failure-responder.js";
 import { validateWorkerRequestSize } from "../server/worker-request-size.js";
 import { streamResponse } from "../server/stream-response.js";
+import { prepareProviderStoryEffect } from "../server/story-provider-preparation.js";
 import {
   FINGERPRINT,
   MUTATION_ID,
@@ -107,6 +108,49 @@ test("HTTP Aside keeps pre-commit cancellation null", async () => {
   await running;
 
   assert.doesNotMatch(response.output, /"type":"done"/u);
+  assert.equal(response.ends, 1);
+});
+
+test("HTTP disconnect revokes an earlier user Stop before Aside preparation", async () => {
+  const request = Readable.from([]) as unknown as IncomingMessage;
+  const response = new FakeResponse();
+  const operation = new AbortController();
+  let started!: () => void;
+  const startedPromise = new Promise<void>((resolve) => { started = resolve; });
+  let release!: () => void;
+  const gate = new Promise<void>((resolve) => { release = resolve; });
+  const running = streamResponse(
+    request,
+    response as unknown as ServerResponse,
+    async (_onDelta, signal, _onReasoning, transportConnected) => {
+      started();
+      await gate;
+      assert.throws(
+        () => prepareProviderStoryEffect({
+          kind: "aside",
+          expectedAsideDocumentId: undefined,
+          document: {
+            schemaVersion: 1,
+            notes: [{ question: "Why?", answer: "Partial answer." }]
+          },
+          cancelled: signal,
+          canCommitStoppedAside: () => transportConnected()
+        }),
+        /Aside was cancelled before it could be saved/u
+      );
+      return null;
+    },
+    () => ({ type: "done" }),
+    operation.signal
+  );
+
+  await startedPromise;
+  operation.abort(new GenerationCancelledError());
+  response.closed = true;
+  response.emit("close");
+  release();
+  await running;
+
   assert.equal(response.ends, 1);
 });
 

--- a/test/story-provider-effect.test.ts
+++ b/test/story-provider-effect.test.ts
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import type { Story, StoryNode } from "../shared/types.js";
-import { GenerationResultError } from "../server/errors.js";
+import {
+  GenerationCancelledError,
+  GenerationResultError
+} from "../server/errors.js";
 import { sha256 } from "../server/story-format.js";
 import { storyAutonameId } from "../server/story-metadata.js";
 import { nodeRewriteId, setNodeRewriteId } from "../server/story-node-text.js";
@@ -201,6 +204,46 @@ test("provider effect preparation rejects an existing cancellation", () => {
       expectedAsideDocumentId: undefined,
       document: { schemaVersion: 1, notes: [] },
       cancelled: cancelled.signal
+    }),
+    (error: unknown) => error instanceof GenerationResultError
+      && error.message === "Aside was cancelled before it could be saved."
+  );
+});
+
+test("provider effect preparation keeps Aside output after a user Stop", () => {
+  const cancelled = new AbortController();
+  cancelled.abort(new GenerationCancelledError());
+  let userStopIsAuthoritative = true;
+
+  const prepared = prepareProviderStoryEffect({
+    kind: "aside",
+    expectedAsideDocumentId: undefined,
+    document: {
+      schemaVersion: 1,
+      notes: [{ question: "Why?", answer: "Partial answer." }]
+    },
+    cancelled: cancelled.signal,
+    canCommitStoppedAside: () => userStopIsAuthoritative
+  });
+
+  assert.deepEqual(prepared.document.notes, [{
+    question: "Why?",
+    answer: "Partial answer."
+  }]);
+  assert.equal("cancelled" in prepared, false);
+  assert.equal("canCommitStoppedAside" in prepared, false);
+
+  userStopIsAuthoritative = false;
+  assert.throws(
+    () => prepareProviderStoryEffect({
+      kind: "aside",
+      expectedAsideDocumentId: undefined,
+      document: {
+        schemaVersion: 1,
+        notes: [{ question: "Why?", answer: "Must not save." }]
+      },
+      cancelled: cancelled.signal,
+      canCommitStoppedAside: () => userStopIsAuthoritative
     }),
     (error: unknown) => error instanceof GenerationResultError
       && error.message === "Aside was cancelled before it could be saved."

--- a/tui/package.json
+++ b/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667",
-  "version": "0.9.6-rc.3",
+  "version": "0.9.6",
   "private": true,
   "description": "A terminal environment for writing fiction with language models",
   "license": "Apache-2.0",

--- a/tui/package.json
+++ b/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667",
-  "version": "0.9.6",
+  "version": "0.9.6-rc.4",
   "private": true,
   "description": "A terminal environment for writing fiction with language models",
   "license": "Apache-2.0",

--- a/tui/src/aside-actions.ts
+++ b/tui/src/aside-actions.ts
@@ -465,6 +465,9 @@ export async function sendAsideQuestion(
     } catch {
       // A committed Side Note must not be hidden by a failed refresh.
     }
+    if (controller.signal.aborted) {
+      state.toast = "Aside stopped · answer kept";
+    }
   } catch (error) {
     if (!current()) return;
     const restore = mayRestore();
@@ -481,8 +484,8 @@ export async function sendAsideQuestion(
 }
 
 /**
- * Stop an in-flight Aside answer. The ask path restores the question when the
- * abort settles. Stays on the Aside surface.
+ * Stop an in-flight Aside answer. Keep received answer text as a Side Note.
+ * If no answer text arrived, restore the question. Stay on the Aside surface.
  */
 export function stopAsideAsk(state: RuntimeState): boolean {
   const surface = state.aside;

--- a/tui/src/demo.ts
+++ b/tui/src/demo.ts
@@ -646,8 +646,8 @@ export const DEMO_SETTINGS_VIEW: SettingsView = {
 };
 
 /** The demo fixture behind the same StoryApi the live server speaks — the app
- *  never branches on which backend it has. Streaming methods honor abort with
- *  the server's invariant: an aborted stream never commits. */
+ *  never branches on which backend it has. Aside keeps answer text that
+ *  streamed before a user Stop. Other aborted streams do not commit. */
 export function demoStoryApi(demo: DemoController): StoryApi {
   const unavailable = (feature: string) => { throw new Error(`${feature} is not available in the demo fixture`); };
   let settingsView = structuredClone(DEMO_SETTINGS_VIEW);
@@ -684,7 +684,6 @@ export function demoStoryApi(demo: DemoController): StoryApi {
       if (signal.aborted) return null;
       const answer = `Demo Aside answer for: ${question}`;
       onDelta(answer);
-      if (signal.aborted) return null;
       const document = appendSideNote(
         asideDocuments.get(storyId) ?? null,
         question,

--- a/tui/src/overlay-actions.ts
+++ b/tui/src/overlay-actions.ts
@@ -791,7 +791,8 @@ async function asideKeyAction(
       surface.confirmClear = false;
       return;
     }
-    // Esc while answering stops the request and restores the question.
+    // Esc stops the request. It keeps received answer text as a Side Note, or
+    // restores the question if no answer text arrived.
     // Esc when idle returns to Write.
     if (surface.busy) {
       // Clear has no abort path. Its missing in-flight question is the

--- a/tui/test/aside-input-queue.test.ts
+++ b/tui/test/aside-input-queue.test.ts
@@ -21,7 +21,7 @@ async function drainMicrotasks(): Promise<void> {
 }
 
 describe("Aside presented input", () => {
-  test("Enter admits a pending ask, repaints deltas, and lets queued Esc abort it", async () => {
+  test("queued Esc keeps an Aside answer that already streamed", async () => {
     const source = demoAppSource();
     let release!: () => void;
     let signal: AbortSignal | null = null;
@@ -35,7 +35,9 @@ describe("Aside presented input", () => {
         emitDelta = onDelta;
         requestSignal.addEventListener("abort", () => { aborted.push(true); }, { once: true });
         await gate;
-        return requestSignal.aborted ? null : { notes: [] };
+        return requestSignal.aborted
+          ? { notes: [{ question: "Why did it change?", answer: "partial answer" }] }
+          : { notes: [] };
       }
     };
     const state = initialState(source, false);
@@ -85,7 +87,12 @@ describe("Aside presented input", () => {
     await drainMicrotasks();
     expect(state.aside.busy).toBeFalse();
     expect(state.aside.streamText).toBe("");
-    expect(state.aside.composer.text).toBe("Why did it change?");
+    expect(state.aside.composer.text).toBe("");
+    expect(state.aside.notes).toEqual([{
+      question: "Why did it change?",
+      answer: "partial answer"
+    }]);
+    expect(state.toast).toBe("Aside stopped · answer kept");
     expect(state.abort).toBeNull();
     backend.dispose();
   });


### PR DESCRIPTION
## Outcome

Keep a stopped partial Aside answer, and publish a replacement beta.

## Changes

- Save received answer text as a Side Note after an authoritative user Stop.
- Restore the question when Stop happens before answer text arrives.
- Revoke save authority after a deadline, shutdown, session close, or transport disconnect.
- Set the workspace and TUI versions to `0.9.6-rc.4`.

## Verification

- `npm run build`
- `npm test` (2 unrelated process timing failures under parallel load; both files pass in isolation)
- `bun run typecheck`
- `bun test` (1 unrelated process timing failure under parallel load; the file passes in isolation)
- `bun bench/perf.ts`
- `bun run build:standalone`
- Autoreview: clean
- Thermo-nuclear code-quality review: clean
- Claude UI/UX review: behavior correct; stale comments corrected

## Risk

Only an authoritative user Stop can save partial text. Higher-authority cancellation and disconnected transports save nothing.

Closes #238

Part of #235