### PR TITLE
docs: link the NovelAI guide and drop a dead reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ request plan. It does not show the authentication header or its credential.
 - [Facts, context, and model providers](docs/model-providers.md)
 - [SillyTavern import](docs/sillytavern-import.md)
 - [Character card import](docs/character-card-import.md)
+- [Move from NovelAI](docs/move-from-novelai.md)
 - [Generation Profile transfer](docs/generation-profile-transfer.md)
 - [Platforms and standalone builds](docs/platforms-and-builds.md)
 - [Development reference](docs/development.md)

--- a/docs/move-from-novelai.md
+++ b/docs/move-from-novelai.md
@@ -201,8 +201,7 @@ stories.
 
 1667 cannot send requests to NovelAI's hosted models. NovelAI's terms do not
 give clear permission for a third-party client. The project closed this work as
-not planned. Refer to
-[issue 286](https://github.com/1667-ai/1667-archive2/issues/286).
+not planned and does not intend to reopen it.
 
 Use an OpenAI-compatible host, Anthropic, or a local model server. 1667 supports
 chat and text completion protocols. The file import and export features do not


### PR DESCRIPTION
Closes #265

## Outcome

A reader can now reach `docs/move-from-novelai.md` from the README, and the
guide no longer points at a link that returns 404.

## Changes

- Add the guide to the README Documentation list, next to the other import
  documents.
- Replace the reference to `1667-archive2` issue 286 with a plain statement of
  the decision. That repository is private, so the link was unreachable for
  every reader.

## Verification

The guide was checked against the code at v0.9.9 before this change. The
technical content is current, so this pull request changes no product claim:

- Supported Scenario versions 0, 1, and 3 match
  `SUPPORTED_NOVELAI_SCENARIO_VERSIONS` in `server/import-scenario.ts`.
- Supported Lorebook versions 1, 3, 4, and 6 match
  `SUPPORTED_LOREBOOK_VERSIONS` in `shared/novelai-lorebook.ts`.
- The 100,000-character Fact limit matches `MAX_FACT_TEXT_CHARS` in
  `shared/types.ts`.
- The export formats match `NovelAiExportFormat` in `server/novelai-export.ts`.
- No NovelAI importer or exporter file has changed since the guide was last
  updated on 2026-08-14.

No other public document links to `1667-archive2`.

## Follow-up

`docs/move-from-sillytavern.md` is not in the repository yet. An unpushed local
branch holds a version from 2026-08-15 that predates the v0.9.9 checks.