### PR TITLE
chore(release): prepare 0.9.7-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,6 @@ This file records notable changes to 1667. Product terms use the definitions in
 
 ## Unreleased
 
-- **Internal errors now include useful diagnostic text.** 1667 shows the
-  error name, the error message, and a short cause chain. It keeps the
-  `err_…` reference as a link to the detailed local log. The visible message
-  does not include a stack or a provider response body.
-
 - **Prompt-plan changes now have a Gemma quality gate.** The gate compares the
   v0.8.0 prompt with a candidate on one frozen story and one fixed profile. It
   uses blind Retake and Continue scores. It requires no score regression for
@@ -264,6 +259,13 @@ This file records notable changes to 1667. Product terms use the definitions in
   palette opens a path prompt with `Tab` completion. The `1667 import-card`
   command accepts one or more JSON or PNG files. It adds their Facts to the
   story that `--story` names.
+
+## 0.9.7-rc.1 - 2026-08-16
+
+- **Internal errors now include useful diagnostic text.** 1667 shows the
+  error name, the error message, and a short cause chain. It keeps the
+  `err_…` reference as a link to the detailed local log. The visible message
+  does not include a stack or a provider response body.
 
 ## 0.9.6 - 2026-08-16
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "1667-workspace",
-  "version": "0.9.6",
+  "version": "0.9.7-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "1667-workspace",
-      "version": "0.9.6",
+      "version": "0.9.7-rc.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@silvia-odwyer/photon-node": "0.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667-workspace",
-  "version": "0.9.6",
+  "version": "0.9.7-rc.1",
   "private": true,
   "description": "Source workspace for the 1667 terminal writing environment",
   "license": "Apache-2.0",

--- a/shared/release-notes.ts
+++ b/shared/release-notes.ts
@@ -11,6 +11,11 @@ export interface ReleaseNote {
  *  a release, and is not included. */
 export const RELEASE_NOTES: readonly ReleaseNote[] = [
   {
+    version: "0.9.7-rc.1",
+    date: "2026-08-16",
+    body: "- **Internal errors now include useful diagnostic text.** 1667 shows the\n  error name, the error message, and a short cause chain. It keeps the\n  `err_…` reference as a link to the detailed local log. The visible message\n  does not include a stack or a provider response body."
+  },
+  {
     version: "0.9.6",
     date: "2026-08-16",
     body: "- **Stopping an Aside answer keeps the text that arrived.** Press `Esc` after\n  answer text appears to save that text as a Side Note. If no answer text\n  appears, 1667 restores the question.\n\n- **The PowerShell Installer shows the command that starts 1667.** After the\n  installation, the Installer shows the exact executable path. This command\n  works when the Install Root is not in `PATH`."

--- a/tui/package.json
+++ b/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667",
-  "version": "0.9.6",
+  "version": "0.9.7-rc.1",
   "private": true,
   "description": "A terminal environment for writing fiction with language models",
   "license": "Apache-2.0",


### PR DESCRIPTION
Prepare the next beta release with the actionable internal-error diagnostics from PR #240.

Changes:
- Set the workspace and TUI versions to 0.9.7-rc.1.
- Move the diagnostics change from Unreleased into its release section.
- Regenerate the embedded release notes.

Verification:
- `npm run build`
- `npm test` (2,503 passed, 226 skipped)
- `bun run typecheck`
- `bun test` (1,998 passed, 2 skipped)
- `bun bench/perf.ts`
- `bun run build:standalone`

Risk:
- Release metadata only. Runtime behavior is unchanged from current main.

Closes #243