### PR TITLE
fix: eliminate flaky test races

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This file records notable changes to 1667. Product terms use the definitions in
 
 ## Unreleased
 
+- **Settings reads remain available during activation.** 1667 now serializes a
+  settings read and a settings authority replacement in one process. A read no
+  longer fails while activation replaces the settings authority.
+
 - **Prompt-plan changes now have a Gemma quality gate.** The gate compares the
   v0.8.0 prompt with a candidate on one frozen story and one fixed profile. It
   uses blind Retake and Continue scores. It requires no score regression for

--- a/server/settings-file-io.ts
+++ b/server/settings-file-io.ts
@@ -7,6 +7,7 @@ import {
   readOptionalPrivateFile,
   removePrivateFile
 } from "./private-file-publication.js";
+import { withReservedPathOwnership } from "./reserved-path-owner.js";
 import { MAX_SETTINGS_STATE_BYTES } from "./settings-v2-scalars.js";
 import { syncDirectory } from "./story-lifecycle.js";
 
@@ -39,9 +40,11 @@ export async function readOptionalMutableSettingsAuthority(
   maxBytes: number
 ): Promise<Buffer | null> {
   try {
-    await inspectPrivateDirectory(path.dirname(file), SETTINGS_FILE_LABEL);
-    return await readBoundedMutableAuthorityFile(file, maxBytes, {
-      requirePrivate: true
+    return await withReservedPathOwnership(file, async () => {
+      await inspectPrivateDirectory(path.dirname(file), SETTINGS_FILE_LABEL);
+      return await readBoundedMutableAuthorityFile(file, maxBytes, {
+        requirePrivate: true
+      });
     });
   } catch (error) {
     if (isErrorCode(error, "ENOENT")) return null;
@@ -66,8 +69,10 @@ export async function publishSettingsFile(
   finalFile: string,
   options: SettingsPublicationOptions = {}
 ): Promise<void> {
-  await renameSettingsFile(nextFile, finalFile, options);
-  await syncDirectory(path.dirname(finalFile));
+  await withReservedPathOwnership(finalFile, async () => {
+    await renameSettingsFile(nextFile, finalFile, options);
+    await syncDirectory(path.dirname(finalFile));
+  });
 }
 
 async function renameSettingsFile(

--- a/test/http-test-client.test.ts
+++ b/test/http-test-client.test.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { announcedTestServerOrigin } from "./http-test-client.js";
+
+test("HTTP test readiness origin waits for a complete stdout line", () => {
+  const prefix = "startup warning\n1667 listening on http://127.0.0.1";
+  let output = prefix;
+  assert.equal(announcedTestServerOrigin(output), null);
+
+  output += ":";
+  assert.equal(announcedTestServerOrigin(output), null);
+
+  output += "43165";
+  assert.equal(announcedTestServerOrigin(output), null);
+
+  output += " (data: /tmp/1667-test-data)";
+  assert.equal(
+    announcedTestServerOrigin(output),
+    "http://127.0.0.1:43165"
+  );
+});
+
+test("HTTP test readiness origin does not accept a mid-port stdout chunk", () => {
+  let output = "1667 listening on http://127.0.0.1:43";
+  assert.equal(announcedTestServerOrigin(output), null);
+
+  output += "165 (data: /tmp/1667-test-data)";
+  assert.equal(
+    announcedTestServerOrigin(output),
+    "http://127.0.0.1:43165"
+  );
+});
+
+test("HTTP test readiness origin requires an explicit numeric port", () => {
+  assert.equal(
+    announcedTestServerOrigin(
+      "1667 listening on http://127.0.0.1 (data: /tmp/1667-test-data)"
+    ),
+    null
+  );
+});

--- a/test/http-test-client.ts
+++ b/test/http-test-client.ts
@@ -43,35 +43,46 @@ export async function waitForTestServer(
     readonly exitCode: number | null;
     readonly signalCode: NodeJS.Signals | null;
   },
-  origin: string,
   output: () => string
-): Promise<void> {
+): Promise<string> {
   const deadline = Date.now() + SERVER_START_BUDGET_MS;
+  let resolvedOrigin: string | null = null;
   while (Date.now() < deadline) {
     if (server.exitCode !== null || server.signalCode !== null) {
       throw new Error(`server exited: ${output()}`);
     }
-    try {
-      const { record } = await readHttpAuthRecord(origin);
-      const response = await fetch(`${origin}/api/health`, {
-        headers: {
-          [HTTP_AUTHORIZATION_HEADER]:
-            bearerAuthorization(record.capabilities.story),
-          [HTTP_CLIENT_PROTOCOL_HEADER]:
-            String(HTTP_API_PROTOCOL_VERSION),
-          [HTTP_SERVER_INSTANCE_HEADER]: record.instanceId
+    resolvedOrigin ??= announcedTestServerOrigin(output());
+    if (resolvedOrigin !== null) {
+      try {
+        const { record } = await readHttpAuthRecord(resolvedOrigin);
+        const response = await fetch(`${resolvedOrigin}/api/health`, {
+          headers: {
+            [HTTP_AUTHORIZATION_HEADER]:
+              bearerAuthorization(record.capabilities.story),
+            [HTTP_CLIENT_PROTOCOL_HEADER]:
+              String(HTTP_API_PROTOCOL_VERSION),
+            [HTTP_SERVER_INSTANCE_HEADER]: record.instanceId
+          }
+        });
+        if (response.ok) {
+          await rememberServerInstance(await response.json(), resolvedOrigin);
+          return resolvedOrigin;
         }
-      });
-      if (response.ok) {
-        await rememberServerInstance(await response.json(), origin);
-        return;
-      }
-    } catch { /* startup */ }
+      } catch { /* startup */ }
+    }
     await new Promise((resolve) => setTimeout(resolve, 25));
   }
   throw new Error(
     `server did not start within ${SERVER_START_BUDGET_MS / 1_000} seconds: ${output()}`
   );
+}
+
+/** Read the origin from the server's post-bind readiness announcement. */
+export function announcedTestServerOrigin(output: string): string | null {
+  const match = /(?:^|\r?\n)1667 listening on (http:\/\/127\.0\.0\.1:(\d+))(?: \(data: |\r?\n)/.exec(output);
+  if (match === null) return null;
+  const port = Number(match[2]);
+  return port > 0 && port <= 65_535 ? match[1]! : null;
 }
 
 export async function stopTestServerProcess(

--- a/test/provider-http-fixture.ts
+++ b/test/provider-http-fixture.ts
@@ -214,7 +214,6 @@ async function startTestApp(
       { encoding: "utf8", mode: 0o600, flag: "wx" }
     );
   }
-  const port = await availablePort();
   const server = spawn(
     process.execPath,
     ["--import", "tsx", "server/index.ts", "--print-logs"],
@@ -223,7 +222,7 @@ async function startTestApp(
       env: {
         ...process.env,
         AI_1667_DATA: dataDir,
-        AI_1667_PORT: String(port)
+        AI_1667_PORT: "0"
       },
       stdio: ["ignore", "pipe", "pipe"]
     }
@@ -235,8 +234,7 @@ async function startTestApp(
     await stopTestServerProcess(server);
     await rm(dataDir, { recursive: true, force: true });
   });
-  const base = `http://127.0.0.1:${port}`;
-  await waitForTestServer(server, base, () => output);
+  const base = await waitForTestServer(server, () => output);
   if (currentDataFormat) await saveFixtureSettings(t, base, settings);
   return base;
 }
@@ -262,16 +260,6 @@ async function saveFixtureSettings(
   assert.equal(result.pendingSettingsRevision, null);
   const saved = await api.getSettings();
   assert.deepEqual(saved.effective, settings);
-}
-
-async function availablePort(): Promise<number> {
-  const probe = createServer();
-  await new Promise<void>((resolve) =>
-    probe.listen(0, "127.0.0.1", resolve)
-  );
-  const port = (probe.address() as AddressInfo).port;
-  await closeServer(probe);
-  return port;
 }
 
 async function closeServer(

--- a/test/settings-state-atomic-read.test.ts
+++ b/test/settings-state-atomic-read.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { link, open, unlink, type FileHandle } from "node:fs/promises";
+import { link, open, readFile, unlink, type FileHandle } from "node:fs/promises";
 import path from "node:path";
 import test, { type TestContext } from "node:test";
 import { DataDirectoryLock } from "../server/data-directory-lock.js";
@@ -21,7 +21,7 @@ import {
   writingDocument
 } from "./settings-store-fixtures.js";
 
-test("current settings read remains valid across atomic replacement", {
+test("current settings read and publication are serialized in one process", {
   timeout: 5_000
 }, async (t) => {
   const dataDir = await initializedFormat2Directory(
@@ -40,35 +40,35 @@ test("current settings read remains valid across atomic replacement", {
 
   const reading = readSettingsState(dataDir);
   await pause.entered;
-  let contentionResolve!: () => void;
-  let publishResolve!: () => void;
-  const contention = new Promise<void>((resolve) => {
-    contentionResolve = resolve;
-  });
-  const publishReleased = new Promise<void>((resolve) => {
-    publishResolve = resolve;
-  });
-  const publishing = publishStagedSettingsState(dataDir, {
-    waitForWindowsContention: async () => {
-      contentionResolve();
-      await publishReleased;
-    }
+  let publishingSettled = false;
+  const publishing = publishStagedSettingsState(dataDir).then(() => {
+    publishingSettled = true;
   });
   try {
-    // The replacement must land before the paused read resumes, or the
-    // assertion below proves nothing. Windows cannot complete the rename while
-    // the read handle is open, so it waits for the contention retry instead.
-    if (process.platform === "win32") {
-      await Promise.race([contention, publishing]);
-    } else {
-      await publishing;
-    }
+    // The read owns the current pathname while its handle is open. The
+    // publication must queue behind it in this process, so the replacement
+    // cannot change the user-visible authority while the read is paused.
+    // A real read yields through the filesystem after publication starts and
+    // gives the writer a meaningful chance to settle if it is not gated.
+    const authorityWhilePaused = await readFile(
+      path.join(dataDir, SETTINGS_STATE_V2_FILE),
+      "utf8"
+    );
+    assert.equal(
+      publishingSettled,
+      false,
+      "publication remains pending while the active settings read is paused"
+    );
+    assert.equal(
+      authorityWhilePaused,
+      INITIAL_SETTINGS_STATE_V2_TEXT,
+      "the authority pathname still exposes the old state while the read is active"
+    );
   } finally {
     pause.release();
   }
 
   assert.deepEqual(await reading, INITIAL_SETTINGS_STATE_V2);
-  publishResolve();
   await publishing;
   assert.deepEqual(await readSettingsState(dataDir), replacement);
 });

--- a/test/story-server-fixture.ts
+++ b/test/story-server-fixture.ts
@@ -1,8 +1,6 @@
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
 import { mkdtemp, rm } from "node:fs/promises";
-import { createServer } from "node:http";
-import type { AddressInfo } from "node:net";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import type test from "node:test";
@@ -32,14 +30,6 @@ export async function emptyLibraryDataDirectory(prefix: string): Promise<string>
   return dataDir;
 }
 
-export async function availablePort(): Promise<number> {
-  const server = createServer();
-  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
-  const port = (server.address() as AddressInfo).port;
-  await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
-  return port;
-}
-
 /** Start the product server on an empty library and give back its origin. The
  * server and its data directory close when the test ends. */
 export async function testApp(
@@ -47,13 +37,12 @@ export async function testApp(
   temporaryPrefix: string
 ): Promise<string> {
   const dataDir = await emptyLibraryDataDirectory(temporaryPrefix);
-  const port = await availablePort();
   const server = spawn(
     process.execPath,
     ["--import", "tsx", "server/index.ts", "--print-logs"],
     {
       cwd: path.resolve(import.meta.dirname, ".."),
-      env: { ...process.env, AI_1667_DATA: dataDir, AI_1667_PORT: String(port) },
+      env: { ...process.env, AI_1667_DATA: dataDir, AI_1667_PORT: "0" },
       stdio: ["ignore", "pipe", "pipe"]
     }
   );
@@ -64,8 +53,7 @@ export async function testApp(
     await stopTestServerProcess(server);
     await rm(dataDir, { recursive: true, force: true });
   });
-  const base = `http://127.0.0.1:${port}`;
-  await waitForTestServer(server, base, () => output);
+  const base = await waitForTestServer(server, () => output);
   return base;
 }
 

--- a/tui/test/worker-api.test.ts
+++ b/tui/test/worker-api.test.ts
@@ -480,11 +480,10 @@ describe("embedded backend worker", () => {
     await chmod(outboxDir, 0o500);
     let backend: Awaited<ReturnType<typeof createWorkerStoryApi>> | null = null;
     try {
-      // Real worker startup on macos-15-intel can exceed 1s under runner
-      // contention; match the sibling real-worker recovery budget.
+      // Keep the absolute startup budget bounded, but use the default 10s
+      // liveness budget for real-worker startup under runner contention.
       backend = await createWorkerStoryApi({
         dataDir,
-        readyTimeoutMs: 1_000,
         startupTimeoutMs: 5_000
       });
       const error = await Promise.race([
@@ -549,11 +548,11 @@ describe("embedded backend worker", () => {
       expectedAggregateVersion
     );
 
-    // Real worker startup competes with the full test pool; fake-worker tests
-    // below retain the tight 100 ms liveness deadline.
+    // Real worker startup competes with the full test pool; use the default
+    // 10s liveness budget. Fake-worker tests below retain the tight 100 ms
+    // liveness deadline.
     const backend = await createWorkerStoryApi({
       dataDir,
-      readyTimeoutMs: 1_000,
       startupTimeoutMs: 5_000
     });
     try {
@@ -590,9 +589,11 @@ describe("embedded backend worker", () => {
       const replay = requests()[0]!;
       worker.message({ type: "result", id: replay.id, value: { id: "retained", nodes: [], path: [] } });
       await backend.recovery;
-      for (let attempt = 0; attempt < 20 && requests().length < 2; attempt += 1) {
+      const requestDeadline = Date.now() + platformPerformanceBudget(5_000);
+      while (requests().length < 2 && Date.now() < requestDeadline) {
         await new Promise((resolve) => setTimeout(resolve, 5));
       }
+      if (requests().length < 2) throw new Error("Timed out waiting for live mutation request");
       expect(requests()).toHaveLength(2);
 
       const live = requests()[1]!;


### PR DESCRIPTION
Closes #41
Closes #50
Closes #58
Closes #109

## Summary

- Serialize settings authority reads and replacement publication in one process.
- Let the operating system assign test-server ports and use the complete post-bind announcement.
- Give real worker startup and outbox recovery platform-scaled budgets with bounded polling.

## Verification

- Root suite: 2,701 passed, 0 failed.
- TUI suite: 2,007 passed, 0 failed.
- Settings serialization stress: 20 consecutive passes.
- Typecheck, schema, release notes, prompt compatibility, and standalone build passed.
- Thermonuclear quality review and autoreview passed clean.