### PR TITLE
Keep slow generation cancellation online

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ This file records notable changes to 1667. Product terms use the definitions in
 
 ## Unreleased
 
+- **A slow generation Stop keeps 1667 open.** If the embedded backend needs
+  more than 10 seconds to stop a generation, 1667 now checks the operation
+  status. It keeps the application open while the backend answers. It still
+  requires a restart if the backend stops answering.
+
 ## 0.9.10-rc.1 - 2026-08-19
 
 - **ChatGPT and Claude subscriptions can connect directly.** Run

--- a/docs/generation-boundaries.md
+++ b/docs/generation-boundaries.md
@@ -157,7 +157,11 @@ same generation ID. If Keep thought is on, it also saves the thought that the
 model sent before Stop. A clean timeout uses the same save behavior.
 Stop hides the stream immediately. The main process gives local durable
 cancellation work 2 seconds to finish. It then gives the embedded backend 10
-seconds to close the provider stream and publish its terminal state.
+seconds to close the provider stream and publish its terminal state. If the
+operation is still active, the main process checks its status every 10 seconds.
+A responsive worker keeps the operation until it publishes a terminal state.
+The main process stops the embedded backend only if the worker does not answer
+a status check.
 After the Stop aborts the request signal, the worker transport sends no more
 live text to the caller. The transport collects the text that arrives after
 the abort. The transport delivers the collected text one time, at terminal

--- a/tui/src/worker-pending.ts
+++ b/tui/src/worker-pending.ts
@@ -25,6 +25,7 @@ export interface PendingCall {
    * so cancellation and terminal settlement skip outbox transitions. */
   readonly durableIntent: boolean;
   cancelled: boolean;
+  cancellationStatusPending: boolean;
   settling: boolean;
   expectedSequence: number;
   readonly openedAtMs: number;
@@ -46,6 +47,7 @@ export interface PendingCall {
   resolve(value: unknown): void;
   reject(error: unknown): void;
   startCancellationGrace(timeoutMs: number, onTimeout: () => void): void;
+  continueCancellationGrace(timeoutMs: number, onTimeout: () => void): void;
   cleanup(): void;
 }
 
@@ -140,6 +142,10 @@ export class PendingRequestRegistry {
       cancellationGraceStarted = true;
       replaceTimeout(timeoutMs, onTimeout);
     };
+    const continueCancellationGrace = (timeoutMs: number, onTimeout: () => void) => {
+      if (!cancellationGraceStarted) return;
+      replaceTimeout(timeoutMs, onTimeout);
+    };
     replaceTimeout(options.timeoutMs, () => options.onTimeout(id));
     const cleanup = () => {
       if (timer !== null) clearTimeout(timer);
@@ -153,6 +159,7 @@ export class PendingRequestRegistry {
       stream: options.stream,
       durableIntent: options.durableIntent,
       cancelled: false,
+      cancellationStatusPending: false,
       settling: false,
       expectedSequence: 0,
       openedAtMs: Date.now(),
@@ -168,6 +175,7 @@ export class PendingRequestRegistry {
       resolve: (value) => resolvePromise(value as T),
       reject: rejectPromise,
       startCancellationGrace,
+      continueCancellationGrace,
       cleanup
     };
     this.calls.set(key, call);

--- a/tui/src/worker-transport.ts
+++ b/tui/src/worker-transport.ts
@@ -522,7 +522,11 @@ export class WorkerTransport {
       return;
     }
     if (message.type === "operation") {
-      if (pending === undefined || pending.settling || message.state === "running") return;
+      if (pending === undefined || pending.settling) return;
+      if (message.state === "running") {
+        if (pending.cancelled) pending.cancellationStatusPending = false;
+        return;
+      }
       if (message.state === "unknown") {
         if (isWorkerMutationMethod(pending.method)) {
           await settleWorkerTerminal({

--- a/tui/src/worker-user-cancellation.ts
+++ b/tui/src/worker-user-cancellation.ts
@@ -17,7 +17,7 @@ interface WorkerUserCancellationOptions {
 }
 
 /** Durably records caller cancellation, delivers it, then, for a mutation,
- * requires terminal worker evidence within a fixed grace period. A
+ * requires terminal worker evidence or a responsive running status. A
  * non-mutating call is read-only advisory: once delivery succeeds, the local
  * call retires immediately, and any worker delta or terminal that arrives
  * for it afterward lands on an unknown ID, which the transport already
@@ -80,7 +80,7 @@ function deliverCancellation(
     retireDeliveredCancellation(options, pending);
     return;
   }
-  armGrace(options, pending, "did not reach terminal state");
+  armStatusCheck(options, pending);
 }
 
 /** A non-mutating call has nothing to fence: there is no durable intent to
@@ -96,17 +96,31 @@ function retireDeliveredCancellation(
   pending.resolve(null);
 }
 
-function armGrace(
+function armStatusCheck(
   options: WorkerUserCancellationOptions,
-  pending: PendingCall,
-  outcome: string
+  pending: PendingCall
 ): void {
-  pending.startCancellationGrace(options.graceMs, () => {
+  const check = () => {
     if (!canDeliverCancellation(options, pending)) return;
-    options.fail(
-      `Embedded backend ${pending.method} cancellation ${outcome} within ${options.graceMs} ms`
-    );
-  });
+    if (pending.cancellationStatusPending) {
+      options.fail(
+        `Embedded backend ${pending.method} stopped responding after cancellation within ${options.graceMs} ms`
+      );
+      return;
+    }
+    pending.cancellationStatusPending = true;
+    try {
+      options.worker.postMessage({ type: "status", id: pending.id });
+    } catch (error) {
+      options.fail(
+        `Embedded backend ${pending.method} cancellation status could not be requested`,
+        error
+      );
+      return;
+    }
+    pending.continueCancellationGrace(options.graceMs, check);
+  };
+  pending.startCancellationGrace(options.graceMs, check);
 }
 
 function canDeliverCancellation(

--- a/tui/test/worker-user-cancellation.test.ts
+++ b/tui/test/worker-user-cancellation.test.ts
@@ -34,7 +34,7 @@ const FILE_BACKED_TEST_TIMEOUT_MS =
   + FILE_BACKED_CONTROL_WAIT_MS
   + platformPerformanceBudget(2_000);
 
-test("caller cancellation hard-fences a mutation that never reaches terminal state", async () => {
+test("caller cancellation hard-fences a mutation when status stops responding", async () => {
   const worker = new FakeWorker();
   const outbox = new RecordingCancellationOutbox();
   const transport = await startTransport(worker, outbox, 20);
@@ -51,12 +51,59 @@ test("caller cancellation hard-fences a mutation that never reaches terminal sta
   expect(await waitForControlMessage(worker, "cancel", request.id)).toMatchObject({
     reason: "user"
   });
+  await waitForControlMessage(worker, "status", request.id);
   expect(await mutationError).toMatchObject({ code: "backend_restart_required" });
   expect((await transport.failure).message).toContain(
-    "cancellation did not reach terminal state"
+    "stopped responding after cancellation"
   );
   expect(worker.terminateCalls).toBe(1);
   await expectRestartRequiredDisposal(transport);
+});
+
+test("a responsive canceled generation stays online past cancellation grace", async () => {
+  const worker = new FakeWorker(true);
+  const outbox = new RecordingCancellationOutbox();
+  const cancelGraceMs = 20;
+  const transport = await startTransport(worker, outbox, cancelGraceMs);
+  const cancel = new AbortController();
+  const outcome = transport.call(
+    "continueStory",
+    {
+      storyId: "story",
+      instruction: "Try again quickly.",
+      genId: "responsive-stop",
+      target: {}
+    },
+    { signal: cancel.signal }
+  );
+  const request = await waitForRequest(worker, "continueStory");
+
+  cancel.abort();
+  await outbox.cancelled;
+  await waitForControlMessage(worker, "cancel", request.id);
+  await waitForControlMessageCount(worker, "status", request.id, 1);
+  worker.message({
+    type: "operation",
+    id: request.id,
+    state: "running",
+    terminal: false
+  });
+  await waitForControlMessageCount(worker, "status", request.id, 2);
+  worker.message({
+    type: "operation",
+    id: request.id,
+    state: "running",
+    terminal: false
+  });
+
+  let failed = false;
+  void transport.failure.then(() => { failed = true; });
+  expect(failed).toBeFalse();
+  expect(worker.terminateCalls).toBe(0);
+
+  worker.message({ type: "complete", id: request.id, value: null });
+  expect(await outcome).toBe(null);
+  await transport.dispose();
 });
 
 test("the default cancellation grace lets a slow generation unwind past two seconds", async () => {
@@ -602,7 +649,7 @@ class UserCancelThrowingWorker extends FakeWorker {
 
 function hasControlMessage(
   worker: FakeWorker,
-  type: "cancel" | "terminalAck",
+  type: "cancel" | "status" | "terminalAck",
   id: WorkerOperationId
 ): boolean {
   return worker.messages.some((message) =>
@@ -612,7 +659,7 @@ function hasControlMessage(
 
 async function waitForControlMessage(
   worker: FakeWorker,
-  type: "cancel" | "terminalAck",
+  type: "cancel" | "status" | "terminalAck",
   id: WorkerOperationId,
   timeoutMs = platformPerformanceBudget(500)
 ): Promise<MainToWorkerMessage> {
@@ -625,6 +672,24 @@ async function waitForControlMessage(
     await new Promise((resolve) => setTimeout(resolve, 1));
   } while (performance.now() < deadline);
   throw new Error(`${type} control message was not sent`);
+}
+
+async function waitForControlMessageCount(
+  worker: FakeWorker,
+  type: "cancel" | "status" | "terminalAck",
+  id: WorkerOperationId,
+  count: number,
+  timeoutMs = platformPerformanceBudget(500)
+): Promise<void> {
+  const deadline = performance.now() + timeoutMs;
+  do {
+    const matches = worker.messages.filter((candidate) =>
+      candidate.type === type && sameWorkerOperationId(candidate.id, id)
+    );
+    if (matches.length >= count) return;
+    await new Promise((resolve) => setTimeout(resolve, 1));
+  } while (performance.now() < deadline);
+  throw new Error(`${type} control message count did not reach ${count}`);
 }
 
 async function rejection(promise: Promise<unknown>): Promise<Error & Record<string, unknown>> {


### PR DESCRIPTION
## Outcome

A slow generation Stop no longer closes 1667 while the embedded worker remains responsive.

## Changes

- Poll worker operation status after the cancellation grace period.
- Keep terminal settlement and stopped-text ownership until the operation finishes.
- Retain the restart fence when the worker does not answer the status check.
- Add integration coverage for responsive and unresponsive cancellation paths.
- Document the cancellation status behavior.

## Verification

- `bun run typecheck`
- `bun test test/worker-user-cancellation.test.ts`
- `bun test test/worker-*.test.ts`
- `bun test --timeout 30000`
- `npm run typecheck`
- `npm test`
- `git diff --check`
- Local autoreview: clean

## Risk

Low. A canceled mutation remains owned until terminal state. The only policy change is that a responsive worker receives repeated status checks instead of an immediate restart.

Closes #274