### PR TITLE
fix(generation): preserve stopped take state

### DIFF
--- a/docs/generation-boundaries.md
+++ b/docs/generation-boundaries.md
@@ -153,7 +153,11 @@ manual renames beat autoname, rewrites and summaries revalidate their source,
 continuations preserve a line moved by the writer, and a Stop save wins by
 generation ID. Stop closes the provider record. If model text arrived before
 Stop, the TUI waits for terminal settlement. It then saves that text with the
-same generation ID.
+same generation ID. If Keep thought is on, it also saves the thought that the
+model sent before Stop. A clean timeout uses the same save behavior.
+Stop hides the stream immediately. The main process gives local durable
+cancellation work 2 seconds to finish. It then gives the embedded backend 10
+seconds to close the provider stream and publish its terminal state.
 After the Stop aborts the request signal, the worker transport sends no more
 live text to the caller. The transport collects the text that arrives after
 the abort. The transport delivers the collected text one time, at terminal

--- a/docs/model-providers.md
+++ b/docs/model-providers.md
@@ -536,9 +536,11 @@ indent keep the thought apart from the prose. Press `T` again to fold the
 thought. The `T` key does nothing on a story part that has no thought.
 
 The **Keep thought** row controls storage. Keep thought is on by default.
-1667 then saves each thought with its take. The thought stays after you
-close the story. Set Keep thought to off to save no thought. 1667 then
-shows each thought while the model writes it, but keeps none of it.
+1667 then saves each thought with its take. This also applies when you stop
+after the model sends prose or when a clean timeout saves that prose. The
+thought stays after you close the story. Set Keep thought to off to save no
+thought. 1667 then shows each thought while the model writes it, but keeps
+none of it.
 
 Some routes cannot return reasoning text. A text completion route is one,
 because that protocol has no field for it. The Reasoning row then shows

--- a/server/generation-http.ts
+++ b/server/generation-http.ts
@@ -404,10 +404,10 @@ export async function continueStory(
   // failing the generation; token probabilities are a diagnostic.
   const tokenProbabilities: TokenProbabilityCollector = { record: null };
   const generationRecordCollector: GenerationRecordCollector = { effective: null };
-  // Read only on a genuine stop (the `raw === null` branch below), to hand a
-  // later, separate stop-save commit a truthful digest of what this attempt
-  // actually sent the client — never trusted from that later request's own
-  // body. Otherwise discarded along with the completed `raw` text.
+  // Read only on a genuine stop or clean timeout, to hand a later, separate
+  // save a truthful digest of what this attempt actually sent the client —
+  // never trusted from that later request's own body. Otherwise discarded
+  // along with the completed `raw` text.
   const partialOutput: PartialOutputCollector = { text: "" };
   const reasoning = reasoningCapture(settings, onReasoning);
   // Filled by whichever stream actually ran, with the exact credentials it
@@ -415,6 +415,33 @@ export async function continueStory(
   // alongside the committed prose so a thought split across the reasoning
   // and prose channels can be caught jointly (`reasoningSafeToStore`).
   const providerSecrets: ProviderSecretsCollector = { secrets: [] };
+  const rememberStoppedGenerationHandoff = () => {
+    if (partialOutput.text.trim().length === 0) return;
+    const reasoningSafeWithRawProse = reasoningSafeToStore(
+      reasoning.collector.record,
+      partialOutput.text,
+      providerSecrets.secrets
+    );
+    const handoff = captureGenerationRecordHandoff({
+      provider: settings.provider,
+      model,
+      operation: continuation.prompt.operation,
+      appendSegmentStart,
+      collector: generationRecordCollector,
+      story,
+      entries: continuationRecordSourceEntries,
+      emittedText: partialOutput.text,
+      // A chapter break can change an append into a trimmed new take before
+      // the client saves it. Check both possible saved forms now, while the
+      // provider credentials are still available.
+      reasoning: reasoningSafeToStore(
+        reasoningSafeWithRawProse,
+        partialOutput.text.trim(),
+        providerSecrets.secrets
+      )
+    });
+    if (handoff !== null) generationAdmission.rememberGenerationRecordHandoff(id, genId, handoff);
+  };
   // Load Image Object bytes only now: every local admission check above
   // already passed, and each one gets verified against its own recorded
   // metadata before it can reach a provider (image-input rollout plan).
@@ -460,10 +487,14 @@ export async function continueStory(
     // required echo is a timeout masking an echo rejection. The rejection
     // is the truth: rethrow it without the clean-timeout stamp, so a caller
     // that preserves streamed prose on timeouts keeps none of this output.
-    if (timeoutProvenanceOf(error) !== null
-      && continuationOutput?.prefixRejected === true) {
+    const timeout = timeoutProvenanceOf(error);
+    if (timeout !== null && continuationOutput?.prefixRejected === true) {
       throw rejectedContinuationEcho();
     }
+    // The TUI offers clean-timeout prose through the same later createNode
+    // save as a user Stop. Preserve its server-owned metadata before the
+    // timeout leaves this request.
+    if (timeout !== null) rememberStoppedGenerationHandoff();
     throw error;
   }
   if (raw === null) {
@@ -476,17 +507,7 @@ export async function continueStory(
     // attach a truthful Generation Record instead of none at all — but only
     // when the provider layer captured something, which happens only once a
     // byte actually streamed (never for a stop before the first one).
-    const handoff = captureGenerationRecordHandoff({
-      provider: settings.provider,
-      model,
-      operation: continuation.prompt.operation,
-      appendSegmentStart,
-      collector: generationRecordCollector,
-      story,
-      entries: continuationRecordSourceEntries,
-      emittedText: partialOutput.text
-    });
-    if (handoff !== null) generationAdmission.rememberGenerationRecordHandoff(id, genId, handoff);
+    rememberStoppedGenerationHandoff();
     return null;
   }
   if (continuation.requiresEcho && continuationOutput?.matchedPrefix !== true) {

--- a/server/generation-record-handoff.ts
+++ b/server/generation-record-handoff.ts
@@ -6,6 +6,7 @@ import {
   type GenerationRecordPromptEntry
 } from "../shared/generation-record.js";
 import type { PromptOperation } from "../shared/prompt-plan.js";
+import type { CapturedReasoning } from "../shared/reasoning.js";
 import type { Provider, Story } from "../shared/types.js";
 import type { GenerationRecordCollector } from "./generation-record-capture.js";
 import { finalizeGenerationRecord, unsupportedGenerationRecord } from "./generation-record-finalize.js";
@@ -58,6 +59,9 @@ export interface GenerationRecordHandoff {
    *  does in `generation-http.ts`). */
   readonly emittedRawDigest: string;
   readonly emittedTrimmedDigest: string;
+  /** The credential-safe thought captured before the stream stopped. The
+   *  later save attaches it only when its prose matches these digests. */
+  readonly reasoning: CapturedReasoning | null;
 }
 
 /** Every text-revision id a handoff's captured entries reference — what
@@ -96,6 +100,9 @@ export function captureGenerationRecordHandoff(input: {
    *  text the client's stream actually received. Hashed below, never
    *  retained. */
   readonly emittedText: string;
+  /** Already checked against the raw and trimmed emitted prose for provider
+   *  credentials. */
+  readonly reasoning: CapturedReasoning | null;
 }): GenerationRecordHandoff | null {
   const effective = input.collector.effective;
   if (effective === null) return null;
@@ -119,8 +126,18 @@ export function captureGenerationRecordHandoff(input: {
     effective,
     entries,
     emittedRawDigest: sha256(input.emittedText),
-    emittedTrimmedDigest: sha256(input.emittedText.trim())
+    emittedTrimmedDigest: sha256(input.emittedText.trim()),
+    reasoning: input.reasoning
   };
+}
+
+function handoffMatchesCommittedText(
+  handoff: GenerationRecordHandoff,
+  appendTo: string | null,
+  committedText: string
+): boolean {
+  const expectedDigest = appendTo === null ? handoff.emittedTrimmedDigest : handoff.emittedRawDigest;
+  return sha256(committedText) === expectedDigest;
 }
 
 /**
@@ -165,8 +182,7 @@ export function finalizeHandoffGenerationRecord(
       new Error("This append's affected range was not captured before the generation stopped.")
     );
   }
-  const expectedDigest = input.appendTo === null ? handoff.emittedTrimmedDigest : handoff.emittedRawDigest;
-  if (sha256(input.committedText) !== expectedDigest) {
+  if (!handoffMatchesCommittedText(handoff, input.appendTo, input.committedText)) {
     return unsupportedGenerationRecord(
       common,
       new Error("The saved text does not match what this generation actually streamed.")
@@ -189,6 +205,19 @@ export function finalizeHandoffGenerationRecord(
   // collector it reads has none — never returns null here.
   if (record === null) throw new Error("Unreachable: a Generation Record handoff always carries effective parameters");
   return record;
+}
+
+/** Returns a stopped generation's thought only for the prose that the same
+ *  generation streamed. */
+export function reasoningForHandoff(
+  handoff: GenerationRecordHandoff | undefined,
+  appendTo: string | null,
+  committedText: string
+): CapturedReasoning | undefined {
+  if (handoff === undefined || handoff.reasoning === null) return undefined;
+  return handoffMatchesCommittedText(handoff, appendTo, committedText)
+    ? handoff.reasoning
+    : undefined;
 }
 
 /** The stop-save Generation Record builder both commit paths need

--- a/server/node-commit.ts
+++ b/server/node-commit.ts
@@ -3,7 +3,11 @@ import { ServiceError } from "./errors.js";
 import { currentModel } from "./generation-http.js";
 import type { GenerationAdmissionRegistry } from "./generation-admission.js";
 import { DEFAULT_INSTRUCTION } from "./generation-prompts.js";
-import { generationRecordForHandoff, type GenerationRecordHandoff } from "./generation-record-handoff.js";
+import {
+  generationRecordForHandoff,
+  reasoningForHandoff,
+  type GenerationRecordHandoff
+} from "./generation-record-handoff.js";
 import type { SettingsStore } from "./settings.js";
 import { commitTake, createEditedTake } from "./story-nodes.js";
 import type { StoryStore } from "./stories.js";
@@ -69,6 +73,7 @@ export async function commitNode(
       // above returns before this runs), or a genId this process never saw
       // stream anything.
       const generationRecord = generationRecordForHandoff(handoff, appendTo, text, new Date().toISOString());
+      const reasoning = reasoningForHandoff(handoff, appendTo, text);
       const { duplicate } = commitTake(story, {
         parentId: appendCrossesBreak ? requestedAppendTo : appendTo === null ? parentId : null,
         appendTo,
@@ -78,6 +83,7 @@ export async function commitNode(
         model,
         genId,
         generationRecord,
+        reasoning,
         ...(mutationNodeId === undefined ? {} : { nodeId: mutationNodeId })
       });
       if (!duplicate) await stories.save(story);

--- a/server/story-service-local.ts
+++ b/server/story-service-local.ts
@@ -5,7 +5,11 @@ import { ServiceError } from "./errors.js";
 import { currentModel } from "./generation-http.js";
 import { DEFAULT_INSTRUCTION } from "./generation-prompts.js";
 import type { GenerationAdmissionRegistry } from "./generation-admission.js";
-import { generationRecordForHandoff, type GenerationRecordHandoff } from "./generation-record-handoff.js";
+import {
+  generationRecordForHandoff,
+  reasoningForHandoff,
+  type GenerationRecordHandoff
+} from "./generation-record-handoff.js";
 import { commitNode } from "./node-commit.js";
 import {
   parseCommitPartialRewrite,
@@ -341,6 +345,7 @@ export class StoryServiceLocal {
             // request saw, so the record's kind and range always follow this
             // commit's own decision.
             const generationRecord = generationRecordForHandoff(handoff, appendTo, text, new Date().toISOString());
+            const reasoning = reasoningForHandoff(handoff, appendTo, text);
             const commit = commitTake(story, {
               parentId: appendCrossesBreak
                 ? requestedAppendTo
@@ -354,6 +359,7 @@ export class StoryServiceLocal {
               model,
               genId,
               generationRecord,
+              reasoning,
               ...(nodeId === undefined ? {} : { nodeId })
             });
             return commit.duplicate ? STORY_UNCHANGED : undefined;

--- a/shared/worker-protocol.ts
+++ b/shared/worker-protocol.ts
@@ -81,7 +81,12 @@ export const WORKER_STARTUP_LIVENESS_TIMEOUT_MS = 10_000;
 export const WORKER_STARTUP_TIMEOUT_MS = 60_000;
 export const WORKER_TERMINATION_CONFIRM_MS = 2_000;
 export const WORKER_SHUTDOWN_GRACE_MS = 5_000;
-export const WORKER_CANCEL_GRACE_MS = 2_000;
+/** Bound local durable work that must finish before cancellation delivery. */
+export const WORKER_CANCEL_PERSISTENCE_TIMEOUT_MS = 2_000;
+/** Stop hides the stream immediately. Give the provider, retained stream
+ *  tail, and durable terminal settlement time to unwind before the main
+ *  process treats the worker as unsafe. */
+export const WORKER_CANCEL_GRACE_MS = 10_000;
 export const WORKER_OPERATION_CAPACITY = 1_024;
 export const WORKER_TERMINAL_RETENTION_MS = 5 * 60_000;
 export const WORKER_MAX_OPERATION_SEQUENCE = (1n << 64n) - 1n;

--- a/test/generation-admission.test.ts
+++ b/test/generation-admission.test.ts
@@ -166,7 +166,8 @@ function fakeHandoff(model: string): GenerationRecordHandoff {
     effective: { wireProtocol: "dry-run", fields: [], adjustments: [] },
     entries: { ok: true, entries: [] },
     emittedRawDigest: sha256(""),
-    emittedTrimmedDigest: sha256("")
+    emittedTrimmedDigest: sha256(""),
+    reasoning: null
   };
 }
 

--- a/test/generation-record-stop-save.test.ts
+++ b/test/generation-record-stop-save.test.ts
@@ -78,6 +78,13 @@ test("a stopped new-take continuation's later save attaches a truthful continue 
   const node = saved.nodes.find((candidate) => candidate.genId === "gen-stop-new-take");
   if (node === undefined) throw new Error("stop-save did not commit a take");
   assert.equal(node.generationRecordIds?.length, 1);
+  assert.equal(node.reasoning, true);
+
+  const reasoning = await stories.loadReasoning(story.id, node.id);
+  assert.equal(reasoning.text, "(dry-run) weighing two openings before picking one.");
+
+  const reloaded = await stories.load(story.id);
+  assert.equal(reloaded.nodes.find((candidate) => candidate.id === node.id)?.reasoning, true);
 
   const record = await stories.loadGenerationRecord(story.id, node.id, node.generationRecordIds![0]!);
   assert.equal(record.kind, "continue");
@@ -137,6 +144,10 @@ test("a stopped append's later save attaches a record with the correct affected 
   if (node === undefined) throw new Error("stop-save append did not commit");
   assert.equal(node.text, rootText + partial);
   assert.equal(node.generationRecordIds?.length, 1);
+  assert.equal(node.reasoning, true);
+
+  const reasoning = await stories.loadReasoning(story.id, rootId);
+  assert.equal(reasoning.text, "(dry-run) weighing two openings before picking one.");
 
   const record = await stories.loadGenerationRecord(story.id, rootId, node.generationRecordIds![0]!);
   assert.equal(record.kind, "append");
@@ -227,6 +238,11 @@ test("a stopped new-take continuation's later save is rejected when the saved te
   const node = saved.nodes.find((candidate) => candidate.genId === "gen-stop-forged");
   if (node === undefined) throw new Error("stop-save did not commit a take");
   assert.equal(node.generationRecordIds?.length, 1);
+  assert.equal(node.reasoning, undefined);
+  await assert.rejects(
+    () => stories.loadReasoning(story.id, node.id),
+    /has no stored thought/
+  );
 
   const record = await stories.loadGenerationRecord(story.id, node.id, node.generationRecordIds![0]!);
   assert.equal(record.kind, "unsupported");
@@ -286,6 +302,11 @@ test("a stopped append's later save is rejected when the saved text is not what 
   if (node === undefined) throw new Error("stop-save append did not commit");
   assert.equal(node.text, `${rootText}${partial} plus forged extra words`);
   assert.equal(node.generationRecordIds?.length, 1);
+  assert.equal(node.reasoning, undefined);
+  await assert.rejects(
+    () => stories.loadReasoning(story.id, node.id),
+    /has no stored thought/
+  );
 
   const record = await stories.loadGenerationRecord(story.id, rootId, node.generationRecordIds![0]!);
   assert.equal(record.kind, "unsupported");

--- a/test/generation-timeouts.test.ts
+++ b/test/generation-timeouts.test.ts
@@ -146,8 +146,15 @@ function refusingStories<M extends "continueStory" | "rewriteNode">(
 
 /** SSE headers plus deltas, then silence: the stream stays open so only the
  * idle deadline can end it. */
-function stall(response: ServerResponse, chunks: readonly string[]): void {
+function stall(response: ServerResponse, chunks: readonly string[], reasoning?: string): void {
   response.writeHead(200, { "content-type": "text/event-stream" });
+  if (reasoning !== undefined) {
+    response.write(
+      `data: ${JSON.stringify({
+        choices: [{ delta: { reasoning_content: reasoning }, finish_reason: null }]
+      })}\n\n`
+    );
+  }
   for (const content of chunks) {
     response.write(
       `data: ${JSON.stringify({
@@ -175,11 +182,13 @@ function timeoutEnvelope(error: unknown) {
 }
 
 providerTest("generation timeouts: a provider idle timeout keeps streamed prose and carries provider-idle provenance", async (t) => {
+  const thought = "The slower opening better fits the scene.";
   const model = await fakeModel(t, (_body, response) => {
-    stall(response, ["The cat ", "stretched slowly"]);
+    stall(response, ["The cat ", "stretched slowly"], thought);
   });
   const { story, nodeId } = fixtureStory();
   const streamed: string[] = [];
+  const admission = new GenerationAdmissionRegistry();
 
   await assert.rejects(
     continueStory(
@@ -188,7 +197,7 @@ providerTest("generation timeouts: a provider idle timeout keeps streamed prose 
       refusingStories<"continueStory">(story),
       stubSettingsStore(timedSettings(model.baseUrl, { assistantPrefill: "supported" })),
       new PromptCacheRuntime(),
-      new GenerationAdmissionRegistry(),
+      admission,
       (delta) => { streamed.push(delta); },
       new AbortController().signal
     ),
@@ -206,6 +215,10 @@ providerTest("generation timeouts: a provider idle timeout keeps streamed prose 
   // The prose that streamed before the deadline reached the caller intact;
   // preserving it is the caller's decision, not a lost cause.
   assert.equal(streamed.join(""), "The cat stretched slowly");
+  assert.equal(
+    admission.generationRecordHandoffFor(story.id, "idle-gen")?.reasoning?.text,
+    thought
+  );
   assert.equal(story.nodes.length, 1);
   assert.equal(story.nodes[0]!.text, STORY_TEXT);
 });

--- a/tui/src/generation-action.ts
+++ b/tui/src/generation-action.ts
@@ -267,10 +267,10 @@ export async function generate(
           appendStreamText(stream, tail);
           if (state.stream === stream) repaint();
         },
-        // Same ownership guard as onDelta, on the reasoning channel. Reasoning
-        // is never persisted in this pass — it only ever lives on the live
-        // stream view — so it appends and repaints exactly like prose, without
-        // any of prose's commit bookkeeping.
+        // Same ownership guard as onDelta, on the reasoning channel. Durable
+        // storage stays server-owned; this callback only updates the live
+        // stream view. It appends and repaints like prose without taking part
+        // in prose commit bookkeeping.
         onReasoning: (delta) => {
           if (!owns()
             || !storyCurrent()

--- a/tui/src/worker-call-allocation.ts
+++ b/tui/src/worker-call-allocation.ts
@@ -21,6 +21,7 @@ interface OpenPendingWorkerCallOptions {
   timeoutMs: number | null;
   deadlineAfterMs: number;
   cancelGraceMs: number;
+  cancelPersistenceTimeoutMs: number;
   pendingRequests: PendingRequestRegistry;
   worker: WorkerLike;
   outbox: SerializedWorkerOutbox;
@@ -52,6 +53,7 @@ export function openPendingWorkerCall<T>(
         worker: options.worker,
         outbox: options.outbox,
         graceMs: options.cancelGraceMs,
+        persistenceTimeoutMs: options.cancelPersistenceTimeoutMs,
         fail: options.failForRestart
       }),
       onTimeout: (id) => {

--- a/tui/src/worker-transport.ts
+++ b/tui/src/worker-transport.ts
@@ -6,6 +6,7 @@ import {
   STREAM_METHODS,
   WORKER_BUILD_IDENTITY,
   WORKER_CANCEL_GRACE_MS,
+  WORKER_CANCEL_PERSISTENCE_TIMEOUT_MS,
   WORKER_MUTATION_DEADLINE_MS,
   WORKER_PROVIDER_CHECK_TIMEOUT_MS,
   WORKER_GENERATION_RECORD_READ_TIMEOUT_MS,
@@ -300,7 +301,8 @@ export class WorkerTransport {
           expectedAggregateVersion: options.expectedAggregateVersion
         }),
         ...(options.signal === undefined ? {} : { signal: options.signal }),
-        graceMs: this.options.cancelGraceMs ?? WORKER_CANCEL_GRACE_MS,
+        graceMs: this.options.cancelGraceMs
+          ?? WORKER_CANCEL_PERSISTENCE_TIMEOUT_MS,
         outbox: this.outbox,
         store: outbox,
         hardFence: (message, cause) => this.failForRestart(message, cause)
@@ -351,6 +353,8 @@ export class WorkerTransport {
         timeoutMs,
         deadlineAfterMs,
         cancelGraceMs: this.options.cancelGraceMs ?? WORKER_CANCEL_GRACE_MS,
+        cancelPersistenceTimeoutMs: this.options.cancelGraceMs
+          ?? WORKER_CANCEL_PERSISTENCE_TIMEOUT_MS,
         pendingRequests: this.pending,
         worker: this.worker,
         outbox: this.outbox,
@@ -401,7 +405,8 @@ export class WorkerTransport {
         await this.stopArchivedMutationCleanup();
         const prepared = preparePendingWorkerShutdown(
           this.pending, this.outbox, this.worker,
-          this.options.cancelGraceMs ?? WORKER_CANCEL_GRACE_MS,
+          this.options.cancelGraceMs
+            ?? WORKER_CANCEL_PERSISTENCE_TIMEOUT_MS,
           (message, cause) => this.failForRestart(message, cause)
         ).then(() => null);
         const restart = await Promise.race([prepared, this.restartSignal]);

--- a/tui/src/worker-user-cancellation.ts
+++ b/tui/src/worker-user-cancellation.ts
@@ -12,6 +12,7 @@ interface WorkerUserCancellationOptions {
   worker: WorkerLike;
   outbox: SerializedWorkerOutbox;
   graceMs: number;
+  persistenceTimeoutMs: number;
   fail(message: string, cause?: unknown): void;
 }
 
@@ -38,9 +39,9 @@ export function cancelPendingWorkerRequest(
   const persistenceTimer = setTimeout(() => {
     if (!options.pendingRequests.isCurrent(pending)) return;
     options.fail(
-      `Embedded backend ${pending.method} cancellation was not durably recorded within ${options.graceMs} ms`
+      `Embedded backend ${pending.method} cancellation was not durably recorded within ${options.persistenceTimeoutMs} ms`
     );
-  }, options.graceMs);
+  }, options.persistenceTimeoutMs);
   void options.outbox.runIndependent(() => store.cancel(mutationId)).then(
     () => {
       clearTimeout(persistenceTimer);

--- a/tui/test/worker-user-cancellation.test.ts
+++ b/tui/test/worker-user-cancellation.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import {
   sameWorkerOperationId,
+  WORKER_CANCEL_PERSISTENCE_TIMEOUT_MS,
   type MainToWorkerMessage,
   type WorkerOperationId
 } from "../../shared/worker-protocol.js";
@@ -57,6 +58,80 @@ test("caller cancellation hard-fences a mutation that never reaches terminal sta
   expect(worker.terminateCalls).toBe(1);
   await expectRestartRequiredDisposal(transport);
 });
+
+test("the default cancellation grace lets a slow generation unwind past two seconds", async () => {
+  const worker = new FakeWorker(true);
+  const outbox = new RecordingCancellationOutbox();
+  const transport = new WorkerTransport({
+    worker,
+    readyTimeoutMs: 100
+  }, outbox);
+  await transport.start();
+  const cancel = new AbortController();
+  const outcome = transport.call(
+    "continueStory",
+    {
+      storyId: "story",
+      instruction: "Continue.",
+      genId: "slow-stop",
+      target: {}
+    },
+    { signal: cancel.signal }
+  ).then(
+    (value) => ({ value }),
+    (error: unknown) => ({ error })
+  );
+  const request = await waitForRequest(worker, "continueStory");
+
+  cancel.abort();
+  await outbox.cancelled;
+  await waitForControlMessage(worker, "cancel", request.id);
+  await new Promise((resolve) => setTimeout(resolve, 2_250));
+
+  expect(worker.terminateCalls).toBe(0);
+  worker.message({
+    type: "complete",
+    id: request.id,
+    value: null
+  });
+  expect(await outcome).toEqual({ value: null });
+  await transport.dispose();
+}, 10_000);
+
+test("the default durable-cancellation fence stays at two seconds", async () => {
+  const worker = new FakeWorker(true);
+  const outbox = new HangingCancellationOutbox();
+  const transport = new WorkerTransport({
+    worker,
+    readyTimeoutMs: 100
+  }, outbox);
+  await transport.start();
+  const cancel = new AbortController();
+  const mutationError = rejection(transport.call(
+    "continueStory",
+    {
+      storyId: "story",
+      instruction: "Continue.",
+      genId: "stalled-stop",
+      target: {}
+    },
+    { signal: cancel.signal }
+  ));
+  await waitForRequest(worker, "continueStory");
+
+  cancel.abort();
+  await outbox.cancelStarted;
+  const failure = await transport.failure;
+
+  expect(failure.message).toContain(
+    `cancellation was not durably recorded within ${WORKER_CANCEL_PERSISTENCE_TIMEOUT_MS} ms`
+  );
+  expect(worker.messages.some((message) => message.type === "cancel")).toBeFalse();
+  expect(worker.terminateCalls).toBe(1);
+  outbox.finishCancel();
+  expect(await mutationError).toBe(failure);
+  await expectRestartRequiredDisposal(transport);
+}, 10_000);
 
 test("stalled durable cancellation hard-fences disposal", async () => {
   const worker = new FakeWorker();


### PR DESCRIPTION
Preserve the model thought when Stop or a clean timeout saves a take. This makes the completed take show the same thought that was visible during streaming.

Changes:

- Carry credential-checked reasoning through the stopped-generation handoff.
- Attach reasoning only when the saved prose matches the streamed prose digest.
- Use the same handoff for clean generation timeouts.
- Keep the 2-second durable cancellation fence.
- Give the embedded backend 10 seconds to report terminal state after cancellation delivery.
- Add transport and generation persistence regression tests.

Verification:

- `npm run typecheck`
- `npm test` (2,497 passed; 226 skipped)
- `cd tui && bun run typecheck`
- `cd tui && bun test` (2,011 passed)
- Autoreview: clean after one accepted timeout-ownership finding was fixed.

Risk:

- A worker that remains stuck after successful cancellation delivery now requires a restart after 10 seconds instead of 2 seconds. Stop still hides the stream immediately. Pre-delivery durable work remains limited to 2 seconds.

Closes #260