### PR TITLE
chore(release): prepare 0.9.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -264,7 +264,7 @@ This file records notable changes to 1667. Product terms use the definitions in
   command accepts one or more JSON or PNG files. It adds their Facts to the
   story that `--story` names.
 
-## 0.9.9-rc.1 - 2026-08-17
+## 0.9.9 - 2026-08-17
 
 - **Stopped takes keep their thought and finish cleanly.** If **Keep thought**
   is on, a take saved after Stop or a clean timeout keeps the thought that was

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "1667-workspace",
-  "version": "0.9.9-rc.1",
+  "version": "0.9.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "1667-workspace",
-      "version": "0.9.9-rc.1",
+      "version": "0.9.9",
       "license": "Apache-2.0",
       "dependencies": {
         "@silvia-odwyer/photon-node": "0.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667-workspace",
-  "version": "0.9.9-rc.1",
+  "version": "0.9.9",
   "private": true,
   "description": "Source workspace for the 1667 terminal writing environment",
   "license": "Apache-2.0",

--- a/shared/release-notes.ts
+++ b/shared/release-notes.ts
@@ -11,7 +11,7 @@ export interface ReleaseNote {
  *  a release, and is not included. */
 export const RELEASE_NOTES: readonly ReleaseNote[] = [
   {
-    version: "0.9.9-rc.1",
+    version: "0.9.9",
     date: "2026-08-17",
     body: "- **Stopped takes keep their thought and finish cleanly.** If **Keep thought**\n  is on, a take saved after Stop or a clean timeout keeps the thought that was\n  visible during streaming. 1667 also gives an embedded model server more time\n  to close after Stop. This prevents a restart-required error during normal\n  cleanup."
   },

--- a/tui/package.json
+++ b/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667",
-  "version": "0.9.9-rc.1",
+  "version": "0.9.9",
   "private": true,
   "description": "A terminal environment for writing fiction with language models",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Outcome

Promote the beta-tested 0.9.9 source to the stable channel.

## Changes

- Set the workspace and terminal interface versions to 0.9.9.
- Mark the 0.9.9 changelog entry as stable.
- Regenerate the in-app release notes.

## Verification

- `npm run build`
- `bun run typecheck` in `tui`
- The identical runtime source passed all local tests and the complete 0.9.9-rc.1 release pipeline.

## Risk

This pull request changes release metadata only. The release workflow still verifies all packages, archives, installers, and provenance before publication.

Closes #263