### PR TITLE
fix: show actionable local error details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ This file records notable changes to 1667. Product terms use the definitions in
 
 ## Unreleased
 
+- **Internal errors now include useful diagnostic text.** 1667 shows the
+  error name, the error message, and a short cause chain. It keeps the
+  `err_…` reference as a link to the detailed local log. The visible message
+  does not include a stack or a provider response body.
+
 - **Prompt-plan changes now have a Gemma quality gate.** The gate compares the
   v0.8.0 prompt with a candidate on one frozen story and one fixed profile. It
   uses blind Retake and Continue scores. It requires no score regression for

--- a/docs/development.md
+++ b/docs/development.md
@@ -11,9 +11,13 @@ read_when:
 
 ## Troubleshoot internal errors
 
-1667 gives unexpected embedded and HTTP backend errors a safe public message.
-After 1667 saves a diagnostic, the public error includes an `err_…` reference.
-Use that reference to find the entry in the private machine-tier log:
+1667 shows a bounded diagnostic for unexpected embedded and HTTP backend
+errors. The diagnostic includes the error name, the error message, and
+a short cause chain. It does not include a stack or a provider response body.
+
+After 1667 saves the detailed diagnostic, the error also includes an `err_…`
+reference. Use that reference to find the entry in the private machine-tier
+log:
 
 - macOS: `~/Library/Application Support/1667/State/log/1667.log`
 - Linux: `$XDG_STATE_HOME/1667/log/1667.log`, or
@@ -29,9 +33,10 @@ Add `--print-logs` to print new diagnostics to stderr:
 1667 --print-logs
 ```
 
-1667 omits provider request and response bodies from the log. The log can
-contain local paths and exception messages. 1667 resets the active log before
-it exceeds 5 MiB. Inspect the log before you share it.
+The error message and the log can contain local paths and exception messages.
+1667 omits provider request and response bodies from both outputs. The log can
+also contain a stack. 1667 resets the active log before it exceeds 5 MiB.
+Inspect the output before you share it.
 
 1667 also saves a diagnostic when the embedded backend stops unexpectedly.
 The host-state fields contain operation names and numeric stream progress.

--- a/server/diagnostic-machine-tier.ts
+++ b/server/diagnostic-machine-tier.ts
@@ -1,4 +1,7 @@
-import type { InternalErrorContext } from "./internal-error-format.js";
+import {
+  formatInternalErrorMessage,
+  type InternalErrorContext
+} from "./internal-error-format.js";
 import { printInternalError } from "./internal-error-log.js";
 import { resolveMachineTierRoot } from "./machine-tier.js";
 import { PublicRuntimeError } from "./errors.js";
@@ -10,8 +13,7 @@ interface DiagnosticMachineTierOptions {
   readonly stderr?: Pick<NodeJS.WriteStream, "write">;
 }
 
-/** Resolve diagnostic storage before its reporter exists. Unexpected details
- * cross this pre-reporter boundary only when explicitly requested. */
+/** Resolve diagnostic storage before its reporter exists. */
 export async function resolveDiagnosticMachineTier(
   configured: string | undefined,
   context: InternalErrorContext,
@@ -38,7 +40,7 @@ export function diagnosticMachineTierFailure(
   return new PublicRuntimeError(
     error instanceof PlatformStateRootError
       ? error.message
-      : "Internal server error",
+      : formatInternalErrorMessage(error),
     { cause: error }
   );
 }

--- a/server/errors.ts
+++ b/server/errors.ts
@@ -75,8 +75,8 @@ export function timeoutProvenanceOf(
   return null;
 }
 
-/** A startup/runtime failure whose message is explicitly safe and actionable
- * at the local process boundary. Unexpected errors remain private. */
+/** A startup/runtime failure whose message is ready for the local process
+ * boundary. */
 export class PublicRuntimeError extends Error {
   constructor(message: string, options: { readonly cause?: unknown } = {}) {
     super(

--- a/server/index.ts
+++ b/server/index.ts
@@ -6,6 +6,7 @@ import {
   internalErrorReference,
   toPublicServiceError
 } from "./service-error-policy.js";
+import { terminalLineText } from "../shared/terminal-text.js";
 
 try {
   const dataDir = resolveDataDirectory();
@@ -44,7 +45,7 @@ try {
   const message = toPublicServiceError(error).message;
   const reference = internalErrorReference(error);
   process.stderr.write(
-    `1667: ${message}${reference === null ? "" : ` (${reference})`}\n`
+    `1667: ${terminalLineText(message)}${reference === null ? "" : ` (${reference})`}\n`
   );
   process.exitCode = 1;
 }

--- a/server/internal-error-format.ts
+++ b/server/internal-error-format.ts
@@ -1,4 +1,5 @@
 import type { DiagnosticReference } from "../shared/diagnostic-reference.js";
+import { sliceWellFormedUtf16Prefix } from "../shared/unicode.js";
 import { ProviderError } from "./errors.js";
 
 const MAX_DIAGNOSTIC_TEXT = 16_384;
@@ -6,11 +7,32 @@ const MAX_CONTEXT_TEXT = 4_096;
 const MAX_CAUSE_DEPTH = 4;
 const MAX_AGGREGATE_ERRORS = 8;
 const MAX_ERROR_GRAPH_NODES = 32;
+const MAX_PUBLIC_DIAGNOSTIC_TEXT = 1_024;
+const MAX_PUBLIC_CAUSE_DEPTH = 3;
+const MAX_PUBLIC_AGGREGATE_ERRORS = 3;
+const MAX_PUBLIC_ERROR_GRAPH_NODES = 16;
 
 export interface InternalErrorContext {
   readonly service: string;
   readonly operation?: string;
   readonly workerOperationId?: string;
+}
+
+/** Return a short, single-line diagnostic for the local process boundary.
+ * The private serializer remains the source of truth for safe error access
+ * and provider redaction. Stacks and provider bodies never enter this text. */
+export function formatInternalErrorMessage(error: unknown): string {
+  const diagnostic = diagnosticError(error, PUBLIC_DIAGNOSTIC_POLICY);
+  const message = formatPublicDiagnostic(diagnostic ?? {
+    name: "Error",
+    message: "<unavailable>"
+  });
+  return message.length <= MAX_PUBLIC_DIAGNOSTIC_TEXT
+    ? message
+    : `${sliceWellFormedUtf16Prefix(
+        message,
+        MAX_PUBLIC_DIAGNOSTIC_TEXT - 1
+      ).trimEnd()}…`;
 }
 
 /** Pure, bounded diagnostic serialization. Provider response-bearing errors
@@ -140,56 +162,147 @@ interface ErrorTraversal {
   remaining: number;
 }
 
+interface DiagnosticTraversalPolicy {
+  readonly causeFirst: boolean;
+  readonly includeStack: boolean;
+  readonly maxAggregateErrors: number;
+  readonly maxDepth: number;
+  readonly maxNodes: number;
+  readonly omitRepeatedReferences: boolean;
+}
+
+const PRIVATE_DIAGNOSTIC_POLICY: DiagnosticTraversalPolicy = Object.freeze({
+  causeFirst: false,
+  includeStack: true,
+  maxAggregateErrors: MAX_AGGREGATE_ERRORS,
+  maxDepth: MAX_CAUSE_DEPTH,
+  maxNodes: MAX_ERROR_GRAPH_NODES,
+  omitRepeatedReferences: false
+});
+
+const PUBLIC_DIAGNOSTIC_POLICY: DiagnosticTraversalPolicy = Object.freeze({
+  causeFirst: true,
+  includeStack: false,
+  maxAggregateErrors: MAX_PUBLIC_AGGREGATE_ERRORS,
+  maxDepth: MAX_PUBLIC_CAUSE_DEPTH,
+  maxNodes: MAX_PUBLIC_ERROR_GRAPH_NODES,
+  omitRepeatedReferences: true
+});
+
+interface DiagnosticNode {
+  readonly name: string;
+  readonly message: string;
+  readonly stack?: string;
+  readonly status?: number;
+  readonly errors?: readonly DiagnosticNode[];
+  readonly cause?: DiagnosticNode;
+}
+
 function diagnosticError(
   error: unknown,
+  policy: DiagnosticTraversalPolicy = PRIVATE_DIAGNOSTIC_POLICY,
   depth = 0,
   traversal: ErrorTraversal = {
     seen: new Set<object>(),
-    remaining: MAX_ERROR_GRAPH_NODES
+    remaining: policy.maxNodes
   }
-): Record<string, unknown> {
+): DiagnosticNode | null {
   if (traversal.remaining <= 0) {
     return {
       name: "TruncatedErrorGraph",
       message: "Error graph limit reached"
     };
   }
-  traversal.remaining -= 1;
   if (safeInstanceOfProviderError(error)) {
+    traversal.remaining -= 1;
     return redactedProviderError(error);
   }
   if (!safeInstanceOfError(error)) {
+    traversal.remaining -= 1;
     return { name: typeof error, message: bounded(safeString(error)) };
   }
   if (traversal.seen.has(error)) {
-    return {
-      name: "CircularErrorReference",
-      message: "Error already serialized"
-    };
+    return policy.omitRepeatedReferences
+      ? null
+      : {
+          name: "CircularErrorReference",
+          message: "Error already serialized"
+        };
   }
+  traversal.remaining -= 1;
   traversal.seen.add(error);
   const name = readErrorProperty(error, "name");
   const message = readErrorProperty(error, "message");
-  const stack = readErrorProperty(error, "stack");
+  const stack = policy.includeStack
+    ? readErrorProperty(error, "stack")
+    : undefined;
   const cause = readErrorProperty(error, "cause");
   const aggregateErrors = readAggregateErrors(error);
+  let serializedCause: DiagnosticNode | null = null;
+  const serializedErrors: DiagnosticNode[] = [];
+  const serializeCause = (): void => {
+    if (cause !== undefined && depth < policy.maxDepth) {
+      serializedCause = diagnosticError(cause, policy, depth + 1, traversal);
+    }
+  };
+  const serializeErrors = (): void => {
+    if (aggregateErrors === null || depth >= policy.maxDepth) return;
+    for (const entry of aggregateErrors) {
+      const serialized = diagnosticError(
+        entry,
+        policy,
+        depth + 1,
+        traversal
+      );
+      if (serialized !== null) serializedErrors.push(serialized);
+      if (serializedErrors.length >= policy.maxAggregateErrors) break;
+    }
+  };
+  if (policy.causeFirst) {
+    serializeCause();
+    serializeErrors();
+  } else {
+    serializeErrors();
+    serializeCause();
+  }
   return {
     name: bounded(safeString(name ?? "Error")),
     message: bounded(safeString(message ?? "<unavailable>")),
     ...(stack === undefined ? {} : { stack: bounded(safeString(stack)) }),
-    ...(aggregateErrors === null || depth >= MAX_CAUSE_DEPTH
-      ? {}
-      : {
-          errors: aggregateErrors.map((entry) =>
-            diagnosticError(entry, depth + 1, traversal))
-        }),
-    ...(cause === undefined || depth >= MAX_CAUSE_DEPTH
-      ? {}
-      : { cause: diagnosticError(cause, depth + 1, traversal) })
+    ...(serializedCause === null ? {} : { cause: serializedCause }),
+    ...(serializedErrors.length === 0 ? {} : { errors: serializedErrors })
   };
 }
 
-function redactedProviderError(error: ProviderError): Record<string, unknown> {
+function formatPublicDiagnostic(
+  diagnostic: DiagnosticNode,
+  depth = 0
+): string {
+  const name = compactPublicText(diagnostic.name, "Error");
+  const message = compactPublicText(diagnostic.message, "<unavailable>");
+  let result = `${name}: ${message}`;
+  if (depth >= MAX_PUBLIC_CAUSE_DEPTH) return result;
+
+  const cause = diagnostic.cause;
+  if (cause !== undefined) {
+    result += `; caused by ${formatPublicDiagnostic(cause, depth + 1)}`;
+  }
+  if (diagnostic.errors !== undefined) {
+    const summaries = diagnostic.errors
+      .map((entry) => formatPublicDiagnostic(entry, depth + 1));
+    if (summaries.length > 0) {
+      result += `; also ${summaries.join("; ")}`;
+    }
+  }
+  return result;
+}
+
+function compactPublicText(value: unknown, fallback: string): string {
+  const text = safeString(value).replace(/\s+/gu, " ").trim();
+  return text.length === 0 ? fallback : text;
+}
+
+function redactedProviderError(error: ProviderError): DiagnosticNode {
   const status = readProviderStatus(error);
   return {
     name: "ProviderError",

--- a/server/service-error-policy.ts
+++ b/server/service-error-policy.ts
@@ -13,6 +13,7 @@ import {
   ServiceError,
   type ServiceErrorCode
 } from "./errors.js";
+import { formatInternalErrorMessage } from "./internal-error-format.js";
 import {
   durableFailureIncident,
   errorFromFailureIncident,
@@ -33,20 +34,14 @@ export interface PublicServiceError {
 
 export interface ServiceErrorClassification {
   readonly publicError: PublicServiceError;
-  readonly exposure: "public" | "private";
+  readonly diagnostic: "none" | "required";
 }
 
 export type StoredServiceError = FailureEnvelope;
 
-type PrivateDiagnosticSelection =
+type DiagnosticSelection =
   | { readonly kind: "none" }
   | { readonly kind: "present"; readonly error: unknown };
-
-const INTERNAL_PUBLIC_ERROR: PublicServiceError = Object.freeze({
-  code: "internal",
-  message: "Internal server error",
-  status: 500
-});
 
 /** One transport-independent exposure policy for HTTP, SSE, and workers. */
 export function classifyServiceError(
@@ -60,7 +55,7 @@ export function classifyServiceError(
         status: error.failure.status ?? 500,
         ...timeoutField(error.failure.timeout)
       },
-      exposure: "public"
+      diagnostic: "none"
     };
   }
   if (error instanceof PublicRuntimeError) {
@@ -70,13 +65,10 @@ export function classifyServiceError(
         message: error.message,
         status: 500
       },
-      exposure: "public"
+      diagnostic: "none"
     };
   }
-  if (error instanceof ServiceError) {
-    if (error.code === "internal") {
-      return { publicError: INTERNAL_PUBLIC_ERROR, exposure: "private" };
-    }
+  if (error instanceof DiagnosticServiceError) {
     return {
       publicError: {
         code: error.code,
@@ -84,7 +76,18 @@ export function classifyServiceError(
         status: error.status,
         ...timeoutField(error.timeout)
       },
-      exposure: "public"
+      diagnostic: "required"
+    };
+  }
+  if (error instanceof ServiceError && error.code !== "internal") {
+    return {
+      publicError: {
+        code: error.code,
+        message: error.message,
+        status: error.status,
+        ...timeoutField(error.timeout)
+      },
+      diagnostic: "none"
     };
   }
   if (error instanceof ProviderError) {
@@ -95,10 +98,17 @@ export function classifyServiceError(
         status: 502,
         ...timeoutField(error.timeout)
       },
-      exposure: "public"
+      diagnostic: "none"
     };
   }
-  return { publicError: INTERNAL_PUBLIC_ERROR, exposure: "private" };
+  return {
+    publicError: {
+      code: "internal",
+      message: formatInternalErrorMessage(error),
+      status: 500
+    },
+    diagnostic: "required"
+  };
 }
 
 function timeoutField(
@@ -117,7 +127,7 @@ export function prepareServiceFailure(
   if (isReportedServiceError(error)) return error.incident;
   const classified = classifyServiceError(error);
   const failure = createFailureEnvelope(classified.publicError);
-  const selected = privateDiagnosticSelection(error, classified);
+  const selected = diagnosticSelection(error, classified);
   if (selected.kind === "none") {
     return publicFailureIncident(failure, error);
   }
@@ -126,10 +136,10 @@ export function prepareServiceFailure(
     : unreportedFailureIncident(failure, error, selected.error);
 }
 
-function privateDiagnosticSelection(
+function diagnosticSelection(
   error: unknown,
   classified = classifyServiceError(error)
-): PrivateDiagnosticSelection {
+): DiagnosticSelection {
   if (error instanceof DiagnosticServiceError) {
     return { kind: "present", error: error.diagnosticCause };
   }
@@ -137,7 +147,7 @@ function privateDiagnosticSelection(
     && error.hasDiagnosticCause) {
     return { kind: "present", error: error.diagnosticCause };
   }
-  return classified.exposure === "private"
+  return classified.diagnostic === "required"
     ? { kind: "present", error }
     : { kind: "none" };
 }
@@ -158,9 +168,9 @@ export function restoreStoredServiceFailure(
     : error;
 }
 
-/** Once a failure envelope is durable, a missing reference is final. Public
- * domain errors keep their original subtype; only unreported private errors
- * need restored provenance to prevent a later transport from inventing one. */
+/** Once a failure envelope is durable, a missing reference is final. Domain
+ * errors keep their original subtype. Unreported diagnostic errors need
+ * restored provenance to prevent a later transport from inventing one. */
 export function finalizeDurableServiceFailure(
   incident: ServiceFailureIncident
 ): unknown {

--- a/server/settings-v2-save-bias-check.ts
+++ b/server/settings-v2-save-bias-check.ts
@@ -105,11 +105,9 @@ export async function assertSavedSamplingBiasResolves(
       // plain SettingsFormatError, the same as every other save-time
       // validation failure in server/settings-v2-store.ts — wrap it the
       // same way (server/settings-v2-mutation.ts, invalidSettingsMutation)
-      // so it reaches the writer as its own 400 message instead of falling
-      // through to a generic "Internal server error" at the transport's
-      // classifyServiceError boundary (server/service-error-policy.ts),
-      // which only recognizes ServiceError and a short allow-list of
-      // other known types.
+      // so it reaches the writer as a 400 validation error instead of an
+      // internal 500 at the classifyServiceError boundary
+      // (server/service-error-policy.ts).
       throw invalidSettingsMutation(error);
     }
   }

--- a/shared/failure-envelope.ts
+++ b/shared/failure-envelope.ts
@@ -196,7 +196,7 @@ export function createFailureEnvelope(
     && message !== null
     && isFailureStatus(failure.status);
   const code: FailureCode = validFailure ? failure.code : "internal";
-  const publicMessage = validFailure && code !== "internal"
+  const publicMessage = validFailure
     ? message
     : "Internal server error";
   const status = validFailure ? failure.status : 500;
@@ -267,9 +267,7 @@ export function isFailureEnvelope(value: unknown): value is FailureEnvelope {
   if (!isFailureCode(failure.code)
     || !validFailureString(failure.message, MAX_FAILURE_MESSAGE_LENGTH)
     || !isFailureStatus(failure.status)
-    || ("timeout" in failure && !isTimeoutProvenance(failure.timeout))
-    || (failure.code === "internal"
-      && failure.message !== "Internal server error")) {
+    || ("timeout" in failure && !isTimeoutProvenance(failure.timeout))) {
     return false;
   }
   if (failure.kind === "plain") {
@@ -453,9 +451,6 @@ export function createCompatibleHttpFailureEnvelope(
     : "invalid_response";
   const message = boundedFailureMessage(failure.message)
     ?? "Internal server error";
-  const publicMessage = code === "internal"
-    ? "Internal server error"
-    : message;
   const status = isFailureStatus(failure.status)
     ? failure.status
     : 500;
@@ -466,7 +461,7 @@ export function createCompatibleHttpFailureEnvelope(
     ? {
         kind: "diagnostic",
         code,
-        message: publicMessage,
+        message,
         status,
         ...timeout,
         diagnosticRef
@@ -474,7 +469,7 @@ export function createCompatibleHttpFailureEnvelope(
     : {
         kind: "plain",
         code,
-        message: publicMessage,
+        message,
         status,
         ...timeout
       });

--- a/test/diagnostic-machine-tier.test.ts
+++ b/test/diagnostic-machine-tier.test.ts
@@ -5,7 +5,7 @@ import {
 } from "../server/diagnostic-machine-tier.js";
 import { PublicRuntimeError } from "../server/errors.js";
 
-test("machine-tier failures stay private before reporter startup", async () => {
+test("machine-tier failures stay actionable before reporter startup", async () => {
   let printed = "";
   const root = new Error("private machine-tier resolution failure");
 
@@ -28,7 +28,10 @@ test("machine-tier failures stay private before reporter startup", async () => {
     ),
     (error: unknown) => {
       assert.ok(error instanceof PublicRuntimeError);
-      assert.equal(error.message, "Internal server error");
+      assert.equal(
+        error.message,
+        "Error: private machine-tier resolution failure"
+      );
       assert.equal(error.cause, root);
       return true;
     }
@@ -61,7 +64,10 @@ test("--print-logs covers machine-tier failures before reporter startup", async 
     ),
     (error: unknown) => {
       assert.ok(error instanceof PublicRuntimeError);
-      assert.equal(error.message, "Internal server error");
+      assert.equal(
+        error.message,
+        "Error: private machine-tier resolution failure"
+      );
       assert.equal(error.cause, root);
       return true;
     }

--- a/test/errors.test.ts
+++ b/test/errors.test.ts
@@ -10,6 +10,7 @@ import {
 } from "../shared/failure-envelope.js";
 import { createDiagnosticReference } from "../server/diagnostic-reference.js";
 import {
+  DiagnosticServiceError,
   GenerationResultError,
   ProviderError,
   PublicRuntimeError,
@@ -28,6 +29,7 @@ import {
   restoreStoredServiceFailure,
   toPublicServiceError
 } from "../server/service-error-policy.js";
+import { hasUnpairedSurrogate } from "../shared/unicode.js";
 
 test("public errors normalize provider status identically for every transport", () => {
   assert.deepEqual(toPublicServiceError(new ProviderError("Unauthorized upstream", 401)), {
@@ -37,24 +39,24 @@ test("public errors normalize provider status identically for every transport", 
     code: "conflict", message: "Changed", status: 409
   });
   assert.deepEqual(toPublicServiceError(new Error("secret")), {
-    code: "internal", message: "Internal server error", status: 500
+    code: "internal", message: "Error: secret", status: 500
   });
   assert.deepEqual(
     classifyServiceError(new ServiceError(500, "private", "internal")),
     {
       publicError: {
-        code: "internal", message: "Internal server error", status: 500
+        code: "internal", message: "ServiceError: private", status: 500
       },
-      exposure: "private"
+      diagnostic: "required"
     }
   );
   assert.deepEqual(
     classifyServiceError(new ServiceError(500, "/private/data/path")),
     {
       publicError: {
-        code: "internal", message: "Internal server error", status: 500
+        code: "internal", message: "ServiceError: /private/data/path", status: 500
       },
-      exposure: "private"
+      diagnostic: "required"
     }
   );
   assert.deepEqual(
@@ -63,7 +65,7 @@ test("public errors normalize provider status identically for every transport", 
       publicError: {
         code: "startup_failure", message: "safe startup detail", status: 500
       },
-      exposure: "public"
+      diagnostic: "none"
     }
   );
   assert.equal(
@@ -76,14 +78,118 @@ test("public errors normalize provider status identically for every transport", 
   );
 });
 
-test("private stored failures publish only persisted diagnostic references", () => {
+test("internal errors expose a bounded cause chain without provider bodies", () => {
+  const responseSecret = "provider-response-secret";
+  const provider = new ProviderError(
+    `Provider response contained ${responseSecret}`,
+    502,
+    responseSecret
+  );
+  const root = new Error("local operation failed", { cause: provider });
+
+  const publicError = toPublicServiceError(root);
+
+  assert.equal(publicError.code, "internal");
+  assert.match(
+    publicError.message,
+    /Error: local operation failed; caused by ProviderError: Provider request failed with HTTP status 502/
+  );
+  assert.doesNotMatch(publicError.message, new RegExp(responseSecret));
+  assert.doesNotMatch(publicError.message, /\bat\s+\S+/);
+  assert.ok(publicError.message.length <= 1_024);
+});
+
+test("diagnostic service errors keep their diagnostic cause out of messages", () => {
+  const secret = "credential=private-provider-key";
+  const error = new DiagnosticServiceError(
+    500,
+    "The operation failed",
+    "internal",
+    new Error(secret)
+  );
+
+  assert.deepEqual(classifyServiceError(error), {
+    publicError: {
+      code: "internal",
+      message: "The operation failed",
+      status: 500
+    },
+    diagnostic: "required"
+  });
+  assert.deepEqual(prepareServiceFailure(error).failure, {
+    kind: "plain",
+    code: "internal",
+    message: "The operation failed",
+    status: 500
+  });
+  assert.doesNotMatch(toPublicServiceError(error).message, new RegExp(secret));
+});
+
+test("aggregate errors expose each useful failure without serializer details", () => {
+  const first = new Error("startup failed");
+  const aggregate = new AggregateError(
+    [first, new Error("cleanup failed")],
+    "startup and cleanup failed",
+    { cause: first }
+  );
+
+  const message = toPublicServiceError(aggregate).message;
+
+  assert.match(message, /AggregateError: startup and cleanup failed/);
+  assert.match(message, /Error: startup failed/);
+  assert.match(message, /Error: cleanup failed/);
+  assert.doesNotMatch(message, /CircularErrorReference|already serialized/);
+});
+
+test("public diagnostics reserve traversal capacity for the primary cause", () => {
+  const noisyBranches = Array.from({ length: 8 }, (_, index) =>
+    new Error(`branch ${index}`, {
+      cause: new Error(`branch ${index} cause`, {
+        cause: new Error(`branch ${index} tail`)
+      })
+    }));
+  const aggregate = new AggregateError(noisyBranches, "many failures", {
+    cause: new Error("primary cause")
+  });
+
+  const message = toPublicServiceError(aggregate).message;
+
+  assert.match(message, /caused by Error: primary cause/);
+  assert.doesNotMatch(message, /caused by TruncatedErrorGraph/);
+});
+
+test("an error named CircularErrorReference remains visible", () => {
+  const named = new Error("real failure");
+  named.name = "CircularErrorReference";
+
+  const message = toPublicServiceError(new AggregateError([
+    named,
+    new Error("later failure")
+  ], "aggregate failed", { cause: named })).message;
+
+  assert.match(message, /CircularErrorReference: real failure/);
+  assert.match(message, /Error: later failure/);
+  assert.doesNotMatch(message, /already serialized/);
+});
+
+test("internal error truncation preserves complete Unicode scalars", () => {
+  const message = toPublicServiceError(
+    new Error(`${"x".repeat(1_015)}😀tail`)
+  ).message;
+
+  assert.equal(hasUnpairedSurrogate(message), false);
+  assert.ok(message.endsWith("…"));
+  assert.doesNotMatch(message, /�/u);
+});
+
+test("internal stored failures publish only persisted diagnostic references", () => {
   const root = new Error("private receipt detail");
   const pending = prepareServiceFailure(root);
 
   assert.deepEqual(pending.failure, {
     kind: "plain",
     code: "internal",
-    message: "Internal server error",
+    message: "Error: private receipt detail",
     status: 500
   });
   const pendingError = errorFromFailureIncident(pending);
@@ -123,7 +229,7 @@ test("private stored failures publish only persisted diagnostic references", () 
   );
   assert.equal(
     (restored as Error).message,
-    "Internal server error"
+    "Error: private receipt detail"
   );
 });
 
@@ -226,7 +332,7 @@ test("failure envelopes normalize invalid HTTP statuses to an internal 500", () 
   }
 });
 
-test("failure envelopes make internal privacy and codes type invariants", () => {
+test("failure envelopes preserve bounded internal diagnostics", () => {
   assert.deepEqual(createFailureEnvelope({
     code: "internal",
     message: "Private path: /srv/1667/settings.json",
@@ -234,7 +340,7 @@ test("failure envelopes make internal privacy and codes type invariants", () => 
   }), {
     kind: "plain",
     code: "internal",
-    message: "Internal server error",
+    message: "Private path: /srv/1667/settings.json",
     status: 500
   });
   assert.deepEqual(decodeFailureEnvelope({
@@ -245,7 +351,7 @@ test("failure envelopes make internal privacy and codes type invariants", () => 
   }), {
     kind: "plain",
     code: "internal",
-    message: "Internal server error",
+    message: "Private tagged path: /srv/1667/settings.json",
     status: 500
   });
   assert.deepEqual(decodeFailureEnvelope({
@@ -323,7 +429,7 @@ test("failure decoder rejects malformed discriminated envelopes", () => {
   }), {
     kind: "plain",
     code: "internal",
-    message: "Internal server error",
+    message: "Private legacy path: /srv/1667/settings.json",
     status: 500
   });
 });

--- a/test/generation-disconnect.test.ts
+++ b/test/generation-disconnect.test.ts
@@ -362,8 +362,7 @@ test("HTTP streams persist private failures and return their reference", async (
 
   const reference = /err_[0-9a-f]{24}/.exec(response.output)?.[0];
   assert.ok(reference);
-  assert.match(response.output, /Internal server error/);
-  assert.doesNotMatch(response.output, /private streaming detail/);
+  assert.match(response.output, /Error: private streaming detail/);
   const stored = await readFile(internalErrorLogPath(machineDir), "utf8");
   assert.match(stored, new RegExp(reference));
   assert.match(stored, /private streaming detail/);

--- a/test/http-auth.test.ts
+++ b/test/http-auth.test.ts
@@ -405,7 +405,9 @@ linuxTest("listener tears down even when removing its auth record fails", async 
 
   let reference: string | null = null;
   await assert.rejects(listener.close(), (error: unknown) => {
-    assert.equal(toPublicServiceError(error).message, "Internal server error");
+    const message = toPublicServiceError(error).message;
+    assert.match(message, /^SyntaxError: /);
+    assert.match(message, /JSON|property name/i);
     reference = internalErrorReference(error);
     assert.match(reference ?? "", /^err_[0-9a-f]{24}$/);
     return true;

--- a/test/http-auth.test.ts
+++ b/test/http-auth.test.ts
@@ -406,8 +406,8 @@ linuxTest("listener tears down even when removing its auth record fails", async 
   let reference: string | null = null;
   await assert.rejects(listener.close(), (error: unknown) => {
     const message = toPublicServiceError(error).message;
-    assert.match(message, /^SyntaxError: /);
-    assert.match(message, /JSON|property name/i);
+    assert.match(message, /^(SyntaxError|StrictJsonError): /);
+    assert.match(message, /JSON|property name|object key/i);
     reference = internalErrorReference(error);
     assert.match(reference ?? "", /^err_[0-9a-f]{24}$/);
     return true;

--- a/test/http-listener-diagnostics.test.ts
+++ b/test/http-listener-diagnostics.test.ts
@@ -57,7 +57,10 @@ linuxTest("listener closes and removes authority when its service factory fails"
       }
     }),
     (error: unknown) => {
-      assert.equal(toPublicServiceError(error).message, "Internal server error");
+      assert.equal(
+        toPublicServiceError(error).message,
+        "Error: service factory failed"
+      );
       reference = internalErrorReference(error);
       assert.match(reference ?? "", /^err_[0-9a-f]{24}$/);
       return true;
@@ -106,7 +109,10 @@ linuxTest("listener binds factory service data before auth publication", async (
         })
     }),
     (error: unknown) => {
-      assert.equal(toPublicServiceError(error).message, "Internal server error");
+      assert.equal(
+        toPublicServiceError(error).message,
+        "Error: HTTP service data directory does not match its selected project"
+      );
       reference = internalErrorReference(error);
       assert.match(reference ?? "", /^err_[0-9a-f]{24}$/);
       return true;
@@ -339,7 +345,7 @@ linuxTest("listener exposes selected storage shape failures only during startup"
   assert.equal(await readFile(internalErrorLogPath(stateRoot), "utf8"), "");
 });
 
-linuxTest("listener keeps unexpected machine-tier failures private", async (t) => {
+linuxTest("listener keeps unexpected machine-tier failures actionable", async (t) => {
   const parent = await privateTemporaryDirectory(
     t,
     "1667-http-state-resolution-"
@@ -355,10 +361,9 @@ linuxTest("listener keeps unexpected machine-tier failures private", async (t) =
     await assert.rejects(
       startHttpListener(),
       (error: unknown) => {
-        assert.equal(
-          toPublicServiceError(error).message,
-          "Internal server error"
-        );
+        const message = toPublicServiceError(error).message;
+        assert.match(message, /^Error: /);
+        assert.ok(message.includes(blockingFile));
         assert.equal(internalErrorReference(error), null);
         return true;
       }
@@ -404,7 +409,13 @@ linuxTest("listener preserves startup and cleanup failures together", async (t) 
       })
     }),
     (error: unknown) => {
-      assert.equal(toPublicServiceError(error).message, "Internal server error");
+      const message = toPublicServiceError(error).message;
+      assert.match(
+        message,
+        /^AggregateError: 1667 HTTP listener startup and cleanup both failed/
+      );
+      assert.match(message, /service initialization failed/);
+      assert.match(message, /service disposal failed/);
       reference = internalErrorReference(error);
       assert.match(reference ?? "", /^err_[0-9a-f]{24}$/);
       return true;
@@ -483,7 +494,7 @@ linuxTest("listener bounds a stalled diagnostic flush during shutdown", async (t
 
   assert.ok(performance.now() - startedAt < 1_000);
   assert.equal(internalErrorReference(failure), null);
-  assert.equal(toPublicServiceError(failure).message, "Internal server error");
+  assert.equal(toPublicServiceError(failure).message, "Error: shutdown failed");
 });
 
 linuxTest("request drain owns diagnostic reporting and the error response", async (t) => {

--- a/test/internal-error-reporter.test.ts
+++ b/test/internal-error-reporter.test.ts
@@ -286,7 +286,7 @@ test("print mode survives an unavailable persistent log", async (t) => {
     failure: {
       kind: "plain",
       code: "internal",
-      message: "Internal server error",
+      message: "ServiceError: diagnostic after open failure",
       status: 500
     }
   });
@@ -320,7 +320,7 @@ test("an unavailable persistent log is visible without exposing details", async 
     failure: {
       kind: "plain",
       code: "internal",
-      message: "Internal server error",
+      message: "Error: private runtime detail",
       status: 500
     }
   });

--- a/test/mutation-outbox.test.ts
+++ b/test/mutation-outbox.test.ts
@@ -379,7 +379,7 @@ test("mutation outbox reads legacy archives without accepting new fields", async
   );
 });
 
-test("legacy internal archive messages stay private during recovery", async (t) => {
+test("legacy internal archive messages stay actionable during recovery", async (t) => {
   const dir = await mkdtemp(path.join(tmpdir(), "1667-outbox-legacy-error-"));
   t.after(() => rm(dir, { recursive: true, force: true }));
   const mutationId = `m1-${Date.now().toString(36)}-${"a".padStart(32, "0")}`;
@@ -419,7 +419,7 @@ test("legacy internal archive messages stay private during recovery", async (t) 
     {
       kind: "plain",
       code: "internal",
-      message: "Internal server error",
+      message: "Private legacy path: /srv/1667/settings.json",
       status: 500
     }
   );

--- a/test/mutation-receipt-diagnostics.test.ts
+++ b/test/mutation-receipt-diagnostics.test.ts
@@ -47,7 +47,7 @@ class MutationReceiptStore extends ProductionMutationReceiptStore {
   }
 }
 
-test("private terminal failures persist diagnostics before receipt references", async (t) => {
+test("internal terminal failures persist diagnostics before receipt references", async (t) => {
   const rootDir = await realpath(
     await mkdtemp(path.join(tmpdir(), "1667-mutation-private-failure-"))
   );
@@ -84,14 +84,14 @@ test("private terminal failures persist diagnostics before receipt references", 
     path.join(dir, `${mutationId}.json`),
     "utf8"
   );
-  assert.doesNotMatch(receiptText, /private mutation detail/);
+  assert.match(receiptText, /private mutation detail/);
   const receipt = JSON.parse(receiptText) as {
     failure: Record<string, unknown>;
   };
   assert.deepEqual(receipt.failure, {
     kind: "diagnostic",
     code: "internal",
-    message: "Internal server error",
+    message: "Error: private mutation detail",
     status: 500,
     diagnosticRef: reference
   });

--- a/test/sampling-e2e.test.ts
+++ b/test/sampling-e2e.test.ts
@@ -406,9 +406,8 @@ test("llama.cpp save-time validation rejects a phrase the live server cannot res
       // The save path must throw a ServiceError, not a bare
       // SettingsFormatError: the worker/HTTP transport's error
       // classification (server/service-error-policy.ts) only recognizes
-      // ServiceError and a short allow-list of other known types, and
-      // reports anything else as a generic "Internal server error" —
-      // which would have silently swallowed this exact validation message.
+      // ServiceError and a short allow-list of other known types. Anything
+      // else becomes an internal 500 and loses the validation semantics.
       assert.ok(error instanceof ServiceError, "expected a ServiceError, not a raw SettingsFormatError");
       assert.equal(error.status, 400);
       return true;

--- a/test/supervised-serve-boundary.test.ts
+++ b/test/supervised-serve-boundary.test.ts
@@ -267,7 +267,7 @@ test("machine-tier startup preserves only actionable state-root failures", () =>
     toPublicServiceError(
       diagnosticMachineTierFailure(new Error("private resolution detail"))
     ).message,
-    "Internal server error"
+    "Error: private resolution detail"
   );
 });
 
@@ -284,7 +284,7 @@ test("local startup storage exposure is shared across transports", () => {
     toPublicServiceError(
       localStartupFailure(new Error("private runtime storage detail"))
     ).message,
-    "Internal server error"
+    "Error: private runtime storage detail"
   );
 });
 

--- a/tui/src/main.ts
+++ b/tui/src/main.ts
@@ -40,6 +40,7 @@ import { parseCanonicalLoopbackOrigin } from "../../shared/http-loopback-origin.
 import {
   createCompatibleHttpFailureEnvelope
 } from "../../shared/failure-envelope.js";
+import { terminalLineText } from "../../shared/terminal-text.js";
 import { resolveMachineTierRoot } from "../../server/machine-tier.js";
 import { resolvePlatformDataDirectory } from "../../server/platform-data-directory.js";
 import { adoptDataDirectory } from "../../server/project-adoption.js";
@@ -614,12 +615,15 @@ export async function runCli(argv = process.argv.slice(2)): Promise<void> {
     await main(argv);
   } catch (error) {
     if (error instanceof UsageError) {
-      process.stderr.write(`1667: ${error.message}\nTry '1667 --help'.\n`);
+      process.stderr.write(
+        `1667: ${terminalLineText(error.message)}\nTry '1667 --help'.\n`
+      );
       process.exitCode = 2;
       return;
     }
     if (error instanceof BackendRestartRequiredError) exitForBackendRestart(error);
-    process.stderr.write(`1667: ${error instanceof Error ? error.message : String(error)}\n`);
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`1667: ${terminalLineText(message)}\n`);
     process.exitCode = 1;
   }
 }

--- a/tui/src/standalone.ts
+++ b/tui/src/standalone.ts
@@ -1,3 +1,5 @@
+import { terminalLineText } from "../../shared/terminal-text.js";
+
 export {};
 
 const argv = process.argv.slice(2);
@@ -52,6 +54,7 @@ function sendPrivateFatal(error: unknown): void {
 
 function boundedMessage(error: unknown): string {
   const message = error instanceof Error ? error.message : String(error);
-  return message.replace(/\s+/gu, " ").trim().slice(0, 1_000)
+  return terminalLineText(message.replace(/\s+/gu, " ").trim())
+    .slice(0, 1_000)
     || "unknown startup failure";
 }

--- a/tui/src/worker-error.ts
+++ b/tui/src/worker-error.ts
@@ -4,12 +4,16 @@ import {
   type CompatibleHttpFailureEnvelope,
   type FailureEnvelope
 } from "../../shared/failure-envelope.js";
+import { terminalLineText } from "../../shared/terminal-text.js";
+import { sliceWellFormedUtf16Prefix } from "../../shared/unicode.js";
 import { ApiFailureError } from "./api-error.js";
 
 export const BACKEND_RESTART_REQUIRED_EXIT_CODE = 75;
+const MAX_BACKEND_RESTART_DETAIL_LENGTH = 1_024;
 
 export class BackendRestartRequiredError extends Error {
   readonly code = "backend_restart_required";
+  readonly detail: string;
   private attachedDiagnosticRef: string | null;
 
   constructor(
@@ -18,6 +22,7 @@ export class BackendRestartRequiredError extends Error {
   ) {
     super(`backend_restart_required: ${message}`, options);
     this.name = "BackendRestartRequiredError";
+    this.detail = message;
     this.attachedDiagnosticRef = isDiagnosticReference(options.diagnosticRef)
       ? options.diagnosticRef
       : null;
@@ -37,6 +42,9 @@ export class BackendRestartRequiredError extends Error {
 export function exitForBackendRestart(
   error?: BackendRestartRequiredError
 ): never {
+  const detail = error === undefined
+    ? ""
+    : backendRestartDetail(error);
   const diagnostic = error?.diagnosticRef === null
     || error?.diagnosticRef === undefined
     ? ""
@@ -45,11 +53,26 @@ export function exitForBackendRestart(
     writeSync(
       process.stderr.fd,
       "1667: the local backend stopped before it confirmed the last change. "
-        + `Restart 1667. Saved state will be checked before more work is accepted.${diagnostic}\n`
+        + `Restart 1667. Saved state will be checked before more work is accepted.${detail}${diagnostic}\n`
     );
   } finally {
     process.exit(BACKEND_RESTART_REQUIRED_EXIT_CODE);
   }
+}
+
+function backendRestartDetail(error: BackendRestartRequiredError): string {
+  const normalized = terminalLineText(
+    error.detail.replace(/\s+/gu, " ").trim()
+  );
+  const bounded = normalized.length <= MAX_BACKEND_RESTART_DETAIL_LENGTH
+    ? normalized
+    : `${sliceWellFormedUtf16Prefix(
+        normalized,
+        MAX_BACKEND_RESTART_DETAIL_LENGTH - 1
+      ).trimEnd()}…`;
+  return bounded.length === 0
+    ? ""
+    : ` Failure detail: ${bounded}${/[.!?…]$/.test(bounded) ? "" : "."}`;
 }
 
 /** Authoritative mutation settlement from the worker transport. */

--- a/tui/src/worker-transport.ts
+++ b/tui/src/worker-transport.ts
@@ -474,7 +474,7 @@ export class WorkerTransport {
     if (message.type === "protocolError") {
       const failure = workerApiErrorFromFailure(message.failure);
       if (this.lifecycle.hasReachedReady) {
-        this.failForRestart(failure.message, failure);
+        this.failForRestart(failure.failure.message, failure);
         return;
       }
       return this.fail(failure, false);

--- a/tui/test/cli-help.test.ts
+++ b/tui/test/cli-help.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
 import {
   AUTH_HELP,
   DECRYPT_HELP,
@@ -139,25 +140,20 @@ test("1667 <command> --help prints that command's page instead of refusing the f
   expect(output).not.toContain("unknown import option");
 });
 
-test("CLI errors cannot write terminal control characters", async () => {
-  const { runCli } = await import("../src/main.js");
-  const originalWrite = process.stderr.write.bind(process.stderr);
-  const originalExitCode = process.exitCode;
-  const captured: string[] = [];
-  process.stderr.write = ((chunk: string) => {
-    captured.push(String(chunk));
-    return true;
-  }) as typeof process.stderr.write;
-  try {
-    await runCli(["--unknown\u001b[31m"]);
-  } finally {
-    process.stderr.write = originalWrite;
-    process.exitCode = originalExitCode;
-  }
+test("CLI errors cannot write terminal control characters", () => {
+  const moduleUrl = new URL("../src/main.ts", import.meta.url).href;
+  const child = spawnSync(process.execPath, [
+    "--eval",
+    `import { runCli } from ${JSON.stringify(moduleUrl)};`
+      + "await runCli(['--unknown\\u001b[31m']);"
+  ], {
+    encoding: "utf8",
+    timeout: 2_000
+  });
 
-  const output = captured.join("");
-  expect(output).toContain("unknown option: --unknown▪[31m");
-  expect(output).not.toContain("\u001b");
+  expect(child.status).toBe(2);
+  expect(child.stderr).toContain("unknown option: --unknown▪[31m");
+  expect(child.stderr).not.toContain("\u001b");
 });
 
 test("the import-lorebook page names every format the command reads", () => {

--- a/tui/test/cli-help.test.ts
+++ b/tui/test/cli-help.test.ts
@@ -139,6 +139,27 @@ test("1667 <command> --help prints that command's page instead of refusing the f
   expect(output).not.toContain("unknown import option");
 });
 
+test("CLI errors cannot write terminal control characters", async () => {
+  const { runCli } = await import("../src/main.js");
+  const originalWrite = process.stderr.write.bind(process.stderr);
+  const originalExitCode = process.exitCode;
+  const captured: string[] = [];
+  process.stderr.write = ((chunk: string) => {
+    captured.push(String(chunk));
+    return true;
+  }) as typeof process.stderr.write;
+  try {
+    await runCli(["--unknown\u001b[31m"]);
+  } finally {
+    process.stderr.write = originalWrite;
+    process.exitCode = originalExitCode;
+  }
+
+  const output = captured.join("");
+  expect(output).toContain("unknown option: --unknown▪[31m");
+  expect(output).not.toContain("\u001b");
+});
+
 test("the import-lorebook page names every format the command reads", () => {
   // A command that grows a format and not its page is the failure this split
   // was made to fix.

--- a/tui/test/regressions.test.ts
+++ b/tui/test/regressions.test.ts
@@ -40,7 +40,7 @@ function key(name: string, sequence: string, shift = false): KeyEvent {
 }
 
 describe("review regressions", () => {
-  test("legacy serve sanitizes private failures without a persisted log", async () => {
+  test("legacy serve shows internal failures without a persisted log", async () => {
     const privateFailure = errorFromFailureIncident(
       await InternalErrorReporter.disabled().report(
         new Error("private /machine/path"),
@@ -50,8 +50,7 @@ describe("review regressions", () => {
 
     const displayed = sanitizeLegacyServeFailure(privateFailure);
 
-    expect(displayed.message).toBe("Internal server error");
-    expect(displayed.message).not.toContain("/machine/path");
+    expect(displayed.message).toBe("Error: private /machine/path");
     expect(displayed.cause).toBe(privateFailure);
   });
 

--- a/tui/test/worker-data-lock.test.ts
+++ b/tui/test/worker-data-lock.test.ts
@@ -6,6 +6,7 @@ import {
   BACKEND_RESTART_REQUIRED_EXIT_CODE,
   BackendRestartRequiredError
 } from "../src/worker-error.js";
+import { hasUnpairedSurrogate } from "../../shared/unicode.js";
 
 describe("embedded worker hard fence", () => {
   test("retains the data lock through process teardown after restart-required failure", async () => {
@@ -58,8 +59,61 @@ describe("embedded worker hard fence", () => {
     expect(child.stderr).toBe(
       "1667: the local backend stopped before it confirmed the last change. "
         + "Restart 1667. Saved state will be checked before more work is accepted. "
+        + "Failure detail: failed. "
         + "Diagnostic reference: err_deadbeefdeadbeefdeadbeef.\n"
     );
+  });
+
+  test("prints the embedded failure detail before its diagnostic reference", () => {
+    const moduleUrl = new URL("../src/worker-error.ts", import.meta.url).href;
+    const child = spawnSync(process.execPath, [
+      "--eval",
+      `import { BackendRestartRequiredError, exitForBackendRestart } from ${JSON.stringify(moduleUrl)};`
+        + "exitForBackendRestart(new BackendRestartRequiredError('worker runtime crashed: injected failure\\u001b[31m'));"
+    ], {
+      encoding: "utf8",
+      timeout: 2_000
+    });
+
+    expect(child.status).toBe(BACKEND_RESTART_REQUIRED_EXIT_CODE);
+    expect(child.stderr).toContain(
+      "Failure detail: worker runtime crashed: injected failure▪[31m."
+    );
+    expect(child.stderr).not.toContain("\u001b");
+    expect(child.stderr).not.toContain("backend_restart_required:");
+  });
+
+  test("bounds the embedded failure detail before synchronous output", () => {
+    const moduleUrl = new URL("../src/worker-error.ts", import.meta.url).href;
+    const child = spawnSync(process.execPath, [
+      "--eval",
+      `import { BackendRestartRequiredError, exitForBackendRestart } from ${JSON.stringify(moduleUrl)};`
+        + "exitForBackendRestart(new BackendRestartRequiredError('x'.repeat(2000)));"
+    ], {
+      encoding: "utf8",
+      timeout: 2_000
+    });
+
+    expect(child.status).toBe(BACKEND_RESTART_REQUIRED_EXIT_CODE);
+    expect(child.stderr).toContain(`Failure detail: ${"x".repeat(1_023)}…`);
+    expect(child.stderr).not.toContain("x".repeat(1_024));
+  });
+
+  test("keeps restart detail Unicode well-formed at its bound", () => {
+    const moduleUrl = new URL("../src/worker-error.ts", import.meta.url).href;
+    const child = spawnSync(process.execPath, [
+      "--eval",
+      `import { BackendRestartRequiredError, exitForBackendRestart } from ${JSON.stringify(moduleUrl)};`
+        + "exitForBackendRestart(new BackendRestartRequiredError('x'.repeat(1022) + '😀tail'));"
+    ], {
+      encoding: "utf8",
+      timeout: 2_000
+    });
+
+    expect(child.status).toBe(BACKEND_RESTART_REQUIRED_EXIT_CODE);
+    expect(hasUnpairedSurrogate(child.stderr)).toBeFalse();
+    expect(child.stderr).toContain(`Failure detail: ${"x".repeat(1_022)}…`);
+    expect(child.stderr).not.toContain("�");
   });
 
   test("releases the data lock for ordinary startup failure", async () => {

--- a/tui/test/worker-error-log.test.ts
+++ b/tui/test/worker-error-log.test.ts
@@ -45,6 +45,10 @@ test("embedded internal errors carry the reference written to the private log", 
     const ref = /err_[0-9a-f]{24}/.exec((error as Error).message)?.[0];
     expect(ref).toBeDefined();
     expect((error as WorkerApiError).diagnosticRef).toBe(ref);
+    expect((error as Error).message).toContain(
+      "StoryFormatError: settings state is not valid strict JSON"
+    );
+    expect((error as Error).message).not.toContain("Internal server error");
     expect((error as Error).message).not.toContain(machineDir);
     const entries = (await readFile(internalErrorLogPath(machineDir), "utf8"))
       .trim()
@@ -108,6 +112,7 @@ test("unexpected worker exits log content-free host and stream progress", async 
     worker.crash("injected worker runtime crash");
     const failure = await backend.failure;
     expect(failure instanceof BackendRestartRequiredError).toBeTrue();
+    expect(failure.message).toContain("injected worker runtime crash");
     expect((failure as BackendRestartRequiredError).diagnosticRef)
       .toMatch(/^err_[0-9a-f]{24}$/);
     expect(await generationFailure).toBe(failure);
@@ -214,6 +219,29 @@ test("worker diagnostics validate the dedicated reference field, not message tex
       stack: "private stack"
     }
   })).toBeFalse();
+});
+
+test("restart failures keep the diagnostic reference out of their detail", async () => {
+  const worker = new FakeWorker(true);
+  const backend = await createWorkerStoryApi({ worker, readyTimeoutMs: 100 });
+  const diagnosticRef = "err_deadbeefdeadbeefdeadbeef";
+
+  worker.message({
+    type: "protocolError",
+    failure: createFailureEnvelope({
+      code: "internal",
+      message: "Error: injected backend failure",
+      status: 500
+    }, diagnosticRef)
+  });
+
+  const failure = await backend.failure;
+  expect(failure).toMatchObject({
+    message: "backend_restart_required: Error: injected backend failure",
+    diagnosticRef
+  });
+  expect(failure.message.match(new RegExp(diagnosticRef, "g"))).toBe(null);
+  await backend.dispose().catch(() => undefined);
 });
 
 test("archived diagnostics remain warnings without worker replay", async () => {


### PR DESCRIPTION
Closes #241

Summary:
- show bounded error names, messages, and cause chains before diagnostic references
- preserve provider-body and diagnostic-only cause redaction
- include actionable embedded backend crash detail with terminal-safe output
- keep detailed local logs and document the visible diagnostic contract

Tests:
- npm run build
- npm test
- cd tui && bun run typecheck
- cd tui && bun test
- cd tui && bun bench/perf.ts
- cd tui && bun run build:standalone
- autoreview
- thermo-nuclear code quality review