### PR TITLE
chore(release): prepare 0.9.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -260,7 +260,7 @@ This file records notable changes to 1667. Product terms use the definitions in
   command accepts one or more JSON or PNG files. It adds their Facts to the
   story that `--story` names.
 
-## 0.9.6-rc.4 - 2026-08-15
+## 0.9.6 - 2026-08-16
 
 - **Stopping an Aside answer keeps the text that arrived.** Press `Esc` after
   answer text appears to save that text as a Side Note. If no answer text

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "1667-workspace",
-  "version": "0.9.6-rc.4",
+  "version": "0.9.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "1667-workspace",
-      "version": "0.9.6-rc.4",
+      "version": "0.9.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@silvia-odwyer/photon-node": "0.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667-workspace",
-  "version": "0.9.6-rc.4",
+  "version": "0.9.6",
   "private": true,
   "description": "Source workspace for the 1667 terminal writing environment",
   "license": "Apache-2.0",

--- a/shared/release-notes.ts
+++ b/shared/release-notes.ts
@@ -11,8 +11,8 @@ export interface ReleaseNote {
  *  a release, and is not included. */
 export const RELEASE_NOTES: readonly ReleaseNote[] = [
   {
-    version: "0.9.6-rc.4",
-    date: "2026-08-15",
+    version: "0.9.6",
+    date: "2026-08-16",
     body: "- **Stopping an Aside answer keeps the text that arrived.** Press `Esc` after\n  answer text appears to save that text as a Side Note. If no answer text\n  appears, 1667 restores the question.\n\n- **The PowerShell Installer shows the command that starts 1667.** After the\n  installation, the Installer shows the exact executable path. This command\n  works when the Install Root is not in `PATH`."
   },
   {

--- a/tui/package.json
+++ b/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667",
-  "version": "0.9.6-rc.4",
+  "version": "0.9.6",
   "private": true,
   "description": "A terminal environment for writing fiction with language models",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Outcome

Promote the verified `0.9.6-rc.4` release candidate to stable `0.9.6`.

## Changes

- Set the workspace and TUI versions to `0.9.6`.
- Mark the 0.9.6 changelog entry as stable.
- Regenerate the embedded release notes.

## Verification

- `npm run notes:check-version -- 0.9.6`
- `npm run build`
- `bun run typecheck`
- `bun run build:standalone`
- `0.9.6-rc.4` full pull request CI: green
- `0.9.6-rc.4` release workflow: green
- Six npm packages: `beta` resolves to `0.9.6-rc.4`
- GitHub prerelease: immutable, with 27 assets

## Risk

This change updates release identity only. Stable uses the exact code published and verified as `0.9.6-rc.4`.

Closes #235