### PR TITLE
fix(installer): bootstrap managed installs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,9 @@
 name: CI
 
 # Public repositories get unlimited standard-runner minutes, so the allowance
-# that ran out no longer applies. The 15-minute timeouts stay: the spend that
-# exhausted it was 61% wedged jobs riding a 30-35 minute limit, and nothing
-# healthy here takes longer than four minutes.
+# that ran out no longer applies. Timeouts still stop wedged jobs. The serial
+# gate needs 25 minutes for the runtime, TUI, standalone, and filesystem lanes.
+# Packaged-platform jobs keep the 15-minute limit.
 on:
   pull_request:
   push:
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   gate:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 25
     steps:
       - name: Check out source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/README.md
+++ b/README.md
@@ -59,6 +59,11 @@ created. The command shows download progress in a terminal. On Windows, exit
 1667 and run the PowerShell Installer again. The Installer shows download
 progress. `1667 upgrade` shows the required command.
 
+Run the Shell Installer again to update a valid Shell Managed Installation. It
+preserves the `installationId`, keeps the previous executable for rollback,
+and sets the selected Installer channel. It refuses an unmanaged executable or
+invalid installation state.
+
 `1667 upgrade --version <version>` selects an exact published release. The
 version can be older than the current version. Before a downgrade, 1667 warns
 that the downgrade can make the Vault unreadable or damage Vault data. Back up

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -41,7 +41,7 @@ This document uses these Technical Names:
 | platform package | A package that contains one native executable |
 | candidate | A possible release package that the workflow has not published |
 | Installer | A Shell Installer or a PowerShell Installer |
-| Shell Installer | A channel-specific release script that installs one native executable |
+| Shell Installer | A channel-specific release script that installs or updates one native executable |
 | PowerShell Installer | A Windows release script that installs one native executable |
 | Managed Installation | An installation that an Installer creates and registers |
 | Ownership Record | The durable file that grants 1667 authority to replace one executable |
@@ -536,8 +536,15 @@ The launcher job does not rebuild native executables. The `publish` job does
 not rebuild them either.
 
 A Managed Installation writes `.1667-install.json` next to the executable. Only
-a valid Ownership Record grants installation authority. npm, source, and copied
-installations stay read-only to `1667 upgrade`.
+a valid Ownership Record grants replacement authority to a Shell Installer or
+`1667 upgrade`. npm, source, and copied installations stay read-only to
+`1667 upgrade`.
+
+The Shell Installer can run again in the Install Root that it created. It
+updates only a valid Shell Managed Installation. It verifies the Ownership
+Record, preserves the `installationId`, retains the previous executable for
+rollback, and sets the selected Installer channel. It refuses an unmanaged
+executable, an invalid Ownership Record, or ambiguous transaction state.
 
 `1667 upgrade` downloads the Platform Package from the canonical npm registry.
 It shows download progress when standard error is a terminal. It writes no
@@ -625,7 +632,7 @@ The command does these checks:
 3. It verifies the up-to-date result from `1667 upgrade --check` and
    `1667 upgrade`.
 4. It executes the verified homepage bytes in the same prefix again. It
-   verifies that the script refuses the existing executable.
+   verifies that the script keeps the active bytes and the `installationId`.
 5. It executes `1667 upgrade --rollback` without a previous executable. It
    verifies the error result and the active executable.
 6. It downloads and verifies the previous installer script. It executes the
@@ -633,7 +640,9 @@ The command does these checks:
    Record.
 7. It copies the previous executable without the Ownership Record. It verifies
    that `1667 upgrade` does not replace the copy.
-8. It upgrades the previous Managed Installation. It verifies upgrade,
+8. It runs the current Shell Installer against the previous Managed
+   Installation. It verifies the current identity, the preserved
+   `installationId`, and the retained previous executable. It then verifies
    rollback, re-upgrade, no-op, and channel-change results. The beta channel can
    hold a release that is more recent than the stable channel. The command first
    asks the beta channel what it offers. It then verifies the applied result

--- a/scripts/release-install-script-body.ts
+++ b/scripts/release-install-script-body.ts
@@ -213,7 +213,7 @@ ${input.digestLines}
       validate_managed_file_safety "\$prefix/\$PREVIOUS_FILE" "rollback executable"
     fi
     CLEANUP_OWNS_STAGING=1
-    rm -f "\$prefix/\$PACKAGE_STAGING_FILE"
+    rm -f "\$prefix/\$PACKAGE_STAGING_FILE" 9>&-
     probe_managed_owned "\$executable" "managed active executable" "\$target"
     active_version=\$MANAGED_PROBE_VERSION
   else
@@ -232,7 +232,7 @@ ${input.digestLines}
   fi
 
   if [ "\$managed_install" -eq 1 ]; then
-    semver_order=\$(semver_compare "\$active_version" "\$PRODUCT_VERSION")
+    semver_order=\$(exec 9>&-; semver_compare "\$active_version" "\$PRODUCT_VERSION")
     if [ "\$semver_order" -gt 0 ]; then
       die "Installer will not downgrade 1667 from \$active_version to \$PRODUCT_VERSION. For an intentional downgrade, run '1667 upgrade --version \$PRODUCT_VERSION'."
     fi
@@ -276,21 +276,21 @@ ${input.digestLines}
     if [ -e "\$prefix/\$PREVIOUS_FILE" ] || [ -L "\$prefix/\$PREVIOUS_FILE" ]; then
       validate_managed_file_safety "\$prefix/\$PREVIOUS_FILE" "rollback executable"
     fi
-    rm -f "\$prefix/\$PREVIOUS_NEXT_FILE"
-    cp "\$executable" "\$prefix/\$PREVIOUS_NEXT_FILE" || die "Could not stage the previous executable"
-    chmod 0755 "\$prefix/\$PREVIOUS_NEXT_FILE"
+    rm -f "\$prefix/\$PREVIOUS_NEXT_FILE" 9>&-
+    cp "\$executable" "\$prefix/\$PREVIOUS_NEXT_FILE" 9>&- || die "Could not stage the previous executable"
+    chmod 0755 "\$prefix/\$PREVIOUS_NEXT_FILE" 9>&-
     if [ -L "\$prefix/\$PREVIOUS_NEXT_FILE" ] || [ ! -f "\$prefix/\$PREVIOUS_NEXT_FILE" ]; then
       die "Staged previous executable is invalid"
     fi
     fsync_path "\$prefix/\$PREVIOUS_NEXT_FILE"
     write_managed_txn "\$prefix" "candidate-ready" "upgrade" "\$INSTALL_CHANNEL" true \
       "\$active_version" "\$PRODUCT_VERSION" "\$OWNERSHIP_ID" "\$target"
-    mv "\$prefix/\$CANDIDATE_FILE" "\$executable"
-    chmod 0755 "\$executable"
+    mv "\$prefix/\$CANDIDATE_FILE" "\$executable" 9>&-
+    chmod 0755 "\$executable" 9>&-
     fsync_path "\$executable"
     write_managed_txn "\$prefix" "ownership-pending" "upgrade" "\$INSTALL_CHANNEL" true \
       "\$active_version" "\$PRODUCT_VERSION" "\$OWNERSHIP_ID" "\$target"
-    mv "\$prefix/\$PREVIOUS_NEXT_FILE" "\$prefix/\$PREVIOUS_FILE"
+    mv "\$prefix/\$PREVIOUS_NEXT_FILE" "\$prefix/\$PREVIOUS_FILE" 9>&-
     fsync_path "\$prefix/\$PREVIOUS_FILE"
     fsync_dir "\$prefix"
     write_ownership "\$prefix" "\$OWNERSHIP_ID" "\$executable" "\$target" "\$INSTALL_CHANNEL"

--- a/scripts/release-install-script-body.ts
+++ b/scripts/release-install-script-body.ts
@@ -318,11 +318,14 @@ ${input.digestLines}
       die "Staged previous executable is invalid"
     fi
     fsync_path "\$prefix/\$PREVIOUS_NEXT_FILE"
-    # The managed record replaces the pre-activation record from here on, and
-    # recovery needs it to survive an interrupted swap.
-    CLEANUP_CLEAR_TXN=0
     write_managed_txn "\$prefix" "candidate-ready" "upgrade" "\$INSTALL_CHANNEL" true \
       "\$active_version" "\$PRODUCT_VERSION" "\$OWNERSHIP_ID" "\$target"
+    # Release the pre-activation claim only after the managed record is on
+    # disk. write_managed_txn can die before it publishes, and the stale
+    # pre-activation record must still be cleared in that case. A die after it
+    # publishes leaves the claim set, which is safe: the candidate has not
+    # replaced the active executable yet, so clearing is self-healing.
+    CLEANUP_CLEAR_TXN=0
     mv "\$prefix/\$CANDIDATE_FILE" "\$executable" 9>&-
     chmod 0755 "\$executable" 9>&-
     fsync_path "\$executable"
@@ -373,6 +376,8 @@ usage() {
   printf 'Use this installer for a fresh Install Root or a valid Shell Managed Installation.\\n'
   printf 'Use 1667 upgrade for later updates when the installed executable runs.\\n'
   printf -- '--force accepts path ownership and write-permission risks.\\n'
+  printf -- 'This Installer runs the 1667 in the Install Root to read its version.\\n'
+  printf -- '--force also accepts that executable when it fails the safety checks.\\n'
   printf 'It waives no checksum, attestation, or version check.\\n'
 }
 

--- a/scripts/release-install-script-body.ts
+++ b/scripts/release-install-script-body.ts
@@ -1,6 +1,7 @@
 /**
  * POSIX Shell Installer body. Generated release assets embed pinned version,
- * channel, archive names, and digests. Fresh install only.
+ * channel, archive names, and digests. It also bootstraps valid managed Unix
+ * installs across release metadata changes.
  */
 import {
   INSTALL_CANDIDATE_FILE,
@@ -28,6 +29,7 @@ import {
   type ShellInstallerExtractLayout
 } from "./release-install-script-extract-lib.js";
 import { SHELL_INSTALLER_LOCK } from "./release-install-script-lock-lib.js";
+import { SHELL_INSTALLER_MANAGED } from "./release-install-script-managed-lib.js";
 import { SHELL_INSTALLER_PROBE } from "./release-install-script-probe-lib.js";
 import { SHELL_INSTALLER_HELPERS } from "./release-install-script-shell-lib.js";
 
@@ -64,6 +66,8 @@ MAX_TAR_BYTES=${SHELL_MAX_TAR_BYTES}
 MAX_EXECUTABLE_BYTES=${SHELL_MAX_EXECUTABLE_BYTES}
 # Cumulative bytes in all regular-file members.
 MAX_FILE_BYTES=${SHELL_MAX_FILE_BYTES}
+# Maximum bytes in a canonical Transaction Record before parsing.
+MAX_TRANSACTION_BYTES=16384
 # Portable curl deadlines: connect bound, then overall transfer bound.
 DOWNLOAD_CONNECT_TIMEOUT_SEC=${SHELL_DOWNLOAD_CONNECT_TIMEOUT_SEC}
 DOWNLOAD_MAX_TIME_SEC=${SHELL_DOWNLOAD_MAX_TIME_SEC}
@@ -84,12 +88,13 @@ PROBE_OUTPUT_FILE='.1667-probe-output'
 # 1 only after this process proves ownership of reserved staging (canonical
 # Transaction Record, or a verified clean fresh root that starts this install).
 CLEANUP_OWNS_STAGING=0
+MANAGED_FORCE=0
 
 main() {
   prefix=
   prefix_set=0
   dry_run=0
-  # --force waives the Install Root permission refusals only. It never waives a
+  # --force waives path ownership and other-writer refusals. It never waives a
   # checksum, an attestation, a release identity, or the version probe: those
   # decide whether the bytes are the release, which no local layout can answer.
   force=0
@@ -123,6 +128,7 @@ main() {
         ;;
     esac
   done
+  MANAGED_FORCE=\$force
 
   target=\$(detect_target) || exit 1
   case "\$target" in
@@ -187,23 +193,66 @@ ${input.digestLines}
     return 0
   fi
 
+  managed_install=0
+  active_version=
   if [ -e "\$executable" ] || [ -L "\$executable" ]; then
-    die "Refusing to replace an existing 1667 at \$executable. Run '1667 upgrade' instead."
+    if [ -L "\$executable" ] || [ ! -f "\$executable" ]; then
+      die "Refusing to replace an unmanaged 1667 at \$executable"
+    fi
+    validate_managed_ownership "\$prefix" "\$executable" "\$target"
+    managed_install=1
+    # A valid Ownership Record proves this root is a managed installation. The
+    # package staging file is the only residue that an older failed updater can
+    # leave without a Transaction Record; remove that exact file under the lock.
+    refuse_prior_managed_path "\$prefix/\$PREVIOUS_NEXT_FILE" "staged previous executable"
+    refuse_prior_managed_path "\$prefix/\$CANDIDATE_FILE" "candidate executable"
+    refuse_prior_managed_path "\$prefix/\$EXTRACT_STAGE" "extract staging"
+    refuse_prior_managed_path "\$prefix/\$PROBE_OUTPUT_FILE" "probe output"
+    refuse_prior_managed_path "\$prefix/\$archive" "Release Archive staging"
+    if [ -e "\$prefix/\$PREVIOUS_FILE" ] || [ -L "\$prefix/\$PREVIOUS_FILE" ]; then
+      validate_managed_file_safety "\$prefix/\$PREVIOUS_FILE" "rollback executable"
+    fi
+    CLEANUP_OWNS_STAGING=1
+    rm -f "\$prefix/\$PACKAGE_STAGING_FILE"
+    probe_managed_owned "\$executable" "managed active executable" "\$target"
+    active_version=\$MANAGED_PROBE_VERSION
+  else
+    # Fail closed on prior managed or reserved staging paths. Do not delete them.
+    # The persistent Install Root lock file is allowed to remain.
+    refuse_prior_managed_path "\$prefix/\$OWNERSHIP_FILE" "Ownership Record"
+    refuse_prior_managed_path "\$prefix/\$PREVIOUS_FILE" "previous executable"
+    refuse_prior_managed_path "\$prefix/\$PREVIOUS_NEXT_FILE" "staged previous executable"
+    refuse_prior_managed_path "\$prefix/\$CANDIDATE_FILE" "candidate executable"
+    refuse_prior_managed_path "\$prefix/\$EXTRACT_STAGE" "extract staging"
+    refuse_prior_managed_path "\$prefix/\$PROBE_OUTPUT_FILE" "probe output"
+    refuse_prior_managed_path "\$prefix/\$PACKAGE_STAGING_FILE" "package staging"
+    refuse_prior_managed_path "\$prefix/\$archive" "Release Archive staging"
+    # Clean root proven; this install now owns reserved staging for EXIT cleanup.
+    CLEANUP_OWNS_STAGING=1
   fi
 
-  # Fail closed on prior managed or reserved staging paths. Do not delete them.
-  # The persistent Install Root lock file is allowed to remain.
-  refuse_prior_managed_path "\$prefix/\$OWNERSHIP_FILE" "Ownership Record"
-  refuse_prior_managed_path "\$prefix/\$PREVIOUS_FILE" "previous executable"
-  refuse_prior_managed_path "\$prefix/\$PREVIOUS_NEXT_FILE" "staged previous executable"
-  refuse_prior_managed_path "\$prefix/\$CANDIDATE_FILE" "candidate executable"
-  refuse_prior_managed_path "\$prefix/\$EXTRACT_STAGE" "extract staging"
-  refuse_prior_managed_path "\$prefix/\$PROBE_OUTPUT_FILE" "probe output"
-  refuse_prior_managed_path "\$prefix/\$PACKAGE_STAGING_FILE" "package staging"
-  refuse_prior_managed_path "\$prefix/\$archive" "Release Archive staging"
+  if [ "\$managed_install" -eq 1 ]; then
+    semver_order=\$(semver_compare "\$active_version" "\$PRODUCT_VERSION")
+    if [ "\$semver_order" -gt 0 ]; then
+      die "Installer will not downgrade 1667 from \$active_version to \$PRODUCT_VERSION. For an intentional downgrade, run '1667 upgrade --version \$PRODUCT_VERSION'."
+    fi
+  fi
 
-  # Clean root proven; this install now owns reserved staging for EXIT cleanup.
-  CLEANUP_OWNS_STAGING=1
+  # A same-version bootstrap is a no-op for executable bytes. It still records
+  # the channel selected by this Installer and retains any rollback executable.
+  if [ "\$managed_install" -eq 1 ] && [ "\$active_version" = "\$PRODUCT_VERSION" ]; then
+    write_ownership "\$prefix" "\$OWNERSHIP_ID" "\$executable" "\$target" "\$INSTALL_CHANNEL"
+    trap - EXIT INT TERM
+    release_lock "\$prefix"
+    (
+      exec 9>&-
+      trap '' PIPE
+      printf '1667 %s (%s) is already installed at %s\\n' \
+        "\$PRODUCT_VERSION" "\$INSTALL_CHANNEL" "\$executable"
+    ) || :
+    return 0
+  fi
+
   url="\$ASSET_BASE/\$archive"
   write_txn "\$prefix" "downloading" "\$target" "\$digest"
   archive_path="\$prefix/\$archive"
@@ -221,18 +270,44 @@ ${input.digestLines}
   # Candidate bytes must be durable before candidate-ready is published.
   # Power loss after a durable txn must not leave a missing or corrupt candidate.
   fsync_path "\$prefix/\$CANDIDATE_FILE"
-  write_txn "\$prefix" "candidate-ready" "\$target" "\$digest"
-  mv "\$prefix/\$CANDIDATE_FILE" "\$executable"
-  chmod 0755 "\$executable"
-  fsync_path "\$executable"
-  # Close the gap: durable activated mark before ownership write.
-  write_txn "\$prefix" "activated" "\$target" "\$digest"
-  # random_hex_32 subshell inherits FD 9; close it so a hung id helper cannot pin.
-  installation_id=\$(
-    exec 9>&-
-    random_hex_32
-  )
-  write_ownership "\$prefix" "\$installation_id" "\$executable" "\$target"
+  if [ "\$managed_install" -eq 1 ]; then
+    # Stage the old active before publishing the managed transaction. The old
+    # active remains in place until the candidate rename commits.
+    if [ -e "\$prefix/\$PREVIOUS_FILE" ] || [ -L "\$prefix/\$PREVIOUS_FILE" ]; then
+      validate_managed_file_safety "\$prefix/\$PREVIOUS_FILE" "rollback executable"
+    fi
+    rm -f "\$prefix/\$PREVIOUS_NEXT_FILE"
+    cp "\$executable" "\$prefix/\$PREVIOUS_NEXT_FILE" || die "Could not stage the previous executable"
+    chmod 0755 "\$prefix/\$PREVIOUS_NEXT_FILE"
+    if [ -L "\$prefix/\$PREVIOUS_NEXT_FILE" ] || [ ! -f "\$prefix/\$PREVIOUS_NEXT_FILE" ]; then
+      die "Staged previous executable is invalid"
+    fi
+    fsync_path "\$prefix/\$PREVIOUS_NEXT_FILE"
+    write_managed_txn "\$prefix" "candidate-ready" "upgrade" "\$INSTALL_CHANNEL" true \
+      "\$active_version" "\$PRODUCT_VERSION" "\$OWNERSHIP_ID" "\$target"
+    mv "\$prefix/\$CANDIDATE_FILE" "\$executable"
+    chmod 0755 "\$executable"
+    fsync_path "\$executable"
+    write_managed_txn "\$prefix" "ownership-pending" "upgrade" "\$INSTALL_CHANNEL" true \
+      "\$active_version" "\$PRODUCT_VERSION" "\$OWNERSHIP_ID" "\$target"
+    mv "\$prefix/\$PREVIOUS_NEXT_FILE" "\$prefix/\$PREVIOUS_FILE"
+    fsync_path "\$prefix/\$PREVIOUS_FILE"
+    fsync_dir "\$prefix"
+    write_ownership "\$prefix" "\$OWNERSHIP_ID" "\$executable" "\$target" "\$INSTALL_CHANNEL"
+  else
+    write_txn "\$prefix" "candidate-ready" "\$target" "\$digest"
+    mv "\$prefix/\$CANDIDATE_FILE" "\$executable"
+    chmod 0755 "\$executable"
+    fsync_path "\$executable"
+    # Close the gap: durable activated mark before ownership write.
+    write_txn "\$prefix" "activated" "\$target" "\$digest"
+    # random_hex_32 subshell inherits FD 9; close it so a hung id helper cannot pin.
+    installation_id=\$(
+      exec 9>&-
+      random_hex_32
+    )
+    write_ownership "\$prefix" "\$installation_id" "\$executable" "\$target"
+  fi
   # Ownership is already fsynced inside write_ownership; clear txn only after that.
   clear_txn "\$prefix"
   trap - EXIT INT TERM
@@ -257,8 +332,9 @@ ${input.digestLines}
 usage() {
   printf 'Usage: install-%s.sh [--prefix /absolute/path] [--dry-run] [--force]\\n' "\$INSTALL_CHANNEL"
   printf 'Installs 1667 %s from the pinned GitHub release archive.\\n' "\$PRODUCT_VERSION"
-  printf 'This installer is for a fresh Install Root only. Use 1667 upgrade later.\\n'
-  printf -- '--force installs into an Install Root that another account can write.\\n'
+  printf 'Use this installer for a fresh Install Root or a valid Shell Managed Installation.\\n'
+  printf 'Use 1667 upgrade for later updates when the installed executable runs.\\n'
+  printf -- '--force accepts path ownership and write-permission risks.\\n'
   printf 'It waives no checksum, attestation, or version check.\\n'
 }
 
@@ -367,6 +443,7 @@ refuse_prior_managed_path() {
 ${SHELL_INSTALLER_DURABLE}
 ${SHELL_INSTALLER_LOCK}
 ${SHELL_INSTALLER_HELPERS}
+${SHELL_INSTALLER_MANAGED}
 ${extract}
 ${SHELL_INSTALLER_PROBE}
 main "\$@"

--- a/scripts/release-install-script-body.ts
+++ b/scripts/release-install-script-body.ts
@@ -278,7 +278,7 @@ ${input.digestLines}
   url="\$ASSET_BASE/\$archive"
   write_txn "\$prefix" "downloading" "\$target" "\$digest"
   archive_path="\$prefix/\$archive"
-  rm -f "\$archive_path"
+  rm -f "\$archive_path" 9>&-
   say "Downloading 1667 \$PRODUCT_VERSION for \$target"
   download_archive "\$url" "\$archive_path"
   say "Checking the download"
@@ -286,7 +286,7 @@ ${input.digestLines}
   write_txn "\$prefix" "extracted" "\$target" "\$digest"
   say "Unpacking"
   extract_candidate "\$prefix" "\$archive_path" "\$archive"
-  rm -f "\$archive_path"
+  rm -f "\$archive_path" 9>&-
   say "Starting 1667 once to confirm it runs"
   probe_candidate "\$prefix/\$CANDIDATE_FILE" "\$target"
   # Candidate bytes must be durable before candidate-ready is published.
@@ -318,8 +318,8 @@ ${input.digestLines}
     write_ownership "\$prefix" "\$OWNERSHIP_ID" "\$executable" "\$target" "\$INSTALL_CHANNEL"
   else
     write_txn "\$prefix" "candidate-ready" "\$target" "\$digest"
-    mv "\$prefix/\$CANDIDATE_FILE" "\$executable"
-    chmod 0755 "\$executable"
+    mv "\$prefix/\$CANDIDATE_FILE" "\$executable" 9>&-
+    chmod 0755 "\$executable" 9>&-
     fsync_path "\$executable"
     # Close the gap: durable activated mark before ownership write.
     write_txn "\$prefix" "activated" "\$target" "\$digest"
@@ -369,7 +369,7 @@ cleanup_install() {
     # Remove staging while this process still holds the lock, then release.
     # Releasing first lets a successor publish staging that this cleanup would delete.
     rm -f "\$root/\$CANDIDATE_FILE" "\$root/\$PROBE_OUTPUT_FILE" \
-      "\$root/\$archive" "\$root/\$PACKAGE_STAGING_FILE" 2>/dev/null || true
+      "\$root/\$archive" "\$root/\$PACKAGE_STAGING_FILE" 9>&- 2>/dev/null || true
     remove_extract_stage "\$root"
   fi
   release_lock "\$root"
@@ -398,7 +398,7 @@ stop_probe() {
   fi
   if [ -n "\${PROBE_PID:-}" ]; then
     kill "\$PROBE_PID" 2>/dev/null || true
-    sleep 1
+    sleep 1 9>&-
     kill -9 "\$PROBE_PID" 2>/dev/null || true
     set +e
     wait "\$PROBE_PID" 2>/dev/null

--- a/scripts/release-install-script-body.ts
+++ b/scripts/release-install-script-body.ts
@@ -209,11 +209,25 @@ ${input.digestLines}
     fi
     validate_managed_ownership "\$prefix" "\$executable" "\$target"
     managed_install=1
-    # A valid Ownership Record proves this root is a managed installation. The
-    # package staging file is the only residue that an older failed updater can
-    # leave without a Transaction Record; remove that exact file under the lock.
-    refuse_prior_managed_path "\$prefix/\$PREVIOUS_NEXT_FILE" "staged previous executable"
-    refuse_prior_managed_path "\$prefix/\$CANDIDATE_FILE" "candidate executable"
+    # A valid Ownership Record proves this root is a managed installation. With
+    # no Transaction Record, remove only the exact residue paths shared with
+    # managed recovery. Validate each path before granting removal authority.
+    if [ "\$RECOVER_STATUS" = none ]; then
+      managed_residue=
+      for managed_residue in \
+        "\$prefix/\$CANDIDATE_FILE" \
+        "\$prefix/\$PACKAGE_STAGING_FILE" \
+        "\$prefix/\$PREVIOUS_NEXT_FILE"; do
+        if [ -e "\$managed_residue" ] || [ -L "\$managed_residue" ]; then
+          validate_managed_file_safety "\$managed_residue" "managed staging"
+          rm -f "\$managed_residue" 9>&-
+        fi
+      done
+    else
+      refuse_prior_managed_path "\$prefix/\$PREVIOUS_NEXT_FILE" "staged previous executable"
+      refuse_prior_managed_path "\$prefix/\$CANDIDATE_FILE" "candidate executable"
+      rm -f "\$prefix/\$PACKAGE_STAGING_FILE" 9>&-
+    fi
     refuse_prior_managed_path "\$prefix/\$EXTRACT_STAGE" "extract staging"
     refuse_prior_managed_path "\$prefix/\$PROBE_OUTPUT_FILE" "probe output"
     refuse_prior_managed_path "\$prefix/\$archive" "Release Archive staging"
@@ -221,7 +235,6 @@ ${input.digestLines}
       validate_managed_file_safety "\$prefix/\$PREVIOUS_FILE" "rollback executable"
     fi
     CLEANUP_OWNS_STAGING=1
-    rm -f "\$prefix/\$PACKAGE_STAGING_FILE" 9>&-
     probe_managed_owned "\$executable" "managed active executable" "\$target"
     active_version=\$MANAGED_PROBE_VERSION
   else

--- a/scripts/release-install-script-body.ts
+++ b/scripts/release-install-script-body.ts
@@ -217,7 +217,8 @@ ${input.digestLines}
       for managed_residue in \
         "\$prefix/\$CANDIDATE_FILE" \
         "\$prefix/\$PACKAGE_STAGING_FILE" \
-        "\$prefix/\$PREVIOUS_NEXT_FILE"; do
+        "\$prefix/\$PREVIOUS_NEXT_FILE" \
+        "\$prefix/\$PROBE_OUTPUT_FILE"; do
         if [ -e "\$managed_residue" ] || [ -L "\$managed_residue" ]; then
           validate_managed_file_safety "\$managed_residue" "managed staging"
           rm -f "\$managed_residue" 9>&-
@@ -226,10 +227,10 @@ ${input.digestLines}
     else
       refuse_prior_managed_path "\$prefix/\$PREVIOUS_NEXT_FILE" "staged previous executable"
       refuse_prior_managed_path "\$prefix/\$CANDIDATE_FILE" "candidate executable"
+      refuse_prior_managed_path "\$prefix/\$PROBE_OUTPUT_FILE" "probe output"
       rm -f "\$prefix/\$PACKAGE_STAGING_FILE" 9>&-
     fi
     refuse_prior_managed_path "\$prefix/\$EXTRACT_STAGE" "extract staging"
-    refuse_prior_managed_path "\$prefix/\$PROBE_OUTPUT_FILE" "probe output"
     refuse_prior_managed_path "\$prefix/\$archive" "Release Archive staging"
     if [ -e "\$prefix/\$PREVIOUS_FILE" ] || [ -L "\$prefix/\$PREVIOUS_FILE" ]; then
       validate_managed_file_safety "\$prefix/\$PREVIOUS_FILE" "rollback executable"

--- a/scripts/release-install-script-body.ts
+++ b/scripts/release-install-script-body.ts
@@ -181,17 +181,25 @@ ${input.digestLines}
   # Run recovery in this shell so PROBE_PID is visible to INT/TERM traps.
   RECOVER_STATUS=
   recover_install "\$prefix" "\$executable" "\$target" "\$digest" "\$archive" || exit 1
-  if [ "\$RECOVER_STATUS" = completed ]; then
-    trap - EXIT INT TERM
-    release_lock "\$prefix"
-    (
-      exec 9>&-
-      trap '' PIPE
-      printf 'Recovered 1667 %s (%s) for %s at %s\\n' \\
-        "\$PRODUCT_VERSION" "\$INSTALL_CHANNEL" "\$target" "\$executable"
-    ) || :
-    return 0
-  fi
+  case "\$RECOVER_STATUS" in
+    completed)
+      trap - EXIT INT TERM
+      release_lock "\$prefix"
+      (
+        exec 9>&-
+        trap '' PIPE
+        printf 'Recovered 1667 %s (%s) for %s at %s\\n' \\
+          "\$PRODUCT_VERSION" "\$INSTALL_CHANNEL" "\$target" "\$executable"
+      ) || :
+      return 0
+      ;;
+    none|reset|managed-reset|managed-completed)
+      # These statuses intentionally continue into the normal bootstrap path.
+      ;;
+    *)
+      die "Unsupported recovery status: \$RECOVER_STATUS"
+      ;;
+  esac
 
   managed_install=0
   active_version=

--- a/scripts/release-install-script-body.ts
+++ b/scripts/release-install-script-body.ts
@@ -88,6 +88,12 @@ PROBE_OUTPUT_FILE='.1667-probe-output'
 # 1 only after this process proves ownership of reserved staging (canonical
 # Transaction Record, or a verified clean fresh root that starts this install).
 CLEANUP_OWNS_STAGING=0
+# 1 only while this process owns a pre-activation Shell Installer Transaction
+# Record it wrote into a Managed Installation. The in-binary updater accepts a
+# Shell Installer record only in the 'activated' phase, so an interrupted
+# managed bootstrap must not leave one behind. A managed Transaction Record is
+# never cleared here: recovery needs it to finish or abort a half-applied swap.
+CLEANUP_CLEAR_TXN=0
 MANAGED_FORCE=0
 
 main() {
@@ -172,6 +178,7 @@ ${input.digestLines}
   # CLEANUP_OWNS_STAGING stays 0 until recovery validates a txn or the fresh path
   # verifies a clean root and begins this install.
   CLEANUP_OWNS_STAGING=0
+  CLEANUP_CLEAR_TXN=0
   acquire_lock "\$prefix"
   # EXIT cleans once. INT/TERM clear traps, clean once, then exit 128+signal.
   trap 'cleanup_install "\$prefix" "\$archive"' EXIT
@@ -276,6 +283,12 @@ ${input.digestLines}
   fi
 
   url="\$ASSET_BASE/\$archive"
+  # A managed bootstrap writes these pre-activation records into a root that
+  # already holds a valid Ownership Record and a working active executable.
+  # Own them so an interrupted bootstrap cannot strand '1667 upgrade'.
+  if [ "\$managed_install" -eq 1 ]; then
+    CLEANUP_CLEAR_TXN=1
+  fi
   write_txn "\$prefix" "downloading" "\$target" "\$digest"
   archive_path="\$prefix/\$archive"
   rm -f "\$archive_path" 9>&-
@@ -305,6 +318,9 @@ ${input.digestLines}
       die "Staged previous executable is invalid"
     fi
     fsync_path "\$prefix/\$PREVIOUS_NEXT_FILE"
+    # The managed record replaces the pre-activation record from here on, and
+    # recovery needs it to survive an interrupted swap.
+    CLEANUP_CLEAR_TXN=0
     write_managed_txn "\$prefix" "candidate-ready" "upgrade" "\$INSTALL_CHANNEL" true \
       "\$active_version" "\$PRODUCT_VERSION" "\$OWNERSHIP_ID" "\$target"
     mv "\$prefix/\$CANDIDATE_FILE" "\$executable" 9>&-
@@ -371,6 +387,12 @@ cleanup_install() {
     rm -f "\$root/\$CANDIDATE_FILE" "\$root/\$PROBE_OUTPUT_FILE" \
       "\$root/\$archive" "\$root/\$PACKAGE_STAGING_FILE" 9>&- 2>/dev/null || true
     remove_extract_stage "\$root"
+  fi
+  # Drop a pre-activation Shell Installer record this process wrote into a
+  # Managed Installation. Do it under the lock, before the lock is released.
+  if [ "\${CLEANUP_CLEAR_TXN:-0}" -eq 1 ]; then
+    clear_txn "\$root"
+    CLEANUP_CLEAR_TXN=0
   fi
   release_lock "\$root"
 }

--- a/scripts/release-install-script-extract-lib.ts
+++ b/scripts/release-install-script-extract-lib.ts
@@ -81,7 +81,7 @@ decompress_archive_bounded() {
   max_blocks=\$((MAX_TAR_BYTES / 512))
   # Private status file next to the private tar (same extract stage).
   gzip_status_path="\${tar_path}.gzip-status"
-  rm -f "\$tar_path" "\$gzip_status_path"
+  rm -f "\$tar_path" "\$gzip_status_path" 9>&-
   # Capture gzip exit in the status file (POSIX sh has no pipefail). dd
   # iflag=fullblock makes count mean complete 512-byte blocks on GNU dd and
   # macOS BSD dd. Close FD 9 in the subshell and on gzip.
@@ -111,7 +111,7 @@ decompress_archive_bounded() {
       cat "\$gzip_status_path"
     fi
   )
-  rm -f "\$gzip_status_path"
+  rm -f "\$gzip_status_path" 9>&-
   # At or below the bound require gzip status 0 so a bad CRC cannot pass.
   if [ -z "\$gzip_status" ] || [ "\$gzip_status" -ne 0 ]; then
     die "Archive decompression failed"
@@ -210,7 +210,7 @@ validate_ustar_physical() {
   fi
   hdr="\$stage/.ustar-hdr"
   zero="\$stage/.ustar-zero"
-  rm -f "\$hdr" "\$zero"
+  rm -f "\$hdr" "\$zero" 9>&-
   (
     exec 9>&-
     dd if=/dev/zero of="\$zero" bs=512 count=1 2>/dev/null
@@ -317,7 +317,7 @@ ${memberAssignLines}
   if [ -z "\$exesize" ] || [ "\$seen" -ne "\$expected_mask" ]; then
     die "Archive layout is not the exact pinned Release Archive layout"
   fi
-  rm -f "\$hdr" "\$zero"
+  rm -f "\$hdr" "\$zero" 9>&-
 }
 
 # Extract only the pinned 1667 executable into private reserved staging.
@@ -333,7 +333,7 @@ extract_candidate() {
   # One exact reserved staging path, protected by the Install Root lock.
   stage="\$root/\$EXTRACT_STAGE"
   remove_extract_stage "\$root"
-  mkdir -m 0700 "\$stage"
+  mkdir -m 0700 "\$stage" 9>&-
   tar_path="\$stage/archive.tar"
   decompress_archive_bounded "\$archive_path" "\$tar_path"
   validate_ustar_physical "\$tar_path" "\$stem" "\$stage"
@@ -354,10 +354,10 @@ extract_candidate() {
   if [ "\$size" -le 0 ] || [ "\$size" -gt "\$MAX_EXECUTABLE_BYTES" ]; then
     die "Release executable size is outside the bound"
   fi
-  rm -f "\$root/\$CANDIDATE_FILE"
-  mv "\$candidate" "\$root/\$CANDIDATE_FILE"
+  rm -f "\$root/\$CANDIDATE_FILE" 9>&-
+  mv "\$candidate" "\$root/\$CANDIDATE_FILE" 9>&-
   # Installer-chosen mode; do not preserve archive modes.
-  chmod 0755 "\$root/\$CANDIDATE_FILE"
+  chmod 0755 "\$root/\$CANDIDATE_FILE" 9>&-
   remove_extract_stage "\$root"
 }
 

--- a/scripts/release-install-script-managed-lib.ts
+++ b/scripts/release-install-script-managed-lib.ts
@@ -26,20 +26,20 @@ validate_managed_file_safety() {
     die "\$label must be a regular non-symbolic-link file"
   fi
   forced=\${MANAGED_FORCE:-0}
-  owner=\$(owner_uid "\$file") || die "Could not inspect \$label ownership"
-  me=\$(id -u)
+  owner=\$(exec 9>&-; owner_uid "\$file") || die "Could not inspect \$label ownership"
+  me=\$(exec 9>&-; id -u)
   if [ "\$owner" != "\$me" ]; then
-    refuse_root "\$forced" "\$label belongs to user \$owner, and you are \$(id -un). 1667 replaces files there during an upgrade, which it cannot do as another user."
+    refuse_root "\$forced" "\$label belongs to user \$owner, and you are \$(exec 9>&-; id -un). 1667 replaces files there during an upgrade, which it cannot do as another user."
     if [ "\$forced" -eq 1 ]; then return 0; fi
   fi
-  mode=\$(file_mode "\$file") || die "Could not inspect \$label permissions"
-  if [ \$(( \$(printf '%d' "0\$mode") & 2 )) -ne 0 ]; then
+  mode=\$(exec 9>&-; file_mode "\$file") || die "Could not inspect \$label permissions"
+  if [ \$(( \$(exec 9>&-; printf '%d' "0\$mode") & 2 )) -ne 0 ]; then
     refuse_root "\$forced" "\$label is writable by every account on this machine (mode \$mode). Any of them could replace what 1667 installs there."
     if [ "\$forced" -eq 1 ]; then return 0; fi
   fi
-  if [ \$(( \$(printf '%d' "0\$mode") & 16 )) -ne 0 ]; then
-    gid=\$(file_gid "\$file") || die "Could not inspect \$label group"
-    if group_other_members "\$gid" "\$(id -un)"; then
+  if [ \$(( \$(exec 9>&-; printf '%d' "0\$mode") & 16 )) -ne 0 ]; then
+    gid=\$(exec 9>&-; file_gid "\$file") || die "Could not inspect \$label group"
+    if group_other_members "\$gid" "\$(exec 9>&-; id -un)"; then
       if [ -n "\$GROUP_OTHERS" ]; then
         refuse_root "\$forced" "\$label is writable by group \${GROUP_NAME:-\$gid} (mode \$mode), which also holds \$GROUP_OTHERS."
         if [ "\$forced" -eq 1 ]; then return 0; fi
@@ -191,34 +191,34 @@ validate_managed_ownership() {
     die "Refusing to replace an existing 1667: Ownership Record is missing (unmanaged installation)"
   fi
   validate_managed_file_safety "\$file" "Ownership Record"
-  mode=\$(file_mode "\$file") || return 1
+  mode=\$(exec 9>&-; file_mode "\$file") || return 1
   [ "\$mode" = 600 ] || die "Ownership Record must have mode 600"
   size=\$(exec 9>&-; wc -c < "\$file" | tr -d ' ')
   [ -n "\$size" ] && [ "\$size" -le 16384 ] || die "Ownership Record is too large"
   text=\$(exec 9>&-; cat "\$file") || die "Could not read Ownership Record"
-  id=\$(managed_json_string_field "\$text" installationId)
-  method=\$(managed_json_string_field "\$text" method)
-  channel=\$(managed_json_string_field "\$text" channel)
-  id_length=\$(printf '%s' "\$id" | wc -c | tr -d ' ')
+  id=\$(exec 9>&-; managed_json_string_field "\$text" installationId)
+  method=\$(exec 9>&-; managed_json_string_field "\$text" method)
+  channel=\$(exec 9>&-; managed_json_string_field "\$text" channel)
+  id_length=\$(exec 9>&-; printf '%s' "\$id" | wc -c | tr -d ' ')
   [ "\$id_length" -eq 32 ] || die "Ownership Record installation id is invalid"
   case "\$id" in *[!0-9a-f]*) die "Ownership Record installation id is invalid" ;; esac
   case "\$channel" in stable|beta) ;; *) die "Ownership Record channel is invalid" ;; esac
   [ "\$method" = shell ] || die "Ownership Record method is invalid"
   expected="\$root/.1667-ownership-validate.\$\$"
-  rm -f "\$expected"
-  if canonical_ownership_bytes "\$id" "\$executable" "\$target" "\$root" "\$channel" > "\$expected" && cmp -s "\$file" "\$expected"; then
-    rm -f "\$expected"
+  rm -f "\$expected" 9>&-
+  if canonical_ownership_bytes "\$id" "\$executable" "\$target" "\$root" "\$channel" > "\$expected" && cmp -s "\$file" "\$expected" 9>&-; then
+    rm -f "\$expected" 9>&-
     OWNERSHIP_ID=\$id
     OWNERSHIP_CHANNEL=\$channel
     return 0
   fi
-  if canonical_ownership_compact_bytes "\$id" "\$executable" "\$target" "\$root" "\$channel" > "\$expected" && cmp -s "\$file" "\$expected"; then
-    rm -f "\$expected"
+  if canonical_ownership_compact_bytes "\$id" "\$executable" "\$target" "\$root" "\$channel" > "\$expected" && cmp -s "\$file" "\$expected" 9>&-; then
+    rm -f "\$expected" 9>&-
     OWNERSHIP_ID=\$id
     OWNERSHIP_CHANNEL=\$channel
     return 0
   fi
-  rm -f "\$expected"
+  rm -f "\$expected" 9>&-
   die "Ownership Record is not a canonical managed record"
 }
 
@@ -256,7 +256,7 @@ write_managed_txn() {
   installation_id=\$8
   target=\$9
   tmp="\$root/.1667-managed-txn.\$\$.tmp"
-  rm -f "\$tmp"
+  rm -f "\$tmp" 9>&-
   umask 077
   if ! (
     exec 9>&-
@@ -267,8 +267,10 @@ write_managed_txn() {
   ); then
     die "Could not create a managed Transaction Record"
   fi
-  mv "\$tmp" "\$root/\$TXN_FILE"
+  fsync_path "\$tmp"
+  mv "\$tmp" "\$root/\$TXN_FILE" 9>&-
   fsync_path "\$root/\$TXN_FILE"
+  fsync_dir "\$root"
 }
 
 validate_managed_txn() {
@@ -276,14 +278,14 @@ validate_managed_txn() {
   target=\$2
   root=\$3
   text=\$(exec 9>&-; cat "\$file") || die "Could not read managed Transaction Record"
-  kind=\$(managed_json_string_field "\$text" kind)
-  phase=\$(managed_json_string_field "\$text" phase)
-  operation=\$(managed_json_string_field "\$text" operation)
-  channel=\$(managed_json_string_field "\$text" channel)
-  update_channel=\$(json_bool_field "\$text" updateChannel)
-  active_version=\$(managed_json_string_field "\$text" activeVersion)
-  candidate_version=\$(managed_json_string_field "\$text" candidateVersion)
-  installation_id=\$(managed_json_string_field "\$text" installationId)
+  kind=\$(exec 9>&-; managed_json_string_field "\$text" kind)
+  phase=\$(exec 9>&-; managed_json_string_field "\$text" phase)
+  operation=\$(exec 9>&-; managed_json_string_field "\$text" operation)
+  channel=\$(exec 9>&-; managed_json_string_field "\$text" channel)
+  update_channel=\$(exec 9>&-; json_bool_field "\$text" updateChannel)
+  active_version=\$(exec 9>&-; managed_json_string_field "\$text" activeVersion)
+  candidate_version=\$(exec 9>&-; managed_json_string_field "\$text" candidateVersion)
+  installation_id=\$(exec 9>&-; managed_json_string_field "\$text" installationId)
   [ "\$kind" = managed ] || die "Install transaction kind is unsupported"
   case "\$phase" in candidate-ready|ownership-pending) ;; *) die "Managed transaction phase is invalid" ;; esac
   case "\$operation" in upgrade|rollback) ;; *) die "Managed transaction operation is invalid" ;; esac
@@ -292,13 +294,13 @@ validate_managed_txn() {
   if ! semver_valid "\$active_version" || ! semver_valid "\$candidate_version"; then
     die "Managed transaction versions are invalid"
   fi
-  id_length=\$(printf '%s' "\$installation_id" | wc -c | tr -d ' ')
+  id_length=\$(exec 9>&-; printf '%s' "\$installation_id" | wc -c | tr -d ' ')
   [ "\$id_length" -eq 32 ] || die "Managed transaction installation id is invalid"
   case "\$installation_id" in *[!0-9a-f]*) die "Managed transaction installation id is invalid" ;; esac
   expected="\$file.validate.\$\$"
-  rm -f "\$expected"
-  if canonical_managed_txn_bytes "\$phase" "\$operation" "\$channel" "\$update_channel" "\$active_version" "\$candidate_version" "\$installation_id" "\$root" "\$target" > "\$expected" && cmp -s "\$file" "\$expected"; then
-    rm -f "\$expected"
+  rm -f "\$expected" 9>&-
+  if canonical_managed_txn_bytes "\$phase" "\$operation" "\$channel" "\$update_channel" "\$active_version" "\$candidate_version" "\$installation_id" "\$root" "\$target" > "\$expected" && cmp -s "\$file" "\$expected" 9>&-; then
+    rm -f "\$expected" 9>&-
     MANAGED_PHASE=\$phase
     MANAGED_OPERATION=\$operation
     MANAGED_CHANNEL=\$channel
@@ -308,7 +310,7 @@ validate_managed_txn() {
     MANAGED_INSTALLATION_ID=\$installation_id
     return 0
   fi
-  rm -f "\$expected"
+  rm -f "\$expected" 9>&-
   die "Install transaction is not a canonical managed record"
 }
 
@@ -326,7 +328,7 @@ finish_managed_recovery() {
     if [ -e "\$root/\$PREVIOUS_FILE" ] || [ -L "\$root/\$PREVIOUS_FILE" ]; then
       validate_managed_file_safety "\$root/\$PREVIOUS_FILE" "rollback executable"
     fi
-    mv "\$root/\$PREVIOUS_NEXT_FILE" "\$root/\$PREVIOUS_FILE"
+    mv "\$root/\$PREVIOUS_NEXT_FILE" "\$root/\$PREVIOUS_FILE" 9>&-
     fsync_path "\$root/\$PREVIOUS_FILE"
     fsync_dir "\$root"
   elif [ -e "\$root/\$PREVIOUS_FILE" ]; then
@@ -345,7 +347,7 @@ finish_managed_recovery() {
     recovery_channel=\$OWNERSHIP_CHANNEL
   fi
   write_ownership "\$root" "\$MANAGED_INSTALLATION_ID" "\$executable" "\$target" "\$recovery_channel"
-  rm -f "\$root/\$CANDIDATE_FILE" "\$root/\$PACKAGE_STAGING_FILE"
+  rm -f "\$root/\$CANDIDATE_FILE" "\$root/\$PACKAGE_STAGING_FILE" 9>&-
   remove_extract_stage "\$root"
   clear_txn "\$root"
   RECOVER_STATUS=managed-completed
@@ -364,8 +366,7 @@ recover_managed_install() {
         probe_managed_owned "\$executable" "managed active executable" "\$target"
         active_version=\$MANAGED_PROBE_VERSION
         if [ "\$active_version" = "\$MANAGED_ACTIVE_VERSION" ]; then
-          rm -f "\$root/\$CANDIDATE_FILE" "\$root/\$PREVIOUS_NEXT_FILE" \
-            "\$root/\$PACKAGE_STAGING_FILE"
+          rm -f "\$root/\$CANDIDATE_FILE" "\$root/\$PREVIOUS_NEXT_FILE" "\$root/\$PACKAGE_STAGING_FILE" 9>&-
           remove_extract_stage "\$root"
           clear_txn "\$root"
           RECOVER_STATUS=managed-reset

--- a/scripts/release-install-script-managed-lib.ts
+++ b/scripts/release-install-script-managed-lib.ts
@@ -358,6 +358,10 @@ recover_managed_install() {
   target=\$3
   validate_managed_ownership "\$root" "\$executable" "\$target"
   [ "\$OWNERSHIP_ID" = "\$MANAGED_INSTALLATION_ID" ] || die "Managed transaction installation id does not match Ownership Record"
+  if [ -e "\$root/\$PROBE_OUTPUT_FILE" ] || [ -L "\$root/\$PROBE_OUTPUT_FILE" ]; then
+    validate_managed_file_safety "\$root/\$PROBE_OUTPUT_FILE" "probe output"
+    rm -f "\$root/\$PROBE_OUTPUT_FILE" 9>&-
+  fi
   CLEANUP_OWNS_STAGING=1
   case "\$MANAGED_PHASE" in
     candidate-ready)

--- a/scripts/release-install-script-managed-lib.ts
+++ b/scripts/release-install-script-managed-lib.ts
@@ -1,0 +1,392 @@
+/** Managed-install bootstrap and recovery embedded in the Shell Installer. */
+export const SHELL_INSTALLER_MANAGED = `
+canonical_ownership_compact_bytes() {
+  id=\$1
+  exe=\$2
+  target=\$3
+  root=\$4
+  channel=\$5
+  printf '%s\\n' "{\\"schemaVersion\\":1,\\"product\\":\\"1667\\",\\"installationId\\":\\"\$id\\",\\"method\\":\\"shell\\",\\"channel\\":\\"\$channel\\",\\"installRoot\\":\\"\$root\\",\\"executable\\":\\"\$exe\\",\\"artifactTarget\\":\\"\$target\\"}"
+}
+
+# Extract a bounded JSON string without splitting on commas. Paths may contain
+# commas, and the complete canonical-byte comparison below remains authoritative.
+managed_json_string_field() {
+  text=\$1
+  key=\$2
+  printf '%s\\n' "\$text" \
+    | sed -n "s/.*\\\"\$key\\\"[[:space:]]*:[[:space:]]*\\\"\\([^\\\"]*\\)\\\".*/\\1/p" \
+    | head -n 1
+}
+
+validate_managed_file_safety() {
+  file=\$1
+  label=\$2
+  if [ -L "\$file" ] || [ ! -f "\$file" ]; then
+    die "\$label must be a regular non-symbolic-link file"
+  fi
+  forced=\${MANAGED_FORCE:-0}
+  owner=\$(owner_uid "\$file") || die "Could not inspect \$label ownership"
+  me=\$(id -u)
+  if [ "\$owner" != "\$me" ]; then
+    refuse_root "\$forced" "\$label belongs to user \$owner, and you are \$(id -un). 1667 replaces files there during an upgrade, which it cannot do as another user."
+    if [ "\$forced" -eq 1 ]; then return 0; fi
+  fi
+  mode=\$(file_mode "\$file") || die "Could not inspect \$label permissions"
+  if [ \$(( \$(printf '%d' "0\$mode") & 2 )) -ne 0 ]; then
+    refuse_root "\$forced" "\$label is writable by every account on this machine (mode \$mode). Any of them could replace what 1667 installs there."
+    if [ "\$forced" -eq 1 ]; then return 0; fi
+  fi
+  if [ \$(( \$(printf '%d' "0\$mode") & 16 )) -ne 0 ]; then
+    gid=\$(file_gid "\$file") || die "Could not inspect \$label group"
+    if group_other_members "\$gid" "\$(id -un)"; then
+      if [ -n "\$GROUP_OTHERS" ]; then
+        refuse_root "\$forced" "\$label is writable by group \${GROUP_NAME:-\$gid} (mode \$mode), which also holds \$GROUP_OTHERS."
+        if [ "\$forced" -eq 1 ]; then return 0; fi
+      fi
+    else
+      refuse_root "\$forced" "\$label is writable by group \$gid (mode \$mode), and this Installer could not read that group's members."
+      if [ "\$forced" -eq 1 ]; then return 0; fi
+    fi
+  fi
+}
+
+probe_managed_owned() {
+  file=\$1
+  label=\$2
+  target=\$3
+  validate_managed_file_safety "\$file" "\$label"
+  probe_managed_active "\$file" "\$target"
+}
+
+# POSIX awk implementation of the shared SemVer grammar. Numeric identifiers
+# cannot have leading zeroes. Prerelease and build identifiers use only the
+# characters allowed by shared/semver.ts.
+semver_valid() {
+  value=\$1
+  printf '%s\\n' "\$value" | awk '
+    function numeric(s) { return s ~ /^(0|[1-9][0-9]*)$/ }
+    function identifier(s) { return s ~ /^[0-9A-Za-z-]+$/ && s != "" }
+    {
+      if (index(\$0, " ") || \$0 == "") exit 1
+      plus = index(\$0, "+")
+      if (plus && index(substr(\$0, plus + 1), "+")) exit 1
+      core = plus ? substr(\$0, 1, plus - 1) : \$0
+      build = plus ? substr(\$0, plus + 1) : ""
+      if (build != "") {
+        n = split(build, b, ".")
+        for (i = 1; i <= n; i++) if (!identifier(b[i])) exit 1
+      } else if (plus) exit 1
+      dash = index(core, "-")
+      pre = dash ? substr(core, dash + 1) : ""
+      base = dash ? substr(core, 1, dash - 1) : core
+      if (dash && pre == "") exit 1
+      if (split(base, v, ".") != 3) exit 1
+      for (i = 1; i <= 3; i++) if (!numeric(v[i])) exit 1
+      if (pre != "") {
+        n = split(pre, p, ".")
+        for (i = 1; i <= n; i++) {
+          if (!identifier(p[i])) exit 1
+          if (p[i] ~ /^[0-9]+$/ && !numeric(p[i])) exit 1
+        }
+      }
+      exit 0
+    }
+    { exit 1 }
+  ' 9>&-
+}
+
+# Compare two already validated SemVer values. Print -1, 0, or 1. Keep numeric
+# comparison textual so large core identifiers do not lose precision in awk.
+semver_compare() {
+  LC_ALL=C awk -v left="\$1" -v right="\$2" '
+    function parse(value, which, plus, dash, core, pre, parts, count, i) {
+      plus = index(value, "+")
+      if (plus) value = substr(value, 1, plus - 1)
+      dash = index(value, "-")
+      if (dash) {
+        core = substr(value, 1, dash - 1)
+        pre = substr(value, dash + 1)
+      } else {
+        core = value
+        pre = ""
+      }
+      count = split(core, parts, "[.]")
+      if (which == "left") {
+        lmajor = parts[1]
+        lminor = parts[2]
+        lpatch = parts[3]
+      } else {
+        rmajor = parts[1]
+        rminor = parts[2]
+        rpatch = parts[3]
+      }
+      if (pre == "") {
+        if (which == "left") lpre_count = 0
+        else rpre_count = 0
+        return
+      }
+      count = split(pre, parts, "[.]")
+      if (which == "left") {
+        lpre_count = count
+        for (i = 1; i <= count; i++) lpre[i] = parts[i]
+      } else {
+        rpre_count = count
+        for (i = 1; i <= count; i++) rpre[i] = parts[i]
+      }
+    }
+    function compare_numeric(left_value, right_value) {
+      if (length(left_value) != length(right_value)) {
+        return length(left_value) < length(right_value) ? -1 : 1
+      }
+      if (("x" left_value) == ("x" right_value)) return 0
+      return ("x" left_value) < ("x" right_value) ? -1 : 1
+    }
+    function compare_identifier(left_value, right_value, left_numeric, right_numeric) {
+      left_numeric = left_value ~ /^[0-9]+$/
+      right_numeric = right_value ~ /^[0-9]+$/
+      if (left_numeric && right_numeric) return compare_numeric(left_value, right_value)
+      if (left_numeric != right_numeric) return left_numeric ? -1 : 1
+      if (left_value == right_value) return 0
+      return ("x" left_value) < ("x" right_value) ? -1 : 1
+    }
+    function compare_prerelease(left_count, right_count, count, i, comparison) {
+      if (left_count == 0) return right_count == 0 ? 0 : 1
+      if (right_count == 0) return -1
+      count = left_count > right_count ? left_count : right_count
+      for (i = 1; i <= count; i++) {
+        if (i > left_count) return -1
+        if (i > right_count) return 1
+        comparison = compare_identifier(lpre[i], rpre[i])
+        if (comparison != 0) return comparison
+      }
+      return 0
+    }
+    function compare_versions(comparison) {
+      comparison = compare_numeric(lmajor, rmajor)
+      if (comparison != 0) return comparison
+      comparison = compare_numeric(lminor, rminor)
+      if (comparison != 0) return comparison
+      comparison = compare_numeric(lpatch, rpatch)
+      if (comparison != 0) return comparison
+      return compare_prerelease(lpre_count, rpre_count)
+    }
+    BEGIN {
+      parse(left, "left")
+      parse(right, "right")
+      print compare_versions()
+    }
+  ' 9>&-
+}
+
+validate_managed_ownership() {
+  root=\$1
+  executable=\$2
+  target=\$3
+  file="\$root/\$OWNERSHIP_FILE"
+  if [ -L "\$file" ]; then
+    die "Ownership Record must not be a symbolic link"
+  fi
+  if [ ! -f "\$file" ]; then
+    die "Refusing to replace an existing 1667: Ownership Record is missing (unmanaged installation)"
+  fi
+  validate_managed_file_safety "\$file" "Ownership Record"
+  mode=\$(file_mode "\$file") || return 1
+  [ "\$mode" = 600 ] || die "Ownership Record must have mode 600"
+  size=\$(exec 9>&-; wc -c < "\$file" | tr -d ' ')
+  [ -n "\$size" ] && [ "\$size" -le 16384 ] || die "Ownership Record is too large"
+  text=\$(exec 9>&-; cat "\$file") || die "Could not read Ownership Record"
+  id=\$(managed_json_string_field "\$text" installationId)
+  method=\$(managed_json_string_field "\$text" method)
+  channel=\$(managed_json_string_field "\$text" channel)
+  id_length=\$(printf '%s' "\$id" | wc -c | tr -d ' ')
+  [ "\$id_length" -eq 32 ] || die "Ownership Record installation id is invalid"
+  case "\$id" in *[!0-9a-f]*) die "Ownership Record installation id is invalid" ;; esac
+  case "\$channel" in stable|beta) ;; *) die "Ownership Record channel is invalid" ;; esac
+  [ "\$method" = shell ] || die "Ownership Record method is invalid"
+  expected="\$root/.1667-ownership-validate.\$\$"
+  rm -f "\$expected"
+  if canonical_ownership_bytes "\$id" "\$executable" "\$target" "\$root" "\$channel" > "\$expected" && cmp -s "\$file" "\$expected"; then
+    rm -f "\$expected"
+    OWNERSHIP_ID=\$id
+    OWNERSHIP_CHANNEL=\$channel
+    return 0
+  fi
+  if canonical_ownership_compact_bytes "\$id" "\$executable" "\$target" "\$root" "\$channel" > "\$expected" && cmp -s "\$file" "\$expected"; then
+    rm -f "\$expected"
+    OWNERSHIP_ID=\$id
+    OWNERSHIP_CHANNEL=\$channel
+    return 0
+  fi
+  rm -f "\$expected"
+  die "Ownership Record is not a canonical managed record"
+}
+
+json_bool_field() {
+  text=\$1
+  key=\$2
+  printf '%s\\n' "\$text" | tr ',' '\\n' \
+    | sed -n "s/.*\\\"\$key\\\"[[:space:]]*:[[:space:]]*//p" \
+    | head -n 1 | tr -d ' }'
+}
+
+canonical_managed_txn_bytes() {
+  phase=\$1
+  operation=\$2
+  channel=\$3
+  update_channel=\$4
+  active_version=\$5
+  candidate_version=\$6
+  installation_id=\$7
+  root=\$8
+  target=\$9
+  # Declared serializer contract: serializeInstallTransactionRecord in
+  # tui/src/install-transaction-record.ts. It writes phase as the final key.
+  printf '%s\\n' "{\\"kind\\":\\"managed\\",\\"schemaVersion\\":1,\\"operation\\":\\"\$operation\\",\\"channel\\":\\"\$channel\\",\\"updateChannel\\":\$update_channel,\\"activeVersion\\":\\"\$active_version\\",\\"candidateVersion\\":\\"\$candidate_version\\",\\"installationId\\":\\"\$installation_id\\",\\"installRoot\\":\\"\$root\\",\\"executable\\":\\"\$root/\$ACTIVE_FILE\\",\\"artifactTarget\\":\\"\$target\\",\\"phase\\":\\"\$phase\\"}"
+}
+
+write_managed_txn() {
+  root=\$1
+  phase=\$2
+  operation=\$3
+  channel=\$4
+  update_channel=\$5
+  active_version=\$6
+  candidate_version=\$7
+  installation_id=\$8
+  target=\$9
+  tmp="\$root/.1667-managed-txn.\$\$.tmp"
+  rm -f "\$tmp"
+  umask 077
+  if ! (
+    exec 9>&-
+    set -C
+    canonical_managed_txn_bytes "\$phase" "\$operation" "\$channel" \
+      "\$update_channel" "\$active_version" "\$candidate_version" \
+      "\$installation_id" "\$root" "\$target" > "\$tmp"
+  ); then
+    die "Could not create a managed Transaction Record"
+  fi
+  mv "\$tmp" "\$root/\$TXN_FILE"
+  fsync_path "\$root/\$TXN_FILE"
+}
+
+validate_managed_txn() {
+  file=\$1
+  target=\$2
+  root=\$3
+  text=\$(exec 9>&-; cat "\$file") || die "Could not read managed Transaction Record"
+  kind=\$(managed_json_string_field "\$text" kind)
+  phase=\$(managed_json_string_field "\$text" phase)
+  operation=\$(managed_json_string_field "\$text" operation)
+  channel=\$(managed_json_string_field "\$text" channel)
+  update_channel=\$(json_bool_field "\$text" updateChannel)
+  active_version=\$(managed_json_string_field "\$text" activeVersion)
+  candidate_version=\$(managed_json_string_field "\$text" candidateVersion)
+  installation_id=\$(managed_json_string_field "\$text" installationId)
+  [ "\$kind" = managed ] || die "Install transaction kind is unsupported"
+  case "\$phase" in candidate-ready|ownership-pending) ;; *) die "Managed transaction phase is invalid" ;; esac
+  case "\$operation" in upgrade|rollback) ;; *) die "Managed transaction operation is invalid" ;; esac
+  case "\$channel" in stable|beta) ;; *) die "Managed transaction channel is invalid" ;; esac
+  case "\$update_channel" in true|false) ;; *) die "Managed transaction updateChannel is invalid" ;; esac
+  if ! semver_valid "\$active_version" || ! semver_valid "\$candidate_version"; then
+    die "Managed transaction versions are invalid"
+  fi
+  id_length=\$(printf '%s' "\$installation_id" | wc -c | tr -d ' ')
+  [ "\$id_length" -eq 32 ] || die "Managed transaction installation id is invalid"
+  case "\$installation_id" in *[!0-9a-f]*) die "Managed transaction installation id is invalid" ;; esac
+  expected="\$file.validate.\$\$"
+  rm -f "\$expected"
+  if canonical_managed_txn_bytes "\$phase" "\$operation" "\$channel" "\$update_channel" "\$active_version" "\$candidate_version" "\$installation_id" "\$root" "\$target" > "\$expected" && cmp -s "\$file" "\$expected"; then
+    rm -f "\$expected"
+    MANAGED_PHASE=\$phase
+    MANAGED_OPERATION=\$operation
+    MANAGED_CHANNEL=\$channel
+    MANAGED_UPDATE_CHANNEL=\$update_channel
+    MANAGED_ACTIVE_VERSION=\$active_version
+    MANAGED_CANDIDATE_VERSION=\$candidate_version
+    MANAGED_INSTALLATION_ID=\$installation_id
+    return 0
+  fi
+  rm -f "\$expected"
+  die "Install transaction is not a canonical managed record"
+}
+
+finish_managed_recovery() {
+  root=\$1
+  executable=\$2
+  target=\$3
+  if [ -e "\$root/\$PREVIOUS_NEXT_FILE" ] || [ -L "\$root/\$PREVIOUS_NEXT_FILE" ]; then
+    if [ -L "\$root/\$PREVIOUS_NEXT_FILE" ] || [ ! -f "\$root/\$PREVIOUS_NEXT_FILE" ]; then
+      die "Managed transaction rollback staging is invalid"
+    fi
+    probe_managed_owned "\$root/\$PREVIOUS_NEXT_FILE" "rollback staging" "\$target"
+    previous_version=\$MANAGED_PROBE_VERSION
+    [ "\$previous_version" = "\$MANAGED_ACTIVE_VERSION" ] || die "Managed transaction rollback staging does not match the active version"
+    if [ -e "\$root/\$PREVIOUS_FILE" ] || [ -L "\$root/\$PREVIOUS_FILE" ]; then
+      validate_managed_file_safety "\$root/\$PREVIOUS_FILE" "rollback executable"
+    fi
+    mv "\$root/\$PREVIOUS_NEXT_FILE" "\$root/\$PREVIOUS_FILE"
+    fsync_path "\$root/\$PREVIOUS_FILE"
+    fsync_dir "\$root"
+  elif [ -e "\$root/\$PREVIOUS_FILE" ]; then
+    if [ -L "\$root/\$PREVIOUS_FILE" ] || [ ! -f "\$root/\$PREVIOUS_FILE" ]; then
+      die "Managed transaction rollback executable is invalid"
+    fi
+    probe_managed_owned "\$root/\$PREVIOUS_FILE" "rollback executable" "\$target"
+    previous_version=\$MANAGED_PROBE_VERSION
+    [ "\$previous_version" = "\$MANAGED_ACTIVE_VERSION" ] || die "Managed transaction rollback executable does not match the active version"
+  else
+    die "Managed transaction has no verified rollback executable"
+  fi
+  if [ "\$MANAGED_UPDATE_CHANNEL" = true ]; then
+    recovery_channel=\$MANAGED_CHANNEL
+  else
+    recovery_channel=\$OWNERSHIP_CHANNEL
+  fi
+  write_ownership "\$root" "\$MANAGED_INSTALLATION_ID" "\$executable" "\$target" "\$recovery_channel"
+  rm -f "\$root/\$CANDIDATE_FILE" "\$root/\$PACKAGE_STAGING_FILE"
+  remove_extract_stage "\$root"
+  clear_txn "\$root"
+  RECOVER_STATUS=managed-completed
+}
+
+recover_managed_install() {
+  root=\$1
+  executable=\$2
+  target=\$3
+  validate_managed_ownership "\$root" "\$executable" "\$target"
+  [ "\$OWNERSHIP_ID" = "\$MANAGED_INSTALLATION_ID" ] || die "Managed transaction installation id does not match Ownership Record"
+  CLEANUP_OWNS_STAGING=1
+  case "\$MANAGED_PHASE" in
+    candidate-ready)
+      if [ -f "\$executable" ] && [ ! -L "\$executable" ]; then
+        probe_managed_owned "\$executable" "managed active executable" "\$target"
+        active_version=\$MANAGED_PROBE_VERSION
+        if [ "\$active_version" = "\$MANAGED_ACTIVE_VERSION" ]; then
+          rm -f "\$root/\$CANDIDATE_FILE" "\$root/\$PREVIOUS_NEXT_FILE" \
+            "\$root/\$PACKAGE_STAGING_FILE"
+          remove_extract_stage "\$root"
+          clear_txn "\$root"
+          RECOVER_STATUS=managed-reset
+          return 0
+        fi
+        if [ "\$active_version" = "\$MANAGED_CANDIDATE_VERSION" ]; then
+          finish_managed_recovery "\$root" "\$executable" "\$target"
+          return 0
+        fi
+      fi
+      die "Managed transaction active executable does not match its record"
+      ;;
+    ownership-pending)
+      if [ ! -f "\$executable" ] || [ -L "\$executable" ]; then
+        die "Managed transaction active executable is missing"
+      fi
+      probe_managed_owned "\$executable" "managed active executable" "\$target"
+      active_version=\$MANAGED_PROBE_VERSION
+      [ "\$active_version" = "\$MANAGED_CANDIDATE_VERSION" ] || die "Managed transaction active executable does not match its record"
+      finish_managed_recovery "\$root" "\$executable" "\$target"
+      ;;
+  esac
+}
+`;

--- a/scripts/release-install-script-managed-lib.ts
+++ b/scripts/release-install-script-managed-lib.ts
@@ -348,7 +348,6 @@ finish_managed_recovery() {
   fi
   write_ownership "\$root" "\$MANAGED_INSTALLATION_ID" "\$executable" "\$target" "\$recovery_channel"
   rm -f "\$root/\$CANDIDATE_FILE" "\$root/\$PACKAGE_STAGING_FILE" 9>&-
-  remove_extract_stage "\$root"
   clear_txn "\$root"
   RECOVER_STATUS=managed-completed
 }
@@ -367,7 +366,6 @@ recover_managed_install() {
         active_version=\$MANAGED_PROBE_VERSION
         if [ "\$active_version" = "\$MANAGED_ACTIVE_VERSION" ]; then
           rm -f "\$root/\$CANDIDATE_FILE" "\$root/\$PREVIOUS_NEXT_FILE" "\$root/\$PACKAGE_STAGING_FILE" 9>&-
-          remove_extract_stage "\$root"
           clear_txn "\$root"
           RECOVER_STATUS=managed-reset
           return 0

--- a/scripts/release-install-script-probe-lib.ts
+++ b/scripts/release-install-script-probe-lib.ts
@@ -21,7 +21,7 @@ MANAGED_PROBE_VERSION=
 run_bounded_probe() {
   candidate=\$1
   out=\$2
-  rm -f "\$out"
+  rm -f "\$out" 9>&-
   # Noclobber makes an output-path race fail closed.
   # The subshell exec makes PROBE_PID the candidate PID, not a wrapper PID.
   (
@@ -77,7 +77,7 @@ probe_candidate() {
   target=\$2
   out="\${candidate%/*}/\$PROBE_OUTPUT_FILE"
   if ! run_bounded_probe "\$candidate" "\$out"; then
-    rm -f "\$out"
+    rm -f "\$out" 9>&-
     die "Candidate version probe failed"
   fi
   # Preserve trailing newlines for identity JSON (command substitution would drop them).
@@ -86,10 +86,10 @@ probe_candidate() {
     exec 9>&-
     cat "\$out"
   ); then
-    rm -f "\$out"
+    rm -f "\$out" 9>&-
     die "Candidate version probe failed"
   fi
-  rm -f "\$out"
+  rm -f "\$out" 9>&-
   product=\$(
     exec 9>&-
     json_string_field "\$out_text" product
@@ -117,17 +117,17 @@ probe_candidate_soft() {
   target=\$2
   out="\${candidate%/*}/\$PROBE_OUTPUT_FILE"
   if ! run_bounded_probe "\$candidate" "\$out"; then
-    rm -f "\$out"
+    rm -f "\$out" 9>&-
     return 1
   fi
   if ! out_text=\$(
     exec 9>&-
     cat "\$out"
   ); then
-    rm -f "\$out"
+    rm -f "\$out" 9>&-
     return 1
   fi
-  rm -f "\$out"
+  rm -f "\$out" 9>&-
   product=\$(
     exec 9>&-
     json_string_field "\$out_text" product
@@ -160,17 +160,17 @@ probe_managed_active() {
   target=\$2
   out="\${candidate%/*}/\$PROBE_OUTPUT_FILE"
   if ! run_bounded_probe "\$candidate" "\$out"; then
-    rm -f "\$out"
+    rm -f "\$out" 9>&-
     die "Managed active executable version probe failed"
   fi
   if ! out_text=\$(
     exec 9>&-
     cat "\$out"
   ); then
-    rm -f "\$out"
+    rm -f "\$out" 9>&-
     die "Managed active executable version probe failed"
   fi
-  rm -f "\$out"
+  rm -f "\$out" 9>&-
   product=\$(exec 9>&-; json_string_field "\$out_text" product)
   version=\$(exec 9>&-; json_string_field "\$out_text" productVersion)
   art=\$(exec 9>&-; json_string_field "\$out_text" artifactTarget)
@@ -178,7 +178,7 @@ probe_managed_active() {
   [ "\$product" = "1667" ] || die "Managed active executable is not 1667"
   [ "\$art" = "\$target" ] || die "Managed active executable target did not match this host"
   [ "\$kind" = "release" ] || die "Managed active executable is not a release build"
-  version_length=\$(printf '%s' "\$version" | wc -c | tr -d ' ')
+  version_length=\$(exec 9>&-; printf '%s' "\$version" | wc -c | tr -d ' ')
   [ -n "\$version" ] && [ "\$version_length" -le 128 ] || die "Managed active executable version is invalid"
   semver_valid "\$version" || die "Managed active executable version is invalid"
   MANAGED_PROBE_VERSION=\$version

--- a/scripts/release-install-script-probe-lib.ts
+++ b/scripts/release-install-script-probe-lib.ts
@@ -16,6 +16,7 @@ json_string_field() {
 # - Child and watchdog are terminated and reaped on timeout and by stop_probe.
 PROBE_PID=
 PROBE_WATCHDOG_PID=
+MANAGED_PROBE_VERSION=
 
 run_bounded_probe() {
   candidate=\$1
@@ -148,5 +149,38 @@ probe_candidate_soft() {
   [ "\$art" = "\$target" ] || return 1
   [ "\$kind" = "release" ] || return 1
   return 0
+}
+
+# Probe an existing managed active executable. Unlike the release candidate
+# probe, this accepts any release version so an older installer can bootstrap
+# across a changed package/NOTICE file. The caller invokes this directly so
+# signal traps can see PROBE_PID; the version is returned in MANAGED_PROBE_VERSION.
+probe_managed_active() {
+  candidate=\$1
+  target=\$2
+  out="\${candidate%/*}/\$PROBE_OUTPUT_FILE"
+  if ! run_bounded_probe "\$candidate" "\$out"; then
+    rm -f "\$out"
+    die "Managed active executable version probe failed"
+  fi
+  if ! out_text=\$(
+    exec 9>&-
+    cat "\$out"
+  ); then
+    rm -f "\$out"
+    die "Managed active executable version probe failed"
+  fi
+  rm -f "\$out"
+  product=\$(exec 9>&-; json_string_field "\$out_text" product)
+  version=\$(exec 9>&-; json_string_field "\$out_text" productVersion)
+  art=\$(exec 9>&-; json_string_field "\$out_text" artifactTarget)
+  kind=\$(exec 9>&-; json_string_field "\$out_text" buildKind)
+  [ "\$product" = "1667" ] || die "Managed active executable is not 1667"
+  [ "\$art" = "\$target" ] || die "Managed active executable target did not match this host"
+  [ "\$kind" = "release" ] || die "Managed active executable is not a release build"
+  version_length=\$(printf '%s' "\$version" | wc -c | tr -d ' ')
+  [ -n "\$version" ] && [ "\$version_length" -le 128 ] || die "Managed active executable version is invalid"
+  semver_valid "\$version" || die "Managed active executable version is invalid"
+  MANAGED_PROBE_VERSION=\$version
 }
 `;

--- a/scripts/release-install-script-shell-lib.ts
+++ b/scripts/release-install-script-shell-lib.ts
@@ -269,17 +269,28 @@ recover_install() {
   archive=\$5
   RECOVER_STATUS=
   txn="\$root/\$TXN_FILE"
+  if [ -L "\$txn" ]; then
+    die "Install transaction must not be a symbolic link"
+  fi
   if [ ! -e "\$txn" ]; then
     # No Transaction Record: do not delete reserved staging. Ownership is unproven.
     RECOVER_STATUS=none
     return 0
   fi
-  if [ -L "\$txn" ]; then
-    die "Install transaction must not be a symbolic link"
-  fi
   if [ ! -f "\$txn" ]; then
     die "Install transaction must be a regular file"
   fi
+  txn_size=\$(exec 9>&-; wc -c < "\$txn" | tr -d ' ')
+  [ -n "\$txn_size" ] && [ "\$txn_size" -le "\$MAX_TRANSACTION_BYTES" ] \
+    || die "Install Transaction Record is too large"
+  txn_text=\$(exec 9>&-; cat "\$txn") || die "Could not read Install Transaction Record"
+  txn_kind=\$(json_string_field "\$txn_text" kind)
+  if [ "\$txn_kind" = managed ]; then
+    validate_managed_txn "\$txn" "\$target" "\$root"
+    recover_managed_install "\$root" "\$executable" "\$target" "\$txn"
+    return 0
+  fi
+  [ "\$txn_kind" = shell-installer ] || die "Install transaction is not a canonical phase record"
   # validate_txn subshell inherits FD 9; close it so a hung validator cannot pin.
   phase=\$(
     exec 9>&-
@@ -289,7 +300,7 @@ recover_install() {
   CLEANUP_OWNS_STAGING=1
   case "\$phase" in
     downloading|extracted)
-      rm -f "\$root/\$CANDIDATE_FILE" "\$root/\$archive"
+      rm -f "\$root/\$CANDIDATE_FILE" "\$root/\$PREVIOUS_NEXT_FILE" "\$root/\$archive"
       remove_extract_stage "\$root"
       clear_txn "\$root"
       RECOVER_STATUS=reset
@@ -325,11 +336,18 @@ recover_install() {
       fi
       probe_candidate "\$executable" "\$target"
       fsync_path "\$executable"
-      installation_id=\$(
-        exec 9>&-
-        random_hex_32
-      )
-      write_ownership "\$root" "\$installation_id" "\$executable" "\$target"
+      ownership="\$root/\$OWNERSHIP_FILE"
+      if [ -e "\$ownership" ] || [ -L "\$ownership" ]; then
+        validate_managed_ownership "\$root" "\$executable" "\$target"
+        [ "\$OWNERSHIP_CHANNEL" = "\$INSTALL_CHANNEL" ] || die "Ownership Record channel does not match the Install Transaction Record"
+        fsync_path "\$ownership"
+      else
+        installation_id=\$(
+          exec 9>&-
+          random_hex_32
+        )
+        write_ownership "\$root" "\$installation_id" "\$executable" "\$target"
+      fi
       rm -f "\$root/\$CANDIDATE_FILE"
       remove_extract_stage "\$root"
       clear_txn "\$root"
@@ -438,13 +456,14 @@ canonical_ownership_bytes() {
   exe=\$2
   target=\$3
   root=\$4
+  channel=\$5
   cat <<EOF
 {
   "schemaVersion": 1,
   "product": "1667",
   "installationId": "\$id",
   "method": "shell",
-  "channel": "\$INSTALL_CHANNEL",
+  "channel": "\$channel",
   "installRoot": "\$root",
   "executable": "\$exe",
   "artifactTarget": "\$target"
@@ -457,6 +476,7 @@ write_ownership() {
   id=\$2
   exe=\$3
   target=\$4
+  channel=\${5:-\$INSTALL_CHANNEL}
   dest="\$root/\$OWNERSHIP_FILE"
   # Refuse a pre-existing destination that is not a regular non-symlink file
   # (directory, device, or symlink) before any atomic replacement.
@@ -474,7 +494,7 @@ write_ownership() {
   if ! (
     exec 9>&-
     set -C
-    canonical_ownership_bytes "\$id" "\$exe" "\$target" "\$root" > "\$tmp"
+    canonical_ownership_bytes "\$id" "\$exe" "\$target" "\$root" "\$channel" > "\$tmp"
   ); then
     die "Could not create an Ownership Record"
   fi
@@ -482,7 +502,7 @@ write_ownership() {
   if ! (
     exec 9>&-
     set -C
-    canonical_ownership_bytes "\$id" "\$exe" "\$target" "\$root" > "\$verify"
+    canonical_ownership_bytes "\$id" "\$exe" "\$target" "\$root" "\$channel" > "\$verify"
   ); then
     rm -f "\$tmp"
     die "Could not create an Ownership Record verification copy"

--- a/scripts/release-install-script-shell-lib.ts
+++ b/scripts/release-install-script-shell-lib.ts
@@ -259,7 +259,9 @@ remove_extract_stage() {
 }
 
 # Recovery runs in the lock-owning shell so PROBE_PID stays visible to traps.
-# Sets RECOVER_STATUS (none|reset|completed). Do not wrap in command substitution.
+# Sets RECOVER_STATUS (none|reset|completed|managed-reset|managed-completed).
+# The caller must handle every value explicitly. Do not wrap in command
+# substitution: recovery runs in the lock-owning shell so probe traps work.
 recover_install() {
   root=\$1
   executable=\$2
@@ -303,7 +305,7 @@ recover_install() {
   CLEANUP_OWNS_STAGING=1
   case "\$phase" in
     downloading|extracted)
-      rm -f "\$root/\$CANDIDATE_FILE" "\$root/\$PREVIOUS_NEXT_FILE" "\$root/\$archive"
+      rm -f "\$root/\$CANDIDATE_FILE" "\$root/\$PREVIOUS_NEXT_FILE" "\$root/\$archive" 9>&-
       remove_extract_stage "\$root"
       clear_txn "\$root"
       RECOVER_STATUS=reset

--- a/scripts/release-install-script-shell-lib.ts
+++ b/scripts/release-install-script-shell-lib.ts
@@ -292,6 +292,11 @@ recover_install() {
   txn_kind=\$(exec 9>&-; json_string_field "\$txn_text" kind)
   if [ "\$txn_kind" = managed ]; then
     validate_managed_txn "\$txn" "\$target" "\$root"
+    # Managed Transaction Records do not own Shell Installer-only staging.
+    # Refuse it before recovery grants cleanup authority.
+    refuse_prior_managed_path "\$root/\$EXTRACT_STAGE" "extract staging"
+    refuse_prior_managed_path "\$root/\$PROBE_OUTPUT_FILE" "probe output"
+    refuse_prior_managed_path "\$root/\$archive" "Release Archive staging"
     recover_managed_install "\$root" "\$executable" "\$target" "\$txn"
     return 0
   fi

--- a/scripts/release-install-script-shell-lib.ts
+++ b/scripts/release-install-script-shell-lib.ts
@@ -67,22 +67,22 @@ group_other_members() {
   if [ -x /usr/bin/getent ] || [ -x /bin/getent ]; then
     getent_bin=/usr/bin/getent
     [ -x "\$getent_bin" ] || getent_bin=/bin/getent
-    line=\$("\$getent_bin" group "\$gid" 2>/dev/null) || return 1
+    line=\$(exec 9>&-; "\$getent_bin" group "\$gid" 2>/dev/null) || return 1
     [ -n "\$line" ] || return 1
     GROUP_NAME=\${line%%:*}
     members=\${line##*:}
   elif [ -x /usr/bin/dscl ]; then
-    GROUP_NAME=\$(/usr/bin/dscl . -search /Groups PrimaryGroupID "\$gid" 2>/dev/null \\
+    GROUP_NAME=\$(exec 9>&-; /usr/bin/dscl . -search /Groups PrimaryGroupID "\$gid" 2>/dev/null \\
       | awk 'NR==1{print \$1}') || return 1
     [ -n "\$GROUP_NAME" ] || return 1
     # A group with nobody in it has no GroupMembership key, and dscl exits
     # nonzero. That is an empty membership, not a failed lookup.
-    members=\$(/usr/bin/dscl . -read "/Groups/\$GROUP_NAME" GroupMembership 2>/dev/null \\
+    members=\$(exec 9>&-; /usr/bin/dscl . -read "/Groups/\$GROUP_NAME" GroupMembership 2>/dev/null \\
       | sed -n 's/^GroupMembership: //p') || members=
   else
     return 1
   fi
-  GROUP_OTHERS=\$(printf '%s' "\$members" | tr ', ' '\\n\\n' \\
+  GROUP_OTHERS=\$(exec 9>&-; printf '%s' "\$members" | tr ', ' '\\n\\n' \\
     | grep -v -e '^\$' -e "^root\\\$" -e "^\$me\\\$" | tr '\\n' ' ' || true)
   GROUP_OTHERS=\${GROUP_OTHERS% }
   return 0
@@ -246,15 +246,15 @@ remove_extract_stage() {
   root=\$1
   stage="\$root/\$EXTRACT_STAGE"
   if [ -L "\$stage" ]; then
-    rm -f "\$stage"
+    rm -f "\$stage" 9>&-
     return 0
   fi
   if [ -d "\$stage" ]; then
-    rm -rf "\$stage"
+    rm -rf "\$stage" 9>&-
     return 0
   fi
   if [ -e "\$stage" ]; then
-    rm -f "\$stage"
+    rm -f "\$stage" 9>&-
   fi
 }
 
@@ -488,7 +488,7 @@ write_ownership() {
   fi
   tmp="\$root/.1667-install.\$\$.tmp"
   verify="\$root/.1667-install.\$\$.verify"
-  rm -f "\$tmp" "\$verify"
+  rm -f "\$tmp" "\$verify" 9>&-
   umask 077
   # Noclobber writers inherit FD 9; close it in each parenthesized subshell.
   if ! (
@@ -498,34 +498,36 @@ write_ownership() {
   ); then
     die "Could not create an Ownership Record"
   fi
+  fsync_path "\$tmp"
   # Keep expected bytes for post-replace verification (mv consumes \$tmp).
   if ! (
     exec 9>&-
     set -C
     canonical_ownership_bytes "\$id" "\$exe" "\$target" "\$root" "\$channel" > "\$verify"
   ); then
-    rm -f "\$tmp"
+    rm -f "\$tmp" 9>&-
     die "Could not create an Ownership Record verification copy"
   fi
-  mv "\$tmp" "\$dest"
-  chmod 0600 "\$dest"
+  mv "\$tmp" "\$dest" 9>&-
+  chmod 0600 "\$dest" 9>&-
   # Ownership must be durable before any later Transaction Record removal.
   fsync_path "\$dest"
+  fsync_dir "\$root"
   # Verify final path type and exact bytes after atomic replacement.
   if [ -L "\$dest" ] || [ ! -f "\$dest" ]; then
-    rm -f "\$verify"
+    rm -f "\$verify" 9>&-
     die "Ownership Record path is not a regular file after write"
   fi
-  if ! cmp -s "\$dest" "\$verify"; then
-    rm -f "\$verify"
+  if ! cmp -s "\$dest" "\$verify" 9>&-; then
+    rm -f "\$verify" 9>&-
     die "Ownership Record verification failed after write"
   fi
-  rm -f "\$verify"
+  rm -f "\$verify" 9>&-
 }
 
 clear_txn() {
   root=\$1
-  rm -f "\$root/\$TXN_FILE"
+  rm -f "\$root/\$TXN_FILE" 9>&-
   fsync_dir "\$root"
 }
 

--- a/scripts/release-install-script-shell-lib.ts
+++ b/scripts/release-install-script-shell-lib.ts
@@ -295,7 +295,6 @@ recover_install() {
     # Managed Transaction Records do not own Shell Installer-only staging.
     # Refuse it before recovery grants cleanup authority.
     refuse_prior_managed_path "\$root/\$EXTRACT_STAGE" "extract staging"
-    refuse_prior_managed_path "\$root/\$PROBE_OUTPUT_FILE" "probe output"
     refuse_prior_managed_path "\$root/\$archive" "Release Archive staging"
     recover_managed_install "\$root" "\$executable" "\$target" "\$txn"
     return 0
@@ -310,7 +309,8 @@ recover_install() {
   CLEANUP_OWNS_STAGING=1
   case "\$phase" in
     downloading|extracted)
-      rm -f "\$root/\$CANDIDATE_FILE" "\$root/\$PREVIOUS_NEXT_FILE" "\$root/\$archive" 9>&-
+      rm -f "\$root/\$CANDIDATE_FILE" "\$root/\$PREVIOUS_NEXT_FILE" \
+        "\$root/\$PROBE_OUTPUT_FILE" "\$root/\$archive" 9>&-
       remove_extract_stage "\$root"
       clear_txn "\$root"
       RECOVER_STATUS=reset

--- a/scripts/release-install-script-shell-lib.ts
+++ b/scripts/release-install-script-shell-lib.ts
@@ -280,11 +280,14 @@ recover_install() {
   if [ ! -f "\$txn" ]; then
     die "Install transaction must be a regular file"
   fi
+  validate_managed_file_safety "\$txn" "Install Transaction Record"
+  txn_mode=\$(exec 9>&-; file_mode "\$txn") || die "Could not inspect Install Transaction Record permissions"
+  [ "\$txn_mode" = 600 ] || die "Install Transaction Record must have mode 600"
   txn_size=\$(exec 9>&-; wc -c < "\$txn" | tr -d ' ')
   [ -n "\$txn_size" ] && [ "\$txn_size" -le "\$MAX_TRANSACTION_BYTES" ] \
     || die "Install Transaction Record is too large"
   txn_text=\$(exec 9>&-; cat "\$txn") || die "Could not read Install Transaction Record"
-  txn_kind=\$(json_string_field "\$txn_text" kind)
+  txn_kind=\$(exec 9>&-; json_string_field "\$txn_text" kind)
   if [ "\$txn_kind" = managed ]; then
     validate_managed_txn "\$txn" "\$target" "\$root"
     recover_managed_install "\$root" "\$executable" "\$target" "\$txn"
@@ -457,7 +460,7 @@ canonical_ownership_bytes() {
   target=\$3
   root=\$4
   channel=\$5
-  cat <<EOF
+  cat 9>&- <<EOF
 {
   "schemaVersion": 1,
   "product": "1667",

--- a/scripts/release-install-script-shell-lib.ts
+++ b/scripts/release-install-script-shell-lib.ts
@@ -201,7 +201,7 @@ write_txn() {
   target=\$3
   digest=\$4
   tmp="\$root/.1667-install-txn.\$\$.tmp"
-  rm -f "\$tmp"
+  rm -f "\$tmp" 9>&-
   umask 077
   # Noclobber writer is a parenthesized subshell that inherits FD 9; close it.
   if ! (
@@ -211,7 +211,7 @@ write_txn() {
   ); then
     die "Could not create a Transaction Record"
   fi
-  mv "\$tmp" "\$root/\$TXN_FILE"
+  mv "\$tmp" "\$root/\$TXN_FILE" 9>&-
   fsync_path "\$root/\$TXN_FILE"
 }
 
@@ -227,16 +227,16 @@ validate_txn() {
   tmp="\$file.validate.\$\$"
   for phase in downloading extracted candidate-ready activated; do
     if ! canonical_txn_bytes "\$phase" "\$expected_target" "\$expected_digest" "\$root" > "\$tmp"; then
-      rm -f "\$tmp"
+      rm -f "\$tmp" 9>&-
       die "Could not build a comparison Transaction Record"
     fi
-    if cmp -s "\$file" "\$tmp"; then
-      rm -f "\$tmp"
+    if cmp -s "\$file" "\$tmp" 9>&-; then
+      rm -f "\$tmp" 9>&-
       printf '%s\\n' "\$phase"
       return 0
     fi
   done
-  rm -f "\$tmp"
+  rm -f "\$tmp" 9>&-
   die "Install transaction is not a canonical phase record"
 }
 
@@ -326,7 +326,7 @@ recover_install() {
             random_hex_32
           )
           write_ownership "\$root" "\$installation_id" "\$executable" "\$target"
-          rm -f "\$root/\$CANDIDATE_FILE"
+          rm -f "\$root/\$CANDIDATE_FILE" 9>&-
           remove_extract_stage "\$root"
           clear_txn "\$root"
           RECOVER_STATUS=completed
@@ -334,7 +334,7 @@ recover_install() {
         fi
         die "Install left an active executable that does not match the pinned release"
       fi
-      rm -f "\$root/\$CANDIDATE_FILE"
+      rm -f "\$root/\$CANDIDATE_FILE" 9>&-
       remove_extract_stage "\$root"
       clear_txn "\$root"
       RECOVER_STATUS=reset
@@ -358,7 +358,7 @@ recover_install() {
         )
         write_ownership "\$root" "\$installation_id" "\$executable" "\$target"
       fi
-      rm -f "\$root/\$CANDIDATE_FILE"
+      rm -f "\$root/\$CANDIDATE_FILE" 9>&-
       remove_extract_stage "\$root"
       clear_txn "\$root"
       RECOVER_STATUS=completed
@@ -412,7 +412,7 @@ download_archive() {
   set -e
   DOWNLOAD_PID=
   if [ "\$status" -ne 0 ]; then
-    rm -f "\$out"
+    rm -f "\$out" 9>&-
     die "Download failed"
   fi
   # size= subshell inherits FD 9; close it so a hung wc cannot pin the lock.
@@ -421,7 +421,7 @@ download_archive() {
     wc -c < "\$out" | tr -d ' '
   )
   if [ "\$size" -le 0 ] || [ "\$size" -gt "\$MAX_ARCHIVE_BYTES" ]; then
-    rm -f "\$out"
+    rm -f "\$out" 9>&-
     die "Release Archive size is outside the bound"
   fi
 }

--- a/scripts/release-install-upgrade-e2e-lib.ts
+++ b/scripts/release-install-upgrade-e2e-lib.ts
@@ -6,7 +6,11 @@ import { releaseTargetForRuntime } from "../shared/release-targets.js";
 import { isSemVerUpgradeAvailable } from "../shared/semver.js";
 import { isPrereleaseVersion } from "./release-publication-assets.js";
 import { INSTALL_PREVIOUS_FILE } from "../shared/install-layout.js";
-import { INSTALL_ACTIVE_EXECUTABLE } from "../shared/install-ownership-record.js";
+import {
+  INSTALL_ACTIVE_EXECUTABLE,
+  INSTALL_OWNERSHIP_FILE,
+  parseInstallOwnershipRecordText
+} from "../shared/install-ownership-record.js";
 import {
   execProcess,
   fetchBytes,
@@ -136,30 +140,35 @@ export async function runInstallUpgradeE2e(
 
   logStepPass(3, "Current managed install upgrade check reports up-to-date");
 
-  // Step 4: Re-running homepage installer into same prefix must refuse
+  // Step 4: Re-running homepage installer into same prefix is idempotent
+  const currentOwnershipBefore = parseInstallOwnershipRecordText(
+    await readFile(path.join(current.prefix, INSTALL_OWNERSHIP_FILE), "utf8")
+  );
   await withUnchangedBytes(
     current.executable,
     4,
     "Re-running homepage installer modified active executable bytes.",
     async () => {
       const reinstall = await executeInstaller(homepageBytes, current.prefix);
-      if (reinstall.exitCode === 0) {
+      if (reinstall.exitCode !== 0) {
         throw new StepError(
           4,
-          "Re-running homepage installer into existing prefix unexpectedly succeeded; expected refusal."
+          `Re-running homepage installer into an existing Managed Installation failed:\n${reinstall.stderr || reinstall.stdout}`
         );
       }
-      const failureOutput = reinstall.stderr + reinstall.stdout;
-      if (!/existing 1667/i.test(failureOutput) || !/1667 upgrade/i.test(failureOutput)) {
+      const currentOwnershipAfter = parseInstallOwnershipRecordText(
+        await readFile(path.join(current.prefix, INSTALL_OWNERSHIP_FILE), "utf8")
+      );
+      if (currentOwnershipAfter.installationId !== currentOwnershipBefore.installationId) {
         throw new StepError(
           4,
-          `Installer refusal output did not identify existing binary and direct user to 1667 upgrade:\n${failureOutput}`
+          "Re-running homepage installer changed the Managed Installation installationId."
         );
       }
     }
   );
 
-  logStepPass(4, "Re-running homepage installer into existing prefix refuses managed binary");
+  logStepPass(4, "Re-running homepage installer keeps the Managed Installation unchanged");
 
   // Step 5: Rollback with no previous executable fails safely with valid JSON error envelope
   await withUnchangedBytes(
@@ -266,31 +275,33 @@ export async function runInstallUpgradeE2e(
 
   const previousBytesBeforeUpgrade = await readFile(previous.executable);
 
-  // 8b: exact-upgrade
-  assertEnvelope(
-    await runUpgrade(
-      previous.executable,
-      ["--version", currentVersion, "--channel", "stable"],
-      8,
-      `Managed upgrade to ${currentVersion}`
-    ),
-    {
-      status: "applied",
-      method: "shell",
-      current: args.fromVersion,
-      target: currentVersion,
-      channel: "stable"
-    },
-    8,
-    "Managed exact-upgrade"
+  // 8b: current Shell Installer bootstrap across the old NOTICE boundary.
+  // This exercises the recovery path that reaches users whose old in-binary
+  // updater cannot validate the current Release Archive.
+  const previousOwnershipBeforeBootstrap = parseInstallOwnershipRecordText(
+    await readFile(path.join(previous.prefix, INSTALL_OWNERSHIP_FILE), "utf8")
   );
-  await probeIdentity(previous.executable, currentIdentity, 8, "Upgraded executable");
+  const bootstrap = await executeInstaller(currentBytes, previous.prefix);
+  if (bootstrap.exitCode !== 0) {
+    throw new StepError(
+      8,
+      `Current Shell Installer could not bootstrap the previous Managed Installation:\n${bootstrap.stderr || bootstrap.stdout}`
+    );
+  }
+  await probeIdentity(previous.executable, currentIdentity, 8, "Bootstrapped executable");
+  await verifyOwnershipRecord(previous.prefix, "stable", 8, "Bootstrapped installation");
+  const previousOwnershipAfterBootstrap = parseInstallOwnershipRecordText(
+    await readFile(path.join(previous.prefix, INSTALL_OWNERSHIP_FILE), "utf8")
+  );
+  if (previousOwnershipAfterBootstrap.installationId !== previousOwnershipBeforeBootstrap.installationId) {
+    throw new StepError(8, "Shell Installer bootstrap changed the installationId.");
+  }
   const currentBytesAfterUpgrade = await readFile(previous.executable);
   const retainedPreviousBytes = await readFile(path.join(previous.prefix, INSTALL_PREVIOUS_FILE));
   if (!retainedPreviousBytes.equals(previousBytesBeforeUpgrade)) {
     throw new StepError(
       8,
-      `${INSTALL_PREVIOUS_FILE} bytes do not match original previous executable bytes.`
+      `${INSTALL_PREVIOUS_FILE} bytes do not match the original executable after Shell Installer bootstrap.`
     );
   }
 
@@ -309,22 +320,19 @@ export async function runInstallUpgradeE2e(
     );
   }
 
-  // 8d: stable re-upgrade
-  assertEnvelope(
-    await runUpgrade(previous.executable, ["--channel", "stable"], 8, "Re-upgrade"),
-    {
-      status: "applied",
-      method: "shell",
-      current: args.fromVersion,
-      target: currentVersion,
-      channel: "stable"
-    },
-    8,
-    "Managed re-upgrade"
-  );
+  // 8d: the current Shell Installer can cross the same boundary again after
+  // rollback. Do not use the old in-binary updater for this step.
+  const rebootstrap = await executeInstaller(currentBytes, previous.prefix);
+  if (rebootstrap.exitCode !== 0) {
+    throw new StepError(
+      8,
+      `Shell Installer re-bootstrap failed:\n${rebootstrap.stderr || rebootstrap.stdout}`
+    );
+  }
   await probeIdentity(previous.executable, currentIdentity, 8, "Re-upgraded executable");
+  await verifyOwnershipRecord(previous.prefix, "stable", 8, "Re-bootstrapped installation");
   if (!(await readFile(previous.executable)).equals(currentBytesAfterUpgrade)) {
-    throw new StepError(8, "Re-upgrade produced executable bytes that differ from the first upgrade.");
+    throw new StepError(8, "Shell Installer re-bootstrap produced different executable bytes.");
   }
 
   // 8e: stable no-op
@@ -390,7 +398,7 @@ export async function runInstallUpgradeE2e(
   }
   await verifyOwnershipRecord(previous.prefix, "beta", 8, "Channel switch");
 
-  logStepPass(8, "Managed previous install upgrades, rolls back, re-upgrades, and switches channel");
+  logStepPass(8, "Shell Installer bootstraps the previous install, then verifies rollback, re-upgrade, and channel switch");
 
   // Step 9: npm external lane
   const npmScratch = path.join(scratchRoot, "npm-lane");

--- a/test/release-install-script-bootstrap.test.ts
+++ b/test/release-install-script-bootstrap.test.ts
@@ -398,6 +398,9 @@ test("Shell Installer rejects invalid SemVer active and transaction identities",
   }), { mode: 0o600 });
   const modeTxnPath = path.join(modePrefix, INSTALL_TRANSACTION_FILE);
   await writeFile(modeTxnPath, modeTxn, { mode: 0o640 });
+  // open(2) masks the requested mode with the ambient umask. Set it explicitly
+  // so the mode gate under test does not invert under a umask of 07x.
+  await chmod(modeTxnPath, 0o640);
   await assert.rejects(
     execFileAsync("sh", [scriptPath, "--prefix", modePrefix], { cwd: scratch }),
     /Install Transaction Record must have mode 600/i

--- a/test/release-install-script-bootstrap.test.ts
+++ b/test/release-install-script-bootstrap.test.ts
@@ -354,6 +354,40 @@ test("Shell Installer rejects invalid SemVer active and transaction identities",
     /Managed transaction versions are invalid/i
   );
   assert.equal(server.hits(), 0);
+
+  const modePrefix = path.join(scratch, "invalid-transaction-mode");
+  await mkdir(modePrefix, { mode: 0o755 });
+  await chmod(modePrefix, 0o755);
+  const modeId = "0123456789abcdef0123456789abcdef";
+  const modeTxn = managedTxn({
+    phase: "candidate-ready",
+    id: modeId,
+    root: modePrefix,
+    target,
+    activeVersion: INSTALL_PRE_VERSION,
+    candidateVersion: INSTALL_VERSION
+  });
+  await writeFile(path.join(modePrefix, "1667"), releaseStub(INSTALL_PRE_VERSION, target), {
+    mode: 0o755
+  });
+  await writeFile(path.join(modePrefix, INSTALL_OWNERSHIP_FILE), prettyOwnership({
+    id: modeId,
+    channel: "stable",
+    root: modePrefix,
+    target
+  }), { mode: 0o600 });
+  const modeTxnPath = path.join(modePrefix, INSTALL_TRANSACTION_FILE);
+  await writeFile(modeTxnPath, modeTxn, { mode: 0o640 });
+  await assert.rejects(
+    execFileAsync("sh", [scriptPath, "--prefix", modePrefix], { cwd: scratch }),
+    /Install Transaction Record must have mode 600/i
+  );
+  await assert.rejects(
+    execFileAsync("sh", [scriptPath, "--prefix", modePrefix, "--force"], { cwd: scratch }),
+    /Install Transaction Record must have mode 600/i
+  );
+  assert.equal(await readFile(modeTxnPath, "utf8"), modeTxn);
+  assert.equal(server.hits(), 0);
 });
 
 test("Shell Installer resets an interrupted managed candidate before bootstrapping", async (t) => {

--- a/test/release-install-script-bootstrap.test.ts
+++ b/test/release-install-script-bootstrap.test.ts
@@ -7,7 +7,13 @@ import test from "node:test";
 import { releaseArchiveFileName } from "../scripts/release-archive.js";
 import { renderInstallScriptsForVersion } from "../scripts/release-install-script.js";
 import { INSTALL_OWNERSHIP_FILE, parseInstallOwnershipRecordText } from "../shared/install-ownership-record.js";
-import { INSTALL_PREVIOUS_FILE, INSTALL_TRANSACTION_FILE } from "../shared/install-layout.js";
+import {
+  INSTALL_CANDIDATE_FILE,
+  INSTALL_PACKAGE_STAGING_FILE,
+  INSTALL_PREVIOUS_FILE,
+  INSTALL_PREVIOUS_NEXT_FILE,
+  INSTALL_TRANSACTION_FILE
+} from "../shared/install-layout.js";
 import type { BuiltArtifactTarget } from "../shared/release-targets.js";
 import { serializeInstallTransactionRecord } from "../tui/src/install-transaction-record.js";
 import {
@@ -200,6 +206,13 @@ test("Shell Installer same-version bootstrap preserves rollback bytes and identi
   const previousBytes = Buffer.from("existing rollback bytes\n");
   await writeFile(path.join(prefix, "1667"), releaseStub(INSTALL_VERSION, target), { mode: 0o755 });
   await writeFile(path.join(prefix, INSTALL_PREVIOUS_FILE), previousBytes, { mode: 0o755 });
+  await writeFile(path.join(prefix, INSTALL_CANDIDATE_FILE), "stale candidate\n", { mode: 0o755 });
+  await writeFile(path.join(prefix, INSTALL_PACKAGE_STAGING_FILE), "stale package\n", { mode: 0o600 });
+  await writeFile(
+    path.join(prefix, INSTALL_PREVIOUS_NEXT_FILE),
+    "stale previous staging\n",
+    { mode: 0o755 }
+  );
   await writeFile(
     path.join(prefix, INSTALL_OWNERSHIP_FILE),
     prettyOwnership({ id, channel: "stable", root: prefix, target }),
@@ -207,6 +220,9 @@ test("Shell Installer same-version bootstrap preserves rollback bytes and identi
   );
   await execFileAsync("sh", [scriptPath, "--prefix", prefix], { cwd: scratch });
   assert.deepEqual(await readFile(path.join(prefix, INSTALL_PREVIOUS_FILE)), previousBytes);
+  await assert.rejects(readFile(path.join(prefix, INSTALL_CANDIDATE_FILE)));
+  await assert.rejects(readFile(path.join(prefix, INSTALL_PACKAGE_STAGING_FILE)));
+  await assert.rejects(readFile(path.join(prefix, INSTALL_PREVIOUS_NEXT_FILE)));
   const ownership = parseInstallOwnershipRecordText(
     await readFile(path.join(prefix, INSTALL_OWNERSHIP_FILE), "utf8")
   );

--- a/test/release-install-script-bootstrap.test.ts
+++ b/test/release-install-script-bootstrap.test.ts
@@ -213,6 +213,7 @@ test("Shell Installer same-version bootstrap preserves rollback bytes and identi
     "stale previous staging\n",
     { mode: 0o755 }
   );
+  await writeFile(path.join(prefix, ".1667-probe-output"), "stale probe output\n", { mode: 0o600 });
   await writeFile(
     path.join(prefix, INSTALL_OWNERSHIP_FILE),
     prettyOwnership({ id, channel: "stable", root: prefix, target }),
@@ -223,6 +224,9 @@ test("Shell Installer same-version bootstrap preserves rollback bytes and identi
   await assert.rejects(readFile(path.join(prefix, INSTALL_CANDIDATE_FILE)));
   await assert.rejects(readFile(path.join(prefix, INSTALL_PACKAGE_STAGING_FILE)));
   await assert.rejects(readFile(path.join(prefix, INSTALL_PREVIOUS_NEXT_FILE)));
+  await assert.rejects(readFile(path.join(prefix, ".1667-probe-output")));
+  await execFileAsync("sh", [scriptPath, "--prefix", prefix], { cwd: scratch });
+  assert.deepEqual(await readFile(path.join(prefix, INSTALL_PREVIOUS_FILE)), previousBytes);
   const ownership = parseInstallOwnershipRecordText(
     await readFile(path.join(prefix, INSTALL_OWNERSHIP_FILE), "utf8")
   );

--- a/test/release-install-script-bootstrap.test.ts
+++ b/test/release-install-script-bootstrap.test.ts
@@ -1,0 +1,525 @@
+import assert from "node:assert/strict";
+import { chmod, mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { createServer } from "node:http";
+import { homedir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { releaseArchiveFileName } from "../scripts/release-archive.js";
+import { renderInstallScriptsForVersion } from "../scripts/release-install-script.js";
+import { INSTALL_OWNERSHIP_FILE, parseInstallOwnershipRecordText } from "../shared/install-ownership-record.js";
+import { INSTALL_PREVIOUS_FILE, INSTALL_TRANSACTION_FILE } from "../shared/install-layout.js";
+import type { BuiltArtifactTarget } from "../shared/release-targets.js";
+import { serializeInstallTransactionRecord } from "../tui/src/install-transaction-record.js";
+import {
+  INSTALL_PRE_VERSION,
+  INSTALL_REPO,
+  canonicalTxnBytes,
+  INSTALL_VERSION,
+  execFileAsync,
+  hostShellInstallerTarget,
+  releaseStub,
+  writePublishedArchives
+} from "./release-install-script-fixture.js";
+
+function prettyOwnership(input: {
+  readonly id: string;
+  readonly channel: "stable" | "beta";
+  readonly root: string;
+  readonly target: string;
+}): string {
+  return "{\n"
+    + "  \"schemaVersion\": 1,\n"
+    + "  \"product\": \"1667\",\n"
+    + "  \"installationId\": \"" + input.id + "\",\n"
+    + "  \"method\": \"shell\",\n"
+    + "  \"channel\": \"" + input.channel + "\",\n"
+    + "  \"installRoot\": \"" + input.root + "\",\n"
+    + "  \"executable\": \"" + input.root + "/1667\",\n"
+    + "  \"artifactTarget\": \"" + input.target + "\"\n"
+    + "}\n";
+}
+
+function compactOwnership(input: {
+  readonly id: string;
+  readonly channel: "stable" | "beta";
+  readonly root: string;
+  readonly target: string;
+}): string {
+  return JSON.stringify({
+    schemaVersion: 1,
+    product: "1667",
+    installationId: input.id,
+    method: "shell",
+    channel: input.channel,
+    installRoot: input.root,
+    executable: input.root + "/1667",
+    artifactTarget: input.target
+  }) + "\n";
+}
+
+function managedTxn(input: {
+  readonly phase: "candidate-ready" | "ownership-pending";
+  readonly id: string;
+  readonly root: string;
+  readonly target: BuiltArtifactTarget;
+  readonly activeVersion: string;
+  readonly candidateVersion: string;
+}): string {
+  return serializeInstallTransactionRecord({
+    kind: "managed",
+    schemaVersion: 1,
+    operation: "upgrade",
+    channel: "beta",
+    updateChannel: true,
+    activeVersion: input.activeVersion,
+    candidateVersion: input.candidateVersion,
+    installationId: input.id,
+    installRoot: input.root,
+    executable: input.root + "/1667",
+    artifactTarget: input.target,
+    phase: input.phase
+  });
+}
+
+async function serveArchives(root: string): Promise<{
+  readonly base: string;
+  readonly close: () => Promise<void>;
+  readonly hits: () => number;
+}> {
+  let requestCount = 0;
+  const server = createServer((request, response) => {
+    requestCount += 1;
+    const file = path.join(root, path.basename(request.url ?? ""));
+    readFile(file).then((bytes) => {
+      response.writeHead(200, {
+        "content-type": "application/gzip",
+        "content-length": bytes.byteLength
+      });
+      response.end(bytes);
+    }, () => {
+      response.writeHead(404);
+      response.end();
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (address === null || typeof address === "string") throw new Error("server address missing");
+  return {
+    base: "http://127.0.0.1:" + address.port,
+    close: () => new Promise<void>((resolve) => server.close(() => resolve())),
+    hits: () => requestCount
+  };
+}
+
+async function writeScript(
+  scratch: string,
+  archiveDir: string,
+  assetBaseUrl: string,
+  fileName = "install-beta.sh"
+): Promise<string> {
+  const digests = await writePublishedArchives(archiveDir, INSTALL_VERSION);
+  const scriptPath = path.join(scratch, fileName);
+  await writeFile(scriptPath, renderInstallScriptsForVersion({
+    version: INSTALL_VERSION,
+    repository: INSTALL_REPO,
+    digests,
+    assetBaseUrl
+  })["install-beta.sh"]!, { mode: 0o755 });
+  return scriptPath;
+}
+
+async function createScratch(label: string): Promise<string> {
+  const parent = path.join(homedir(), ".cache", "1667-tests");
+  await mkdir(parent, { recursive: true, mode: 0o755 });
+  return await mkdtemp(path.join(parent, label));
+}
+
+test("Shell Installer bootstraps old pretty and compact managed records", async (t) => {
+  const target = hostShellInstallerTarget();
+  if (target === null) {
+    t.skip("Host cannot run the POSIX Shell Installer");
+    return;
+  }
+  for (const encoding of ["pretty", "compact"] as const) {
+    const scratch = await createScratch("bootstrap-");
+    t.after(() => rm(scratch, { recursive: true, force: true }));
+    const archiveDir = path.join(scratch, "archives");
+    await mkdir(archiveDir, { recursive: true });
+    const server = await serveArchives(archiveDir);
+    t.after(server.close);
+    const scriptPath = await writeScript(scratch, archiveDir, server.base, "install-" + encoding + ".sh");
+    const prefix = path.join(scratch, "prefix," + encoding);
+    await mkdir(prefix, { mode: 0o755 });
+    await chmod(prefix, 0o755);
+    const id = "0123456789abcdef0123456789abcdef";
+    const oldVersion = encoding === "pretty" ? INSTALL_PRE_VERSION : "1.2.3-rc.1+build.7";
+    const oldBytes: Buffer = Buffer.from(releaseStub(oldVersion, target));
+    await writeFile(path.join(prefix, "1667"), oldBytes, { mode: 0o755 });
+    await writeFile(
+      path.join(prefix, INSTALL_OWNERSHIP_FILE),
+      encoding === "pretty"
+        ? prettyOwnership({ id, channel: "stable", root: prefix, target })
+        : compactOwnership({ id, channel: "stable", root: prefix, target }),
+      { mode: 0o600 }
+    );
+    // The old updater downloads this file before its pinned NOTICE check fails.
+    await writeFile(path.join(prefix, ".1667-package.tgz"), "old failed update\n", {
+      mode: 0o600
+    });
+    await execFileAsync("sh", [scriptPath, "--prefix", prefix], { cwd: scratch });
+    assert.notDeepEqual(await readFile(path.join(prefix, "1667")), oldBytes);
+    assert.deepEqual(await readFile(path.join(prefix, INSTALL_PREVIOUS_FILE)), oldBytes);
+    const ownership = parseInstallOwnershipRecordText(
+      await readFile(path.join(prefix, INSTALL_OWNERSHIP_FILE), "utf8")
+    );
+    assert.equal(ownership.installationId, id);
+    assert.equal(ownership.channel, "beta");
+    assert.equal(ownership.artifactTarget, target);
+    await assert.rejects(readFile(path.join(prefix, ".1667-package.tgz")));
+    assert.equal(server.hits(), 1);
+  }
+});
+
+test("Shell Installer same-version bootstrap preserves rollback bytes and identity", async (t) => {
+  const target = hostShellInstallerTarget();
+  if (target === null) {
+    t.skip("Host cannot run the POSIX Shell Installer");
+    return;
+  }
+  const scratch = await createScratch("bootstrap-same-");
+  t.after(() => rm(scratch, { recursive: true, force: true }));
+  const archiveDir = path.join(scratch, "archives");
+  await mkdir(archiveDir, { recursive: true });
+  const server = await serveArchives(archiveDir);
+  t.after(server.close);
+  const scriptPath = await writeScript(scratch, archiveDir, server.base);
+  const prefix = path.join(scratch, "prefix");
+  await mkdir(prefix, { mode: 0o755 });
+  await chmod(prefix, 0o755);
+  const id = "abcdefabcdefabcdefabcdefabcdefab";
+  const previousBytes = Buffer.from("existing rollback bytes\n");
+  await writeFile(path.join(prefix, "1667"), releaseStub(INSTALL_VERSION, target), { mode: 0o755 });
+  await writeFile(path.join(prefix, INSTALL_PREVIOUS_FILE), previousBytes, { mode: 0o755 });
+  await writeFile(
+    path.join(prefix, INSTALL_OWNERSHIP_FILE),
+    prettyOwnership({ id, channel: "stable", root: prefix, target }),
+    { mode: 0o600 }
+  );
+  await execFileAsync("sh", [scriptPath, "--prefix", prefix], { cwd: scratch });
+  assert.deepEqual(await readFile(path.join(prefix, INSTALL_PREVIOUS_FILE)), previousBytes);
+  const ownership = parseInstallOwnershipRecordText(
+    await readFile(path.join(prefix, INSTALL_OWNERSHIP_FILE), "utf8")
+  );
+  assert.equal(ownership.installationId, id);
+  assert.equal(ownership.channel, "beta");
+  assert.equal(server.hits(), 0);
+
+  const badPrefix = path.join(scratch, "bad-previous");
+  await mkdir(badPrefix, { mode: 0o755 });
+  await chmod(badPrefix, 0o755);
+  await writeFile(path.join(badPrefix, "1667"), releaseStub(INSTALL_VERSION, target), { mode: 0o755 });
+  await writeFile(path.join(badPrefix, INSTALL_OWNERSHIP_FILE), prettyOwnership({
+    id,
+    channel: "stable",
+    root: badPrefix,
+    target
+  }), { mode: 0o600 });
+  await mkdir(path.join(badPrefix, INSTALL_PREVIOUS_FILE), { mode: 0o700 });
+  await assert.rejects(
+    execFileAsync("sh", [scriptPath, "--prefix", badPrefix], { cwd: scratch }),
+    /rollback executable must be a regular/i
+  );
+  assert.equal(server.hits(), 0);
+});
+
+test("Shell Installer refuses to downgrade a newer managed active", async (t) => {
+  const target = hostShellInstallerTarget();
+  if (target === null) {
+    t.skip("Host cannot run the POSIX Shell Installer");
+    return;
+  }
+  const scratch = await createScratch("bootstrap-downgrade-");
+  t.after(() => rm(scratch, { recursive: true, force: true }));
+  const archiveDir = path.join(scratch, "archives");
+  await mkdir(archiveDir, { recursive: true });
+  const server = await serveArchives(archiveDir);
+  t.after(server.close);
+  const scriptPath = await writeScript(scratch, archiveDir, server.base);
+  const prefix = path.join(scratch, "prefix");
+  await mkdir(prefix, { mode: 0o755 });
+  await chmod(prefix, 0o755);
+  const id = "0123456789abcdef0123456789abcdef";
+  const newerVersion = "2.0.0-rc.1+build.7";
+  const activeBytes = Buffer.from(releaseStub(newerVersion, target));
+  const ownershipBytes = prettyOwnership({ id, channel: "stable", root: prefix, target });
+  await writeFile(path.join(prefix, "1667"), activeBytes, { mode: 0o755 });
+  await writeFile(path.join(prefix, INSTALL_OWNERSHIP_FILE), ownershipBytes, { mode: 0o600 });
+
+  await assert.rejects(
+    execFileAsync("sh", [scriptPath, "--prefix", prefix], { cwd: scratch }),
+    /Installer will not downgrade.*1667 upgrade --version 1\.2\.3/i
+  );
+  assert.deepEqual(await readFile(path.join(prefix, "1667")), activeBytes);
+  assert.equal(await readFile(path.join(prefix, INSTALL_OWNERSHIP_FILE), "utf8"), ownershipBytes);
+  await assert.rejects(readFile(path.join(prefix, INSTALL_TRANSACTION_FILE)));
+  assert.equal(server.hits(), 0);
+});
+
+test("Shell Installer refuses an unsafe managed active unless forced", async (t) => {
+  const target = hostShellInstallerTarget();
+  if (target === null) {
+    t.skip("Host cannot run the POSIX Shell Installer");
+    return;
+  }
+  const scratch = await createScratch("bootstrap-safety-");
+  t.after(() => rm(scratch, { recursive: true, force: true }));
+  const archiveDir = path.join(scratch, "archives");
+  await mkdir(archiveDir, { recursive: true });
+  const server = await serveArchives(archiveDir);
+  t.after(server.close);
+  const scriptPath = await writeScript(scratch, archiveDir, server.base);
+  const prefix = path.join(scratch, "prefix");
+  await mkdir(prefix, { mode: 0o755 });
+  await chmod(prefix, 0o755);
+  const id = "abcdefabcdefabcdefabcdefabcdefab";
+  await writeFile(path.join(prefix, "1667"), releaseStub(INSTALL_VERSION, target), { mode: 0o777 });
+  await chmod(path.join(prefix, "1667"), 0o777);
+  await writeFile(path.join(prefix, INSTALL_OWNERSHIP_FILE), prettyOwnership({
+    id,
+    channel: "stable",
+    root: prefix,
+    target
+  }), { mode: 0o600 });
+  await assert.rejects(
+    execFileAsync("sh", [scriptPath, "--prefix", prefix], { cwd: scratch }),
+    /managed active executable is writable by every account/i
+  );
+  await execFileAsync("sh", [scriptPath, "--prefix", prefix, "--force"], { cwd: scratch });
+  assert.equal(server.hits(), 0);
+});
+
+test("Shell Installer rejects invalid SemVer active and transaction identities", async (t) => {
+  const target = hostShellInstallerTarget();
+  if (target === null) {
+    t.skip("Host cannot run the POSIX Shell Installer");
+    return;
+  }
+  const scratch = await createScratch("bootstrap-semver-");
+  t.after(() => rm(scratch, { recursive: true, force: true }));
+  const archiveDir = path.join(scratch, "archives");
+  await mkdir(archiveDir, { recursive: true });
+  const server = await serveArchives(archiveDir);
+  t.after(server.close);
+  const scriptPath = await writeScript(scratch, archiveDir, server.base);
+  const invalidVersions = ["1.2", "01.2.3", "1.2.3-01", "1.2.3+"];
+  for (const [index, invalidVersion] of invalidVersions.entries()) {
+    const prefix = path.join(scratch, "invalid-" + index);
+    await mkdir(prefix, { mode: 0o755 });
+    await chmod(prefix, 0o755);
+    const id = ("0000000000000000000000000000000" + index).slice(-32);
+    await writeFile(path.join(prefix, "1667"), releaseStub(invalidVersion, target), { mode: 0o755 });
+    await writeFile(path.join(prefix, INSTALL_OWNERSHIP_FILE), prettyOwnership({
+      id,
+      channel: "stable",
+      root: prefix,
+      target
+    }), { mode: 0o600 });
+    await assert.rejects(
+      execFileAsync("sh", [scriptPath, "--prefix", prefix], { cwd: scratch }),
+      /version is invalid/i
+    );
+  }
+
+  const txnPrefix = path.join(scratch, "invalid-transaction");
+  await mkdir(txnPrefix, { mode: 0o755 });
+  await chmod(txnPrefix, 0o755);
+  const id = "fedcba9876543210fedcba9876543210";
+  await writeFile(path.join(txnPrefix, "1667"), releaseStub(INSTALL_PRE_VERSION, target), { mode: 0o755 });
+  await writeFile(path.join(txnPrefix, INSTALL_OWNERSHIP_FILE), prettyOwnership({
+    id,
+    channel: "stable",
+    root: txnPrefix,
+    target
+  }), { mode: 0o600 });
+  await writeFile(path.join(txnPrefix, ".1667-install-txn.json"), managedTxn({
+    phase: "candidate-ready",
+    id,
+    root: txnPrefix,
+    target,
+    activeVersion: INSTALL_PRE_VERSION,
+    candidateVersion: "1.2.3-01"
+  }), { mode: 0o600 });
+  await assert.rejects(
+    execFileAsync("sh", [scriptPath, "--prefix", txnPrefix], { cwd: scratch }),
+    /Managed transaction versions are invalid/i
+  );
+  assert.equal(server.hits(), 0);
+});
+
+test("Shell Installer resets an interrupted managed candidate before bootstrapping", async (t) => {
+  const target = hostShellInstallerTarget();
+  if (target === null) {
+    t.skip("Host cannot run the POSIX Shell Installer");
+    return;
+  }
+  const scratch = await createScratch("bootstrap-recover-");
+  t.after(() => rm(scratch, { recursive: true, force: true }));
+  const archiveDir = path.join(scratch, "archives");
+  await mkdir(archiveDir, { recursive: true });
+  const server = await serveArchives(archiveDir);
+  t.after(server.close);
+  const scriptPath = await writeScript(scratch, archiveDir, server.base);
+  const prefix = path.join(scratch, "prefix");
+  await mkdir(prefix, { mode: 0o755 });
+  await chmod(prefix, 0o755);
+  const id = "0123456789abcdef0123456789abcdef";
+  const oldBytes: Buffer = Buffer.from(releaseStub(INSTALL_PRE_VERSION, target));
+  await writeFile(path.join(prefix, "1667"), oldBytes, { mode: 0o755 });
+  await writeFile(path.join(prefix, INSTALL_OWNERSHIP_FILE), prettyOwnership({
+    id,
+    channel: "stable",
+    root: prefix,
+    target
+  }), { mode: 0o600 });
+  await writeFile(path.join(prefix, INSTALL_PREVIOUS_FILE + ".next"), oldBytes, { mode: 0o755 });
+  await writeFile(path.join(prefix, ".1667-candidate"), "discarded candidate\n", { mode: 0o755 });
+  await writeFile(path.join(prefix, ".1667-package.tgz"), "discarded package\n", { mode: 0o600 });
+  await writeFile(path.join(prefix, ".1667-install-txn.json"), managedTxn({
+    phase: "candidate-ready",
+    id,
+    root: prefix,
+    target,
+    activeVersion: INSTALL_PRE_VERSION,
+    candidateVersion: INSTALL_VERSION
+  }), { mode: 0o600 });
+
+  await execFileAsync("sh", [scriptPath, "--prefix", prefix], { cwd: scratch });
+  assert.deepEqual(await readFile(path.join(prefix, INSTALL_PREVIOUS_FILE)), oldBytes);
+  await assert.rejects(readFile(path.join(prefix, INSTALL_PREVIOUS_FILE + ".next")));
+  await assert.rejects(readFile(path.join(prefix, ".1667-candidate")));
+  await assert.rejects(readFile(path.join(prefix, ".1667-package.tgz")));
+
+  const malformedPrefix = path.join(scratch, "malformed-previous");
+  await mkdir(malformedPrefix, { mode: 0o755 });
+  await chmod(malformedPrefix, 0o755);
+  const malformedActive = Buffer.from(releaseStub(INSTALL_VERSION, target));
+  const malformedPrevious = Buffer.from(releaseStub(INSTALL_PRE_VERSION, target));
+  const malformedOwnership = prettyOwnership({
+    id,
+    channel: "stable",
+    root: malformedPrefix,
+    target
+  });
+  const malformedTxn = managedTxn({
+    phase: "ownership-pending",
+    id,
+    root: malformedPrefix,
+    target,
+    activeVersion: INSTALL_PRE_VERSION,
+    candidateVersion: INSTALL_VERSION
+  });
+  await writeFile(path.join(malformedPrefix, "1667"), malformedActive, { mode: 0o755 });
+  await writeFile(path.join(malformedPrefix, INSTALL_OWNERSHIP_FILE), malformedOwnership, { mode: 0o600 });
+  await writeFile(path.join(malformedPrefix, INSTALL_PREVIOUS_FILE + ".next"), malformedPrevious, { mode: 0o755 });
+  await mkdir(path.join(malformedPrefix, INSTALL_PREVIOUS_FILE), { mode: 0o700 });
+  await writeFile(path.join(malformedPrefix, INSTALL_TRANSACTION_FILE), malformedTxn, { mode: 0o600 });
+  await assert.rejects(
+    execFileAsync("sh", [scriptPath, "--prefix", malformedPrefix], { cwd: scratch }),
+    /rollback executable must be a regular/i
+  );
+  assert.deepEqual(await readFile(path.join(malformedPrefix, "1667")), malformedActive);
+  assert.equal(await readFile(path.join(malformedPrefix, INSTALL_OWNERSHIP_FILE), "utf8"), malformedOwnership);
+  assert.deepEqual(await readFile(path.join(malformedPrefix, INSTALL_PREVIOUS_FILE + ".next")), malformedPrevious);
+  assert.equal((await stat(path.join(malformedPrefix, INSTALL_PREVIOUS_FILE))).isDirectory(), true);
+  assert.equal(await readFile(path.join(malformedPrefix, INSTALL_TRANSACTION_FILE), "utf8"), malformedTxn);
+  assert.equal(server.hits(), 1);
+});
+
+test("Shell Installer clears managed rollback staging during shell recovery", async (t) => {
+  const target = hostShellInstallerTarget();
+  if (target === null) {
+    t.skip("Host cannot run the POSIX Shell Installer");
+    return;
+  }
+  const scratch = await createScratch("bootstrap-shell-recover-");
+  t.after(() => rm(scratch, { recursive: true, force: true }));
+  const archiveDir = path.join(scratch, "archives");
+  await mkdir(archiveDir, { recursive: true });
+  const digests = await writePublishedArchives(archiveDir, INSTALL_VERSION);
+  const server = await serveArchives(archiveDir);
+  t.after(server.close);
+  const scriptPath = await writeScript(scratch, archiveDir, server.base);
+  const prefix = path.join(scratch, "prefix");
+  await mkdir(prefix, { mode: 0o755 });
+  await chmod(prefix, 0o755);
+  const id = "0123456789abcdef0123456789abcdef";
+  const oldBytes = Buffer.from(releaseStub(INSTALL_PRE_VERSION, target));
+  await writeFile(path.join(prefix, "1667"), oldBytes, { mode: 0o755 });
+  await writeFile(path.join(prefix, INSTALL_OWNERSHIP_FILE), prettyOwnership({
+    id,
+    channel: "stable",
+    root: prefix,
+    target
+  }), { mode: 0o600 });
+  await writeFile(path.join(prefix, INSTALL_PREVIOUS_FILE + ".next"), oldBytes, { mode: 0o755 });
+  const archiveName = releaseArchiveFileName(INSTALL_VERSION, target);
+  const digest = digests[archiveName];
+  if (digest === undefined) throw new Error("host archive digest missing");
+  await writeFile(path.join(prefix, INSTALL_TRANSACTION_FILE), canonicalTxnBytes({
+    phase: "extracted",
+    version: INSTALL_VERSION,
+    channel: "beta",
+    target,
+    digest,
+    root: prefix
+  }), { mode: 0o600 });
+
+  await execFileAsync("sh", [scriptPath, "--prefix", prefix], { cwd: scratch });
+  assert.deepEqual(await readFile(path.join(prefix, INSTALL_PREVIOUS_FILE)), oldBytes);
+  await assert.rejects(readFile(path.join(prefix, INSTALL_PREVIOUS_FILE + ".next")));
+  assert.equal(server.hits(), 1);
+});
+
+test("Shell Installer refuses unmanaged and non-canonical managed state", async (t) => {
+  const target = hostShellInstallerTarget();
+  if (target === null) {
+    t.skip("Host cannot run the POSIX Shell Installer");
+    return;
+  }
+  const scratch = await createScratch("bootstrap-refuse-");
+  t.after(() => rm(scratch, { recursive: true, force: true }));
+  const archiveDir = path.join(scratch, "archives");
+  await mkdir(archiveDir, { recursive: true });
+  const server = await serveArchives(archiveDir);
+  t.after(server.close);
+  const scriptPath = await writeScript(scratch, archiveDir, server.base);
+  for (const [label, record] of [
+    ["unmanaged", null],
+    ["invalid", "{\"schemaVersion\":1,\"product\":\"1667\",\"extra\":true}\n"]
+  ] as const) {
+    const prefix = path.join(scratch, label);
+    await mkdir(prefix, { mode: 0o755 });
+    await chmod(prefix, 0o755);
+    const oldBytes: Buffer = Buffer.from(releaseStub(INSTALL_PRE_VERSION, target));
+    await writeFile(path.join(prefix, "1667"), oldBytes, { mode: 0o755 });
+    if (record !== null) {
+      await writeFile(path.join(prefix, INSTALL_OWNERSHIP_FILE), record, { mode: 0o600 });
+    }
+    await assert.rejects(
+      execFileAsync("sh", [scriptPath, "--prefix", prefix], { cwd: scratch }),
+      /existing 1667|canonical|Ownership Record/i
+    );
+    assert.deepEqual(await readFile(path.join(prefix, "1667")), oldBytes, label + " active must survive");
+  }
+  const oversizedPrefix = path.join(scratch, "oversized-transaction");
+  await mkdir(oversizedPrefix, { mode: 0o755 });
+  await chmod(oversizedPrefix, 0o755);
+  const oversizedTxn = Buffer.alloc(16_385, 0x78);
+  await writeFile(path.join(oversizedPrefix, INSTALL_TRANSACTION_FILE), oversizedTxn, { mode: 0o600 });
+  await assert.rejects(
+    execFileAsync("sh", [scriptPath, "--prefix", oversizedPrefix], { cwd: scratch }),
+    /Transaction Record is too large/i
+  );
+  assert.deepEqual(await readFile(path.join(oversizedPrefix, INSTALL_TRANSACTION_FILE)), oversizedTxn);
+  assert.equal(server.hits(), 0);
+});

--- a/test/release-install-script-bootstrap.test.ts
+++ b/test/release-install-script-bootstrap.test.ts
@@ -577,3 +577,45 @@ test("Shell Installer refuses unmanaged and non-canonical managed state", async 
   assert.deepEqual(await readFile(path.join(oversizedPrefix, INSTALL_TRANSACTION_FILE)), oversizedTxn);
   assert.equal(server.hits(), 0);
 });
+
+// An interrupted managed bootstrap must not strand the in-binary updater. The
+// pre-activation records the Installer writes are Shell Installer records, and
+// `1667 upgrade` accepts a Shell Installer record only in the `activated`
+// phase. An already installed 1667 carries its own copy of that rule, so the
+// Installer, not the updater, has to clear the record it wrote.
+test("Shell Installer clears its pre-activation record when a managed bootstrap fails", async (t) => {
+  const target = hostShellInstallerTarget();
+  if (target === null) {
+    t.skip("Host cannot run the POSIX Shell Installer");
+    return;
+  }
+  const scratch = await createScratch("bootstrap-fail-txn-");
+  t.after(() => rm(scratch, { recursive: true, force: true }));
+  const archiveDir = path.join(scratch, "archives");
+  await mkdir(archiveDir, { recursive: true });
+  // The server serves an empty directory, so every Release Archive request is
+  // a 404 and the download fails after the Transaction Record is on disk.
+  const serveDir = path.join(scratch, "empty");
+  await mkdir(serveDir, { recursive: true });
+  const server = await serveArchives(serveDir);
+  t.after(server.close);
+  const scriptPath = await writeScript(scratch, archiveDir, server.base);
+  const prefix = path.join(scratch, "prefix");
+  await mkdir(prefix, { mode: 0o755 });
+  await chmod(prefix, 0o755);
+  const id = "0123456789abcdef0123456789abcdef";
+  const oldBytes = Buffer.from(releaseStub(INSTALL_PRE_VERSION, target));
+  await writeFile(path.join(prefix, "1667"), oldBytes, { mode: 0o755 });
+  const ownership = prettyOwnership({ id, channel: "stable", root: prefix, target });
+  await writeFile(path.join(prefix, INSTALL_OWNERSHIP_FILE), ownership, { mode: 0o600 });
+
+  await assert.rejects(execFileAsync("sh", [scriptPath, "--prefix", prefix], { cwd: scratch }));
+
+  // No Transaction Record survives, so `1667 upgrade` still sees a clean root.
+  await assert.rejects(readFile(path.join(prefix, INSTALL_TRANSACTION_FILE)));
+  // The Managed Installation is untouched and still usable.
+  assert.deepEqual(await readFile(path.join(prefix, "1667")), oldBytes);
+  assert.equal(await readFile(path.join(prefix, INSTALL_OWNERSHIP_FILE), "utf8"), ownership);
+  await assert.rejects(readFile(path.join(prefix, INSTALL_CANDIDATE_FILE)));
+  await assert.rejects(readFile(path.join(prefix, INSTALL_PREVIOUS_NEXT_FILE)));
+});

--- a/test/release-install-script-lock-fd.test.ts
+++ b/test/release-install-script-lock-fd.test.ts
@@ -12,14 +12,17 @@ import {
 import { homedir } from "node:os";
 import path from "node:path";
 import test from "node:test";
+import { releaseArchiveFileName } from "../scripts/release-archive.js";
 import { renderInstallScriptsForVersion } from "../scripts/release-install-script.js";
 import {
   createInstallOwnershipRecord,
   INSTALL_OWNERSHIP_FILE,
   serializeInstallOwnershipRecord
 } from "../shared/install-ownership-record.js";
+import { INSTALL_TRANSACTION_FILE } from "../shared/install-layout.js";
 import { acquireInstallationLock } from "../tui/src/install-lock.js";
 import {
+  canonicalTxnBytes,
   INSTALL_REPO,
   INSTALL_VERSION,
   hostShellInstallerTarget,
@@ -114,6 +117,113 @@ test("managed ownership comparison helper cannot retain the Install Root lock", 
   const exit = await exitPromise;
   assert.equal(exit.signal, "SIGKILL");
   assert.equal(processAlive(cmpPid), true, "stalled helper must survive parent death");
+
+  const lock = await acquireInstallationLock(prefix);
+  await lock.release();
+});
+
+test("extracted recovery cleanup cannot retain the Install Root lock", async (t) => {
+  const target = hostShellInstallerTarget();
+  if (target === null) {
+    t.skip("Host cannot run the POSIX Shell Installer");
+    return;
+  }
+  const parent = path.join(homedir(), ".cache", "1667-tests");
+  await mkdir(parent, { recursive: true, mode: 0o755 });
+  await chmod(parent, 0o755);
+  const root = await mkdtemp(path.join(parent, "install-lock-rm-"));
+  t.after(() => rm(root, { recursive: true, force: true }));
+
+  const prefix = path.join(root, "prefix");
+  const tools = path.join(root, "tools");
+  const rmPidPath = path.join(root, "rm.pid");
+  await mkdir(prefix, { mode: 0o755 });
+  await chmod(prefix, 0o755);
+  await mkdir(tools, { mode: 0o755 });
+  const escapedRmPidPath = rmPidPath.replace(/'/g, "'\\''");
+  const stalledRm = "#!/bin/sh\n"
+    + "for arg do\n"
+    + "  case \"$arg\" in\n"
+    + "    */.1667-candidate|*/.1667-previous.next)\n"
+    + "      printf '%s\\n' \"$$\" > '" + escapedRmPidPath + "'\n"
+    + "      trap '' TERM INT\n"
+    + "      exec sleep 3600\n"
+    + "      ;;\n"
+    + "  esac\n"
+    + "done\n"
+    + "exec /bin/rm \"$@\"\n";
+  await writeFile(path.join(tools, "rm"), stalledRm, { mode: 0o755 });
+
+  const archiveDir = path.join(root, "archives");
+  const digests = await writePublishedArchives(archiveDir, INSTALL_VERSION);
+  const archiveName = releaseArchiveFileName(INSTALL_VERSION, target);
+  const digest = digests[archiveName];
+  if (digest === undefined) throw new Error("host archive digest missing");
+  await writeFile(path.join(prefix, ".1667-candidate"), "candidate\n", { mode: 0o600 });
+  await writeFile(path.join(prefix, ".1667-previous.next"), "previous\n", { mode: 0o600 });
+  await writeFile(
+    path.join(prefix, INSTALL_TRANSACTION_FILE),
+    canonicalTxnBytes({
+      phase: "extracted",
+      version: INSTALL_VERSION,
+      channel: "beta",
+      target,
+      digest,
+      root: prefix
+    }),
+    { mode: 0o600 }
+  );
+
+  const scriptPath = path.join(root, "install-beta.sh");
+  await writeFile(scriptPath, renderInstallScriptsForVersion({
+    version: INSTALL_VERSION,
+    repository: INSTALL_REPO,
+    digests,
+    assetBaseUrl: "http://127.0.0.1:1"
+  })["install-beta.sh"]!, { mode: 0o755 });
+
+  const child = spawn("sh", [scriptPath, "--prefix", prefix], {
+    cwd: root,
+    env: {
+      ...process.env,
+      PATH: tools + path.delimiter + (process.env["PATH"] ?? "/usr/bin:/bin")
+    },
+    stdio: ["ignore", "pipe", "pipe"]
+  });
+  child.stdout?.resume();
+  child.stderr?.resume();
+  let childExited = false;
+  const exitPromise = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>(
+    (resolve) => child.on("exit", (code, signal) => {
+      childExited = true;
+      resolve({ code, signal });
+    })
+  );
+  let rmPid: number | undefined;
+  t.after(() => {
+    if (rmPid !== undefined && processAlive(rmPid)) {
+      try {
+        process.kill(rmPid, "SIGKILL");
+      } catch {
+        // Already gone.
+      }
+    }
+    if (!childExited && child.pid !== undefined) {
+      try {
+        process.kill(child.pid, "SIGKILL");
+      } catch {
+        // Already gone.
+      }
+    }
+  });
+
+  rmPid = await waitForPid(rmPidPath);
+  assert.equal(processAlive(rmPid), true, "cleanup helper must be stalled");
+  assert.ok(child.pid !== undefined, "installer parent pid missing");
+  process.kill(child.pid, "SIGKILL");
+  const exit = await exitPromise;
+  assert.equal(exit.signal, "SIGKILL");
+  assert.equal(processAlive(rmPid), true, "stalled helper must survive parent death");
 
   const lock = await acquireInstallationLock(prefix);
   await lock.release();

--- a/test/release-install-script-lock-fd.test.ts
+++ b/test/release-install-script-lock-fd.test.ts
@@ -1,0 +1,144 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import {
+  access,
+  chmod,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  writeFile
+} from "node:fs/promises";
+import { homedir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { renderInstallScriptsForVersion } from "../scripts/release-install-script.js";
+import {
+  createInstallOwnershipRecord,
+  INSTALL_OWNERSHIP_FILE,
+  serializeInstallOwnershipRecord
+} from "../shared/install-ownership-record.js";
+import { acquireInstallationLock } from "../tui/src/install-lock.js";
+import {
+  INSTALL_REPO,
+  INSTALL_VERSION,
+  hostShellInstallerTarget,
+  releaseStub,
+  writePublishedArchives
+} from "./release-install-script-fixture.js";
+
+test("managed ownership comparison helper cannot retain the Install Root lock", async (t) => {
+  const target = hostShellInstallerTarget();
+  if (target === null) {
+    t.skip("Host cannot run the POSIX Shell Installer");
+    return;
+  }
+  const parent = path.join(homedir(), ".cache", "1667-tests");
+  await mkdir(parent, { recursive: true, mode: 0o755 });
+  await chmod(parent, 0o755);
+  const root = await mkdtemp(path.join(parent, "install-lock-fd-"));
+  t.after(() => rm(root, { recursive: true, force: true }));
+
+  const prefix = path.join(root, "prefix");
+  const tools = path.join(root, "tools");
+  const cmpPidPath = path.join(root, "cmp.pid");
+  await mkdir(prefix, { mode: 0o755 });
+  await chmod(prefix, 0o755);
+  await mkdir(tools, { mode: 0o755 });
+  const escapedCmpPidPath = cmpPidPath.replace(/'/g, "'\\''");
+  const stalledCmp = "#!/bin/sh\n"
+    + "printf '%s\\n' \"$$\" > '" + escapedCmpPidPath + "'\n"
+    + "trap '' TERM INT\n"
+    + "exec sleep 3600\n";
+  await writeFile(path.join(tools, "cmp"), stalledCmp, { mode: 0o755 });
+
+  const executable = path.join(prefix, "1667");
+  const ownership = serializeInstallOwnershipRecord(createInstallOwnershipRecord({
+    installationId: "0123456789abcdef0123456789abcdef",
+    channel: "beta",
+    installRoot: prefix,
+    executable,
+    artifactTarget: target
+  }));
+  await writeFile(executable, releaseStub(INSTALL_VERSION, target), { mode: 0o755 });
+  await writeFile(path.join(prefix, INSTALL_OWNERSHIP_FILE), ownership, { mode: 0o600 });
+
+  const scriptPath = path.join(root, "install-beta.sh");
+  const digests = await writePublishedArchives(path.join(root, "archives"), INSTALL_VERSION);
+  await writeFile(scriptPath, renderInstallScriptsForVersion({
+    version: INSTALL_VERSION,
+    repository: INSTALL_REPO,
+    digests,
+    assetBaseUrl: "http://127.0.0.1:1"
+  })["install-beta.sh"]!, { mode: 0o755 });
+
+  const child = spawn("sh", [scriptPath, "--prefix", prefix], {
+    cwd: root,
+    env: {
+      ...process.env,
+      PATH: tools + path.delimiter + (process.env["PATH"] ?? "/usr/bin:/bin")
+    },
+    stdio: ["ignore", "pipe", "pipe"]
+  });
+  child.stdout?.resume();
+  child.stderr?.resume();
+  let childExited = false;
+  const exitPromise = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>(
+    (resolve) => child.on("exit", (code, signal) => {
+      childExited = true;
+      resolve({ code, signal });
+    })
+  );
+  let cmpPid: number | undefined;
+  t.after(() => {
+    if (cmpPid !== undefined && processAlive(cmpPid)) {
+      try {
+        process.kill(cmpPid, "SIGKILL");
+      } catch {
+        // Already gone.
+      }
+    }
+    if (!childExited && child.pid !== undefined) {
+      try {
+        process.kill(child.pid, "SIGKILL");
+      } catch {
+        // Already gone.
+      }
+    }
+  });
+
+  cmpPid = await waitForPid(cmpPidPath);
+  assert.equal(processAlive(cmpPid), true, "comparison helper must be stalled");
+  assert.ok(child.pid !== undefined, "installer parent pid missing");
+  process.kill(child.pid, "SIGKILL");
+  const exit = await exitPromise;
+  assert.equal(exit.signal, "SIGKILL");
+  assert.equal(processAlive(cmpPid), true, "stalled helper must survive parent death");
+
+  const lock = await acquireInstallationLock(prefix);
+  await lock.release();
+});
+
+async function waitForPid(filePath: string, timeoutMs = 5_000): Promise<number> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const pid = Number((await readFile(filePath, "utf8")).trim());
+      if (Number.isInteger(pid) && pid > 0 && processAlive(pid)) return pid;
+    } catch {
+      // Helper has not started yet.
+    }
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  await access(filePath);
+  throw new Error("comparison helper did not start");
+}
+
+function processAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/test/release-install-script-lock-fd.test.ts
+++ b/test/release-install-script-lock-fd.test.ts
@@ -229,6 +229,107 @@ test("extracted recovery cleanup cannot retain the Install Root lock", async (t)
   await lock.release();
 });
 
+test("version-changing managed bootstrap does not leak the Install Root lock to archive cleanup", async (t) => {
+  const target = hostShellInstallerTarget();
+  if (target === null) {
+    t.skip("Host cannot run the POSIX Shell Installer");
+    return;
+  }
+  const parent = path.join(homedir(), ".cache", "1667-tests");
+  await mkdir(parent, { recursive: true, mode: 0o755 });
+  await chmod(parent, 0o755);
+  const root = await mkdtemp(path.join(parent, "install-lock-managed-bootstrap-"));
+  t.after(() => rm(root, { recursive: true, force: true }));
+
+  const prefix = path.join(root, "prefix");
+  const tools = path.join(root, "tools");
+  const rmPidPath = path.join(root, "rm.pid");
+  await mkdir(prefix, { mode: 0o755 });
+  await chmod(prefix, 0o755);
+  await mkdir(tools, { mode: 0o755 });
+  const archiveName = releaseArchiveFileName(INSTALL_VERSION, target);
+  const escapedRmPidPath = rmPidPath.replace(/'/g, "'\\''");
+  const stalledRm = "#!/bin/sh\n"
+    + "for arg do\n"
+    + "  case \"$arg\" in\n"
+    + "    */" + archiveName + ")\n"
+    + "      printf '%s\\n' \"$$\" > '" + escapedRmPidPath + "'\n"
+    + "      trap '' TERM INT\n"
+    + "      exec sleep 3600\n"
+    + "      ;;\n"
+    + "  esac\n"
+    + "done\n"
+    + "exec /bin/rm \"$@\"\n";
+  await writeFile(path.join(tools, "rm"), stalledRm, { mode: 0o755 });
+
+  const executable = path.join(prefix, "1667");
+  const ownership = serializeInstallOwnershipRecord(createInstallOwnershipRecord({
+    installationId: "0123456789abcdef0123456789abcdef",
+    channel: "beta",
+    installRoot: prefix,
+    executable,
+    artifactTarget: target
+  }));
+  await writeFile(executable, releaseStub("1.2.2", target), { mode: 0o755 });
+  await writeFile(path.join(prefix, INSTALL_OWNERSHIP_FILE), ownership, { mode: 0o600 });
+
+  const archiveDir = path.join(root, "archives");
+  const digests = await writePublishedArchives(archiveDir, INSTALL_VERSION);
+  const scriptPath = path.join(root, "install-beta.sh");
+  await writeFile(scriptPath, renderInstallScriptsForVersion({
+    version: INSTALL_VERSION,
+    repository: INSTALL_REPO,
+    digests,
+    assetBaseUrl: "http://127.0.0.1:1"
+  })["install-beta.sh"]!, { mode: 0o755 });
+
+  const child = spawn("sh", [scriptPath, "--prefix", prefix], {
+    cwd: root,
+    env: {
+      ...process.env,
+      PATH: tools + path.delimiter + (process.env["PATH"] ?? "/usr/bin:/bin")
+    },
+    stdio: ["ignore", "pipe", "pipe"]
+  });
+  child.stdout?.resume();
+  child.stderr?.resume();
+  let childExited = false;
+  const exitPromise = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>(
+    (resolve) => child.on("exit", (code, signal) => {
+      childExited = true;
+      resolve({ code, signal });
+    })
+  );
+  let rmPid: number | undefined;
+  t.after(() => {
+    if (rmPid !== undefined && processAlive(rmPid)) {
+      try {
+        process.kill(rmPid, "SIGKILL");
+      } catch {
+        // Already gone.
+      }
+    }
+    if (!childExited && child.pid !== undefined) {
+      try {
+        process.kill(child.pid, "SIGKILL");
+      } catch {
+        // Already gone.
+      }
+    }
+  });
+
+  rmPid = await waitForPid(rmPidPath);
+  assert.equal(processAlive(rmPid), true, "archive cleanup helper must be stalled");
+  assert.ok(child.pid !== undefined, "installer parent pid missing");
+  process.kill(child.pid, "SIGKILL");
+  const exit = await exitPromise;
+  assert.equal(exit.signal, "SIGKILL");
+  assert.equal(processAlive(rmPid), true, "stalled helper must survive parent death");
+
+  const lock = await acquireInstallationLock(prefix);
+  await lock.release();
+});
+
 async function waitForPid(filePath: string, timeoutMs = 5_000): Promise<number> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {

--- a/test/release-install-script-recover-signal.test.ts
+++ b/test/release-install-script-recover-signal.test.ts
@@ -92,7 +92,7 @@ exec sleep 3600
     digest: hostDigest,
     root: installRoot
   });
-  await writeFile(path.join(prefix, INSTALL_TRANSACTION_FILE), txnBytes);
+  await writeFile(path.join(prefix, INSTALL_TRANSACTION_FILE), txnBytes, { mode: 0o600 });
 
   const child = spawn("sh", [scriptPath, "--prefix", prefix], {
     cwd: root,

--- a/test/release-install-script-recover-signal.test.ts
+++ b/test/release-install-script-recover-signal.test.ts
@@ -182,6 +182,121 @@ exec sleep 3600
   await lock.release();
 });
 
+test("SIGTERM and SIGINT during managed active probe exit cleanly", async (t) => {
+  const homeScratch = path.join(homedir(), ".cache", "1667-tests");
+  await mkdir(homeScratch, { recursive: true, mode: 0o755 });
+  await chmod(homeScratch, 0o755);
+  const root = await mkdtemp(path.join(homeScratch, "install-managed-probe-signal-"));
+  t.after(() => rm(root, { recursive: true, force: true }));
+
+  const hostTarget = hostShellInstallerTarget();
+  if (hostTarget === null) {
+    t.skip("Host cannot run the POSIX Shell Installer");
+    return;
+  }
+  const digests = await writePublishedArchives(path.join(root, "archives"), INSTALL_VERSION);
+  const scriptBody = renderInstallScriptsForVersion({
+    version: INSTALL_VERSION,
+    repository: INSTALL_REPO,
+    digests,
+    assetBaseUrl: "http://127.0.0.1:1"
+  })["install-beta.sh"]!;
+  const scriptPath = path.join(root, "install-managed-signal.sh");
+  await writeFile(scriptPath, scriptBody, { mode: 0o755 });
+
+  const signals: readonly [NodeJS.Signals, number][] = [
+    ["SIGTERM", 143],
+    ["SIGINT", 130]
+  ];
+  for (const [signal, expectedExit] of signals) {
+    const prefix = path.join(root, signal.toLowerCase());
+    await mkdir(prefix, { mode: 0o755 });
+    await chmod(prefix, 0o755);
+    const probePidPath = path.join(root, signal.toLowerCase() + ".probe.pid");
+    const hangStub = `#!/bin/sh
+printf '%s\\n' "$$" > '${probePidPath.replace(/'/g, `'\\''`)}'
+trap '' TERM INT
+exec sleep 3600
+`;
+    const id = "0123456789abcdef0123456789abcdef";
+    const ownership: string = JSON.stringify({
+      schemaVersion: 1,
+      product: "1667",
+      installationId: id,
+      method: "shell",
+      channel: "beta",
+      installRoot: prefix,
+      executable: prefix + "/1667",
+      artifactTarget: hostTarget
+    }) + "\n";
+    await writeFile(path.join(prefix, "1667"), hangStub, { mode: 0o755 });
+    await writeFile(path.join(prefix, INSTALL_OWNERSHIP_FILE), ownership, { mode: 0o600 });
+
+    const child = spawn("sh", [scriptPath, "--prefix", prefix], {
+      cwd: root,
+      stdio: ["ignore", "pipe", "pipe"]
+    });
+    child.stdout?.resume();
+    child.stderr?.resume();
+    let childExited = false;
+    const exitPromise = new Promise<number | null>((resolve) => {
+      child.on("exit", (code) => {
+        childExited = true;
+        resolve(code);
+      });
+    });
+    let probePid: number | undefined;
+    try {
+      const probeStarted = await waitForProbePid(probePidPath, exitPromise, 8_000);
+      if (typeof probeStarted !== "number") {
+        throw new Error("managed active probe did not start before installer exit or timeout");
+      }
+      probePid = probeStarted;
+      assert.equal(processAlive(probePid), true, "managed probe must be alive before signal");
+      assert.ok(child.pid !== undefined, "installer parent pid missing");
+      process.kill(child.pid, signal);
+
+      const killTimer = setTimeout(() => {
+        if (child.pid !== undefined && !childExited) {
+          try {
+            process.kill(child.pid, "SIGKILL");
+          } catch {
+            // Gone.
+          }
+        }
+      }, 5_000);
+      let exitCode: number | null;
+      try {
+        exitCode = await exitPromise;
+      } finally {
+        clearTimeout(killTimer);
+      }
+      assert.equal(exitCode, expectedExit);
+      assert.equal(processAlive(probePid), false, "managed probe must be reaped");
+      assert.equal(await readFile(path.join(prefix, INSTALL_OWNERSHIP_FILE), "utf8"), ownership);
+      await access(path.join(prefix, "1667"));
+      await assert.rejects(access(path.join(prefix, INSTALL_TRANSACTION_FILE)));
+      const lock = await acquireInstallationLock(prefix);
+      await lock.release();
+    } finally {
+      if (probePid !== undefined && processAlive(probePid)) {
+        try {
+          process.kill(probePid, "SIGKILL");
+        } catch {
+          // Gone.
+        }
+      }
+      if (!childExited && child.pid !== undefined) {
+        try {
+          process.kill(child.pid, "SIGKILL");
+        } catch {
+          // Gone.
+        }
+      }
+    }
+  }
+});
+
 function processAlive(pid: number): boolean {
   try {
     process.kill(pid, 0);

--- a/test/release-install-script-recovery-edge.test.ts
+++ b/test/release-install-script-recovery-edge.test.ts
@@ -63,24 +63,32 @@ function managedTxn(input: {
   readonly id: string;
   readonly root: string;
   readonly target: BuiltArtifactTarget;
+  readonly phase?: "candidate-ready" | "ownership-pending";
+  readonly channel?: "stable" | "beta";
+  readonly updateChannel?: boolean;
+  readonly activeVersion?: string;
+  readonly candidateVersion?: string;
 }): string {
   return serializeInstallTransactionRecord({
     kind: "managed",
     schemaVersion: 1,
     operation: "upgrade",
-    channel: "beta",
-    updateChannel: true,
-    activeVersion: INSTALL_PRE_VERSION,
-    candidateVersion: INSTALL_VERSION,
+    channel: input.channel ?? "beta",
+    updateChannel: input.updateChannel ?? true,
+    activeVersion: input.activeVersion ?? INSTALL_PRE_VERSION,
+    candidateVersion: input.candidateVersion ?? INSTALL_VERSION,
     installationId: input.id,
     installRoot: input.root,
     executable: input.root + "/1667",
     artifactTarget: input.target,
-    phase: "ownership-pending"
+    phase: input.phase ?? "ownership-pending"
   });
 }
 
-async function writeScript(root: string): Promise<{
+async function writeScript(
+  root: string,
+  channel: "stable" | "beta" = "beta"
+): Promise<{
   readonly scriptPath: string;
   readonly digest: string;
 }> {
@@ -91,14 +99,31 @@ async function writeScript(root: string): Promise<{
   const archive = releaseArchiveFileName(INSTALL_VERSION, target);
   const digest = digests[archive];
   if (digest === undefined) throw new Error("host archive digest missing");
-  const scriptPath = path.join(root, "install-beta.sh");
+  const scriptPath = path.join(root, "install-" + channel + ".sh");
   await writeFile(scriptPath, renderInstallScriptsForVersion({
     version: INSTALL_VERSION,
     repository: INSTALL_REPO,
     digests,
     assetBaseUrl: "http://127.0.0.1:1"
-  })["install-beta.sh"]!, { mode: 0o755 });
+  })["install-" + channel + ".sh"]!, { mode: 0o755 });
   return { scriptPath, digest };
+}
+
+function recoveryHarness(scriptBody: string): string {
+  const marker = "\nmain \"\$@\"\n";
+  if (!scriptBody.endsWith(marker)) throw new Error("generated Shell Installer main marker missing");
+  return scriptBody.slice(0, -marker.length)
+    + "\nprefix=\"\$1\"\n"
+    + "target=\"\$2\"\n"
+    + "digest=\"\$3\"\n"
+    + "archive=\"\$4\"\n"
+    + "executable=\"\$prefix/\$ACTIVE_FILE\"\n"
+    + "CLEANUP_OWNS_STAGING=0\n"
+    + "MANAGED_FORCE=0\n"
+    + "acquire_lock \"\$prefix\"\n"
+    + "recover_install \"\$prefix\" \"\$executable\" \"\$target\" \"\$digest\" \"\$archive\"\n"
+    + "printf '%s\\n' \"\$RECOVER_STATUS\"\n"
+    + "release_lock \"\$prefix\"\n";
 }
 
 test("activated recovery preserves valid ownership and rejects malformed ownership", async (t) => {
@@ -168,6 +193,88 @@ test("activated recovery preserves valid ownership and rejects malformed ownersh
       const ownershipStat = await lstat(path.join(prefix, INSTALL_OWNERSHIP_FILE));
       assert.equal(ownershipStat.isSymbolicLink(), item.record === "dangling");
     }
+  }
+});
+
+test("managed recovery consumes canonical TUI transactions for both phases", async (t) => {
+  const target = hostShellInstallerTarget();
+  if (target === null) {
+    t.skip("Host cannot run the POSIX Shell Installer");
+    return;
+  }
+  const root = await createScratch("install-recovery-managed-");
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const beta = await writeScript(root, "beta");
+  const stable = await writeScript(root, "stable");
+  const cases = [
+    {
+      label: "candidate-ready",
+      phase: "candidate-ready" as const,
+      script: stable.scriptPath,
+      transactionChannel: "beta" as const,
+      updateChannel: false,
+      expectedChannel: "stable" as const
+    },
+    {
+      label: "ownership-pending",
+      phase: "ownership-pending" as const,
+      script: beta.scriptPath,
+      transactionChannel: "beta" as const,
+      updateChannel: true,
+      expectedChannel: "beta" as const
+    }
+  ] as const;
+
+  for (const [index, item] of cases.entries()) {
+    const prefix = path.join(root, item.label);
+    await mkdir(prefix, { mode: 0o755 });
+    await chmod(prefix, 0o755);
+    const id = (index === 0
+      ? "0123456789abcdef0123456789abcdef"
+      : "fedcba9876543210fedcba9876543210");
+    const activeBytes: Buffer = Buffer.from(releaseStub(INSTALL_VERSION, target));
+    const previousBytes: Buffer = Buffer.from(releaseStub(INSTALL_PRE_VERSION, target));
+    await writeFile(path.join(prefix, "1667"), activeBytes, { mode: 0o755 });
+    await writeFile(path.join(prefix, INSTALL_OWNERSHIP_FILE), compactOwnership({
+      id,
+      channel: "stable",
+      root: prefix,
+      target
+    }), { mode: 0o600 });
+    await writeFile(path.join(prefix, INSTALL_PREVIOUS_FILE + ".next"), previousBytes, {
+      mode: 0o755
+    });
+    const txn = managedTxn({
+      id,
+      root: prefix,
+      target,
+      phase: item.phase,
+      channel: item.transactionChannel,
+      updateChannel: item.updateChannel
+    });
+    const txnPath = path.join(prefix, INSTALL_TRANSACTION_FILE);
+    await writeFile(txnPath, txn, { mode: 0o600 });
+
+    const harnessPath = path.join(root, item.label + "-harness.sh");
+    const scriptBody = await readFile(item.script, "utf8");
+    await writeFile(harnessPath, recoveryHarness(scriptBody), { mode: 0o755 });
+    const archive = releaseArchiveFileName(INSTALL_VERSION, target);
+    const digest = item.script === beta.scriptPath ? beta.digest : stable.digest;
+    const result = await execFileAsync(
+      "sh",
+      [harnessPath, prefix, target, digest, archive],
+      { cwd: root }
+    );
+    assert.match(result.stdout, /managed-completed/);
+    assert.deepEqual(await readFile(path.join(prefix, "1667")), activeBytes);
+    assert.deepEqual(await readFile(path.join(prefix, INSTALL_PREVIOUS_FILE)), previousBytes);
+    await assert.rejects(readFile(path.join(prefix, INSTALL_PREVIOUS_FILE + ".next")));
+    await assert.rejects(readFile(txnPath));
+    const ownership = parseInstallOwnershipRecordText(
+      await readFile(path.join(prefix, INSTALL_OWNERSHIP_FILE), "utf8")
+    );
+    assert.equal(ownership.installationId, id);
+    assert.equal(ownership.channel, item.expectedChannel);
   }
 });
 

--- a/test/release-install-script-recovery-edge.test.ts
+++ b/test/release-install-script-recovery-edge.test.ts
@@ -278,6 +278,53 @@ test("managed recovery consumes canonical TUI transactions for both phases", asy
   }
 });
 
+test("managed recovery refuses Shell Installer-only staging", async (t) => {
+  const target = hostShellInstallerTarget();
+  if (target === null) {
+    t.skip("Host cannot run the POSIX Shell Installer");
+    return;
+  }
+  const root = await createScratch("install-recovery-managed-shell-stage-");
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const { scriptPath } = await writeScript(root);
+  const prefix = path.join(root, "prefix");
+  await mkdir(prefix, { mode: 0o755 });
+  await chmod(prefix, 0o755);
+  const id = "0123456789abcdef0123456789abcdef";
+  const activeBytes: Buffer = Buffer.from(releaseStub(INSTALL_VERSION, target));
+  const previousNextBytes: Buffer = Buffer.from(releaseStub(INSTALL_PRE_VERSION, target));
+  const ownership = compactOwnership({ id, root: prefix, target });
+  const txn = managedTxn({
+    id,
+    root: prefix,
+    target,
+    phase: "candidate-ready"
+  });
+  const txnPath = path.join(prefix, INSTALL_TRANSACTION_FILE);
+  const extractStage = path.join(prefix, ".1667-extract");
+  await writeFile(path.join(prefix, "1667"), activeBytes, { mode: 0o755 });
+  await writeFile(path.join(prefix, INSTALL_OWNERSHIP_FILE), ownership, { mode: 0o600 });
+  await writeFile(path.join(prefix, INSTALL_PREVIOUS_FILE + ".next"), previousNextBytes, {
+    mode: 0o755
+  });
+  await mkdir(extractStage, { mode: 0o700 });
+  await writeFile(path.join(extractStage, "partial"), "preserve\n", { mode: 0o600 });
+  await writeFile(txnPath, txn, { mode: 0o600 });
+
+  await assert.rejects(
+    execFileAsync("sh", [scriptPath, "--prefix", prefix], { cwd: root }),
+    /extract staging/i
+  );
+  assert.deepEqual(await readFile(path.join(prefix, "1667")), activeBytes);
+  assert.equal(await readFile(path.join(prefix, INSTALL_OWNERSHIP_FILE), "utf8"), ownership);
+  assert.deepEqual(
+    await readFile(path.join(prefix, INSTALL_PREVIOUS_FILE + ".next")),
+    previousNextBytes
+  );
+  assert.equal(await readFile(txnPath, "utf8"), txn);
+  assert.equal(await readFile(path.join(extractStage, "partial"), "utf8"), "preserve\n");
+});
+
 test("Shell Installer refuses a dangling transaction record", async (t) => {
   const target = hostShellInstallerTarget();
   if (target === null) {

--- a/test/release-install-script-recovery-edge.test.ts
+++ b/test/release-install-script-recovery-edge.test.ts
@@ -1,0 +1,228 @@
+import assert from "node:assert/strict";
+import {
+  chmod,
+  lstat,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  symlink,
+  writeFile
+} from "node:fs/promises";
+import { homedir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { releaseArchiveFileName } from "../scripts/release-archive.js";
+import { renderInstallScriptsForVersion } from "../scripts/release-install-script.js";
+import {
+  INSTALL_PREVIOUS_FILE,
+  INSTALL_TRANSACTION_FILE
+} from "../shared/install-layout.js";
+import {
+  INSTALL_OWNERSHIP_FILE,
+  parseInstallOwnershipRecordText
+} from "../shared/install-ownership-record.js";
+import type { BuiltArtifactTarget } from "../shared/release-targets.js";
+import { serializeInstallTransactionRecord } from "../tui/src/install-transaction-record.js";
+import {
+  INSTALL_PRE_VERSION,
+  INSTALL_REPO,
+  INSTALL_VERSION,
+  canonicalTxnBytes,
+  execFileAsync,
+  hostShellInstallerTarget,
+  releaseStub,
+  writePublishedArchives
+} from "./release-install-script-fixture.js";
+
+async function createScratch(label: string): Promise<string> {
+  const parent = path.join(homedir(), ".cache", "1667-tests");
+  await mkdir(parent, { recursive: true, mode: 0o755 });
+  return await mkdtemp(path.join(parent, label));
+}
+
+function compactOwnership(input: {
+  readonly id: string;
+  readonly channel?: "stable" | "beta";
+  readonly root: string;
+  readonly target: string;
+}): string {
+  return JSON.stringify({
+    schemaVersion: 1,
+    product: "1667",
+    installationId: input.id,
+    method: "shell",
+    channel: input.channel ?? "beta",
+    installRoot: input.root,
+    executable: input.root + "/1667",
+    artifactTarget: input.target
+  }) + "\n";
+}
+
+function managedTxn(input: {
+  readonly id: string;
+  readonly root: string;
+  readonly target: BuiltArtifactTarget;
+}): string {
+  return serializeInstallTransactionRecord({
+    kind: "managed",
+    schemaVersion: 1,
+    operation: "upgrade",
+    channel: "beta",
+    updateChannel: true,
+    activeVersion: INSTALL_PRE_VERSION,
+    candidateVersion: INSTALL_VERSION,
+    installationId: input.id,
+    installRoot: input.root,
+    executable: input.root + "/1667",
+    artifactTarget: input.target,
+    phase: "ownership-pending"
+  });
+}
+
+async function writeScript(root: string): Promise<{
+  readonly scriptPath: string;
+  readonly digest: string;
+}> {
+  const archives = path.join(root, "archives");
+  const digests = await writePublishedArchives(archives, INSTALL_VERSION);
+  const target = hostShellInstallerTarget();
+  if (target === null) throw new Error("host cannot run the POSIX Shell Installer");
+  const archive = releaseArchiveFileName(INSTALL_VERSION, target);
+  const digest = digests[archive];
+  if (digest === undefined) throw new Error("host archive digest missing");
+  const scriptPath = path.join(root, "install-beta.sh");
+  await writeFile(scriptPath, renderInstallScriptsForVersion({
+    version: INSTALL_VERSION,
+    repository: INSTALL_REPO,
+    digests,
+    assetBaseUrl: "http://127.0.0.1:1"
+  })["install-beta.sh"]!, { mode: 0o755 });
+  return { scriptPath, digest };
+}
+
+test("activated recovery preserves valid ownership and rejects malformed ownership", async (t) => {
+  const target = hostShellInstallerTarget();
+  if (target === null) {
+    t.skip("Host cannot run the POSIX Shell Installer");
+    return;
+  }
+  const root = await createScratch("install-recovery-ownership-");
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const { scriptPath, digest } = await writeScript(root);
+  const id = "0123456789abcdef0123456789abcdef";
+  const cases = [
+    { label: "valid", record: "valid" },
+    { label: "channel-mismatch", record: "channel-mismatch" },
+    { label: "malformed", record: "malformed" },
+    { label: "dangling", record: "dangling" }
+  ] as const;
+  for (const item of cases) {
+    const prefix = path.join(root, item.label);
+    await mkdir(prefix, { mode: 0o755 });
+    await chmod(prefix, 0o755);
+    const active: Buffer = Buffer.from(releaseStub(INSTALL_VERSION, target));
+    const txn = canonicalTxnBytes({
+      phase: "activated",
+      version: INSTALL_VERSION,
+      channel: "beta",
+      target,
+      digest,
+      root: prefix
+    });
+    await writeFile(path.join(prefix, "1667"), active, { mode: 0o755 });
+    await writeFile(path.join(prefix, INSTALL_TRANSACTION_FILE), txn, { mode: 0o600 });
+    const ownership = compactOwnership({
+      id,
+      channel: item.record === "channel-mismatch" ? "stable" : "beta",
+      root: prefix,
+      target
+    });
+    if (item.record === "dangling") {
+      await symlink("missing-ownership", path.join(prefix, INSTALL_OWNERSHIP_FILE));
+    } else {
+      await writeFile(
+        path.join(prefix, INSTALL_OWNERSHIP_FILE),
+        item.record === "malformed" ? "{\"schemaVersion\":1}\n" : ownership,
+        { mode: 0o600 }
+      );
+    }
+
+    if (item.record === "valid") {
+      await execFileAsync("sh", [scriptPath, "--prefix", prefix], { cwd: root });
+      const recovered = parseInstallOwnershipRecordText(
+        await readFile(path.join(prefix, INSTALL_OWNERSHIP_FILE), "utf8")
+      );
+      assert.equal(recovered.installationId, id);
+      assert.equal(await readFile(path.join(prefix, INSTALL_OWNERSHIP_FILE), "utf8"), ownership);
+      await assert.rejects(readFile(path.join(prefix, INSTALL_TRANSACTION_FILE)));
+    } else {
+      await assert.rejects(
+        execFileAsync("sh", [scriptPath, "--prefix", prefix], { cwd: root }),
+        item.record === "channel-mismatch"
+          ? /Ownership Record channel does not match/i
+          : /Ownership Record|symbolic link|canonical/i
+      );
+      assert.deepEqual(await readFile(path.join(prefix, "1667")), active);
+      assert.equal(await readFile(path.join(prefix, INSTALL_TRANSACTION_FILE), "utf8"), txn);
+      const ownershipStat = await lstat(path.join(prefix, INSTALL_OWNERSHIP_FILE));
+      assert.equal(ownershipStat.isSymbolicLink(), item.record === "dangling");
+    }
+  }
+});
+
+test("Shell Installer refuses a dangling transaction record", async (t) => {
+  const target = hostShellInstallerTarget();
+  if (target === null) {
+    t.skip("Host cannot run the POSIX Shell Installer");
+    return;
+  }
+  const root = await createScratch("install-recovery-txn-link-");
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const { scriptPath } = await writeScript(root);
+  const prefix = path.join(root, "prefix");
+  await mkdir(prefix, { mode: 0o755 });
+  await chmod(prefix, 0o755);
+  const txnPath = path.join(prefix, INSTALL_TRANSACTION_FILE);
+  await symlink("missing-transaction", txnPath);
+  await assert.rejects(
+    execFileAsync("sh", [scriptPath, "--prefix", prefix], { cwd: root }),
+    /Install transaction must not be a symbolic link/i
+  );
+  assert.equal((await lstat(txnPath)).isSymbolicLink(), true);
+});
+
+test("Managed recovery refuses dangling rollback staging before fallback", async (t) => {
+  const target = hostShellInstallerTarget();
+  if (target === null) {
+    t.skip("Host cannot run the POSIX Shell Installer");
+    return;
+  }
+  const root = await createScratch("install-recovery-previous-link-");
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const { scriptPath } = await writeScript(root);
+  const prefix = path.join(root, "prefix");
+  await mkdir(prefix, { mode: 0o755 });
+  await chmod(prefix, 0o755);
+  const id = "fedcba9876543210fedcba9876543210";
+  const active = Buffer.from(releaseStub(INSTALL_VERSION, target));
+  const previous = Buffer.from(releaseStub(INSTALL_PRE_VERSION, target));
+  const ownership = compactOwnership({ id, root: prefix, target });
+  const txn = managedTxn({ id, root: prefix, target });
+  await writeFile(path.join(prefix, "1667"), active, { mode: 0o755 });
+  await writeFile(path.join(prefix, INSTALL_OWNERSHIP_FILE), ownership, { mode: 0o600 });
+  await writeFile(path.join(prefix, INSTALL_PREVIOUS_FILE), previous, { mode: 0o755 });
+  const previousNext = path.join(prefix, INSTALL_PREVIOUS_FILE + ".next");
+  await symlink("missing-previous", previousNext);
+  await writeFile(path.join(prefix, INSTALL_TRANSACTION_FILE), txn, { mode: 0o600 });
+
+  await assert.rejects(
+    execFileAsync("sh", [scriptPath, "--prefix", prefix], { cwd: root }),
+    /rollback staging is invalid|regular/i
+  );
+  assert.deepEqual(await readFile(path.join(prefix, "1667")), active);
+  assert.equal(await readFile(path.join(prefix, INSTALL_OWNERSHIP_FILE), "utf8"), ownership);
+  assert.deepEqual(await readFile(path.join(prefix, INSTALL_PREVIOUS_FILE)), previous);
+  assert.equal(await readFile(path.join(prefix, INSTALL_TRANSACTION_FILE), "utf8"), txn);
+  assert.equal((await lstat(previousNext)).isSymbolicLink(), true);
+});

--- a/test/release-install-script-recovery-edge.test.ts
+++ b/test/release-install-script-recovery-edge.test.ts
@@ -244,6 +244,8 @@ test("managed recovery consumes canonical TUI transactions for both phases", asy
     await writeFile(path.join(prefix, INSTALL_PREVIOUS_FILE + ".next"), previousBytes, {
       mode: 0o755
     });
+    const probeOutput = path.join(prefix, ".1667-probe-output");
+    await writeFile(probeOutput, "stale probe output\n", { mode: 0o600 });
     const txn = managedTxn({
       id,
       root: prefix,
@@ -269,12 +271,14 @@ test("managed recovery consumes canonical TUI transactions for both phases", asy
     assert.deepEqual(await readFile(path.join(prefix, "1667")), activeBytes);
     assert.deepEqual(await readFile(path.join(prefix, INSTALL_PREVIOUS_FILE)), previousBytes);
     await assert.rejects(readFile(path.join(prefix, INSTALL_PREVIOUS_FILE + ".next")));
+    await assert.rejects(readFile(probeOutput));
     await assert.rejects(readFile(txnPath));
     const ownership = parseInstallOwnershipRecordText(
       await readFile(path.join(prefix, INSTALL_OWNERSHIP_FILE), "utf8")
     );
     assert.equal(ownership.installationId, id);
     assert.equal(ownership.channel, item.expectedChannel);
+    await execFileAsync("sh", [item.script, "--prefix", prefix], { cwd: root });
   }
 });
 
@@ -323,6 +327,48 @@ test("managed recovery refuses Shell Installer-only staging", async (t) => {
   );
   assert.equal(await readFile(txnPath, "utf8"), txn);
   assert.equal(await readFile(path.join(extractStage, "partial"), "utf8"), "preserve\n");
+});
+
+test("managed recovery preserves probe output when ownership identity mismatches", async (t) => {
+  const target = hostShellInstallerTarget();
+  if (target === null) {
+    t.skip("Host cannot run the POSIX Shell Installer");
+    return;
+  }
+  const root = await createScratch("install-recovery-managed-id-mismatch-");
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const { scriptPath } = await writeScript(root);
+  const prefix = path.join(root, "prefix");
+  await mkdir(prefix, { mode: 0o755 });
+  await chmod(prefix, 0o755);
+  const txnId = "0123456789abcdef0123456789abcdef";
+  const ownershipId = "fedcba9876543210fedcba9876543210";
+  const activeBytes: Buffer = Buffer.from(releaseStub(INSTALL_VERSION, target));
+  const previousNextBytes: Buffer = Buffer.from(releaseStub(INSTALL_PRE_VERSION, target));
+  const ownership = compactOwnership({ id: ownershipId, root: prefix, target });
+  const txn = managedTxn({ id: txnId, root: prefix, target });
+  const txnPath = path.join(prefix, INSTALL_TRANSACTION_FILE);
+  const probeOutput = path.join(prefix, ".1667-probe-output");
+  await writeFile(path.join(prefix, "1667"), activeBytes, { mode: 0o755 });
+  await writeFile(path.join(prefix, INSTALL_OWNERSHIP_FILE), ownership, { mode: 0o600 });
+  await writeFile(path.join(prefix, INSTALL_PREVIOUS_FILE + ".next"), previousNextBytes, {
+    mode: 0o755
+  });
+  await writeFile(probeOutput, "preserve mismatched identity\n", { mode: 0o600 });
+  await writeFile(txnPath, txn, { mode: 0o600 });
+
+  await assert.rejects(
+    execFileAsync("sh", [scriptPath, "--prefix", prefix], { cwd: root }),
+    /installation id does not match/i
+  );
+  assert.deepEqual(await readFile(path.join(prefix, "1667")), activeBytes);
+  assert.equal(await readFile(path.join(prefix, INSTALL_OWNERSHIP_FILE), "utf8"), ownership);
+  assert.deepEqual(
+    await readFile(path.join(prefix, INSTALL_PREVIOUS_FILE + ".next")),
+    previousNextBytes
+  );
+  assert.equal(await readFile(probeOutput, "utf8"), "preserve mismatched identity\n");
+  assert.equal(await readFile(txnPath, "utf8"), txn);
 });
 
 test("Shell Installer refuses a dangling transaction record", async (t) => {

--- a/test/release-install-script-strict.test.ts
+++ b/test/release-install-script-strict.test.ts
@@ -113,6 +113,21 @@ test("generated installer durably fsyncs ownership before clearing the transacti
     body,
     /case "\$RECOVER_STATUS" in[\s\S]*?completed\)[\s\S]*?none\|reset\|managed-reset\|managed-completed\)[\s\S]*?\*\)[\s\S]*?Unsupported recovery status/
   );
+  const managedRecoveryDispatch = body.indexOf('if [ "$txn_kind" = managed ]; then');
+  const managedRecoveryCall = body.indexOf(
+    'recover_managed_install "$root" "$executable" "$target" "$txn"',
+    managedRecoveryDispatch
+  );
+  assert.ok(managedRecoveryDispatch >= 0, "managed recovery dispatch is present");
+  assert.ok(managedRecoveryCall > managedRecoveryDispatch, "managed recovery call is present");
+  for (const path of [
+    'refuse_prior_managed_path "$root/$EXTRACT_STAGE" "extract staging"',
+    'refuse_prior_managed_path "$root/$PROBE_OUTPUT_FILE" "probe output"',
+    'refuse_prior_managed_path "$root/$archive" "Release Archive staging"'
+  ]) {
+    const guard = body.indexOf(path, managedRecoveryDispatch);
+    assert.ok(guard > managedRecoveryDispatch && guard < managedRecoveryCall, path + " is guarded");
+  }
   const managedBootstrapStart = body.indexOf(
     '    validate_managed_ownership "$prefix" "$executable" "$target"'
   );

--- a/test/release-install-script-strict.test.ts
+++ b/test/release-install-script-strict.test.ts
@@ -44,7 +44,7 @@ test("generated installer durably fsyncs ownership before clearing the transacti
   assert.match(body, /fsync_dir\(\)/);
   assert.match(body, /clear_txn\(\)/);
   // write_txn and write_ownership publish then fsync the file and parent dir.
-  assert.match(body, /mv "\$tmp" "\$root\/\$TXN_FILE"\s*\n\s*fsync_path "\$root\/\$TXN_FILE"/);
+  assert.match(body, /mv "\$tmp" "\$root\/\$TXN_FILE" 9>&-\s*\n\s*fsync_path "\$root\/\$TXN_FILE"/);
   assert.match(
     body,
     /mv "\$tmp" "\$dest" 9>&-\s*\n\s*chmod 0600 "\$dest" 9>&-\s*\n\s*# Ownership must be durable[\s\S]*?fsync_path "\$dest"/
@@ -201,7 +201,7 @@ test("generated installer durably fsyncs ownership before clearing the transacti
     "active executable is fsynced after activation rename"
   );
   // Active executable is fsynced after activation rename.
-  assert.match(body, /chmod 0755 "\$executable"\s*\n\s*fsync_path "\$executable"/);
+  assert.match(body, /chmod 0755 "\$executable" 9>&-\s*\n\s*fsync_path "\$executable"/);
   // Recovery candidate-ready: fsync active before ownership publish and txn clear.
   const recoverSoft = body.indexOf("probe_candidate_soft");
   assert.ok(recoverSoft >= 0, "recovery probes the active executable");

--- a/test/release-install-script-strict.test.ts
+++ b/test/release-install-script-strict.test.ts
@@ -71,13 +71,18 @@ test("generated installer durably fsyncs ownership before clearing the transacti
     'fsync_path "$prefix/$CANDIDATE_FILE"',
     probeAt
   );
+  const freshInstallAt = body.indexOf(
+    '  else\n    write_txn "$prefix" "candidate-ready"',
+    probeAt
+  );
+  assert.ok(freshInstallAt > probeAt, "fresh install branch remains present");
   const candidateReadyAt = body.indexOf(
     'write_txn "$prefix" "candidate-ready"',
-    probeAt
+    freshInstallAt
   );
   const renameActiveAt = body.indexOf(
     'mv "$prefix/$CANDIDATE_FILE" "$executable"',
-    probeAt
+    freshInstallAt
   );
   const fsyncActiveAt = body.indexOf('fsync_path "$executable"', renameActiveAt);
   assert.ok(fsyncCandidateAt > probeAt, "install path fsyncs the candidate after probe");
@@ -107,6 +112,12 @@ test("generated installer durably fsyncs ownership before clearing the transacti
   assert.ok(recoverFsync > recoverSoft, "recovery fsyncs active after probe");
   assert.ok(recoverOwnership > recoverFsync, "recovery writes ownership after fsync_path active");
   assert.ok(recoverClear > recoverOwnership, "recovery clears txn after ownership");
+  const activatedRecovery = body.indexOf('    activated)');
+  const activatedOwnershipFsync = body.indexOf('fsync_path "$ownership"', activatedRecovery);
+  const activatedClear = body.indexOf('clear_txn "$root"', activatedRecovery);
+  assert.ok(activatedRecovery >= 0, "activated recovery branch is present");
+  assert.ok(activatedOwnershipFsync > activatedRecovery, "activated recovery fsyncs existing ownership");
+  assert.ok(activatedClear > activatedOwnershipFsync, "activated recovery clears txn after ownership fsync");
   // Durability failure is never ignored (sync child also closes lock FD 9).
   assert.doesNotMatch(body, /sync \|\| true/);
   assert.match(body, /sync 9>&- \|\| die/);

--- a/test/release-install-script-strict.test.ts
+++ b/test/release-install-script-strict.test.ts
@@ -47,8 +47,78 @@ test("generated installer durably fsyncs ownership before clearing the transacti
   assert.match(body, /mv "\$tmp" "\$root\/\$TXN_FILE"\s*\n\s*fsync_path "\$root\/\$TXN_FILE"/);
   assert.match(
     body,
-    /mv "\$tmp" "\$dest"\s*\n\s*chmod 0600 "\$dest"\s*\n\s*# Ownership must be durable[\s\S]*?fsync_path "\$dest"/
+    /mv "\$tmp" "\$dest" 9>&-\s*\n\s*chmod 0600 "\$dest" 9>&-\s*\n\s*# Ownership must be durable[\s\S]*?fsync_path "\$dest"/
   );
+  const managedTxnWriter = body.indexOf("write_managed_txn()");
+  const managedTxnTempFsync = body.indexOf('fsync_path "$tmp"', managedTxnWriter);
+  const managedTxnMove = body.indexOf(
+    'mv "$tmp" "$root/$TXN_FILE" 9>&-',
+    managedTxnWriter
+  );
+  const managedTxnPublishedFsync = body.indexOf(
+    'fsync_path "$root/$TXN_FILE"',
+    managedTxnMove
+  );
+  const managedTxnParentFsync = body.indexOf('fsync_dir "$root"', managedTxnPublishedFsync);
+  assert.ok(managedTxnWriter >= 0, "managed transaction writer is present");
+  assert.ok(managedTxnTempFsync > managedTxnWriter, "managed txn temp is fsynced before publish");
+  assert.ok(managedTxnMove > managedTxnTempFsync, "managed txn moves only after temp fsync");
+  assert.ok(
+    managedTxnPublishedFsync > managedTxnMove,
+    "published managed txn is fsynced after move"
+  );
+  assert.ok(
+    managedTxnParentFsync > managedTxnPublishedFsync,
+    "managed txn parent directory is fsynced after publish"
+  );
+  const ownershipWriter = body.indexOf("write_ownership()");
+  const ownershipTempFsync = body.indexOf('fsync_path "$tmp"', ownershipWriter);
+  const ownershipMove = body.indexOf('mv "$tmp" "$dest" 9>&-', ownershipWriter);
+  const ownershipPublishedFsync = body.indexOf('fsync_path "$dest"', ownershipMove);
+  const ownershipParentFsync = body.indexOf('fsync_dir "$root"', ownershipPublishedFsync);
+  assert.ok(ownershipWriter >= 0, "ownership writer is present");
+  assert.ok(ownershipTempFsync > ownershipWriter, "ownership temp is fsynced before publish");
+  assert.ok(ownershipMove > ownershipTempFsync, "ownership moves only after temp fsync");
+  assert.ok(
+    ownershipPublishedFsync > ownershipMove,
+    "published ownership is fsynced after move"
+  );
+  assert.ok(
+    ownershipParentFsync > ownershipPublishedFsync,
+    "ownership parent directory is fsynced after publish"
+  );
+  assert.match(
+    body,
+    /semver_order=\$\(exec 9>&-;\s*semver_compare "\$active_version" "\$PRODUCT_VERSION"\)/
+  );
+  assert.match(
+    body,
+    /group_other_members "\$gid" "\$\(exec 9>&-; id -un\)"/
+  );
+  const managedBootstrapStart = body.indexOf(
+    '    validate_managed_ownership "$prefix" "$executable" "$target"'
+  );
+  const freshMutationStart = body.indexOf(
+    '  else\n    write_txn "$prefix" "candidate-ready"',
+    managedBootstrapStart
+  );
+  assert.ok(managedBootstrapStart >= 0, "managed bootstrap branch is present");
+  assert.ok(freshMutationStart > managedBootstrapStart, "fresh branch follows managed branch");
+  const managedBootstrap = body.slice(managedBootstrapStart, freshMutationStart);
+  for (const command of [
+    'rm -f "$prefix/$PACKAGE_STAGING_FILE" 9>&-',
+    'rm -f "$prefix/$PREVIOUS_NEXT_FILE" 9>&-',
+    'cp "$executable" "$prefix/$PREVIOUS_NEXT_FILE" 9>&-',
+    'chmod 0755 "$prefix/$PREVIOUS_NEXT_FILE" 9>&-',
+    'mv "$prefix/$CANDIDATE_FILE" "$executable" 9>&-',
+    'chmod 0755 "$executable" 9>&-',
+    'mv "$prefix/$PREVIOUS_NEXT_FILE" "$prefix/$PREVIOUS_FILE" 9>&-'
+  ]) {
+    assert.ok(
+      managedBootstrap.includes(command),
+      "managed path closes FD 9 for " + command
+    );
+  }
   // Pre-existing non-regular Ownership Record destination is refused.
   assert.match(body, /Ownership Record path is not a regular file/);
   assert.match(body, /Ownership Record must not be a symbolic link/);
@@ -63,7 +133,7 @@ test("generated installer durably fsyncs ownership before clearing the transacti
   assert.ok(ownershipCall >= 0, "install path writes ownership");
   assert.ok(clearTxnCall > ownershipCall, "clear_txn runs after write_ownership");
   // clear_txn removes the txn then fsyncs the Install Root so the unlink is durable.
-  assert.match(body, /rm -f "\$root\/\$TXN_FILE"\s*\n\s*fsync_dir "\$root"/);
+  assert.match(body, /rm -f "\$root\/\$TXN_FILE" 9>&-\s*\n\s*fsync_dir "\$root"/);
   // Candidate file is fsynced before candidate-ready is published (not after).
   const probeAt = body.indexOf('probe_candidate "$prefix/$CANDIDATE_FILE" "$target"');
   assert.ok(probeAt >= 0, "install path probes the candidate");

--- a/test/release-install-script-strict.test.ts
+++ b/test/release-install-script-strict.test.ts
@@ -122,7 +122,6 @@ test("generated installer durably fsyncs ownership before clearing the transacti
   assert.ok(managedRecoveryCall > managedRecoveryDispatch, "managed recovery call is present");
   for (const path of [
     'refuse_prior_managed_path "$root/$EXTRACT_STAGE" "extract staging"',
-    'refuse_prior_managed_path "$root/$PROBE_OUTPUT_FILE" "probe output"',
     'refuse_prior_managed_path "$root/$archive" "Release Archive staging"'
   ]) {
     const guard = body.indexOf(path, managedRecoveryDispatch);
@@ -600,6 +599,8 @@ test("recovery removes exact extract staging and keeps unrelated paths", async (
   const stage = path.join(prefix, ".1667-extract");
   await mkdir(stage, { mode: 0o700 });
   await writeFile(path.join(stage, "partial-member"), "interrupted-extract\n");
+  const probeOutput = path.join(prefix, ".1667-probe-output");
+  await writeFile(probeOutput, "interrupted-probe\n", { mode: 0o600 });
   const unrelated = path.join(prefix, "unrelated-keep.txt");
   const unrelatedBytes = Buffer.from("must-survive-recovery\n");
   await writeFile(unrelated, unrelatedBytes);
@@ -624,6 +625,7 @@ test("recovery removes exact extract staging and keeps unrelated paths", async (
   await execFileAsync("sh", [scriptPath, "--prefix", prefix], { cwd: root });
 
   await assert.rejects(access(stage));
+  await assert.rejects(access(probeOutput));
   assert.equal(await readFile(unrelated).then((b) => b.equals(unrelatedBytes)), true);
   assert.equal(await readFile(path.join(lookalike, "keep"), "utf8"), "keep\n");
   // Fresh install completed after recovery reset.

--- a/test/release-install-script-strict.test.ts
+++ b/test/release-install-script-strict.test.ts
@@ -109,6 +109,10 @@ test("generated installer durably fsyncs ownership before clearing the transacti
     body,
     /recover_install\(\) \{[\s\S]*?validate_managed_file_safety "\$txn" "Install Transaction Record"[\s\S]*?txn_mode=\$\(exec 9>&-; file_mode "\$txn"\)[\s\S]*?\[ "\$txn_mode" = 600 \]/
   );
+  assert.match(
+    body,
+    /case "\$RECOVER_STATUS" in[\s\S]*?completed\)[\s\S]*?none\|reset\|managed-reset\|managed-completed\)[\s\S]*?\*\)[\s\S]*?Unsupported recovery status/
+  );
   const managedBootstrapStart = body.indexOf(
     '    validate_managed_ownership "$prefix" "$executable" "$target"'
   );

--- a/test/release-install-script-strict.test.ts
+++ b/test/release-install-script-strict.test.ts
@@ -95,6 +95,20 @@ test("generated installer durably fsyncs ownership before clearing the transacti
     body,
     /group_other_members "\$gid" "\$\(exec 9>&-; id -un\)"/
   );
+  assert.match(
+    body,
+    /txn_kind=\$\(exec 9>&-;\s*json_string_field "\$txn_text" kind\)/
+  );
+  const ownershipRenderer = body.indexOf("canonical_ownership_bytes()");
+  assert.ok(ownershipRenderer >= 0, "historical Ownership Record renderer is present");
+  assert.ok(
+    body.indexOf("cat 9>&- <<EOF", ownershipRenderer) > ownershipRenderer,
+    "historical Ownership Record renderer closes the lock fd"
+  );
+  assert.match(
+    body,
+    /recover_install\(\) \{[\s\S]*?validate_managed_file_safety "\$txn" "Install Transaction Record"[\s\S]*?txn_mode=\$\(exec 9>&-; file_mode "\$txn"\)[\s\S]*?\[ "\$txn_mode" = 600 \]/
+  );
   const managedBootstrapStart = body.indexOf(
     '    validate_managed_ownership "$prefix" "$executable" "$target"'
   );
@@ -336,7 +350,11 @@ test(
       digest: hostDigest,
       root: installRoot
     });
-    await writeFile(path.join(prefix, ".1667-install-txn.json"), mutate(good, installRoot));
+    await writeFile(
+      path.join(prefix, ".1667-install-txn.json"),
+      mutate(good, installRoot),
+      { mode: 0o600 }
+    );
     await assert.rejects(
       execFileAsync("sh", [scriptPath, "--prefix", prefix], { cwd: root }),
       /canonical phase record/i
@@ -482,7 +500,8 @@ test(
         target: hostTarget,
         digest: liveDigest,
         root: installRoot
-      })
+      }),
+      { mode: 0o600 }
     );
     // Recovery resets then installs; after reset the pinned archive is gone and
     // the unrelated archive must still match its original bytes.
@@ -579,7 +598,8 @@ test("recovery removes exact extract staging and keeps unrelated paths", async (
       target: hostTarget,
       digest: liveDigest,
       root: installRoot
-    })
+    }),
+    { mode: 0o600 }
   );
 
   await execFileAsync("sh", [scriptPath, "--prefix", prefix], { cwd: root });

--- a/test/release-install-script.test.ts
+++ b/test/release-install-script.test.ts
@@ -592,7 +592,8 @@ test("Shell Installer installs, probes identity, refuses existing binaries, reco
       target: hostTarget,
       digest: hostDigest,
       root: recoverRoot
-    })
+    }),
+    { mode: 0o600 }
   );
   await execFileAsync("sh", [recoverScriptPath, "--prefix", recoverPrefix], { cwd: root });
   const recovered = parseInstallOwnershipRecordText(
@@ -620,7 +621,8 @@ test("Shell Installer installs, probes identity, refuses existing binaries, reco
       target: hostTarget,
       digest: hostDigest,
       root: readyRoot
-    })
+    }),
+    { mode: 0o600 }
   );
   await execFileAsync("sh", [recoverScriptPath, "--prefix", readyPrefix], { cwd: root });
   parseInstallOwnershipRecordText(
@@ -641,7 +643,8 @@ test("Shell Installer installs, probes identity, refuses existing binaries, reco
       target: hostTarget,
       digest: hostDigest,
       root: badTxnRoot
-    })
+    }),
+    { mode: 0o600 }
   );
   await assert.rejects(
     execFileAsync("sh", [recoverScriptPath, "--prefix", badTxnPrefix], { cwd: root }),

--- a/tui/src/install-transaction-record.ts
+++ b/tui/src/install-transaction-record.ts
@@ -58,7 +58,7 @@ export type InstallTransactionFileRecord =
 export function serializeInstallTransactionRecord(
   record: InstallTransactionRecord
 ): string {
-  return `${JSON.stringify({
+  const ordered: InstallTransactionRecord = {
     kind: record.kind,
     schemaVersion: record.schemaVersion,
     operation: record.operation,
@@ -71,7 +71,8 @@ export function serializeInstallTransactionRecord(
     executable: record.executable,
     artifactTarget: record.artifactTarget,
     phase: record.phase
-  })}\n`;
+  };
+  return JSON.stringify(ordered) + "\n";
 }
 
 const SHELL_TXN_KEYS = new Set([

--- a/tui/src/install-transaction-record.ts
+++ b/tui/src/install-transaction-record.ts
@@ -51,6 +51,29 @@ export type InstallTransactionFileRecord =
   | ShellInstallerTransactionRecord
   | InstallTransactionRecord;
 
+/**
+ * Serializes a managed Install Transaction Record for the shared on-disk contract.
+ * Keep the field order stable: the POSIX Shell Installer compares these bytes.
+ */
+export function serializeInstallTransactionRecord(
+  record: InstallTransactionRecord
+): string {
+  return `${JSON.stringify({
+    kind: record.kind,
+    schemaVersion: record.schemaVersion,
+    operation: record.operation,
+    channel: record.channel,
+    updateChannel: record.updateChannel,
+    activeVersion: record.activeVersion,
+    candidateVersion: record.candidateVersion,
+    installationId: record.installationId,
+    installRoot: record.installRoot,
+    executable: record.executable,
+    artifactTarget: record.artifactTarget,
+    phase: record.phase
+  })}\n`;
+}
+
 const SHELL_TXN_KEYS = new Set([
   "kind",
   "schemaVersion",

--- a/tui/src/install-transaction.ts
+++ b/tui/src/install-transaction.ts
@@ -36,6 +36,7 @@ import type { ManagedInstallPaths } from "./install-layout.js";
 import { assertSafeInstallRoot, assertSafeOwnedPath } from "./install-path-safety.js";
 import {
   parseInstallTransactionFileRecord,
+  serializeInstallTransactionRecord,
   type InstallTransactionRecord
 } from "./install-transaction-record.js";
 import {
@@ -89,7 +90,7 @@ export function writeTransactionRecord(
   removeQuietly(temporary);
   writeExclusiveFile({
     path: temporary,
-    data: `${JSON.stringify(record)}\n`,
+    data: serializeInstallTransactionRecord(record),
     mode: 0o600,
     finalPath: paths.transaction
   });

--- a/tui/test/install-transaction-record.test.ts
+++ b/tui/test/install-transaction-record.test.ts
@@ -1,0 +1,27 @@
+import { expect, test } from "bun:test";
+import {
+  parseInstallTransactionFileRecord,
+  serializeInstallTransactionRecord
+} from "../src/install-transaction-record.js";
+
+test("managed Transaction Records serialize in the declared canonical order", () => {
+  const parsed = parseInstallTransactionFileRecord(JSON.stringify({
+    phase: "ownership-pending",
+    artifactTarget: "darwin-arm64",
+    executable: "/tmp/1667-prefix,with-comma/1667",
+    installRoot: "/tmp/1667-prefix,with-comma",
+    installationId: "0123456789abcdef0123456789abcdef",
+    candidateVersion: "1.2.3-rc.1+build.7",
+    activeVersion: "1.2.2",
+    updateChannel: true,
+    channel: "beta",
+    operation: "upgrade",
+    schemaVersion: 1,
+    kind: "managed"
+  }));
+
+  if (parsed.kind !== "managed") throw new Error("expected a managed record");
+  expect(serializeInstallTransactionRecord(parsed)).toBe(
+    "{\"kind\":\"managed\",\"schemaVersion\":1,\"operation\":\"upgrade\",\"channel\":\"beta\",\"updateChannel\":true,\"activeVersion\":\"1.2.2\",\"candidateVersion\":\"1.2.3-rc.1+build.7\",\"installationId\":\"0123456789abcdef0123456789abcdef\",\"installRoot\":\"/tmp/1667-prefix,with-comma\",\"executable\":\"/tmp/1667-prefix,with-comma/1667\",\"artifactTarget\":\"darwin-arm64\",\"phase\":\"ownership-pending\"}\n"
+  );
+});


### PR DESCRIPTION
## Outcome

The Shell Installer can now update a valid existing Shell Managed Installation. This gives users a recovery path when an old in-binary updater rejects a newer package NOTICE file.

`NOTICE` changed in 0.9.10-rc.1. Every executable built before that commit pins the old licence-file digests, so 0.9.7, 0.9.8, and 0.9.9 installations all refuse a 0.9.10 package. The broken check is already on disk in those installations, so the recovery must come from the Installer rather than from the updater.

## Changes

- Validate historical and current canonical Ownership Records.
- Preserve the installation ID and previous executable during bootstrap.
- Share canonical managed transaction bytes with the runtime updater.
- Recover interrupted managed bootstrap transactions safely.
- Refuse unmanaged roots, ambiguous state, unsafe paths, and silent downgrades.
- Clear a pre-activation Shell Installer Transaction Record when a managed bootstrap stops.
- Extend the stable install-upgrade end-to-end gate and installer documentation.

## Verification

- npm run build
- npm test
- tui: bun run typecheck
- tui: bun test (2,058 passed, 2 skipped)
- tui: bun bench/perf.ts
- tui: bun run build:standalone
- Installer suites pass under `umask 077` as well as the default umask.
- Rendered Installer parses under `sh -n`, `dash -n`, and `bash -n`.
- Branch review: two rounds. Round 1 reported an interrupted managed bootstrap that stranded `1667 upgrade`. Round 2 reported an ordering defect in that fix. Both are fixed and covered by a regression test.

## Risks and limitations

- A pinned Installer refuses to replace a newer active release. Users must use the explicit versioned upgrade command for an intentional downgrade.
- A prerelease publishes only the beta Installer. The homepage command serves the stable Installer, so a stable release is required before an affected user recovers through the documented command.
- Steps 8b and 8d of the end-to-end gate now run the Shell Installer instead of the in-binary updater, because the previous stable release cannot cross the NOTICE boundary. The gate therefore has no unconditional assertion that an in-binary upgrade applies a version change. That assertion can return once both sides of the boundary carry the corrected policy.

Tracks #268
