### PR TITLE
chore(release): prepare 0.9.8-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,18 +5,6 @@ This file records notable changes to 1667. Product terms use the definitions in
 
 ## Unreleased
 
-- **Settings shows important controls and help sooner.** The system prompt is
-  now near the top of the panel. The panel uses its bottom space to show how
-  many settings are above or below the visible list. Select a setting to read
-  its complete description. Long descriptions wrap instead of ending at the
-  panel edge. The descriptions now explain the effect of each setting.
-
-- **The cache-stable continuation prompt is now an optional experiment.** The
-  **prompt layout** row in a Generation Profile is off by default. The off
-  value keeps the v0.8.0 Continue and Retake prompt. The on value moves the
-  operation-specific contract after the story history. Profile Export files
-  preserve the enabled value.
-
 - **Prompt-plan changes now have a Gemma quality gate.** The gate compares the
   v0.8.0 prompt with a candidate on one frozen story and one fixed profile. It
   uses blind Retake and Continue scores. It requires no score regression for
@@ -271,6 +259,20 @@ This file records notable changes to 1667. Product terms use the definitions in
   palette opens a path prompt with `Tab` completion. The `1667 import-card`
   command accepts one or more JSON or PNG files. It adds their Facts to the
   story that `--story` names.
+
+## 0.9.8-rc.1 - 2026-08-17
+
+- **Settings shows important controls and help sooner.** The system prompt is
+  now near the top of the panel. The panel uses its bottom space to show how
+  many settings are above or below the visible list. Select a setting to read
+  its complete description. Long descriptions wrap instead of ending at the
+  panel edge. The descriptions now explain the effect of each setting.
+
+- **The cache-stable continuation prompt is now an optional experiment.** The
+  **prompt layout** row in a Generation Profile is off by default. The off
+  value keeps the v0.8.0 Continue and Retake prompt. The on value moves the
+  operation-specific contract after the story history. Profile Export files
+  preserve the enabled value.
 
 ## 0.9.7 - 2026-08-16
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "1667-workspace",
-  "version": "0.9.7",
+  "version": "0.9.8-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "1667-workspace",
-      "version": "0.9.7",
+      "version": "0.9.8-rc.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@silvia-odwyer/photon-node": "0.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667-workspace",
-  "version": "0.9.7",
+  "version": "0.9.8-rc.1",
   "private": true,
   "description": "Source workspace for the 1667 terminal writing environment",
   "license": "Apache-2.0",

--- a/shared/release-notes.ts
+++ b/shared/release-notes.ts
@@ -11,6 +11,11 @@ export interface ReleaseNote {
  *  a release, and is not included. */
 export const RELEASE_NOTES: readonly ReleaseNote[] = [
   {
+    version: "0.9.8-rc.1",
+    date: "2026-08-17",
+    body: "- **Settings shows important controls and help sooner.** The system prompt is\n  now near the top of the panel. The panel uses its bottom space to show how\n  many settings are above or below the visible list. Select a setting to read\n  its complete description. Long descriptions wrap instead of ending at the\n  panel edge. The descriptions now explain the effect of each setting.\n\n- **The cache-stable continuation prompt is now an optional experiment.** The\n  **prompt layout** row in a Generation Profile is off by default. The off\n  value keeps the v0.8.0 Continue and Retake prompt. The on value moves the\n  operation-specific contract after the story history. Profile Export files\n  preserve the enabled value."
+  },
+  {
     version: "0.9.7",
     date: "2026-08-16",
     body: "- **Internal errors now include useful diagnostic text.** 1667 shows the\n  error name, the error message, and a short cause chain. It keeps the\n  `err_…` reference as a link to the detailed local log. The visible message\n  does not include a stack or a provider response body."

--- a/tui/package.json
+++ b/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667",
-  "version": "0.9.7",
+  "version": "0.9.8-rc.1",
   "private": true,
   "description": "A terminal environment for writing fiction with language models",
   "license": "Apache-2.0",


### PR DESCRIPTION
Prepare the beta release for the Settings panel redesign and the optional cache-stable prompt layout.

Changes:

- Set the workspace and TUI versions to 0.9.8-rc.1.
- Move the two new changes from Unreleased into the 0.9.8-rc.1 section.
- Regenerate the embedded release notes.

Verification:

- npm run build
- npm test: 2,494 passed and 226 skipped
- cd tui && bun run typecheck
- cd tui && bun test: 2,009 passed and 2 skipped
- cd tui && bun bench/perf.ts
- cd tui && bun run build:standalone
- npm run notes:check-version -- 0.9.8-rc.1

Risk:

- Release metadata only. Runtime behavior is unchanged from current main.
- Stable publication follows only after this beta publication completes.

Closes #249