### PR TITLE
chore(release): prepare 0.9.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -260,7 +260,7 @@ This file records notable changes to 1667. Product terms use the definitions in
   command accepts one or more JSON or PNG files. It adds their Facts to the
   story that `--story` names.
 
-## 0.9.8-rc.1 - 2026-08-17
+## 0.9.8 - 2026-08-17
 
 - **Settings shows important controls and help sooner.** The system prompt is
   now near the top of the panel. The panel uses its bottom space to show how

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "1667-workspace",
-  "version": "0.9.8-rc.1",
+  "version": "0.9.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "1667-workspace",
-      "version": "0.9.8-rc.1",
+      "version": "0.9.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@silvia-odwyer/photon-node": "0.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667-workspace",
-  "version": "0.9.8-rc.1",
+  "version": "0.9.8",
   "private": true,
   "description": "Source workspace for the 1667 terminal writing environment",
   "license": "Apache-2.0",

--- a/shared/release-notes.ts
+++ b/shared/release-notes.ts
@@ -11,7 +11,7 @@ export interface ReleaseNote {
  *  a release, and is not included. */
 export const RELEASE_NOTES: readonly ReleaseNote[] = [
   {
-    version: "0.9.8-rc.1",
+    version: "0.9.8",
     date: "2026-08-17",
     body: "- **Settings shows important controls and help sooner.** The system prompt is\n  now near the top of the panel. The panel uses its bottom space to show how\n  many settings are above or below the visible list. Select a setting to read\n  its complete description. Long descriptions wrap instead of ending at the\n  panel edge. The descriptions now explain the effect of each setting.\n\n- **The cache-stable continuation prompt is now an optional experiment.** The\n  **prompt layout** row in a Generation Profile is off by default. The off\n  value keeps the v0.8.0 Continue and Retake prompt. The on value moves the\n  operation-specific contract after the story history. Profile Export files\n  preserve the enabled value."
   },

--- a/tui/package.json
+++ b/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667",
-  "version": "0.9.8-rc.1",
+  "version": "0.9.8",
   "private": true,
   "description": "A terminal environment for writing fiction with language models",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Outcome

Promote the verified 0.9.8-rc.1 source to the stable 0.9.8 release.

## Changes

- Set the workspace and TUI versions to 0.9.8.
- Rename the 0.9.8-rc.1 changelog section to 0.9.8.
- Regenerate the embedded release notes.

## Verification

- `npm run build`
- `npm run notes:check-version -- 0.9.8`
- `cd tui && bun run typecheck`
- The 0.9.8-rc.1 release completed for all six npm packages and all release assets.
- The beta branch passed the full local test, performance, and standalone build gate.
- The beta pull request passed every supported platform check.

## Risks and limitations

This pull request changes release metadata only. The stable workflow will rebuild the verified source.

Closes #251