### PR TITLE
test: stabilize summary append refusal

### DIFF
--- a/test/summary-take.test.ts
+++ b/test/summary-take.test.ts
@@ -57,10 +57,18 @@ providerTest("summary take: offset source lands beneath a cut sibling, preserves
   const summary = saved.path[1]!;
   assert.equal(summary.role, "summary");
   assert.equal(summary.text, "Detailed continuity recap.");
+  const summaryBeforeAppend = saved.nodes.find((node) => node.id === summary.id);
+  assert.ok(summaryBeforeAppend);
   const append = await fetchWithApiProtocol(`${base}/api/stories/${story.id}/continue`, post({
     appendTo: summary.id, expectedTextHash: sha256(summary.text), instruction: "", genId: "bad-summary-append"
   }));
-  assert.equal(append.status, 400);
+  await assertSummaryAppendRefused(append);
+  const afterAppend = await getStory(base, story.id);
+  assert.deepEqual(
+    afterAppend.nodes.find((node) => node.id === summary.id),
+    summaryBeforeAppend,
+    "a refused summary append must not change the summary"
+  );
 });
 
 providerTest("summary take: completion does not steal a line extended while streaming", async (t) => {
@@ -332,6 +340,19 @@ function doneNodeId(events: string): string {
   const nodeId = /"type":"done","nodeId":"([^"]+)"/.exec(events)?.[1];
   assert.ok(nodeId, `missing summary node id in ${events}`);
   return nodeId;
+}
+
+// Summary validation runs before provider dispatch, but a slow load can let
+// streamResponse's heartbeat open first; HTTP 400 and HTTP 200/SSE error are
+// both valid wire forms for this refusal.
+async function assertSummaryAppendRefused(response: Response): Promise<void> {
+  const body = await response.text();
+  if (response.status === 400) {
+    assert.match(body, /Cannot write inside a summary/);
+    return;
+  }
+  assert.equal(response.status, 200);
+  assert.match(body, /"type":"error"[\s\S]*Cannot write inside a summary/);
 }
 
 async function seededStory(base: string, text: string): Promise<StoryPayload> {


### PR DESCRIPTION
Closes #255.

## Summary

- Accept the two valid refusal wire forms.
- Verify the summary does not change.
- Document the heartbeat race.

## Verification

- 10 focused repetitions passed.
- Full root and TUI gates passed.
- Thermonuclear review passed.
- Autoreview passed.