### PR TITLE
test(clipboard): give the real helper tests a hang guard

### DIFF
--- a/tui/test/clipboard-macos.test.ts
+++ b/tui/test/clipboard-macos.test.ts
@@ -3,6 +3,7 @@ import { readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, test } from "bun:test";
+import { budgetTimeout } from "../../test/performance-budget.js";
 import { MAX_SOURCE_IMAGE_BYTES } from "../../shared/image-attachment.js";
 import { runClipboardHelperProcess, type ClipboardCommandRunner } from "../src/clipboard-command-runner.js";
 import {
@@ -115,6 +116,41 @@ describe("macOS clipboard image read, through the injectable seam", () => {
   });
 });
 
+/**
+ * The real helper's healthy wall cost, rounded up. `budgetTimeout` takes this
+ * as setup work that no budget measures, because this file has no budget for
+ * the helper: it checks the helper's reply, not its speed.
+ */
+const REAL_HELPER_WALL_MS = 1_000;
+
+/**
+ * The deadline for one real helper run. This is a hang guard, not a
+ * performance budget. Nothing in this file measures how fast the helper runs.
+ *
+ * The Windows helper carried the same flat 5-second deadline, and a hosted
+ * runner crossed it at random (issue #267). This test has not failed that
+ * way, because `osascript` starts faster than `powershell.exe`, which also
+ * compiles C# through `Add-Type` on every run. The cause is not specific to
+ * Windows though. A hosted runner shares its cores with other jobs, so a flat
+ * wall-clock deadline measures the runner and not the product, which is the
+ * failure `test/performance-budget.ts` describes at its top. The Intel macOS
+ * runner is the slowest target this project builds for, and it takes the
+ * largest slack from that same table.
+ *
+ * `tui/src/clipboard-macos.ts` keeps its own, much smaller deadline for the
+ * same helper. That deadline is a product decision: a paste holds the TUI
+ * input queue until the helper answers. This deadline only stops a wedged
+ * test.
+ */
+const REAL_HELPER_DEADLINE_MS = budgetTimeout([], REAL_HELPER_WALL_MS);
+
+/**
+ * The per-test timeout for the real helper test. This stays above the helper
+ * deadline, so a wedged helper fails on the assertions below instead of on an
+ * opaque test timeout.
+ */
+const REAL_HELPER_TEST_TIMEOUT_MS = REAL_HELPER_DEADLINE_MS * 2;
+
 describe("macOS clipboard image read, on a real machine", () => {
   test.skipIf(process.platform !== "darwin")(
     "returns no image when the clipboard holds no image, proven through the real helper",
@@ -133,11 +169,12 @@ describe("macOS clipboard image read, on a real machine", () => {
       const path = join(tmpdir(), `1667-clipboard-test-${randomBytes(16).toString("hex")}.tmp`);
       const { error, stdout } = await runClipboardHelperProcess(
         macosClipboardImageHelperCommand(path),
-        { timeoutMs: 5_000, killSignal: "SIGKILL", maxBuffer: 4_096 }
+        { timeoutMs: REAL_HELPER_DEADLINE_MS, killSignal: "SIGKILL", maxBuffer: 4_096 }
       );
       expect(error).toBeNull();
       expect(stdout.trim()).toBe("none");
-    }
+    },
+    REAL_HELPER_TEST_TIMEOUT_MS
   );
 
   test.skipIf(process.platform !== "darwin")(

--- a/tui/test/clipboard-windows.test.ts
+++ b/tui/test/clipboard-windows.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { budgetTimeout } from "../../test/performance-budget.js";
 import { MAX_SOURCE_IMAGE_BYTES } from "../../shared/image-attachment.js";
 import { runClipboardHelperProcess, type ClipboardCommandRunner } from "../src/clipboard-command-runner.js";
 import {
@@ -67,6 +68,48 @@ describe("Windows clipboard image read, through the injectable seam", () => {
   });
 });
 
+/**
+ * The real helper's measured healthy wall cost, rounded up. `budgetTimeout`
+ * takes this as setup work that no budget measures, because this file has no
+ * budget for the helper: it checks the helper's reply, not its speed.
+ */
+const REAL_HELPER_WALL_MS = 1_000;
+
+/**
+ * The deadline for one real helper run. This is a hang guard, not a
+ * performance budget. Nothing in this file measures how fast the helper runs.
+ *
+ * The old deadline was a flat 5 seconds, and it failed the CI job at random
+ * (issue #267). Across 40 healthy Windows CI runs, the helper measured 470ms
+ * to 2,196ms, with a median of 696ms. Every failed run measured between
+ * 5,031ms and 5,757ms. The gap between those two ranges shows a crossed
+ * deadline, not slow work. A hosted runner shares its cores with other jobs,
+ * and its process starts and its disk reads change speed by a large factor.
+ * One local run under heavy load measured 9,208ms, and the helper still gave
+ * the correct NO_IMAGE reply with no error. That delay comes from the runner,
+ * not from the product, which is the failure `test/performance-budget.ts`
+ * describes at its top. `budgetTimeout` supplies the contention slack that
+ * covers it.
+ *
+ * Windows sets a second, larger limit of its own. A clipboard read can wait
+ * up to 30 seconds for a delayed-render owner, and Windows does not let a
+ * caller change that limit. The old 5-second deadline was below the
+ * platform's own worst case. This deadline stays above it.
+ */
+const REAL_HELPER_DEADLINE_MS = budgetTimeout([], REAL_HELPER_WALL_MS);
+
+/**
+ * The per-test timeout for the real helper test. This stays above the
+ * helper deadline, so a wedged helper fails on the assertions below
+ * instead of on an opaque test timeout.
+ *
+ * `tui/src/clipboard-windows.ts` keeps its own, much smaller deadline for
+ * the same helper. That deadline is a product decision: a paste holds the
+ * TUI input queue until the helper answers. This deadline only stops a
+ * wedged test.
+ */
+const REAL_HELPER_TEST_TIMEOUT_MS = REAL_HELPER_DEADLINE_MS * 2;
+
 describe("Windows clipboard image read, on a real machine", () => {
   test.skipIf(process.platform !== "win32")(
     "returns no image when the clipboard holds no image, proven through the real helper",
@@ -82,12 +125,13 @@ describe("Windows clipboard image read, on a real machine", () => {
       // code did not throw, and the clipboard genuinely held no image, all
       // in one command.
       const { error, stdout } = await runClipboardHelperProcess(windowsClipboardImageCommand(), {
-        timeoutMs: 5_000,
+        timeoutMs: REAL_HELPER_DEADLINE_MS,
         maxBuffer: Math.ceil((MAX_SOURCE_IMAGE_BYTES * 4) / 3) + 4_096
       });
       expect(error).toBeNull();
       expect(stdout.trim()).toBe("NO_IMAGE");
-    }
+    },
+    REAL_HELPER_TEST_TIMEOUT_MS
   );
 
   test.skipIf(process.platform !== "win32")(


### PR DESCRIPTION
Tracks #267

## Summary

The real-machine clipboard tests gave their platform helper a flat 5-second
deadline. That deadline measures the runner, not the product, so the
`packaged-windows-x64` job failed at random.

The helper is correct. Only the deadline was wrong.

## Evidence

Sampled 47 `packaged-windows-x64` jobs with usable logs, covering the whole
life of the test:

- 40 passing runs measured **470ms to 2,196ms**, median **696ms**.
- All 7 failing runs measured **5,031ms to 5,757ms**, killed at the deadline
  with `killed: true, signal: "SIGTERM"`.

The gap between those two ranges shows a crossed deadline rather than slow
work. Failures do not correlate with date, branch, or runner image version.

Reproduced the mechanism locally on Windows 11:

- Idle: the helper measures about **310ms**.
- Under 48 competing processes: **1,665ms to 2,915ms**.
- Under 160 competing processes: one run took **9,208ms**, and it still
  returned the correct `NO_IMAGE` reply with no error.

Windows sets a larger limit of its own: a clipboard read can wait up to 30
seconds for a delayed-render owner, and Windows does not let a caller change
that limit. The old 5-second deadline sat below the platform's own worst
case.

This is the failure `test/performance-budget.ts` already describes at its
top: "That delay comes from the scheduler, not from the product. A
wall-clock budget counts the delay as product time and fails the test at
random."

## Change

Both real-machine tests now take their helper deadline from `budgetTimeout`
in `test/performance-budget.ts`, which owns the contention slack for a
hosted runner, and each test keeps a per-test timeout above its own helper
deadline. On `win32 x64` the deadline becomes 62,000ms.

Both assertions are unchanged, so the test proves exactly what it proved
before: `powershell.exe` started, `Add-Type` compiled, the Job Object code
did not throw, and the clipboard held no image.

`tui/test/clipboard-macos.test.ts` has never failed this way, but it carried
the same flat deadline and the same exposure, so it gets the same treatment.

## What this deliberately does not change

`tui/src/clipboard-windows.ts` and `tui/src/clipboard-macos.ts` keep their
own 5-second deadlines. Raising those would make a real problem worse: a
paste holds the TUI input queue until the helper answers, so a longer
product deadline turns a dropped paste into a longer visible freeze.

## Verification

- The four test files the Windows job runs: 43 pass, 0 fail.
- The clipboard test under 160 and 200 competing processes: 10 pass, 0 fail,
  across four consecutive runs.
- `bun run typecheck` in `tui`: clean.
- `npm run build` (schema, release notes, `tsc --noEmit`): clean.
- Windows runtime platform tests: 11 pass, 0 fail.
- `scripts/check-commit-attribution.ts`: clean.
