### PR TITLE
test(windows): remove flaky timing assumptions

### DIFF
--- a/test/image-normalize.test.ts
+++ b/test/image-normalize.test.ts
@@ -209,9 +209,7 @@ test("the PNG reduction sequence shrinks dimensions, never drops transparency", 
 test("a payload truncated deep inside compressed data is isolated to one child process", async () => {
   const source = await opaquePng(600, 400);
   const corrupted = corruptPayload(source, 40, 200);
-  const outcome = await launchImageNormalizeChild(corrupted, "image/png", {
-    deadlineMs: 10_000
-  }).then(
+  const outcome = await launchImageNormalizeChild(corrupted, "image/png").then(
     () => ({ ok: true as const }),
     (error: unknown) => ({ ok: false as const, error })
   );
@@ -225,7 +223,7 @@ test("a payload truncated deep inside compressed data is isolated to one child p
   // one-normalization-per-child design isolates a panicked WASM instance
   // to the process that panicked rather than poisoning the next request.
   const clean = await opaquePng(64, 64);
-  const result = await launchImageNormalizeChild(clean, "image/png", { deadlineMs: 10_000 });
+  const result = await launchImageNormalizeChild(clean, "image/png");
   assert.equal(result.mediaType, "image/png");
 });
 

--- a/test/windows-platform-contract.test.ts
+++ b/test/windows-platform-contract.test.ts
@@ -182,23 +182,17 @@ test("Windows machine tier accepts an 8.3 ancestor alias", {
   await assertPrivateSecurity(root);
 });
 
-test("Node Windows adapter stays inside the server startup budget", {
+test("Node Windows adapter prepares the server root inside its startup budget", {
   skip: process.platform !== "win32" || process.versions.bun !== undefined,
   timeout: 10_000
 }, async (t) => {
   const parent = await temporaryDirectory(t, "1667-windows-node-adapter-");
-  const roots = Array.from(
-    { length: 4 },
-    (_, index) => path.join(parent, `state-${index}`)
-  );
+  const root = path.join(parent, "state");
   const adapter = createNodeWindowsPrivateStateRootAdapter();
 
-  assert.deepEqual(
-    await Promise.all(
-      roots.map(async (root) =>
-        await adapter.preparePrivateStateRoot(root))
-    ),
-    roots
+  assert.equal(
+    await adapter.preparePrivateStateRoot(root),
+    root
   );
 });
 


### PR DESCRIPTION
Closes #34
Closes #158

## Summary

- Test the one state root that the Node server prepares at startup.
- Use the production image-stage deadline for the invalid-image child-process contract.
- Keep the Windows owner check and the `image_invalid` verdict check unchanged.

## Root cause

The state-root test started four helper processes for different roots at the same time. The product prepares one server root at startup. The extra parallel work caused unrelated native security contention.

The image test replaced the 60-second product deadline with a 10-second deadline. A failed Windows run ended at 10.27 seconds while the Job Object helper ran under load. The deadline reported `image_normalization_failed` before the normalizer could report `image_invalid`.

## Verification

- `npm run typecheck`
- Both changed integration tests on Windows
- Windows CI test group: both changed contracts passed. An unrelated local archive fixture failed because local `bash` did not pass its positional archive argument.
- Codex autoreview: no findings
