### PR TITLE
fix: finish subscription beta follow-up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ This file records notable changes to 1667. Product terms use the definitions in
   status. It keeps the application open while the backend answers. It still
   requires a restart if the backend stops answering.
 
+## 0.9.10-rc.2 - 2026-08-19
+
+- **Fresh Settings can select a signed-in subscription plan.** When exactly
+  one plan is signed in, Settings selects that plan as an unsaved draft. Both
+  or neither signed-in plan keeps the current choice. Settings does not replace
+  a choice that the user saved.
+
+- **Managed upgrades accept updated legal notices.** An installed version no
+  longer compares a new package's `LICENSE` and `NOTICE` files with its own old
+  copies. The release process still requires the reviewed files. The updater
+   still checks the package contents, metadata, integrity, and source identity.
+
 ## 0.9.10-rc.1 - 2026-08-19
 
 - **ChatGPT and Claude subscriptions can connect directly.** Run

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,8 @@ This file records notable changes to 1667. Product terms use the definitions in
 ## 0.9.10-rc.1 - 2026-08-19
 
 - **ChatGPT and Claude subscriptions can connect directly.** Run
-  `1667 auth login openai-codex` to connect a ChatGPT plan. Run
-  `1667 auth login anthropic` to connect a Claude plan. Settings can use both
+  `1667 auth login chatgpt` to connect a ChatGPT plan. Run
+  `1667 auth login claude` to connect a Claude plan. Settings can use both
   connections. 1667 keeps the subscription credentials on this machine.
 
 ## 0.9.9 - 2026-08-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,12 @@ This file records notable changes to 1667. Product terms use the definitions in
 
 ## Unreleased
 
+## 0.9.10-rc.2 - 2026-08-19
+
 - **A slow generation Stop keeps 1667 open.** If the embedded backend needs
   more than 10 seconds to stop a generation, 1667 now checks the operation
   status. It keeps the application open while the backend answers. It still
   requires a restart if the backend stops answering.
-
-## 0.9.10-rc.2 - 2026-08-19
 
 - **Fresh Settings can select a signed-in subscription plan.** When exactly
   one plan is signed in, Settings selects that plan as an unsaved draft. Both
@@ -20,7 +20,7 @@ This file records notable changes to 1667. Product terms use the definitions in
 - **Managed upgrades accept updated legal notices.** An installed version no
   longer compares a new package's `LICENSE` and `NOTICE` files with its own old
   copies. The release process still requires the reviewed files. The updater
-   still checks the package contents, metadata, integrity, and source identity.
+  still checks the package contents, metadata, integrity, and source identity.
 
 ## 0.9.10-rc.1 - 2026-08-19
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "1667-workspace",
-  "version": "0.9.10-rc.1",
+  "version": "0.9.10-rc.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "1667-workspace",
-      "version": "0.9.10-rc.1",
+      "version": "0.9.10-rc.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@earendil-works/pi-ai": "0.84.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667-workspace",
-  "version": "0.9.10-rc.1",
+  "version": "0.9.10-rc.2",
   "private": true,
   "description": "Source workspace for the 1667 terminal writing environment",
   "license": "Apache-2.0",

--- a/server/settings-v2-store.ts
+++ b/server/settings-v2-store.ts
@@ -90,6 +90,7 @@ import {
 } from "./settings-state-slot.js";
 import { requireFreshUnseenMutationId } from "./mutation-id-policy.js";
 import { parseSettingsDocumentV2 } from "./settings-v2-codec.js";
+import { INITIAL_SETTINGS_STATE_V2_HASH } from "./settings-v2-initial-vectors.js";
 import { storedCredentialSecretId } from "../shared/settings-stored-credential.js";
 import { assertSavedSamplingBiasResolves } from "./settings-v2-save-bias-check.js";
 import {
@@ -115,6 +116,14 @@ export { SAMPLING_BIAS_SAVE_PROBE_DEADLINE_MS } from "./settings-v2-save-bias-ch
  * targeted supersession deletion in the shared machine tier. */
 const MINTED_SECRET_ID_PATTERN =
   /\.k[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
+/** Only this release's exact initial state may authorize the client-side
+ * subscription draft default. A successor-owned slot must never be inferred
+ * from its downgraded schema-2 view. */
+function subscriptionAutoSelectEligible(slot: SettingsStateSlot): boolean {
+  return slot.kind === "v2"
+    && hashSettingsStateV2(slot.state) === INITIAL_SETTINGS_STATE_V2_HASH;
+}
 
 export interface SettingsV2StoreOptions {
   readonly coordinator?: MutationCoordinator;
@@ -190,9 +199,11 @@ export class SettingsV2Store {
   }
 
   async loadView(): Promise<SettingsView> {
-    const view = settingsViewFromState(await readSettingsState(this.dataDir));
+    const slot = await readSettingsStateSlot(this.dataDir);
+    const view = settingsViewFromState(settingsStateSlotReadOnlyView(slot));
     return {
       ...view,
+      subscriptionAutoSelectEligible: subscriptionAutoSelectEligible(slot),
       subscriptionAuth: await readSubscriptionAuthState(this.subscription.credentials)
     };
   }

--- a/server/settings-v2-store.ts
+++ b/server/settings-v2-store.ts
@@ -90,17 +90,16 @@ import {
 } from "./settings-state-slot.js";
 import { requireFreshUnseenMutationId } from "./mutation-id-policy.js";
 import { parseSettingsDocumentV2 } from "./settings-v2-codec.js";
-import { INITIAL_SETTINGS_STATE_V2_HASH } from "./settings-v2-initial-vectors.js";
 import { storedCredentialSecretId } from "../shared/settings-stored-credential.js";
 import { assertSavedSamplingBiasResolves } from "./settings-v2-save-bias-check.js";
 import {
   createSubscriptionRuntime,
-  readSubscriptionAuthState,
   providerSecretIdsToKeep,
   storedSecretIdsInDocument,
   storedSecretIdsInState,
   type SubscriptionRuntimeDependencies
 } from "./subscription-runtime.js";
+import { readSettingsView } from "./settings-v2-view-read.js";
 
 type Clock = () => Date;
 export type SettingsActivationMode = "activation-capable" | "recover-only";
@@ -116,14 +115,6 @@ export { SAMPLING_BIAS_SAVE_PROBE_DEADLINE_MS } from "./settings-v2-save-bias-ch
  * targeted supersession deletion in the shared machine tier. */
 const MINTED_SECRET_ID_PATTERN =
   /\.k[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
-
-/** Only this release's exact initial state may authorize the client-side
- * subscription draft default. A successor-owned slot must never be inferred
- * from its downgraded schema-2 view. */
-function subscriptionAutoSelectEligible(slot: SettingsStateSlot): boolean {
-  return slot.kind === "v2"
-    && hashSettingsStateV2(slot.state) === INITIAL_SETTINGS_STATE_V2_HASH;
-}
 
 export interface SettingsV2StoreOptions {
   readonly coordinator?: MutationCoordinator;
@@ -198,14 +189,8 @@ export class SettingsV2Store {
     settingsViewFromState(state);
   }
 
-  async loadView(): Promise<SettingsView> {
-    const slot = await readSettingsStateSlot(this.dataDir);
-    const view = settingsViewFromState(settingsStateSlotReadOnlyView(slot));
-    return {
-      ...view,
-      subscriptionAutoSelectEligible: subscriptionAutoSelectEligible(slot),
-      subscriptionAuth: await readSubscriptionAuthState(this.subscription.credentials)
-    };
+  loadView(): Promise<SettingsView> {
+    return readSettingsView(this.dataDir, this.subscription.credentials);
   }
 
   /** The route's runtime settings AND its stored image-input override,

--- a/server/settings-v2-store.ts
+++ b/server/settings-v2-store.ts
@@ -94,6 +94,7 @@ import { storedCredentialSecretId } from "../shared/settings-stored-credential.j
 import { assertSavedSamplingBiasResolves } from "./settings-v2-save-bias-check.js";
 import {
   createSubscriptionRuntime,
+  readSubscriptionAuthState,
   providerSecretIdsToKeep,
   storedSecretIdsInDocument,
   storedSecretIdsInState,
@@ -189,7 +190,11 @@ export class SettingsV2Store {
   }
 
   async loadView(): Promise<SettingsView> {
-    return settingsViewFromState(await readSettingsState(this.dataDir));
+    const view = settingsViewFromState(await readSettingsState(this.dataDir));
+    return {
+      ...view,
+      subscriptionAuth: await readSubscriptionAuthState(this.subscription.credentials)
+    };
   }
 
   /** The route's runtime settings AND its stored image-input override,

--- a/server/settings-v2-view-read.ts
+++ b/server/settings-v2-view-read.ts
@@ -1,0 +1,31 @@
+import type { CredentialStore } from "@earendil-works/pi-ai";
+import type { SettingsView } from "../shared/settings-v2-types.js";
+import { hashSettingsStateV2 } from "./settings-v2-codec.js";
+import { INITIAL_SETTINGS_STATE_V2_HASH } from "./settings-v2-initial-vectors.js";
+import { readSettingsStateSlot } from "./settings-state-file.js";
+import {
+  settingsStateSlotReadOnlyView,
+  type SettingsStateSlot
+} from "./settings-state-slot.js";
+import { readSubscriptionAuthState } from "./subscription-runtime.js";
+import { settingsViewFromState } from "./settings-v2-runtime.js";
+
+/** Read the settings view and its machine-tier subscription presentation. */
+export async function readSettingsView(
+  dataDir: string,
+  credentials: Pick<CredentialStore, "read">
+): Promise<SettingsView> {
+  const slot = await readSettingsStateSlot(dataDir);
+  const view = settingsViewFromState(settingsStateSlotReadOnlyView(slot));
+  return {
+    ...view,
+    subscriptionAutoSelectEligible: exactInitialStateOwnedByThisRelease(slot),
+    subscriptionAuth: await readSubscriptionAuthState(credentials)
+  };
+}
+
+/** A successor-owned slot must not be inferred from its downgraded view. */
+function exactInitialStateOwnedByThisRelease(slot: SettingsStateSlot): boolean {
+  return slot.kind === "v2"
+    && hashSettingsStateV2(slot.state) === INITIAL_SETTINGS_STATE_V2_HASH;
+}

--- a/server/subscription-runtime.ts
+++ b/server/subscription-runtime.ts
@@ -1,7 +1,8 @@
-import type { CredentialStore, Models } from "@earendil-works/pi-ai";
+import type { Credential, CredentialStore, Models } from "@earendil-works/pi-ai";
 import type {
   SettingsDocumentV2,
-  SettingsStateV2
+  SettingsStateV2,
+  SubscriptionAuthState
 } from "../shared/settings-v2-types.js";
 import {
   SUBSCRIPTION_SECRET_IDS,
@@ -13,6 +14,45 @@ import { createSubscriptionModels } from "./subscription-models.js";
 export interface SubscriptionRuntimeDependencies {
   readonly credentials: CredentialStore;
   readonly models: Models;
+}
+
+/** Read the safe sign-in state used by Settings and auth status surfaces. */
+export async function readSubscriptionAuthState(
+  credentials: Pick<CredentialStore, "read">
+): Promise<SubscriptionAuthState> {
+  const [chatgpt, claude] = await Promise.all([
+    readSubscriptionCredentialStatus(credentials, "openai-codex"),
+    readSubscriptionCredentialStatus(credentials, "anthropic")
+  ]);
+  return { chatgpt, claude };
+}
+
+/** A credential is signed in when its local OAuth envelope has usable fields.
+ * Expiry does not make it signed out: Pi can refresh it on next use. */
+export function isUsableOAuthCredential(
+  credential: Credential | undefined
+): credential is Extract<Credential, { type: "oauth" }> {
+  return credential?.type === "oauth"
+    && typeof credential.access === "string"
+    && credential.access.length > 0
+    && typeof credential.refresh === "string"
+    && credential.refresh.length > 0
+    && Number.isFinite(credential.expires);
+}
+
+async function readSubscriptionCredentialStatus(
+  credentials: Pick<CredentialStore, "read">,
+  providerId: "openai-codex" | "anthropic"
+): Promise<"signed-in" | "signed-out"> {
+  try {
+    return isUsableOAuthCredential(await credentials.read(providerId))
+      ? "signed-in"
+      : "signed-out";
+  } catch {
+    // Settings must stay usable when one machine-tier envelope is corrupt or
+    // unavailable. A status is positive only when it can be proved.
+    return "signed-out";
+  }
 }
 
 /** Create one shared subscription runtime for a machine-tier secret store. */

--- a/shared/build-identity.ts
+++ b/shared/build-identity.ts
@@ -65,10 +65,12 @@ export const AI_1667_PRODUCT = "1667" as const;
  * export result. A v20 client against a v21 server would not know the new
  * response and failure shapes. v22 carries the server-resolved active prose
  * continuation layout in the Settings view. A v21 client would reject that
- * additive closed-record field. */
-export const HTTP_API_PROTOCOL_VERSION = 22;
-export const HTTP_MIN_CLIENT_PROTOCOL_VERSION = 22;
-export const HTTP_MAX_CLIENT_PROTOCOL_VERSION = 22;
+ * additive closed-record field. v23 carries machine-tier subscription sign-in
+ * state in the Settings view. A v22 client would reject that additive field
+ * before it can use the rest of Settings. */
+export const HTTP_API_PROTOCOL_VERSION = 23;
+export const HTTP_MIN_CLIENT_PROTOCOL_VERSION = 23;
+export const HTTP_MAX_CLIENT_PROTOCOL_VERSION = 23;
 
 export type ArtifactTarget = "source" | BuiltArtifactTarget;
 

--- a/shared/platform-package-policy.ts
+++ b/shared/platform-package-policy.ts
@@ -10,7 +10,6 @@ import {
 import {
   MAX_RELEASE_SBOM_BYTES,
   RELEASE_LICENSE,
-  RELEASE_LICENSE_FILE_DIGESTS,
   RELEASE_LICENSE_FILES,
   RELEASE_PACKAGE_REPOSITORY,
   type TarballEntry
@@ -37,7 +36,9 @@ export interface ValidatedPlatformPackage {
 
 /**
  * Validates a platform package inspection against the same entry policy used by
- * release preflight: exact paths, modes, licence digests, manifests, and bounds.
+ * release preflight: exact paths, modes, manifests, and bounds. Reviewed
+ * licence-file digests belong to release/build-time validation; an installed
+ * updater must accept a later release that changes NOTICE or LICENSE.
  */
 export function validatePlatformPackageInspection(input: {
   readonly packageName: PublishedPlatformPackage;
@@ -214,13 +215,6 @@ function assertEntryPolicy(
       ? MAX_RELEASE_SBOM_BYTES
       : 1024 * 1024;
   if (entry.size > maximum) throw new Error(`${entry.path} exceeds its size bound`);
-  for (const name of RELEASE_LICENSE_FILES) {
-    if (entry.path !== `package/${name}`) continue;
-    const pinned = RELEASE_LICENSE_FILE_DIGESTS[name];
-    if (entry.sha256 !== pinned.sha256 || entry.size !== pinned.bytes) {
-      throw new Error(`${entry.path} is not the reviewed ${name} file`);
-    }
-  }
 }
 
 function exactStringArray(value: unknown, expected: readonly string[], label: string): void {

--- a/shared/release-notes.ts
+++ b/shared/release-notes.ts
@@ -13,7 +13,7 @@ export const RELEASE_NOTES: readonly ReleaseNote[] = [
   {
     version: "0.9.10-rc.2",
     date: "2026-08-19",
-    body: "- **Fresh Settings can select a signed-in subscription plan.** When exactly\n  one plan is signed in, Settings selects that plan as an unsaved draft. Both\n  or neither signed-in plan keeps the current choice. Settings does not replace\n  a choice that the user saved.\n\n- **Managed upgrades accept updated legal notices.** An installed version no\n  longer compares a new package's `LICENSE` and `NOTICE` files with its own old\n  copies. The release process still requires the reviewed files. The updater\n  still checks the package contents, metadata, integrity, and source identity."
+    body: "- **A slow generation Stop keeps 1667 open.** If the embedded backend needs\n  more than 10 seconds to stop a generation, 1667 now checks the operation\n  status. It keeps the application open while the backend answers. It still\n  requires a restart if the backend stops answering.\n\n- **Fresh Settings can select a signed-in subscription plan.** When exactly\n  one plan is signed in, Settings selects that plan as an unsaved draft. Both\n  or neither signed-in plan keeps the current choice. Settings does not replace\n  a choice that the user saved.\n\n- **Managed upgrades accept updated legal notices.** An installed version no\n  longer compares a new package's `LICENSE` and `NOTICE` files with its own old\n  copies. The release process still requires the reviewed files. The updater\n  still checks the package contents, metadata, integrity, and source identity."
   },
   {
     version: "0.9.10-rc.1",

--- a/shared/release-notes.ts
+++ b/shared/release-notes.ts
@@ -11,6 +11,11 @@ export interface ReleaseNote {
  *  a release, and is not included. */
 export const RELEASE_NOTES: readonly ReleaseNote[] = [
   {
+    version: "0.9.10-rc.2",
+    date: "2026-08-19",
+    body: "- **Fresh Settings can select a signed-in subscription plan.** When exactly\n  one plan is signed in, Settings selects that plan as an unsaved draft. Both\n  or neither signed-in plan keeps the current choice. Settings does not replace\n  a choice that the user saved.\n\n- **Managed upgrades accept updated legal notices.** An installed version no\n  longer compares a new package's `LICENSE` and `NOTICE` files with its own old\n  copies. The release process still requires the reviewed files. The updater\n  still checks the package contents, metadata, integrity, and source identity."
+  },
+  {
     version: "0.9.10-rc.1",
     date: "2026-08-19",
     body: "- **ChatGPT and Claude subscriptions can connect directly.** Run\n  `1667 auth login chatgpt` to connect a ChatGPT plan. Run\n  `1667 auth login claude` to connect a Claude plan. Settings can use both\n  connections. 1667 keeps the subscription credentials on this machine."

--- a/shared/release-notes.ts
+++ b/shared/release-notes.ts
@@ -13,7 +13,7 @@ export const RELEASE_NOTES: readonly ReleaseNote[] = [
   {
     version: "0.9.10-rc.1",
     date: "2026-08-19",
-    body: "- **ChatGPT and Claude subscriptions can connect directly.** Run\n  `1667 auth login openai-codex` to connect a ChatGPT plan. Run\n  `1667 auth login anthropic` to connect a Claude plan. Settings can use both\n  connections. 1667 keeps the subscription credentials on this machine."
+    body: "- **ChatGPT and Claude subscriptions can connect directly.** Run\n  `1667 auth login chatgpt` to connect a ChatGPT plan. Run\n  `1667 auth login claude` to connect a Claude plan. Settings can use both\n  connections. 1667 keeps the subscription credentials on this machine."
   },
   {
     version: "0.9.9",

--- a/shared/settings-response-decoder.ts
+++ b/shared/settings-response-decoder.ts
@@ -54,7 +54,7 @@ export function decodeSettingsViewResponse(
     "pendingRevision", "document", "effective", "effectiveProse", "lastActivationOutcome"
   ], [
     "effectiveProseReasoning", "effectiveProseContinuationPromptLayout",
-    "subscriptionAuth"
+    "subscriptionAuth", "subscriptionAutoSelectEligible"
   ]);
   const effective = decodeGenerationSettingsResponse(response.effective);
   const effectiveProse = decodeGenerationSettingsResponse(response.effectiveProse);
@@ -74,6 +74,15 @@ export function decodeSettingsViewResponse(
   const subscriptionAuth = Object.hasOwn(response, "subscriptionAuth")
     ? decodeSubscriptionAuth(response.subscriptionAuth)
     : undefined;
+  const subscriptionAutoSelectEligible = Object.hasOwn(
+    response,
+    "subscriptionAutoSelectEligible"
+  )
+    ? booleanValue(
+      response.subscriptionAutoSelectEligible,
+      "settings view.subscriptionAutoSelectEligible"
+    )
+    : undefined;
   if (response.dataFormat === 1) {
     if (response.editable !== false || response.stateGeneration !== null
       || response.activeRevision !== null || response.pendingRevision !== null
@@ -92,6 +101,9 @@ export function decodeSettingsViewResponse(
       effectiveProseReasoning,
       effectiveProseContinuationPromptLayout,
       ...(subscriptionAuth === undefined ? {} : { subscriptionAuth }),
+      ...(subscriptionAutoSelectEligible === undefined
+        ? {}
+        : { subscriptionAutoSelectEligible }),
       lastActivationOutcome: null
     };
   }
@@ -111,6 +123,9 @@ export function decodeSettingsViewResponse(
     effectiveProseReasoning,
     effectiveProseContinuationPromptLayout,
     ...(subscriptionAuth === undefined ? {} : { subscriptionAuth }),
+    ...(subscriptionAutoSelectEligible === undefined
+      ? {}
+      : { subscriptionAutoSelectEligible }),
     lastActivationOutcome: response.lastActivationOutcome === null
       ? null
       : decodeActivationOutcome(response.lastActivationOutcome)
@@ -127,6 +142,11 @@ function decodeSubscriptionAuth(value: unknown): SubscriptionAuthState {
 
 function subscriptionAuthStatus(value: unknown, label: string): SubscriptionAuthStatus {
   return oneOf(value, ["signed-in", "signed-out"] as const, label);
+}
+
+function booleanValue(value: unknown, label: string): boolean {
+  if (typeof value !== "boolean") invalid(label);
+  return value;
 }
 
 function reasoningDisplayValue(value: unknown, label: string): ReasoningDisplayV2 {

--- a/shared/settings-response-decoder.ts
+++ b/shared/settings-response-decoder.ts
@@ -9,6 +9,8 @@ import {
   type SettingsDocumentV2,
   type SettingsMutationResult,
   type SettingsView,
+  type SubscriptionAuthState,
+  type SubscriptionAuthStatus,
   type SubscriptionProtocolV2
 } from "./settings-v2-types.js";
 import { CONTINUATION_PROMPT_LAYOUTS } from "./continuation-prompt-optimization.js";
@@ -50,7 +52,10 @@ export function decodeSettingsViewResponse(
   const response = closedRecord(value, "settings view", [
     "dataFormat", "editable", "stateGeneration", "activeRevision",
     "pendingRevision", "document", "effective", "effectiveProse", "lastActivationOutcome"
-  ], ["effectiveProseReasoning", "effectiveProseContinuationPromptLayout"]);
+  ], [
+    "effectiveProseReasoning", "effectiveProseContinuationPromptLayout",
+    "subscriptionAuth"
+  ]);
   const effective = decodeGenerationSettingsResponse(response.effective);
   const effectiveProse = decodeGenerationSettingsResponse(response.effectiveProse);
   const effectiveProseReasoning = Object.hasOwn(response, "effectiveProseReasoning")
@@ -65,6 +70,9 @@ export function decodeSettingsViewResponse(
       CONTINUATION_PROMPT_LAYOUTS,
       "settings view.effectiveProseContinuationPromptLayout"
     )
+    : undefined;
+  const subscriptionAuth = Object.hasOwn(response, "subscriptionAuth")
+    ? decodeSubscriptionAuth(response.subscriptionAuth)
     : undefined;
   if (response.dataFormat === 1) {
     if (response.editable !== false || response.stateGeneration !== null
@@ -83,6 +91,7 @@ export function decodeSettingsViewResponse(
       effectiveProse,
       effectiveProseReasoning,
       effectiveProseContinuationPromptLayout,
+      ...(subscriptionAuth === undefined ? {} : { subscriptionAuth }),
       lastActivationOutcome: null
     };
   }
@@ -101,10 +110,23 @@ export function decodeSettingsViewResponse(
     effectiveProse,
     effectiveProseReasoning,
     effectiveProseContinuationPromptLayout,
+    ...(subscriptionAuth === undefined ? {} : { subscriptionAuth }),
     lastActivationOutcome: response.lastActivationOutcome === null
       ? null
       : decodeActivationOutcome(response.lastActivationOutcome)
   };
+}
+
+function decodeSubscriptionAuth(value: unknown): SubscriptionAuthState {
+  const auth = closedRecord(value, "settings subscription auth", ["chatgpt", "claude"]);
+  return {
+    chatgpt: subscriptionAuthStatus(auth.chatgpt, "settings subscription auth.chatgpt"),
+    claude: subscriptionAuthStatus(auth.claude, "settings subscription auth.claude")
+  };
+}
+
+function subscriptionAuthStatus(value: unknown, label: string): SubscriptionAuthStatus {
+  return oneOf(value, ["signed-in", "signed-out"] as const, label);
 }
 
 function reasoningDisplayValue(value: unknown, label: string): ReasoningDisplayV2 {

--- a/shared/settings-v2-types.ts
+++ b/shared/settings-v2-types.ts
@@ -3,7 +3,11 @@ import type {
 } from "./continuation-prompt-optimization.js";
 import type { GenerationSettings } from "./types.js";
 
-export type { SettingsView } from "./settings-v2-view.js";
+export type {
+  SettingsView,
+  SubscriptionAuthState,
+  SubscriptionAuthStatus
+} from "./settings-v2-view.js";
 
 export const SETTINGS_PROTOCOL_V2_VALUES = [
   "dry-run",

--- a/shared/settings-v2-view.ts
+++ b/shared/settings-v2-view.ts
@@ -6,6 +6,14 @@ import type {
   SettingsDocumentV2
 } from "./settings-v2-types.js";
 
+export type SubscriptionAuthStatus = "signed-in" | "signed-out";
+
+/** Machine-tier sign-in state used by Settings presentation. */
+export interface SubscriptionAuthState {
+  readonly chatgpt: SubscriptionAuthStatus;
+  readonly claude: SubscriptionAuthStatus;
+}
+
 /** The settings data that a client can read. The continuation layout is an
  * active-route value, never a pending document projection. */
 export type SettingsView =
@@ -17,6 +25,8 @@ export type SettingsView =
       readonly pendingRevision: null;
       readonly document: null;
       readonly effective: GenerationSettings;
+      /** Read-only machine-tier status for Settings presentation. */
+      readonly subscriptionAuth?: SubscriptionAuthState;
       /** The active continuation route. Format 1 falls back to `effective`. */
       readonly effectiveProse: GenerationSettings;
       /** The active prose route's `GenerationProfileV2.reasoning`, resolved
@@ -38,6 +48,8 @@ export type SettingsView =
       readonly pendingRevision: number | null;
       readonly document: SettingsDocumentV2;
       readonly effective: GenerationSettings;
+      /** Read-only machine-tier status for Settings presentation. */
+      readonly subscriptionAuth?: SubscriptionAuthState;
       /** The active continuation route, never a pending document projection. */
       readonly effectiveProse: GenerationSettings;
       /** See the format-1 variant's own doc — same field, same resolution. */

--- a/shared/settings-v2-view.ts
+++ b/shared/settings-v2-view.ts
@@ -27,6 +27,8 @@ export type SettingsView =
       readonly effective: GenerationSettings;
       /** Read-only machine-tier status for Settings presentation. */
       readonly subscriptionAuth?: SubscriptionAuthState;
+      /** Server-certified pristine state for subscription auto-selection. */
+      readonly subscriptionAutoSelectEligible?: boolean;
       /** The active continuation route. Format 1 falls back to `effective`. */
       readonly effectiveProse: GenerationSettings;
       /** The active prose route's `GenerationProfileV2.reasoning`, resolved
@@ -50,6 +52,8 @@ export type SettingsView =
       readonly effective: GenerationSettings;
       /** Read-only machine-tier status for Settings presentation. */
       readonly subscriptionAuth?: SubscriptionAuthState;
+      /** Server-certified pristine state for subscription auto-selection. */
+      readonly subscriptionAutoSelectEligible?: boolean;
       /** The active continuation route, never a pending document projection. */
       readonly effectiveProse: GenerationSettings;
       /** See the format-1 variant's own doc — same field, same resolution. */

--- a/test/build-identity.test.ts
+++ b/test/build-identity.test.ts
@@ -40,12 +40,13 @@ test("source identity is explicit and cannot masquerade as a packaged build", ()
   // server, and a v19 client collapses every image code it does not know to
   // `internal`, so it cannot tell a writer that a Draft Lease expired. v21
   // adds Aside routes, Aside failure codes, and the Markdown export fidelity
-  // contract. v22 adds the active prose continuation layout to Settings. An
-  // older peer must fail at preflight.
+  // contract. v22 adds the active prose continuation layout to Settings. v23
+  // adds machine-tier subscription sign-in state to Settings. An older peer
+  // must fail at preflight.
   assert.equal(
     HTTP_API_PROTOCOL_VERSION,
-    22,
-    "Aside routes, failure codes, export fidelity, and active prompt layout require HTTP API v22"
+    23,
+    "Aside routes, failure codes, export fidelity, active prompt layout, and subscription auth require HTTP API v23"
   );
   const source = createSourceBuildIdentity("1.2.3");
   assert.deepEqual(source, {

--- a/test/settings-schema-successor.test.ts
+++ b/test/settings-schema-successor.test.ts
@@ -164,6 +164,11 @@ test("a schema-3 settings state opens and every setting reads correctly", async 
 
   const view = await store.loadView();
   assert.equal(view.editable, true);
+  assert.equal(
+    view.subscriptionAutoSelectEligible,
+    false,
+    "a successor-owned state cannot authorize the subscription draft default"
+  );
   assert.equal(view.document?.schemaVersion, 2, "the store presents a schema-2 read-only view");
   const capabilities = view.document?.models["builtin:dry-run"]?.capabilities;
   assert.equal(capabilities?.temperature, "supported");

--- a/test/subscription-credentials.integration.test.ts
+++ b/test/subscription-credentials.integration.test.ts
@@ -18,6 +18,7 @@ import {
   writeProviderSecret
 } from "../server/provider-secret-store.js";
 import { SettingsV2Store } from "../server/settings-v2-store.js";
+import { INITIAL_SETTINGS_DOCUMENT_V2 } from "../server/settings-v2-default.js";
 import { convertGenerationSettingsV1 } from "../server/settings-v2-conversion.js";
 import { parseSettingsDocumentV2 } from "../server/settings-v2-codec.js";
 import type { GenerationSettings } from "../shared/types.js";
@@ -368,6 +369,14 @@ test("settings view exposes subscription sign-in state", async (t) => {
     chatgpt: "signed-in",
     claude: "signed-out"
   });
+  assert.equal(view.subscriptionAutoSelectEligible, true);
+
+  const changed = parseSettingsDocumentV2({
+    ...INITIAL_SETTINGS_DOCUMENT_V2,
+    writing: { defaultAuthorBrief: "A saved settings document." }
+  });
+  await store.save(saveCommand(MUTATION_A, 1, changed));
+  assert.equal((await store.loadView()).subscriptionAutoSelectEligible, false);
 });
 
 test("settings pruning keeps machine-owned subscription credentials", async (t) => {

--- a/test/subscription-credentials.integration.test.ts
+++ b/test/subscription-credentials.integration.test.ts
@@ -356,6 +356,20 @@ test("subscription reserved secret IDs cannot become normal provider auth", () =
   }));
 });
 
+test("settings view exposes subscription sign-in state", async (t) => {
+  const dataDir = await initializedFormat2Directory(t, "1667-settings-subscription-auth-state-");
+  const credentials = createSubscriptionCredentialStore(dataDir);
+  await credentials.modify("openai-codex", async () => oauth(ACCESS));
+  const store = new SettingsV2Store(dataDir, { now: () => FIXED_TIME });
+  await store.init();
+
+  const view = await store.loadView();
+  assert.deepEqual(view.subscriptionAuth, {
+    chatgpt: "signed-in",
+    claude: "signed-out"
+  });
+});
+
 test("settings pruning keeps machine-owned subscription credentials", async (t) => {
   const dataDir = await initializedFormat2Directory(t, "1667-subscription-prune-");
   const credentials = createSubscriptionCredentialStore(dataDir);

--- a/tui/package.json
+++ b/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667",
-  "version": "0.9.10-rc.1",
+  "version": "0.9.10-rc.2",
   "private": true,
   "description": "A terminal environment for writing fiction with language models",
   "license": "Apache-2.0",

--- a/tui/src/auth-cli.ts
+++ b/tui/src/auth-cli.ts
@@ -16,6 +16,7 @@ import {
   resolveMachineTierRoot,
   resolveMachineTierRootPath
 } from "../../server/machine-tier.js";
+import { isUsableOAuthCredential } from "../../server/subscription-runtime.js";
 import { terminalLineText } from "../../shared/terminal-text.js";
 import { promptVaultPassword } from "./project-prompt.js";
 
@@ -401,17 +402,6 @@ function isTerminalPromptCancellation(error: unknown): boolean {
   return error.message === "Vault Password prompt cancelled"
     || error.message === "Vault Password prompt input ended"
     || error.message === "Vault Password prompt input closed";
-}
-
-function isUsableOAuthCredential(
-  credential: Credential | undefined
-): credential is Extract<Credential, { type: "oauth" }> {
-  return credential?.type === "oauth"
-    && typeof credential.access === "string"
-    && credential.access.length > 0
-    && typeof credential.refresh === "string"
-    && credential.refresh.length > 0
-    && Number.isFinite(credential.expires);
 }
 
 function notifyTerminalAuth(output: AuthCliOutput, event: AuthEvent): void {

--- a/tui/src/overlay-publication.ts
+++ b/tui/src/overlay-publication.ts
@@ -4,7 +4,10 @@ import { libraryRows } from "./library-model.js";
 import type { RuntimeState } from "./state.js";
 import { applyGenerationSettings } from "./runtime-settings.js";
 import { activeSettingsEdit } from "./settings-edit-state.js";
-import { reconcileSettingsOverlay } from "./settings-overlay-model.js";
+import {
+  autoSelectSettingsSubscriptionPlan,
+  reconcileSettingsOverlay
+} from "./settings-overlay-model.js";
 
 interface StoryCatalogSource { stories: StorySummary[] }
 interface SettingsViewSource {
@@ -63,6 +66,7 @@ export function publishSettingsView(
       activeSettingsEdit(state, overlay)
     );
     overlay.view = view;
+    autoSelectSettingsSubscriptionPlan(overlay);
     overlay.result = null;
     if (message !== null) state.toast = message;
   }

--- a/tui/src/overlay-publication.ts
+++ b/tui/src/overlay-publication.ts
@@ -4,10 +4,8 @@ import { libraryRows } from "./library-model.js";
 import type { RuntimeState } from "./state.js";
 import { applyGenerationSettings } from "./runtime-settings.js";
 import { activeSettingsEdit } from "./settings-edit-state.js";
-import {
-  autoSelectSettingsSubscriptionPlan,
-  reconcileSettingsOverlay
-} from "./settings-overlay-model.js";
+import { reconcileSettingsOverlay } from "./settings-overlay-model.js";
+import { autoSelectSettingsSubscriptionPlan } from "./settings-subscription-default.js";
 
 interface StoryCatalogSource { stories: StorySummary[] }
 interface SettingsViewSource {

--- a/tui/src/overlay-publication.ts
+++ b/tui/src/overlay-publication.ts
@@ -58,13 +58,14 @@ export function publishSettingsView(
   applyGenerationSettings(state, source, view);
   const overlay = state.settings;
   if (overlay !== null) {
+    const edit = activeSettingsEdit(state, overlay);
     const message = reconcileSettingsOverlay(
       overlay,
       view,
-      activeSettingsEdit(state, overlay)
+      edit
     );
     overlay.view = view;
-    autoSelectSettingsSubscriptionPlan(overlay);
+    autoSelectSettingsSubscriptionPlan(overlay, edit);
     overlay.result = null;
     if (message !== null) state.toast = message;
   }

--- a/tui/src/settings-context-detection.ts
+++ b/tui/src/settings-context-detection.ts
@@ -28,7 +28,10 @@ export async function detectSettingsContext(
   if (subscriptionPreset !== null) {
     overlay.result = {
       state: "warning",
-      message: `${settingsSubscriptionLoginHint(subscriptionPreset)} Enter context size manually.`
+      message: `${settingsSubscriptionLoginHint(
+        subscriptionPreset,
+        overlay.view.subscriptionAuth
+      )} Enter context size manually.`
     };
     overlay.resultRow = "context-window";
     context.repaint();
@@ -117,7 +120,10 @@ export async function checkSettings(
   if (subscriptionPreset !== null) {
     overlay.result = {
       state: "warning",
-      message: `${settingsSubscriptionLoginHint(subscriptionPreset)} Connection check is unavailable here.`
+      message: `${settingsSubscriptionLoginHint(
+        subscriptionPreset,
+        overlay.view.subscriptionAuth
+      )} Connection check is unavailable here.`
     };
     overlay.resultRow = "base-url";
     context.repaint();

--- a/tui/src/settings-overlay-model.ts
+++ b/tui/src/settings-overlay-model.ts
@@ -48,7 +48,6 @@ import {
   settingsTextDraftWithTextPreset
 } from "./settings-text.js";
 import { settingsPlanRowDisabled } from "./settings-subscription.js";
-import { autoSelectSettingsSubscriptionPlan } from "./settings-subscription-default.js";
 import { renameSettingsProfile } from "./settings-profile-draft.js";
 import { settingsModelDisplayText } from "./settings-profile-controls.js";
 import type {
@@ -111,7 +110,6 @@ export {
   settingsDraftChanged,
   settleSettingsOverlaySave
 } from "./settings-overlay-reconciliation.js";
-export { autoSelectSettingsSubscriptionPlan } from "./settings-subscription-default.js";
 
 type SettingsInlineRow = Exclude<SettingsRowId, "system-prompt" | "sampling">;
 
@@ -146,7 +144,6 @@ export function initialSettingsOverlay(
     deleteArmedProfileId: null,
     modelPicker: null
   };
-  autoSelectSettingsSubscriptionPlan(overlay);
   return overlay;
 }
 

--- a/tui/src/settings-overlay-model.ts
+++ b/tui/src/settings-overlay-model.ts
@@ -48,6 +48,7 @@ import {
   settingsTextDraftWithTextPreset
 } from "./settings-text.js";
 import { settingsPlanRowDisabled } from "./settings-subscription.js";
+import { autoSelectSettingsSubscriptionPlan } from "./settings-subscription-default.js";
 import { renameSettingsProfile } from "./settings-profile-draft.js";
 import { settingsModelDisplayText } from "./settings-profile-controls.js";
 import type {
@@ -110,6 +111,7 @@ export {
   settingsDraftChanged,
   settleSettingsOverlaySave
 } from "./settings-overlay-reconciliation.js";
+export { autoSelectSettingsSubscriptionPlan } from "./settings-subscription-default.js";
 
 type SettingsInlineRow = Exclude<SettingsRowId, "system-prompt" | "sampling">;
 
@@ -119,7 +121,7 @@ export function initialSettingsOverlay(
   selectedProfileId?: string
 ): SettingsOverlayState {
   const draft = settingsTextDraftForView(view, selectedProfileId);
-  return {
+  const overlay: SettingsOverlayState = {
     view,
     base: draft,
     draft,
@@ -144,6 +146,8 @@ export function initialSettingsOverlay(
     deleteArmedProfileId: null,
     modelPicker: null
   };
+  autoSelectSettingsSubscriptionPlan(overlay);
+  return overlay;
 }
 
 export function settingsRowEditValue(

--- a/tui/src/settings-row-presentations.ts
+++ b/tui/src/settings-row-presentations.ts
@@ -114,7 +114,7 @@ export function settingsRows(
   const subscriptionPreset = settingsSubscriptionPreset(overlay);
   const subscriptionHint = subscriptionPreset === null
     ? null
-    : settingsSubscriptionLoginHint(subscriptionPreset);
+    : settingsSubscriptionLoginHint(subscriptionPreset, overlay.view.subscriptionAuth);
   const insecureNeeded = providerChoice.plaintextDefaultRequiresOwnedLoopback === true
     && !localProviderPresetsSupported()
     && isPlainHttp(settings.baseUrl)

--- a/tui/src/settings-subscription-default.ts
+++ b/tui/src/settings-subscription-default.ts
@@ -1,5 +1,3 @@
-import { hashSettingsDocumentV2 } from "../../server/settings-v2-codec.js";
-import { INITIAL_SETTINGS_DOCUMENT_V2_HASH } from "../../server/settings-v2-initial-vectors.js";
 import { replaceSettingsProviderDraft } from "./settings-draft-transition.js";
 import { settingsDraftChanged } from "./settings-overlay-reconciliation.js";
 import {
@@ -18,16 +16,7 @@ export function autoSelectSettingsSubscriptionPlan(
 ): boolean {
   if (!overlay.view.editable || settingsDraftChanged(overlay)) return false;
   const preset = settingsSubscriptionAutoPreset(overlay.view);
-  if (
-    preset === null
-    || overlay.view.activeRevision !== 1
-    || overlay.view.pendingRevision !== null
-  ) return false;
-  const document = overlay.draft.document;
-  if (
-    document === null
-    || hashSettingsDocumentV2(document) !== INITIAL_SETTINGS_DOCUMENT_V2_HASH
-  ) return false;
+  if (preset === null || overlay.view.subscriptionAutoSelectEligible !== true) return false;
   const choice = SETTINGS_PROVIDER_CHOICES.find((candidate) => candidate.id === preset);
   if (choice === undefined) return false;
   const generation = {

--- a/tui/src/settings-subscription-default.ts
+++ b/tui/src/settings-subscription-default.ts
@@ -6,15 +6,17 @@ import {
 import {
   settingsSubscriptionAutoPreset
 } from "./settings-subscription.js";
+import type { ActiveSettingsEdit } from "./settings-edit-state.js";
 import type { SettingsOverlayState } from "./state.js";
 import { SETTINGS_PROVIDER_CHOICES } from "./settings-provider-choices.js";
 
 /** Apply one signed-in plan only to the untouched built-in draft.
  * The selected plan remains a draft until the writer saves Settings. */
 export function autoSelectSettingsSubscriptionPlan(
-  overlay: SettingsOverlayState
+  overlay: SettingsOverlayState,
+  activeEdit: ActiveSettingsEdit | null
 ): boolean {
-  if (!overlay.view.editable || settingsDraftChanged(overlay)) return false;
+  if (activeEdit !== null || !overlay.view.editable || settingsDraftChanged(overlay)) return false;
   const preset = settingsSubscriptionAutoPreset(overlay.view);
   if (preset === null || overlay.view.subscriptionAutoSelectEligible !== true) return false;
   const choice = SETTINGS_PROVIDER_CHOICES.find((candidate) => candidate.id === preset);

--- a/tui/src/settings-subscription-default.ts
+++ b/tui/src/settings-subscription-default.ts
@@ -16,7 +16,10 @@ export function autoSelectSettingsSubscriptionPlan(
   overlay: SettingsOverlayState,
   activeEdit: ActiveSettingsEdit | null
 ): boolean {
-  if (activeEdit !== null || !overlay.view.editable || settingsDraftChanged(overlay)) return false;
+  if (activeEdit !== null
+    || overlay.modelPicker !== null
+    || !overlay.view.editable
+    || settingsDraftChanged(overlay)) return false;
   const preset = settingsSubscriptionAutoPreset(overlay.view);
   if (preset === null || overlay.view.subscriptionAutoSelectEligible !== true) return false;
   const choice = settingsProviderChoice(overlay.draft.generation, preset);

--- a/tui/src/settings-subscription-default.ts
+++ b/tui/src/settings-subscription-default.ts
@@ -18,6 +18,8 @@ export function autoSelectSettingsSubscriptionPlan(
 ): boolean {
   if (activeEdit !== null
     || overlay.modelPicker !== null
+    || overlay.sampling !== null
+    || overlay.profileTransfer !== null
     || !overlay.view.editable
     || settingsDraftChanged(overlay)) return false;
   const preset = settingsSubscriptionAutoPreset(overlay.view);

--- a/tui/src/settings-subscription-default.ts
+++ b/tui/src/settings-subscription-default.ts
@@ -9,6 +9,10 @@ import {
 import type { ActiveSettingsEdit } from "./settings-edit-state.js";
 import type { SettingsOverlayState } from "./state.js";
 import { settingsProviderChoice } from "./settings-provider-choices.js";
+import {
+  restoreSettingsCursor,
+  settingsCursorRowIdentity
+} from "./settings-row-navigation.js";
 
 /** Apply one signed-in plan only to the untouched built-in draft.
  * The selected plan remains a draft until the writer saves Settings. */
@@ -24,6 +28,7 @@ export function autoSelectSettingsSubscriptionPlan(
     || settingsDraftChanged(overlay)) return false;
   const preset = settingsSubscriptionAutoPreset(overlay.view);
   if (preset === null || overlay.view.subscriptionAutoSelectEligible !== true) return false;
+  const cursorRow = settingsCursorRowIdentity(overlay);
   const choice = settingsProviderChoice(overlay.draft.generation, preset);
   const generation = {
     ...overlay.draft.generation,
@@ -34,5 +39,6 @@ export function autoSelectSettingsSubscriptionPlan(
     overlay,
     settingsTextDraftWithSubscriptionPlan(overlay.draft, preset, generation)
   );
+  restoreSettingsCursor(overlay, cursorRow);
   return true;
 }

--- a/tui/src/settings-subscription-default.ts
+++ b/tui/src/settings-subscription-default.ts
@@ -1,0 +1,43 @@
+import { hashSettingsDocumentV2 } from "../../server/settings-v2-codec.js";
+import { INITIAL_SETTINGS_DOCUMENT_V2_HASH } from "../../server/settings-v2-initial-vectors.js";
+import { replaceSettingsProviderDraft } from "./settings-draft-transition.js";
+import { settingsDraftChanged } from "./settings-overlay-reconciliation.js";
+import {
+  settingsTextDraftWithSubscriptionPlan
+} from "./settings-text.js";
+import {
+  settingsSubscriptionAutoPreset
+} from "./settings-subscription.js";
+import type { SettingsOverlayState } from "./state.js";
+import { SETTINGS_PROVIDER_CHOICES } from "./settings-provider-choices.js";
+
+/** Apply one signed-in plan only to the untouched built-in draft.
+ * The selected plan remains a draft until the writer saves Settings. */
+export function autoSelectSettingsSubscriptionPlan(
+  overlay: SettingsOverlayState
+): boolean {
+  if (!overlay.view.editable || settingsDraftChanged(overlay)) return false;
+  const preset = settingsSubscriptionAutoPreset(overlay.view);
+  if (
+    preset === null
+    || overlay.view.activeRevision !== 1
+    || overlay.view.pendingRevision !== null
+  ) return false;
+  const document = overlay.draft.document;
+  if (
+    document === null
+    || hashSettingsDocumentV2(document) !== INITIAL_SETTINGS_DOCUMENT_V2_HASH
+  ) return false;
+  const choice = SETTINGS_PROVIDER_CHOICES.find((candidate) => candidate.id === preset);
+  if (choice === undefined) return false;
+  const generation = {
+    ...overlay.draft.generation,
+    provider: choice.provider,
+    ...choice.defaults
+  };
+  replaceSettingsProviderDraft(
+    overlay,
+    settingsTextDraftWithSubscriptionPlan(overlay.draft, preset, generation)
+  );
+  return true;
+}

--- a/tui/src/settings-subscription-default.ts
+++ b/tui/src/settings-subscription-default.ts
@@ -8,7 +8,7 @@ import {
 } from "./settings-subscription.js";
 import type { ActiveSettingsEdit } from "./settings-edit-state.js";
 import type { SettingsOverlayState } from "./state.js";
-import { SETTINGS_PROVIDER_CHOICES } from "./settings-provider-choices.js";
+import { settingsProviderChoice } from "./settings-provider-choices.js";
 
 /** Apply one signed-in plan only to the untouched built-in draft.
  * The selected plan remains a draft until the writer saves Settings. */
@@ -19,8 +19,7 @@ export function autoSelectSettingsSubscriptionPlan(
   if (activeEdit !== null || !overlay.view.editable || settingsDraftChanged(overlay)) return false;
   const preset = settingsSubscriptionAutoPreset(overlay.view);
   if (preset === null || overlay.view.subscriptionAutoSelectEligible !== true) return false;
-  const choice = SETTINGS_PROVIDER_CHOICES.find((candidate) => candidate.id === preset);
-  if (choice === undefined) return false;
+  const choice = settingsProviderChoice(overlay.draft.generation, preset);
   const generation = {
     ...overlay.draft.generation,
     provider: choice.provider,

--- a/tui/src/settings-subscription.ts
+++ b/tui/src/settings-subscription.ts
@@ -1,6 +1,9 @@
 import { isSubscriptionPresetV2 } from "../../shared/settings-v2-types.js";
 import { resolveSettingsProfile } from "../../shared/settings-route.js";
-import type { SettingsView } from "../../shared/settings-v2-types.js";
+import type {
+  SettingsView,
+  SubscriptionAuthState
+} from "../../shared/settings-v2-types.js";
 import type { SettingsOverlayState, SettingsRowId } from "./state.js";
 
 export type SettingsSubscriptionPreset = "chatgpt-plan" | "claude-plan";
@@ -62,8 +65,17 @@ export function settingsPlanRowDisabled(
 }
 
 export function settingsSubscriptionLoginHint(
-  preset: SettingsSubscriptionPreset
+  preset: SettingsSubscriptionPreset,
+  subscriptionAuth?: SubscriptionAuthState
 ): string {
+  const signedIn = preset === "chatgpt-plan"
+    ? subscriptionAuth?.chatgpt === "signed-in"
+    : subscriptionAuth?.claude === "signed-in";
+  if (signedIn) {
+    return preset === "chatgpt-plan"
+      ? "ChatGPT plan is signed in. ChatGPT output length is best effort."
+      : "Claude plan is signed in. Claude plan support is experimental.";
+  }
   return preset === "chatgpt-plan"
     ? "In a terminal, run 1667 auth login chatgpt to sign in. ChatGPT output length is best effort."
     : "In a terminal, run 1667 auth login claude to sign in. Claude plan support is experimental.";

--- a/tui/src/settings-subscription.ts
+++ b/tui/src/settings-subscription.ts
@@ -1,8 +1,22 @@
 import { isSubscriptionPresetV2 } from "../../shared/settings-v2-types.js";
 import { resolveSettingsProfile } from "../../shared/settings-route.js";
+import type { SettingsView } from "../../shared/settings-v2-types.js";
 import type { SettingsOverlayState, SettingsRowId } from "./state.js";
 
 export type SettingsSubscriptionPreset = "chatgpt-plan" | "claude-plan";
+
+/** Return the one plan that Settings may offer as an automatic draft choice.
+ * Both or neither signed-in plans leave the writer's provider untouched. */
+export function settingsSubscriptionAutoPreset(
+  view: SettingsView
+): SettingsSubscriptionPreset | null {
+  if (!view.editable || view.subscriptionAuth === undefined) return null;
+  const signedIn = [
+    view.subscriptionAuth.chatgpt === "signed-in" ? "chatgpt-plan" : null,
+    view.subscriptionAuth.claude === "signed-in" ? "claude-plan" : null
+  ].filter((preset): preset is SettingsSubscriptionPreset => preset !== null);
+  return signedIn.length === 1 ? signedIn[0]! : null;
+}
 
 const SUBSCRIPTION_HIDDEN_ROWS: ReadonlySet<SettingsRowId> = new Set([
   "base-url",
@@ -51,6 +65,6 @@ export function settingsSubscriptionLoginHint(
   preset: SettingsSubscriptionPreset
 ): string {
   return preset === "chatgpt-plan"
-    ? "Sign in with 1667 auth login chatgpt. ChatGPT output length is best effort."
-    : "Sign in with 1667 auth login claude. Claude plan support is experimental.";
+    ? "In a terminal, run 1667 auth login chatgpt to sign in. ChatGPT output length is best effort."
+    : "In a terminal, run 1667 auth login claude to sign in. Claude plan support is experimental.";
 }

--- a/tui/test/api-compat.test.ts
+++ b/tui/test/api-compat.test.ts
@@ -1518,6 +1518,22 @@ test("HTTP StoryApi rejects DNS loopback before compatibility fetch", async () =
   expect(calls).toEqual([]);
 });
 
+test("HTTP StoryApi rejects a protocol-22 server before Settings decodes subscription auth", async () => {
+  const calls: string[] = [];
+  globalThis.fetch = (async (input) => {
+    calls.push(String(input));
+    return Response.json(metadata(undefined, {
+      apiProtocolVersion: 22,
+      minClientProtocolVersion: 22,
+      maxClientProtocolVersion: 22
+    }));
+  }) as typeof fetch;
+
+  const failure = await rejection(createApi("http://127.0.0.1:7373").listStories());
+  expect((failure as Error).message).toContain("Incompatible");
+  expect(calls).toEqual(["http://127.0.0.1:7373/api/health"]);
+});
+
 test("HTTP StoryApi rejects an older compatibility range and malformed metadata", async () => {
   for (const response of [
     metadata(undefined, {

--- a/tui/test/managed-install-policy.test.ts
+++ b/tui/test/managed-install-policy.test.ts
@@ -319,6 +319,65 @@ test("canonical package fixtures reject missing required entries", async () => {
   }
 });
 
+test("managed extraction accepts a future NOTICE but keeps archive safety policy", async () => {
+  const { materializeCandidate } = await import("../src/upgrade-candidate.js");
+  const root = managedScratchRoot("policy-notice-");
+  try {
+    const futureNotice = "Copyright 2027 1667 contributors.\n";
+    const cases = [
+      {
+        label: "future NOTICE",
+        package: buildCanonicalPlatformPackage({
+          packageName: PACKAGE,
+          version: NEXT,
+          target: TARGET,
+          noticeBody: futureNotice
+        }),
+        accepted: true
+      },
+      {
+        label: "empty NOTICE",
+        package: buildCanonicalPlatformPackage({
+          packageName: PACKAGE,
+          version: NEXT,
+          target: TARGET,
+          noticeBody: ""
+        }),
+        accepted: false
+      },
+      {
+        label: "unsafe NOTICE mode",
+        package: buildCanonicalPlatformPackage({
+          packageName: PACKAGE,
+          version: NEXT,
+          target: TARGET,
+          badMode: "package/NOTICE"
+        }),
+        accepted: false
+      }
+    ] as const;
+    for (const sample of cases) {
+      const destination = path.join(root, `candidate-${sample.label.replaceAll(" ", "-")}`);
+      writeFileSync(path.join(root, `${sample.label}.tgz`), sample.package.bytes);
+      let accepted = true;
+      try {
+        await materializeCandidate({
+          packagePath: path.join(root, `${sample.label}.tgz`),
+          destinationPath: destination,
+          packageName: PACKAGE,
+          version: NEXT,
+          signal: new AbortController().signal
+        });
+      } catch {
+        accepted = false;
+      }
+      expect(accepted).toBe(sample.accepted);
+    }
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("package build-manifest accepts real release schema; rejects skew", async () => {
   const { createReleasePackageBuildManifest } =
     await import("../../scripts/release-package-templates.js");

--- a/tui/test/managed-package-fixture.ts
+++ b/tui/test/managed-package-fixture.ts
@@ -90,6 +90,7 @@ export function buildCanonicalPlatformPackage(input: {
   readonly target: BuiltArtifactTarget;
   readonly omit?: string;
   readonly badMode?: string;
+  readonly noticeBody?: Buffer | string;
   readonly buildManifestBody?: string;
   readonly sourceCommit?: string;
   readonly buildTimestamp?: string;
@@ -107,13 +108,14 @@ export function buildCanonicalPlatformPackage(input: {
     throw new Error("fixture package name does not match target");
   }
   const license = readFileSync(path.join(repoRoot, "LICENSE"));
-  const notice = readFileSync(path.join(repoRoot, "NOTICE"));
+  const notice = input.noticeBody ?? readFileSync(path.join(repoRoot, "NOTICE"));
   if (createHash("sha256").update(license).digest("hex")
     !== RELEASE_LICENSE_FILE_DIGESTS.LICENSE.sha256) {
     throw new Error("fixture LICENSE digest drifted from the release pin");
   }
-  if (createHash("sha256").update(notice).digest("hex")
-    !== RELEASE_LICENSE_FILE_DIGESTS.NOTICE.sha256) {
+  if (input.noticeBody === undefined
+    && createHash("sha256").update(notice).digest("hex")
+      !== RELEASE_LICENSE_FILE_DIGESTS.NOTICE.sha256) {
     throw new Error("fixture NOTICE digest drifted from the release pin");
   }
   const packageBuildManifest = input.buildManifestBody ?? JSON.stringify(

--- a/tui/test/release-notes.test.ts
+++ b/tui/test/release-notes.test.ts
@@ -42,4 +42,12 @@ describe("release notes codegen", () => {
       expect(changelog).toContain(`## ${note.version} - ${note.date}`);
     }
   });
+
+  test("the subscription release note uses the public sign-in commands", () => {
+    const note = RELEASE_NOTES.find((candidate) => candidate.version === "0.9.10-rc.1");
+    expect(note?.body).toContain("1667 auth login chatgpt");
+    expect(note?.body).toContain("1667 auth login claude");
+    expect(note?.body).not.toContain("1667 auth login openai-codex");
+    expect(note?.body).not.toContain("1667 auth login anthropic");
+  });
 });

--- a/tui/test/settings-form.test.ts
+++ b/tui/test/settings-form.test.ts
@@ -406,7 +406,7 @@ describe("the settings row model stays one list", () => {
     expect(rows.find((row) => row.id === "provider")?.value)
       .toContain("ChatGPT plan");
     expect(rows.find((row) => row.id === "provider")?.hint)
-      .toBe("Sign in with 1667 auth login chatgpt. ChatGPT output length is best effort.");
+      .toBe("In a terminal, run 1667 auth login chatgpt to sign in. ChatGPT output length is best effort.");
     expect(rows.find((row) => row.id === "text-prompt-format")?.disabled).toBe(true);
     expect(rows.find((row) => row.id === "text-prompt-format")?.hint)
       .toBe("Available with text-completion providers.");
@@ -429,6 +429,28 @@ describe("the settings row model stays one list", () => {
         contextWindow: 1_000_000
       }
     });
+  });
+
+  test("Claude plan help names its terminal sign-in command", async () => {
+    const { state, press } = settingsHarness();
+    await openSettings(press);
+    const overlay = state.settings!;
+    const draft = settingsTextDraftWithSubscriptionPlan(
+      overlay.draft,
+      "claude-plan",
+      {
+        ...overlay.draft.generation,
+        provider: "anthropic",
+        baseUrl: "",
+        model: "claude-sonnet-4-6",
+        apiKeyEnv: null,
+        contextWindow: 1_000_000
+      }
+    );
+    const rows = settingsRows({ ...overlay, draft }, state.config);
+
+    expect(rows.find((row) => row.id === "provider")?.hint)
+      .toBe("In a terminal, run 1667 auth login claude to sign in. Claude plan support is experimental.");
   });
 
   test("subscription plans skip legacy discovery and context probes", async () => {

--- a/tui/test/settings-form.test.ts
+++ b/tui/test/settings-form.test.ts
@@ -12,7 +12,10 @@ import {
   discoverSettingsModels,
   publishCurrentSettingsModelDiscovery
 } from "../src/settings-model-discovery.js";
-import { detectSettingsContext } from "../src/settings-context-detection.js";
+import {
+  checkSettings,
+  detectSettingsContext
+} from "../src/settings-context-detection.js";
 import {
   initialSettingsOverlay,
   settingsRows,
@@ -385,6 +388,10 @@ describe("the settings row model stays one list", () => {
     const { state, press } = settingsHarness();
     await openSettings(press);
     const overlay = state.settings!;
+    overlay.view = {
+      ...overlay.view,
+      subscriptionAuth: { chatgpt: "signed-out", claude: "signed-out" }
+    };
     overlay.draft = settingsTextDraftWithSubscriptionPlan(
       overlay.draft,
       "chatgpt-plan",
@@ -435,6 +442,10 @@ describe("the settings row model stays one list", () => {
     const { state, press } = settingsHarness();
     await openSettings(press);
     const overlay = state.settings!;
+    overlay.view = {
+      ...overlay.view,
+      subscriptionAuth: { chatgpt: "signed-out", claude: "signed-out" }
+    };
     const draft = settingsTextDraftWithSubscriptionPlan(
       overlay.draft,
       "claude-plan",
@@ -457,6 +468,10 @@ describe("the settings row model stays one list", () => {
     const { source, state, backend, press } = settingsHarness();
     await openSettings(press);
     const overlay = state.settings!;
+    overlay.view = {
+      ...overlay.view,
+      subscriptionAuth: { chatgpt: "signed-in", claude: "signed-out" }
+    };
     overlay.draft = settingsTextDraftWithSubscriptionPlan(
       overlay.draft,
       "chatgpt-plan",
@@ -496,7 +511,12 @@ describe("the settings row model stays one list", () => {
 
     expect(discoveryCalls).toBe(0);
     expect(probeCalls).toBe(0);
-    expect(overlay.result?.message).toContain("Enter context size manually");
+    expect(overlay.result?.message).toContain("ChatGPT plan is signed in.");
+    expect(overlay.result?.message).not.toContain("auth login");
+
+    await checkSettings(state, source, context, overlay);
+    expect(overlay.result?.message).toContain("ChatGPT plan is signed in.");
+    expect(overlay.result?.message).not.toContain("auth login");
   });
 
   test("subscription plans hide probe keys and ignore direct probe shortcuts", async () => {

--- a/tui/test/settings-subscription-default.test.ts
+++ b/tui/test/settings-subscription-default.test.ts
@@ -22,7 +22,8 @@ import {
 function initialSettingsView(
   subscriptionAuth: SubscriptionAuthState,
   activeRevision = 1,
-  document: SettingsDocumentV2 = INITIAL_SETTINGS_DOCUMENT_V2
+  document: SettingsDocumentV2 = INITIAL_SETTINGS_DOCUMENT_V2,
+  subscriptionAutoSelectEligible = true
 ): Extract<SettingsView, { dataFormat: 2 }> {
   const effective = basicSettingsFromDocument(document);
   return {
@@ -35,6 +36,7 @@ function initialSettingsView(
     effective,
     effectiveProse: effective,
     subscriptionAuth,
+    subscriptionAutoSelectEligible,
     lastActivationOutcome: null
   };
 }
@@ -85,10 +87,34 @@ test("both or neither signed-in plans leave the default provider untouched", asy
   }
 });
 
+test("cached signed-in auth does not create a draft before fresh settings arrive", async () => {
+  const { source, state, press } = harness();
+  source.settingsView = initialSettingsView({
+    chatgpt: "signed-in",
+    claude: "signed-out"
+  });
+  const fresh = initialSettingsView({
+    chatgpt: "signed-out",
+    claude: "signed-out"
+  });
+  source.api.getSettings = async () => fresh;
+
+  await openSettings(press);
+
+  expect(settingsSubscriptionPreset(state.settings!)).toBe(null);
+  expect(settingsProviderChoice(state.settings!.draft.generation).id).toBe("dry-run");
+  expect(settingsDraftChanged(state.settings!)).toBeFalse();
+});
+
 test("a pending activation keeps the pristine provider untouched", async () => {
   const { source, state, press } = harness();
   source.settingsView = {
-    ...initialSettingsView({ chatgpt: "signed-in", claude: "signed-out" }),
+    ...initialSettingsView(
+      { chatgpt: "signed-in", claude: "signed-out" },
+      1,
+      INITIAL_SETTINGS_DOCUMENT_V2,
+      false
+    ),
     pendingRevision: 2
   };
   source.api.getSettings = async () => source.settingsView;
@@ -138,7 +164,8 @@ test("a saved provider, API key, or local route is never replaced", async () => 
     source.settingsView = initialSettingsView(
       { chatgpt: "signed-in", claude: "signed-out" },
       2,
-      fixture.document
+      fixture.document,
+      false
     );
     source.api.getSettings = async () => source.settingsView;
 

--- a/tui/test/settings-subscription-default.test.ts
+++ b/tui/test/settings-subscription-default.test.ts
@@ -10,12 +10,16 @@ import type {
   SubscriptionAuthState
 } from "../../shared/settings-v2-types.js";
 import { selectSettingsRoute } from "../../shared/settings-route.js";
+import { setComposerText } from "../src/composer-model.js";
 import { settingsDraftChanged } from "../src/settings-overlay-reconciliation.js";
 import { settingsRows } from "../src/settings-overlay-model.js";
 import { settingsProviderChoice } from "../src/settings-provider-choices.js";
 import { settingsSubscriptionPreset } from "../src/settings-subscription.js";
 import {
+  deferred,
+  key,
   openSettings,
+  selectRow,
   settingsHarness as harness
 } from "./settings-test-harness.js";
 
@@ -104,6 +108,34 @@ test("cached signed-in auth does not create a draft before fresh settings arrive
   expect(settingsSubscriptionPreset(state.settings!)).toBe(null);
   expect(settingsProviderChoice(state.settings!.draft.generation).id).toBe("dry-run");
   expect(settingsDraftChanged(state.settings!)).toBeFalse();
+});
+
+test("a delayed settings refresh cannot select below an active inline edit", async () => {
+  const { source, state, press } = harness();
+  source.settingsView = initialSettingsView({
+    chatgpt: "signed-out",
+    claude: "signed-out"
+  });
+  const entered = deferred<void>();
+  const gate = deferred<SettingsView>();
+  source.api.getSettings = async () => {
+    entered.resolve();
+    return gate.promise;
+  };
+
+  const opening = openSettings(press);
+  await entered.promise;
+  await selectRow(press, state, "model");
+  await press(key("return"));
+  setComposerText(state.settings!.edit!.composer, "typed-before-refresh");
+  gate.resolve(initialSettingsView({
+    chatgpt: "signed-in",
+    claude: "signed-out"
+  }));
+  await opening;
+
+  expect(settingsSubscriptionPreset(state.settings!)).toBe(null);
+  expect(state.settings!.edit?.composer.text).toBe("typed-before-refresh");
 });
 
 test("a pending activation keeps the pristine provider untouched", async () => {

--- a/tui/test/settings-subscription-default.test.ts
+++ b/tui/test/settings-subscription-default.test.ts
@@ -191,6 +191,42 @@ test("a delayed settings refresh cannot select below an open model picker", asyn
   expect(settingsProviderChoice(state.settings!.draft.generation).id).toBe("dry-run");
 });
 
+test("a delayed settings refresh cannot select below nested Settings surfaces", async () => {
+  for (const surface of ["sampling", "profile-transfer"] as const) {
+    const { source, state, press } = harness();
+    source.settingsView = initialSettingsView({
+      chatgpt: "signed-out",
+      claude: "signed-out"
+    });
+    const entered = deferred<void>();
+    const gate = deferred<SettingsView>();
+    source.api.getSettings = async () => {
+      entered.resolve();
+      return gate.promise;
+    };
+
+    const opening = openSettings(press);
+    await entered.promise;
+    await selectRow(press, state, surface === "sampling" ? "sampling" : "profile");
+    await press(key(surface === "sampling" ? "return" : "i"));
+    const before = surface === "sampling"
+      ? state.settings!.sampling
+      : state.settings!.profileTransfer;
+    expect(before).not.toBe(null);
+
+    gate.resolve(initialSettingsView({
+      chatgpt: "signed-in",
+      claude: "signed-out"
+    }));
+    await opening;
+
+    expect(surface === "sampling"
+      ? state.settings!.sampling
+      : state.settings!.profileTransfer).toEqual(before);
+    expect(settingsProviderChoice(state.settings!.draft.generation).id).toBe("dry-run");
+  }
+});
+
 test("a pending activation keeps the pristine provider untouched", async () => {
   const { source, state, press } = harness();
   source.settingsView = {

--- a/tui/test/settings-subscription-default.test.ts
+++ b/tui/test/settings-subscription-default.test.ts
@@ -1,0 +1,151 @@
+import { expect, test } from "bun:test";
+import { INITIAL_SETTINGS_DOCUMENT_V2 } from "../../server/settings-v2-default.js";
+import {
+  applyBasicSettingsDraft,
+  basicSettingsFromDocument
+} from "../../shared/settings-basic-draft.js";
+import type {
+  SettingsDocumentV2,
+  SettingsView,
+  SubscriptionAuthState
+} from "../../shared/settings-v2-types.js";
+import { selectSettingsRoute } from "../../shared/settings-route.js";
+import { settingsDraftChanged } from "../src/settings-overlay-reconciliation.js";
+import { settingsProviderChoice } from "../src/settings-provider-choices.js";
+import { settingsSubscriptionPreset } from "../src/settings-subscription.js";
+import {
+  openSettings,
+  settingsHarness as harness
+} from "./settings-test-harness.js";
+
+function initialSettingsView(
+  subscriptionAuth: SubscriptionAuthState,
+  activeRevision = 1,
+  document: SettingsDocumentV2 = INITIAL_SETTINGS_DOCUMENT_V2
+): Extract<SettingsView, { dataFormat: 2 }> {
+  const effective = basicSettingsFromDocument(document);
+  return {
+    dataFormat: 2,
+    editable: true,
+    stateGeneration: activeRevision,
+    activeRevision,
+    pendingRevision: null,
+    document,
+    effective,
+    effectiveProse: effective,
+    subscriptionAuth,
+    lastActivationOutcome: null
+  };
+}
+
+test("one signed-in plan becomes an unsaved provider draft", async () => {
+  for (const fixture of [
+    {
+      provider: "chatgpt-plan" as const,
+      auth: { chatgpt: "signed-in", claude: "signed-out" } as const
+    },
+    {
+      provider: "claude-plan" as const,
+      auth: { chatgpt: "signed-out", claude: "signed-in" } as const
+    }
+  ]) {
+    const { source, state, press } = harness();
+    source.settingsView = initialSettingsView(fixture.auth);
+    source.api.getSettings = async () => source.settingsView;
+
+    await openSettings(press);
+
+    expect(settingsSubscriptionPreset(state.settings!)).toBe(fixture.provider);
+    expect(settingsDraftChanged(state.settings!)).toBeTrue();
+    expect(source.settingsView.effective.provider).toBe("dry-run");
+    expect(source.settingsView.effective.apiKeyEnv).toBe(null);
+  }
+});
+
+test("both or neither signed-in plans leave the default provider untouched", async () => {
+  for (const auth of [
+    { chatgpt: "signed-in", claude: "signed-in" },
+    { chatgpt: "signed-out", claude: "signed-out" }
+  ] as const) {
+    const { source, state, press } = harness();
+    source.settingsView = initialSettingsView(auth);
+    source.api.getSettings = async () => source.settingsView;
+
+    await openSettings(press);
+
+    expect(settingsSubscriptionPreset(state.settings!)).toBe(null);
+    expect(settingsProviderChoice(state.settings!.draft.generation).id).toBe("dry-run");
+    expect(settingsDraftChanged(state.settings!)).toBeFalse();
+  }
+});
+
+test("a pending activation keeps the pristine provider untouched", async () => {
+  const { source, state, press } = harness();
+  source.settingsView = {
+    ...initialSettingsView({ chatgpt: "signed-in", claude: "signed-out" }),
+    pendingRevision: 2
+  };
+  source.api.getSettings = async () => source.settingsView;
+
+  await openSettings(press);
+
+  expect(settingsSubscriptionPreset(state.settings!)).toBe(null);
+  expect(settingsProviderChoice(state.settings!.draft.generation).id).toBe("dry-run");
+  expect(settingsDraftChanged(state.settings!)).toBeFalse();
+});
+
+test("a saved provider, API key, or local route is never replaced", async () => {
+  const initial = basicSettingsFromDocument(INITIAL_SETTINGS_DOCUMENT_V2);
+  const saved = [
+    {
+      choice: "openai",
+      document: applyBasicSettingsDraft(INITIAL_SETTINGS_DOCUMENT_V2, {
+        ...initial,
+        provider: "openai-compatible",
+        baseUrl: "https://api.openai.com/v1",
+        model: "gpt-5.4",
+        apiKeyEnv: "OPENAI_API_KEY",
+        contextWindow: null
+      })
+    },
+    {
+      choice: "ollama",
+      document: applyBasicSettingsDraft(INITIAL_SETTINGS_DOCUMENT_V2, {
+        ...initial,
+        provider: "openai-compatible",
+        baseUrl: "http://127.0.0.1:11434/v1",
+        model: "llama3.2",
+        apiKeyEnv: null,
+        contextWindow: null
+      })
+    },
+    {
+      // The document still has the checked-in default shape. Revision 2
+      // proves that a writer explicitly saved the default provider.
+      choice: "dry-run",
+      document: INITIAL_SETTINGS_DOCUMENT_V2
+    }
+  ] as const;
+
+  for (const fixture of saved) {
+    const { source, state, press } = harness();
+    source.settingsView = initialSettingsView(
+      { chatgpt: "signed-in", claude: "signed-out" },
+      2,
+      fixture.document
+    );
+    source.api.getSettings = async () => source.settingsView;
+
+    await openSettings(press);
+
+    expect(settingsProviderChoice(
+      state.settings!.draft.generation,
+      selectSettingsRoute(
+        state.settings!.draft.document!,
+        "default"
+      ).connection.preset
+    ).id).toBe(fixture.choice);
+    expect(settingsSubscriptionPreset(state.settings!)).toBe(null);
+    expect(settingsDraftChanged(state.settings!)).toBeFalse();
+  }
+});

--- a/tui/test/settings-subscription-default.test.ts
+++ b/tui/test/settings-subscription-default.test.ts
@@ -11,6 +11,7 @@ import type {
 } from "../../shared/settings-v2-types.js";
 import { selectSettingsRoute } from "../../shared/settings-route.js";
 import { settingsDraftChanged } from "../src/settings-overlay-reconciliation.js";
+import { settingsRows } from "../src/settings-overlay-model.js";
 import { settingsProviderChoice } from "../src/settings-provider-choices.js";
 import { settingsSubscriptionPreset } from "../src/settings-subscription.js";
 import {
@@ -59,6 +60,11 @@ test("one signed-in plan becomes an unsaved provider draft", async () => {
     expect(settingsDraftChanged(state.settings!)).toBeTrue();
     expect(source.settingsView.effective.provider).toBe("dry-run");
     expect(source.settingsView.effective.apiKeyEnv).toBe(null);
+    const providerHint = settingsRows(state.settings!, state.config)
+      .find((row) => row.id === "provider")?.hint;
+    expect(providerHint).toBe(fixture.provider === "chatgpt-plan"
+      ? "ChatGPT plan is signed in. ChatGPT output length is best effort."
+      : "Claude plan is signed in. Claude plan support is experimental.");
   }
 });
 

--- a/tui/test/settings-subscription-default.test.ts
+++ b/tui/test/settings-subscription-default.test.ts
@@ -18,6 +18,7 @@ import {
 import { settingsDraftChanged } from "../src/settings-overlay-reconciliation.js";
 import { settingsRows } from "../src/settings-overlay-model.js";
 import { settingsProviderChoice } from "../src/settings-provider-choices.js";
+import { settingsCursorRowIdentity } from "../src/settings-row-navigation.js";
 import { settingsSubscriptionPreset } from "../src/settings-subscription.js";
 import {
   deferred,
@@ -140,6 +141,32 @@ test("a delayed settings refresh cannot select below an active inline edit", asy
 
   expect(settingsSubscriptionPreset(state.settings!)).toBe(null);
   expect(state.settings!.edit?.composer.text).toBe("typed-before-refresh");
+});
+
+test("a delayed settings refresh keeps the selected row after auto-selection", async () => {
+  const { source, state, press } = harness();
+  source.settingsView = initialSettingsView({
+    chatgpt: "signed-out",
+    claude: "signed-out"
+  });
+  const entered = deferred<void>();
+  const gate = deferred<SettingsView>();
+  source.api.getSettings = async () => {
+    entered.resolve();
+    return gate.promise;
+  };
+
+  const opening = openSettings(press);
+  await entered.promise;
+  await selectRow(press, state, "model");
+  expect(settingsCursorRowIdentity(state.settings!)).toBe("model");
+  gate.resolve(initialSettingsView({
+    chatgpt: "signed-in",
+    claude: "signed-out"
+  }));
+  await opening;
+
+  expect(settingsCursorRowIdentity(state.settings!)).toBe("model");
 });
 
 test("a delayed settings refresh cannot select below an open model picker", async () => {

--- a/tui/test/settings-subscription-default.test.ts
+++ b/tui/test/settings-subscription-default.test.ts
@@ -11,6 +11,10 @@ import type {
 } from "../../shared/settings-v2-types.js";
 import { selectSettingsRoute } from "../../shared/settings-route.js";
 import { setComposerText } from "../src/composer-model.js";
+import {
+  publishCurrentSettingsModelDiscovery,
+  settingsModelSelectionTargetIdentity
+} from "../src/settings-model-discovery.js";
 import { settingsDraftChanged } from "../src/settings-overlay-reconciliation.js";
 import { settingsRows } from "../src/settings-overlay-model.js";
 import { settingsProviderChoice } from "../src/settings-provider-choices.js";
@@ -136,6 +140,55 @@ test("a delayed settings refresh cannot select below an active inline edit", asy
 
   expect(settingsSubscriptionPreset(state.settings!)).toBe(null);
   expect(state.settings!.edit?.composer.text).toBe("typed-before-refresh");
+});
+
+test("a delayed settings refresh cannot select below an open model picker", async () => {
+  const { source, state, press } = harness();
+  source.settingsView = initialSettingsView({
+    chatgpt: "signed-out",
+    claude: "signed-out"
+  });
+  const entered = deferred<void>();
+  const gate = deferred<SettingsView>();
+  const models = Array.from({ length: 9 }, (_, index) => ({
+    remoteId: `model-${String(index + 1).padStart(2, "0")}`,
+    name: `Model ${String(index + 1).padStart(2, "0")}`,
+    contextWindow: 32_768,
+    maxOutputTokens: null,
+    source: "openai-models" as const
+  }));
+  source.api.getSettings = async () => {
+    entered.resolve();
+    return gate.promise;
+  };
+
+  const opening = openSettings(press);
+  await entered.promise;
+  const overlay = state.settings!;
+  publishCurrentSettingsModelDiscovery(overlay, {
+    observedAt: "2026-01-01T00:00:00.000Z",
+    models
+  });
+  overlay.modelDiscoveryTargetIdentity = JSON.stringify([
+    overlay.view.stateGeneration,
+    JSON.stringify([
+      overlay.draft.selectedProfileId,
+      settingsModelSelectionTargetIdentity(overlay)
+    ])
+  ]);
+  await selectRow(press, state, "model");
+  await press(key("return"));
+  expect(state.settings!.modelPicker).not.toBe(null);
+  const picker = state.settings!.modelPicker;
+
+  gate.resolve(initialSettingsView({
+    chatgpt: "signed-in",
+    claude: "signed-out"
+  }));
+  await opening;
+
+  expect(state.settings!.modelPicker).toEqual(picker);
+  expect(settingsProviderChoice(state.settings!.draft.generation).id).toBe("dry-run");
 });
 
 test("a pending activation keeps the pristine provider untouched", async () => {


### PR DESCRIPTION
Tracks #268
Tracks #270

## What changed

This change completes the subscription beta follow-up and prepares
`0.9.10-rc.2`.

- Fresh Settings selects one signed-in ChatGPT or Claude plan as an unsaved
  draft. The server must certify that the Settings state is its exact initial
  state. The selection does not run while the user edits or uses a nested
  Settings surface.
- Settings confirms a signed-in plan. A signed-out plan shows the correct
  terminal command.
- HTTP protocol 23 owns the new Settings response fields. Older clients fail
  during compatibility preflight.
- Managed upgrades accept a future nonempty `LICENSE` or `NOTICE` file. The
  release process continues to require the reviewed file digests and all other
  package checks.
- The changelog and generated release notes include all changes in
  `0.9.10-rc.2`.

## How it was verified

- `npm run build`
- `npm test`: 2,531 passed, 226 skipped, and 0 failed
- `cd tui && bun run typecheck`
- `cd tui && bun test --timeout 30000`: 2,057 passed, 2 skipped, and 0 failed
- `cd tui && bun run build:standalone`
- Briefed autoreview: clean
- Briefed thermo-nuclear maintainability review: clean
- Claude UI/UX review: clean

## Risks and limitations

- An old updater that pins an old legal-file digest still needs one fresh
  installation. This release prevents the same failure in later upgrades.
- Auto-selection changes only the Settings draft. The user must save it.
- The HTTP protocol change intentionally rejects older client and newer server
  combinations before Settings data is read.
