### PR TITLE
chore(release): prepare 0.9.10-rc.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ This file records notable changes to 1667. Product terms use the definitions in
 
 ## Unreleased
 
+## 0.9.10-rc.3 - 2026-08-19
+
+- **This beta has no additional product changes.** It contains the same
+  behavior as 0.9.10-rc.2.
+
 ## 0.9.10-rc.2 - 2026-08-19
 
 - **A slow generation Stop keeps 1667 open.** If the embedded backend needs

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "1667-workspace",
-  "version": "0.9.10-rc.2",
+  "version": "0.9.10-rc.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "1667-workspace",
-      "version": "0.9.10-rc.2",
+      "version": "0.9.10-rc.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@earendil-works/pi-ai": "0.84.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667-workspace",
-  "version": "0.9.10-rc.2",
+  "version": "0.9.10-rc.3",
   "private": true,
   "description": "Source workspace for the 1667 terminal writing environment",
   "license": "Apache-2.0",

--- a/shared/release-notes.ts
+++ b/shared/release-notes.ts
@@ -11,6 +11,11 @@ export interface ReleaseNote {
  *  a release, and is not included. */
 export const RELEASE_NOTES: readonly ReleaseNote[] = [
   {
+    version: "0.9.10-rc.3",
+    date: "2026-08-19",
+    body: "- **This beta has no additional product changes.** It contains the same\n  behavior as 0.9.10-rc.2."
+  },
+  {
     version: "0.9.10-rc.2",
     date: "2026-08-19",
     body: "- **A slow generation Stop keeps 1667 open.** If the embedded backend needs\n  more than 10 seconds to stop a generation, 1667 now checks the operation\n  status. It keeps the application open while the backend answers. It still\n  requires a restart if the backend stops answering.\n\n- **Fresh Settings can select a signed-in subscription plan.** When exactly\n  one plan is signed in, Settings selects that plan as an unsaved draft. Both\n  or neither signed-in plan keeps the current choice. Settings does not replace\n  a choice that the user saved.\n\n- **Managed upgrades accept updated legal notices.** An installed version no\n  longer compares a new package's `LICENSE` and `NOTICE` files with its own old\n  copies. The release process still requires the reviewed files. The updater\n  still checks the package contents, metadata, integrity, and source identity."

--- a/tui/package.json
+++ b/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667",
-  "version": "0.9.10-rc.2",
+  "version": "0.9.10-rc.3",
   "private": true,
   "description": "A terminal environment for writing fiction with language models",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Outcome

Prepare `0.9.10-rc.3` as another beta release.

There are no product changes after `0.9.10-rc.2`. This patch updates the root,
lockfile, and TUI versions. It also adds an explicit changelog entry and
regenerates the embedded release notes.

## Verification

- `npm run build`
- `npm test`
- `npm --prefix tui run typecheck`
- `npm --prefix tui test -- --timeout 30000`
- `npm --prefix tui run build:standalone`
- `npm run notes:check-version -- 0.9.10-rc.3`
- `git diff --check`
- Briefed autoreview: clean
- Briefed thermo-nuclear maintainability review: clean

## Risk

The patch changes release metadata only. The release workflow will rebuild and
verify all six npm packages from the tagged merge commit.

Tracks #268
Tracks #270
