### PR TITLE
chore(release): prepare 0.9.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -260,7 +260,7 @@ This file records notable changes to 1667. Product terms use the definitions in
   command accepts one or more JSON or PNG files. It adds their Facts to the
   story that `--story` names.
 
-## 0.9.7-rc.1 - 2026-08-16
+## 0.9.7 - 2026-08-16
 
 - **Internal errors now include useful diagnostic text.** 1667 shows the
   error name, the error message, and a short cause chain. It keeps the

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "1667-workspace",
-  "version": "0.9.7-rc.1",
+  "version": "0.9.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "1667-workspace",
-      "version": "0.9.7-rc.1",
+      "version": "0.9.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@silvia-odwyer/photon-node": "0.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667-workspace",
-  "version": "0.9.7-rc.1",
+  "version": "0.9.7",
   "private": true,
   "description": "Source workspace for the 1667 terminal writing environment",
   "license": "Apache-2.0",

--- a/shared/release-notes.ts
+++ b/shared/release-notes.ts
@@ -11,7 +11,7 @@ export interface ReleaseNote {
  *  a release, and is not included. */
 export const RELEASE_NOTES: readonly ReleaseNote[] = [
   {
-    version: "0.9.7-rc.1",
+    version: "0.9.7",
     date: "2026-08-16",
     body: "- **Internal errors now include useful diagnostic text.** 1667 shows the\n  error name, the error message, and a short cause chain. It keeps the\n  `err_…` reference as a link to the detailed local log. The visible message\n  does not include a stack or a provider response body."
   },

--- a/tui/package.json
+++ b/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667",
-  "version": "0.9.7-rc.1",
+  "version": "0.9.7",
   "private": true,
   "description": "A terminal environment for writing fiction with language models",
   "license": "Apache-2.0",


### PR DESCRIPTION
Promote the verified 0.9.7-rc.1 source change to the stable 0.9.7 release.

Changes:
- Set the workspace and TUI versions to 0.9.7.
- Rename the release-note section from the beta version to the stable version.
- Regenerate the embedded release notes.

Verification:
- Full beta gate passed: 2,503 root tests and 1,998 TUI tests.
- `npm run build`
- `npm run notes:check-version -- 0.9.7`
- `bun run typecheck`
- Beta publication completed for all six packages and immutable assets.

Risk:
- Stable promotion changes release metadata only.

Closes #244