### PR TITLE
chore(release): prepare 0.9.9-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -264,6 +264,14 @@ This file records notable changes to 1667. Product terms use the definitions in
   command accepts one or more JSON or PNG files. It adds their Facts to the
   story that `--story` names.
 
+## 0.9.9-rc.1 - 2026-08-17
+
+- **Stopped takes keep their thought and finish cleanly.** If **Keep thought**
+  is on, a take saved after Stop or a clean timeout keeps the thought that was
+  visible during streaming. 1667 also gives an embedded model server more time
+  to close after Stop. This prevents a restart-required error during normal
+  cleanup.
+
 ## 0.9.8 - 2026-08-17
 
 - **Settings shows important controls and help sooner.** The system prompt is

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "1667-workspace",
-  "version": "0.9.8",
+  "version": "0.9.9-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "1667-workspace",
-      "version": "0.9.8",
+      "version": "0.9.9-rc.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@silvia-odwyer/photon-node": "0.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667-workspace",
-  "version": "0.9.8",
+  "version": "0.9.9-rc.1",
   "private": true,
   "description": "Source workspace for the 1667 terminal writing environment",
   "license": "Apache-2.0",

--- a/shared/release-notes.ts
+++ b/shared/release-notes.ts
@@ -11,6 +11,11 @@ export interface ReleaseNote {
  *  a release, and is not included. */
 export const RELEASE_NOTES: readonly ReleaseNote[] = [
   {
+    version: "0.9.9-rc.1",
+    date: "2026-08-17",
+    body: "- **Stopped takes keep their thought and finish cleanly.** If **Keep thought**\n  is on, a take saved after Stop or a clean timeout keeps the thought that was\n  visible during streaming. 1667 also gives an embedded model server more time\n  to close after Stop. This prevents a restart-required error during normal\n  cleanup."
+  },
+  {
     version: "0.9.8",
     date: "2026-08-17",
     body: "- **Settings shows important controls and help sooner.** The system prompt is\n  now near the top of the panel. The panel uses its bottom space to show how\n  many settings are above or below the visible list. Select a setting to read\n  its complete description. Long descriptions wrap instead of ending at the\n  panel edge. The descriptions now explain the effect of each setting.\n\n- **The cache-stable continuation prompt is now an optional experiment.** The\n  **prompt layout** row in a Generation Profile is off by default. The off\n  value keeps the v0.8.0 Continue and Retake prompt. The on value moves the\n  operation-specific contract after the story history. Profile Export files\n  preserve the enabled value."

--- a/tui/package.json
+++ b/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667",
-  "version": "0.9.8",
+  "version": "0.9.9-rc.1",
   "private": true,
   "description": "A terminal environment for writing fiction with language models",
   "license": "Apache-2.0",


### PR DESCRIPTION
Prepare the beta release for stopped-take thought persistence and clean embedded-backend cancellation.

Changes:

- Set the workspace and TUI versions to 0.9.9-rc.1.
- Add the focused 0.9.9-rc.1 changelog section.
- Regenerate the embedded release notes.

Verification:

- `npm run build`
- `npm test` (2,497 passed; 226 skipped)
- `cd tui && bun run typecheck`
- `cd tui && bun test` (2,011 passed)
- `cd tui && bun bench/perf.ts`
- `cd tui && bun run build:standalone`
- `npm run notes:check-version -- 0.9.9-rc.1`

Risk:

- Release metadata only. Runtime behavior is unchanged from current `main`.
- Stable publication follows only after beta publication completes.

Closes #261