### PR TITLE
chore(release): prepare 0.9.10-rc.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ This file records notable changes to 1667. Product terms use the definitions in
 
 ## Unreleased
 
+## 0.9.10-rc.4 - 2026-08-20
+
+- **The Shell Installer can update a Managed Installation.** Run the Installer
+  again to recover when an old 1667 version refuses a package with updated
+  legal notices. The Installer keeps the Installation ID and the previous
+  executable. It refuses an unmanaged executable and an automatic downgrade.
+
 ## 0.9.10-rc.3 - 2026-08-19
 
 - **This beta has no additional product changes.** It contains the same

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "1667-workspace",
-  "version": "0.9.10-rc.3",
+  "version": "0.9.10-rc.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "1667-workspace",
-      "version": "0.9.10-rc.3",
+      "version": "0.9.10-rc.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@earendil-works/pi-ai": "0.84.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667-workspace",
-  "version": "0.9.10-rc.3",
+  "version": "0.9.10-rc.4",
   "private": true,
   "description": "Source workspace for the 1667 terminal writing environment",
   "license": "Apache-2.0",

--- a/shared/release-notes.ts
+++ b/shared/release-notes.ts
@@ -11,6 +11,11 @@ export interface ReleaseNote {
  *  a release, and is not included. */
 export const RELEASE_NOTES: readonly ReleaseNote[] = [
   {
+    version: "0.9.10-rc.4",
+    date: "2026-08-20",
+    body: "- **The Shell Installer can update a Managed Installation.** Run the Installer\n  again to recover when an old 1667 version refuses a package with updated\n  legal notices. The Installer keeps the Installation ID and the previous\n  executable. It refuses an unmanaged executable and an automatic downgrade."
+  },
+  {
     version: "0.9.10-rc.3",
     date: "2026-08-19",
     body: "- **This beta has no additional product changes.** It contains the same\n  behavior as 0.9.10-rc.2."

--- a/tui/package.json
+++ b/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667",
-  "version": "0.9.10-rc.3",
+  "version": "0.9.10-rc.4",
   "private": true,
   "description": "A terminal environment for writing fiction with language models",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Outcome

Prepare 1667 0.9.10-rc.4 for beta publication. This beta includes the Shell Installer recovery path before the stable release.

## Changes

- Set the root, lockfile, and TUI versions to 0.9.10-rc.4.
- Add the 0.9.10-rc.4 changelog section.
- Regenerate the embedded release notes.

## Verification

- `npm run build`
- `npm test` (2,550 passed, 226 skipped)
- `tui: bun run typecheck`
- `tui: bun test` (2,058 passed, 2 skipped)
- `tui: bun bench/perf.ts`
- `tui: bun run build:standalone`
- `npm run notes:check-version -- 0.9.10-rc.4`

## Risks and limitations

- This version publishes to the beta channel.
- The homepage remains on the stable Installer until 0.9.10 is published.

Tracks #268
