### PR TITLE
feat(settings): list subscription plan models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This file records notable changes to 1667. Product terms use the definitions in
 
 ## Unreleased
 
+- **ChatGPT and Claude plans show their bundled model catalogs.** Select a
+  model in Settings, or enter a model ID manually.
+
 ## 0.9.10-rc.4 - 2026-08-20
 
 - **The Shell Installer can update a Managed Installation.** Run the Installer

--- a/docs/model-providers.md
+++ b/docs/model-providers.md
@@ -355,10 +355,11 @@ change model behavior, output limits, request cost, and privacy controls.
 ChatGPT output length is best effort. The provider can stop before the
 configured maximum or apply its own limit. Claude plan support is experimental.
 
-1667 does not run model discovery for a plan connection. Enter the model ID
-manually in the **model** row. The plan choices use `gpt-5.4` and
-`claude-sonnet-4-6` as current defaults; the provider catalog remains the
-authority. If plan sign-in is unavailable, use an API-key connection. Use
+1667 reads each plan model list from the bundled Pi catalog. Select a model in
+the **model** row, or enter a model ID manually. Catalog updates arrive with Pi
+dependency updates. The plan choices use `gpt-5.4` and `claude-sonnet-4-6` as
+current defaults. The provider catalog remains the authority. If plan sign-in
+is unavailable, use an API-key connection. Use
 **OpenAI** or **OpenAI-compatible** with an OpenAI key for ChatGPT-compatible
 work. Use **Anthropic** with an Anthropic API key for Claude-compatible work.
 

--- a/evals/gemma-prompt-quality/profile.ts
+++ b/evals/gemma-prompt-quality/profile.ts
@@ -3,7 +3,7 @@ import { readFile } from "node:fs/promises";
 import { canonicalJson } from "../../server/canonical-json.js";
 import { importProfileExport } from "../../server/import-profile-export.js";
 import { parseJsonRejectingDuplicateKeys } from "../../server/strict-json.js";
-import { effectiveStandardGenerationRuntime } from "../../server/settings-v2-conversion.js";
+import { effectiveStandardGenerationRuntime } from "../../server/settings-runtime-resolver.js";
 import {
   defaultModelCapabilities
 } from "../../shared/settings-provider-defaults.js";

--- a/evals/gemma-prompt-quality/profile.ts
+++ b/evals/gemma-prompt-quality/profile.ts
@@ -3,8 +3,7 @@ import { readFile } from "node:fs/promises";
 import { canonicalJson } from "../../server/canonical-json.js";
 import { importProfileExport } from "../../server/import-profile-export.js";
 import { parseJsonRejectingDuplicateKeys } from "../../server/strict-json.js";
-import { effectiveGenerationRuntime } from "../../server/settings-v2-conversion.js";
-import { createSubscriptionRuntime } from "../../server/subscription-runtime.js";
+import { effectiveStandardGenerationRuntime } from "../../server/settings-v2-conversion.js";
 import {
   defaultModelCapabilities
 } from "../../shared/settings-provider-defaults.js";
@@ -39,8 +38,6 @@ export interface ReplayProfile {
   /** The complete manifest explicitly records the raw token-bias map. */
   readonly logitBiasState: "empty" | "present";
 }
-
-const SUBSCRIPTION_RUNTIME = createSubscriptionRuntime(process.cwd());
 
 /** Shape shared by replay and evidence artifacts before canonical projection. */
 export interface ReplayProfileBoundary {
@@ -232,13 +229,7 @@ export function replaySettings(
     optimization,
     apiKeyEnv
   );
-  return effectiveGenerationRuntime(
-    document,
-    "default",
-    {},
-    undefined,
-    { subscription: SUBSCRIPTION_RUNTIME }
-  ).settings;
+  return effectiveStandardGenerationRuntime(document).settings;
 }
 
 function replaySettingsDocument(

--- a/evals/gemma-prompt-quality/profile.ts
+++ b/evals/gemma-prompt-quality/profile.ts
@@ -4,6 +4,7 @@ import { canonicalJson } from "../../server/canonical-json.js";
 import { importProfileExport } from "../../server/import-profile-export.js";
 import { parseJsonRejectingDuplicateKeys } from "../../server/strict-json.js";
 import { effectiveGenerationRuntime } from "../../server/settings-v2-conversion.js";
+import { createSubscriptionRuntime } from "../../server/subscription-runtime.js";
 import {
   defaultModelCapabilities
 } from "../../shared/settings-provider-defaults.js";
@@ -38,6 +39,8 @@ export interface ReplayProfile {
   /** The complete manifest explicitly records the raw token-bias map. */
   readonly logitBiasState: "empty" | "present";
 }
+
+const SUBSCRIPTION_RUNTIME = createSubscriptionRuntime(process.cwd());
 
 /** Shape shared by replay and evidence artifacts before canonical projection. */
 export interface ReplayProfileBoundary {
@@ -229,7 +232,13 @@ export function replaySettings(
     optimization,
     apiKeyEnv
   );
-  return effectiveGenerationRuntime(document).settings;
+  return effectiveGenerationRuntime(
+    document,
+    "default",
+    {},
+    undefined,
+    { subscription: SUBSCRIPTION_RUNTIME }
+  ).settings;
 }
 
 function replaySettingsDocument(

--- a/server/model-discovery.ts
+++ b/server/model-discovery.ts
@@ -1,7 +1,10 @@
+import { anthropicProvider } from "@earendil-works/pi-ai/providers/anthropic";
+import { openaiCodexProvider } from "@earendil-works/pi-ai/providers/openai-codex";
 import type {
   DiscoveredModelV2,
   ModelDiscoveryResultV2,
-  ModelDiscoverySourceV2
+  ModelDiscoverySourceV2,
+  SubscriptionProtocolV2
 } from "../shared/settings-v2-types.js";
 import { isSubscriptionProtocolV2 } from "../shared/settings-v2-types.js";
 import type { GenerationSettings } from "../shared/types.js";
@@ -27,7 +30,10 @@ export async function discoverProviderModels(
   }
   const runtime = providerRuntimeFor(settings);
   if (runtime.protocol !== undefined && isSubscriptionProtocolV2(runtime.protocol)) {
-    return { observedAt: now().toISOString(), models: [] };
+    return {
+      observedAt: now().toISOString(),
+      models: subscriptionCatalog(runtime.protocol)
+    };
   }
   const root = providerRoot(settings);
   const timeoutMs = Math.min(runtime.timeouts.totalMs, 30_000);
@@ -56,6 +62,23 @@ export async function discoverProviderModels(
     observedAt: now().toISOString(),
     models: result
   };
+}
+
+function subscriptionCatalog(
+  protocol: SubscriptionProtocolV2
+): readonly DiscoveredModelV2[] {
+  const provider = protocol === "openai-codex-responses"
+    ? openaiCodexProvider()
+    : anthropicProvider();
+  return provider.getModels()
+    .slice(0, MAX_DISCOVERED_MODELS)
+    .map((model) => ({
+      remoteId: model.id,
+      name: model.name,
+      contextWindow: model.contextWindow,
+      maxOutputTokens: model.maxTokens,
+      source: "pi-catalog"
+    }));
 }
 
 function anthropicDiscoveryUrl(settings: GenerationSettings): string {

--- a/server/model-discovery.ts
+++ b/server/model-discovery.ts
@@ -1,3 +1,4 @@
+import type { Api, Model, Models } from "@earendil-works/pi-ai";
 import type {
   DiscoveredModelV2,
   ModelDiscoveryResultV2,
@@ -20,6 +21,49 @@ import {
 } from "./settings-v2-scalars.js";
 
 const MAX_DISCOVERED_MODELS = 256;
+
+type NetworkDiscoverySourceV2 = Exclude<ModelDiscoverySourceV2, "pi-catalog">;
+
+interface DiscoveryCandidate {
+  readonly remoteId: unknown;
+  readonly name: unknown;
+  readonly contextWindow: readonly unknown[];
+  readonly maxOutputTokens: readonly unknown[];
+}
+
+interface NetworkCatalogAdapter {
+  readonly entries: (data: unknown) => readonly unknown[] | null;
+  readonly candidate: (entry: unknown) => DiscoveryCandidate | null;
+}
+
+const NETWORK_CATALOG_ADAPTERS = {
+  "anthropic-models": {
+    entries: dataEntries,
+    candidate: (entry) => objectCandidate(entry, {
+      id: "id",
+      name: "display_name",
+      contextWindow: "max_input_tokens",
+      maxOutputTokens: "max_tokens"
+    })
+  },
+  "openai-models": {
+    entries: dataEntries,
+    candidate: openAiCandidate
+  },
+  "lm-studio-models": {
+    entries: dataEntries,
+    candidate: (entry) => objectCandidate(entry, {
+      id: "id",
+      name: "name",
+      contextWindow: "loaded_context_length",
+      maxOutputTokens: "max_output_tokens"
+    })
+  },
+  "ollama-tags": {
+    entries: modelEntries,
+    candidate: ollamaCandidate
+  }
+} satisfies Record<NetworkDiscoverySourceV2, NetworkCatalogAdapter>;
 
 export async function discoverProviderModels(
   settings: GenerationSettings,
@@ -68,10 +112,19 @@ export async function discoverProviderModels(
 function subscriptionCatalog(
   runtime: SubscriptionProviderRuntime
 ): readonly DiscoveredModelV2[] {
-  const providerId = subscriptionProviderForProtocol(runtime.protocol);
-  return normalizeDiscoveredModels(
-    runtime.subscription.models.getModels(providerId),
-    "pi-catalog"
+  return discoverSubscriptionCatalog(runtime.subscription.models, runtime.protocol);
+}
+
+/** Project one Pi provider catalog through the durable discovery policy. */
+export function discoverSubscriptionCatalog(
+  models: Pick<Models, "getModels">,
+  protocol: SubscriptionProviderRuntime["protocol"]
+): readonly DiscoveredModelV2[] {
+  const providerId = subscriptionProviderForProtocol(protocol);
+  return sanitizeCandidates(
+    models.getModels(providerId),
+    "pi-catalog",
+    piCandidate
   );
 }
 
@@ -85,7 +138,7 @@ function anthropicDiscoveryUrl(settings: GenerationSettings): string {
 async function discover(
   settings: GenerationSettings,
   url: string,
-  source: ModelDiscoverySourceV2,
+  source: NetworkDiscoverySourceV2,
   headers: Readonly<Record<string, string>>,
   timeoutMs: number,
   signal?: AbortSignal
@@ -94,43 +147,32 @@ async function discover(
     signal,
     timeoutMs
   });
-  const entries = source === "ollama-tags"
-    ? isObject(data) && Array.isArray(data.models) ? data.models : null
-    : isObject(data) && Array.isArray(data.data) ? data.data : null;
+  const adapter = NETWORK_CATALOG_ADAPTERS[source];
+  const entries = adapter.entries(data);
   if (entries === null) {
     throw new ProviderError(`Model discovery returned an invalid ${source} catalog.`);
   }
-  return normalizeDiscoveredModels(entries, source);
+  return sanitizeCandidates(entries, source, adapter.candidate);
 }
 
-function normalizeDiscoveredModels(
-  entries: readonly unknown[],
-  source: ModelDiscoverySourceV2
+function sanitizeCandidates<T>(
+  entries: readonly T[],
+  source: ModelDiscoverySourceV2,
+  candidateFor: (entry: T) => DiscoveryCandidate | null
 ): readonly DiscoveredModelV2[] {
   const result: DiscoveredModelV2[] = [];
   const seen = new Set<string>();
   for (const entry of entries) {
-    if (!isObject(entry)) continue;
-    const remoteId = modelId(entry, source);
+    const candidate = candidateFor(entry);
+    if (candidate === null) continue;
+    const remoteId = safeModelId(candidate.remoteId);
     if (remoteId === null || seen.has(remoteId)) continue;
     seen.add(remoteId);
     result.push({
       remoteId,
-      name: modelName(entry, remoteId),
-      contextWindow: source === "anthropic-models"
-        ? modelScalar(entry, "max_input_tokens")
-        : source === "pi-catalog"
-          ? modelScalar(entry, "contextWindow")
-        : source === "lm-studio-models"
-          ? modelScalar(entry, "loaded_context_length")
-          : modelScalar(entry, "loaded_context_length")
-            ?? modelScalar(entry, "context_length")
-            ?? modelScalar(entry, "max_context_length"),
-      maxOutputTokens: source === "anthropic-models"
-        ? modelScalar(entry, "max_tokens")
-        : source === "pi-catalog"
-          ? modelScalar(entry, "maxTokens")
-        : modelScalar(entry, "max_output_tokens"),
+      name: safeModelName(candidate.name, remoteId),
+      contextWindow: firstSafeModelScalar(candidate.contextWindow),
+      maxOutputTokens: firstSafeModelScalar(candidate.maxOutputTokens),
       source
     });
     if (result.length === MAX_DISCOVERED_MODELS) break;
@@ -138,13 +180,7 @@ function normalizeDiscoveredModels(
   return result;
 }
 
-function modelId(
-  entry: Record<string, unknown>,
-  source: ModelDiscoverySourceV2
-): string | null {
-  const value = source === "ollama-tags"
-    ? typeof entry.model === "string" ? entry.model : entry.name
-    : entry.id;
+function safeModelId(value: unknown): string | null {
   if (
     typeof value !== "string"
     || value.length === 0
@@ -158,13 +194,9 @@ function modelId(
     : null;
 }
 
-function modelName(entry: Record<string, unknown>, fallback: string): string {
-  const value = typeof entry.display_name === "string"
-    ? entry.display_name
-    : typeof entry.name === "string"
-      ? entry.name
-      : fallback;
-  const safe = value.trim().length === 0
+function safeModelName(value: unknown, fallback: string): string {
+  const safe = typeof value !== "string"
+    || value.trim().length === 0
     || hasUnpairedSurrogate(value)
     || value.normalize("NFC") !== value
     ? fallback
@@ -172,14 +204,84 @@ function modelName(entry: Record<string, unknown>, fallback: string): string {
   return Array.from(safe).slice(0, 256).join("");
 }
 
-function modelScalar(entry: Record<string, unknown>, key: string): number | null {
-  const value = entry[key];
+function safeModelScalar(value: unknown): number | null {
   return typeof value === "number"
     && Number.isSafeInteger(value)
     && value > 0
     && value <= MAX_SETTINGS_TOKEN_COUNT
     ? value
     : null;
+}
+
+function firstSafeModelScalar(values: readonly unknown[]): number | null {
+  for (const value of values) {
+    const scalar = safeModelScalar(value);
+    if (scalar !== null) return scalar;
+  }
+  return null;
+}
+
+function dataEntries(data: unknown): readonly unknown[] | null {
+  return isObject(data) && Array.isArray(data.data) ? data.data : null;
+}
+
+function modelEntries(data: unknown): readonly unknown[] | null {
+  return isObject(data) && Array.isArray(data.models) ? data.models : null;
+}
+
+function objectCandidate(
+  entry: unknown,
+  keys: {
+    readonly id: string;
+    readonly name: string;
+    readonly contextWindow: string;
+    readonly maxOutputTokens: string;
+  }
+): DiscoveryCandidate | null {
+  if (!isObject(entry)) return null;
+  return {
+    remoteId: entry[keys.id],
+    name: typeof entry[keys.name] === "string" ? entry[keys.name] : entry.name,
+    contextWindow: [entry[keys.contextWindow]],
+    maxOutputTokens: [entry[keys.maxOutputTokens]]
+  };
+}
+
+function openAiCandidate(entry: unknown): DiscoveryCandidate | null {
+  if (!isObject(entry)) return null;
+  return {
+    remoteId: entry.id,
+    name: typeof entry.display_name === "string" ? entry.display_name : entry.name,
+    contextWindow: [
+      entry.loaded_context_length,
+      entry.context_length,
+      entry.max_context_length
+    ],
+    maxOutputTokens: [entry.max_output_tokens]
+  };
+}
+
+function ollamaCandidate(entry: unknown): DiscoveryCandidate | null {
+  if (!isObject(entry)) return null;
+  return {
+    remoteId: typeof entry.model === "string" ? entry.model : entry.name,
+    name: typeof entry.display_name === "string" ? entry.display_name : entry.name,
+    contextWindow: [
+      entry.loaded_context_length,
+      entry.context_length,
+      entry.max_context_length
+    ],
+    maxOutputTokens: [entry.max_output_tokens]
+  };
+}
+
+function piCandidate(model: Model<Api>): DiscoveryCandidate {
+  return {
+    remoteId: model.id,
+    name: model.name,
+    contextWindow: [model.contextWindow],
+    maxOutputTokens: [model.maxTokens]
+  };
 }
 
 function isObject(value: unknown): value is Record<string, unknown> {

--- a/server/model-discovery.ts
+++ b/server/model-discovery.ts
@@ -1,11 +1,14 @@
-import type { Api, Model, Models } from "@earendil-works/pi-ai";
 import type {
-  DiscoveredModelV2,
   ModelDiscoveryResultV2,
   ModelDiscoverySourceV2
 } from "../shared/settings-v2-types.js";
 import type { GenerationSettings } from "../shared/types.js";
-import { hasUnpairedSurrogate, unicodeScalarLength } from "../shared/unicode.js";
+import {
+  MAX_DISCOVERED_MODELS,
+  discoverBundledModels,
+  sanitizeDiscoveredModels,
+  type ModelDiscoveryCandidate
+} from "../shared/model-discovery-catalog.js";
 import { ProviderError } from "./errors.js";
 import { getProviderJson } from "./provider-json.js";
 import {
@@ -15,25 +18,12 @@ import {
 } from "./provider-runtime.js";
 import { providerRoot, providerUrl } from "./providers.js";
 import { subscriptionProviderForProtocol } from "./subscription-protocol.js";
-import {
-  MAX_SETTINGS_REMOTE_ID_SCALARS,
-  MAX_SETTINGS_TOKEN_COUNT
-} from "./settings-v2-scalars.js";
-
-const MAX_DISCOVERED_MODELS = 256;
 
 type NetworkDiscoverySourceV2 = Exclude<ModelDiscoverySourceV2, "pi-catalog">;
 
-interface DiscoveryCandidate {
-  readonly remoteId: unknown;
-  readonly name: unknown;
-  readonly contextWindow: readonly unknown[];
-  readonly maxOutputTokens: readonly unknown[];
-}
-
 interface NetworkCatalogAdapter {
   readonly entries: (data: unknown) => readonly unknown[] | null;
-  readonly candidate: (entry: unknown) => DiscoveryCandidate | null;
+  readonly candidate: (entry: unknown) => ModelDiscoveryCandidate | null;
 }
 
 const NETWORK_CATALOG_ADAPTERS = {
@@ -111,21 +101,9 @@ export async function discoverProviderModels(
 
 function subscriptionCatalog(
   runtime: SubscriptionProviderRuntime
-): readonly DiscoveredModelV2[] {
-  return discoverSubscriptionCatalog(runtime.subscription.models, runtime.protocol);
-}
-
-/** Project one Pi provider catalog through the durable discovery policy. */
-export function discoverSubscriptionCatalog(
-  models: Pick<Models, "getModels">,
-  protocol: SubscriptionProviderRuntime["protocol"]
-): readonly DiscoveredModelV2[] {
-  const providerId = subscriptionProviderForProtocol(protocol);
-  return sanitizeCandidates(
-    models.getModels(providerId),
-    "pi-catalog",
-    piCandidate
-  );
+): ModelDiscoveryResultV2["models"] {
+  const providerId = subscriptionProviderForProtocol(runtime.protocol);
+  return discoverBundledModels(runtime.subscription.models.getModels(providerId));
 }
 
 function anthropicDiscoveryUrl(settings: GenerationSettings): string {
@@ -142,7 +120,7 @@ async function discover(
   headers: Readonly<Record<string, string>>,
   timeoutMs: number,
   signal?: AbortSignal
-): Promise<readonly DiscoveredModelV2[]> {
+): Promise<ModelDiscoveryResultV2["models"]> {
   const data = await getProviderJson(settings, url, headers, {
     signal,
     timeoutMs
@@ -152,73 +130,7 @@ async function discover(
   if (entries === null) {
     throw new ProviderError(`Model discovery returned an invalid ${source} catalog.`);
   }
-  return sanitizeCandidates(entries, source, adapter.candidate);
-}
-
-function sanitizeCandidates<T>(
-  entries: readonly T[],
-  source: ModelDiscoverySourceV2,
-  candidateFor: (entry: T) => DiscoveryCandidate | null
-): readonly DiscoveredModelV2[] {
-  const result: DiscoveredModelV2[] = [];
-  const seen = new Set<string>();
-  for (const entry of entries) {
-    const candidate = candidateFor(entry);
-    if (candidate === null) continue;
-    const remoteId = safeModelId(candidate.remoteId);
-    if (remoteId === null || seen.has(remoteId)) continue;
-    seen.add(remoteId);
-    result.push({
-      remoteId,
-      name: safeModelName(candidate.name, remoteId),
-      contextWindow: firstSafeModelScalar(candidate.contextWindow),
-      maxOutputTokens: firstSafeModelScalar(candidate.maxOutputTokens),
-      source
-    });
-    if (result.length === MAX_DISCOVERED_MODELS) break;
-  }
-  return result;
-}
-
-function safeModelId(value: unknown): string | null {
-  if (
-    typeof value !== "string"
-    || value.length === 0
-    || value.trim() !== value
-    || hasUnpairedSurrogate(value)
-    || value.normalize("NFC") !== value
-  ) return null;
-  return unicodeScalarLength(value, MAX_SETTINGS_REMOTE_ID_SCALARS)
-    <= MAX_SETTINGS_REMOTE_ID_SCALARS
-    ? value
-    : null;
-}
-
-function safeModelName(value: unknown, fallback: string): string {
-  const safe = typeof value !== "string"
-    || value.trim().length === 0
-    || hasUnpairedSurrogate(value)
-    || value.normalize("NFC") !== value
-    ? fallback
-    : value;
-  return Array.from(safe).slice(0, 256).join("");
-}
-
-function safeModelScalar(value: unknown): number | null {
-  return typeof value === "number"
-    && Number.isSafeInteger(value)
-    && value > 0
-    && value <= MAX_SETTINGS_TOKEN_COUNT
-    ? value
-    : null;
-}
-
-function firstSafeModelScalar(values: readonly unknown[]): number | null {
-  for (const value of values) {
-    const scalar = safeModelScalar(value);
-    if (scalar !== null) return scalar;
-  }
-  return null;
+  return sanitizeDiscoveredModels(entries, source, adapter.candidate);
 }
 
 function dataEntries(data: unknown): readonly unknown[] | null {
@@ -237,7 +149,7 @@ function objectCandidate(
     readonly contextWindow: string;
     readonly maxOutputTokens: string;
   }
-): DiscoveryCandidate | null {
+): ModelDiscoveryCandidate | null {
   if (!isObject(entry)) return null;
   return {
     remoteId: entry[keys.id],
@@ -247,7 +159,7 @@ function objectCandidate(
   };
 }
 
-function openAiCandidate(entry: unknown): DiscoveryCandidate | null {
+function openAiCandidate(entry: unknown): ModelDiscoveryCandidate | null {
   if (!isObject(entry)) return null;
   return {
     remoteId: entry.id,
@@ -261,7 +173,7 @@ function openAiCandidate(entry: unknown): DiscoveryCandidate | null {
   };
 }
 
-function ollamaCandidate(entry: unknown): DiscoveryCandidate | null {
+function ollamaCandidate(entry: unknown): ModelDiscoveryCandidate | null {
   if (!isObject(entry)) return null;
   return {
     remoteId: typeof entry.model === "string" ? entry.model : entry.name,
@@ -272,15 +184,6 @@ function ollamaCandidate(entry: unknown): DiscoveryCandidate | null {
       entry.max_context_length
     ],
     maxOutputTokens: [entry.max_output_tokens]
-  };
-}
-
-function piCandidate(model: Model<Api>): DiscoveryCandidate {
-  return {
-    remoteId: model.id,
-    name: model.name,
-    contextWindow: [model.contextWindow],
-    maxOutputTokens: [model.maxTokens]
   };
 }
 

--- a/server/model-discovery.ts
+++ b/server/model-discovery.ts
@@ -1,18 +1,16 @@
 import type {
   DiscoveredModelV2,
   ModelDiscoveryResultV2,
-  ModelDiscoverySourceV2,
-  SubscriptionProtocolV2
+  ModelDiscoverySourceV2
 } from "../shared/settings-v2-types.js";
-import { isSubscriptionProtocolV2 } from "../shared/settings-v2-types.js";
 import type { GenerationSettings } from "../shared/types.js";
 import { hasUnpairedSurrogate, unicodeScalarLength } from "../shared/unicode.js";
 import { ProviderError } from "./errors.js";
 import { getProviderJson } from "./provider-json.js";
 import {
+  isSubscriptionProviderRuntime,
   providerRuntimeFor,
-  subscriptionRuntimeFor,
-  type ProviderRuntime
+  type SubscriptionProviderRuntime
 } from "./provider-runtime.js";
 import { providerRoot, providerUrl } from "./providers.js";
 import { subscriptionProviderForProtocol } from "./subscription-protocol.js";
@@ -32,10 +30,10 @@ export async function discoverProviderModels(
     return { observedAt: now().toISOString(), models: [] };
   }
   const runtime = providerRuntimeFor(settings);
-  if (runtime.protocol !== undefined && isSubscriptionProtocolV2(runtime.protocol)) {
+  if (isSubscriptionProviderRuntime(runtime)) {
     return {
       observedAt: now().toISOString(),
-      models: subscriptionCatalog(runtime, runtime.protocol)
+      models: subscriptionCatalog(runtime)
     };
   }
   const root = providerRoot(settings);
@@ -68,19 +66,13 @@ export async function discoverProviderModels(
 }
 
 function subscriptionCatalog(
-  runtime: ProviderRuntime,
-  protocol: SubscriptionProtocolV2
+  runtime: SubscriptionProviderRuntime
 ): readonly DiscoveredModelV2[] {
-  const providerId = subscriptionProviderForProtocol(protocol);
-  return subscriptionRuntimeFor(runtime).models.getModels(providerId)
-    .slice(0, MAX_DISCOVERED_MODELS)
-    .map((model) => ({
-      remoteId: model.id,
-      name: model.name,
-      contextWindow: model.contextWindow,
-      maxOutputTokens: model.maxTokens,
-      source: "pi-catalog"
-    }));
+  const providerId = subscriptionProviderForProtocol(runtime.protocol);
+  return normalizeDiscoveredModels(
+    runtime.subscription.models.getModels(providerId),
+    "pi-catalog"
+  );
 }
 
 function anthropicDiscoveryUrl(settings: GenerationSettings): string {
@@ -108,6 +100,13 @@ async function discover(
   if (entries === null) {
     throw new ProviderError(`Model discovery returned an invalid ${source} catalog.`);
   }
+  return normalizeDiscoveredModels(entries, source);
+}
+
+function normalizeDiscoveredModels(
+  entries: readonly unknown[],
+  source: ModelDiscoverySourceV2
+): readonly DiscoveredModelV2[] {
   const result: DiscoveredModelV2[] = [];
   const seen = new Set<string>();
   for (const entry of entries) {
@@ -120,6 +119,8 @@ async function discover(
       name: modelName(entry, remoteId),
       contextWindow: source === "anthropic-models"
         ? modelScalar(entry, "max_input_tokens")
+        : source === "pi-catalog"
+          ? modelScalar(entry, "contextWindow")
         : source === "lm-studio-models"
           ? modelScalar(entry, "loaded_context_length")
           : modelScalar(entry, "loaded_context_length")
@@ -127,6 +128,8 @@ async function discover(
             ?? modelScalar(entry, "max_context_length"),
       maxOutputTokens: source === "anthropic-models"
         ? modelScalar(entry, "max_tokens")
+        : source === "pi-catalog"
+          ? modelScalar(entry, "maxTokens")
         : modelScalar(entry, "max_output_tokens"),
       source
     });

--- a/server/model-discovery.ts
+++ b/server/model-discovery.ts
@@ -1,5 +1,3 @@
-import { anthropicProvider } from "@earendil-works/pi-ai/providers/anthropic";
-import { openaiCodexProvider } from "@earendil-works/pi-ai/providers/openai-codex";
 import type {
   DiscoveredModelV2,
   ModelDiscoveryResultV2,
@@ -11,8 +9,13 @@ import type { GenerationSettings } from "../shared/types.js";
 import { hasUnpairedSurrogate, unicodeScalarLength } from "../shared/unicode.js";
 import { ProviderError } from "./errors.js";
 import { getProviderJson } from "./provider-json.js";
-import { providerRuntimeFor } from "./provider-runtime.js";
+import {
+  providerRuntimeFor,
+  subscriptionRuntimeFor,
+  type ProviderRuntime
+} from "./provider-runtime.js";
 import { providerRoot, providerUrl } from "./providers.js";
+import { subscriptionProviderForProtocol } from "./subscription-protocol.js";
 import {
   MAX_SETTINGS_REMOTE_ID_SCALARS,
   MAX_SETTINGS_TOKEN_COUNT
@@ -32,7 +35,7 @@ export async function discoverProviderModels(
   if (runtime.protocol !== undefined && isSubscriptionProtocolV2(runtime.protocol)) {
     return {
       observedAt: now().toISOString(),
-      models: subscriptionCatalog(runtime.protocol)
+      models: subscriptionCatalog(runtime, runtime.protocol)
     };
   }
   const root = providerRoot(settings);
@@ -65,12 +68,11 @@ export async function discoverProviderModels(
 }
 
 function subscriptionCatalog(
+  runtime: ProviderRuntime,
   protocol: SubscriptionProtocolV2
 ): readonly DiscoveredModelV2[] {
-  const provider = protocol === "openai-codex-responses"
-    ? openaiCodexProvider()
-    : anthropicProvider();
-  return provider.getModels()
+  const providerId = subscriptionProviderForProtocol(protocol);
+  return subscriptionRuntimeFor(runtime).models.getModels(providerId)
     .slice(0, MAX_DISCOVERED_MODELS)
     .map((model) => ({
       remoteId: model.id,

--- a/server/provider-runtime.ts
+++ b/server/provider-runtime.ts
@@ -17,7 +17,10 @@ import {
   type ContinuationPromptLayout,
   type ContinuationPromptOptimizationV2
 } from "../shared/continuation-prompt-optimization.js";
-import { EMPTY_SAMPLING_V2 } from "../shared/settings-v2-types.js";
+import {
+  EMPTY_SAMPLING_V2,
+  isSubscriptionProtocolV2
+} from "../shared/settings-v2-types.js";
 import type { GenerationSettings } from "../shared/types.js";
 import { defaultConnectionTimeouts } from "../shared/settings-provider-defaults.js";
 import {
@@ -36,10 +39,8 @@ const PROVIDER_SECRET_REDACTORS = new WeakMap<
   (value: string) => string
 >();
 
-export interface ProviderRuntime {
+interface ProviderRuntimeBase {
   readonly preset: SettingsPresetV2;
-  /** Absent only on legacy test/runtime attachments. */
-  readonly protocol?: SettingsProtocolV2 | SubscriptionProtocolV2;
   /** Text routes use raw prompts when this value is absent. */
   readonly textPromptFormat?: "raw" | "server-template" | "chatml";
   /** From `ModelConnectionV2.splitThinkTags`. A text route otherwise passes
@@ -72,9 +73,20 @@ export interface ProviderRuntime {
   readonly continuationPromptLayout?: ContinuationPromptLayout;
   readonly capabilities: ModelCapabilitiesV2;
   readonly sampling: SamplingSettingsV2;
-  /** Present only for the fixed subscription protocols. */
-  readonly subscription?: SubscriptionRuntimeDependencies;
 }
+
+export interface SubscriptionProviderRuntime extends ProviderRuntimeBase {
+  readonly protocol: SubscriptionProtocolV2;
+  readonly subscription: SubscriptionRuntimeDependencies;
+}
+
+export interface StandardProviderRuntime extends ProviderRuntimeBase {
+  /** Absent only on legacy test/runtime attachments. */
+  readonly protocol?: Exclude<SettingsProtocolV2, SubscriptionProtocolV2>;
+  readonly subscription?: never;
+}
+
+export type ProviderRuntime = SubscriptionProviderRuntime | StandardProviderRuntime;
 
 type RuntimeSettings = GenerationSettings & {
   readonly [PROVIDER_RUNTIME]?: ProviderRuntime;
@@ -123,13 +135,10 @@ export function providerRuntimeFor(settings: GenerationSettings): ProviderRuntim
   return (settings as RuntimeSettings)[PROVIDER_RUNTIME] ?? legacyProviderRuntime(settings);
 }
 
-export function subscriptionRuntimeFor(
+export function isSubscriptionProviderRuntime(
   runtime: ProviderRuntime
-): SubscriptionRuntimeDependencies {
-  if (runtime.subscription === undefined) {
-    throw new ProviderError("Subscription credential storage is unavailable.");
-  }
-  return runtime.subscription;
+): runtime is SubscriptionProviderRuntime {
+  return runtime.protocol !== undefined && isSubscriptionProtocolV2(runtime.protocol);
 }
 
 export function hasProviderRuntime(settings: GenerationSettings): boolean {
@@ -142,9 +151,8 @@ export function providerRuntimeFromV2(
   capabilities: ModelCapabilitiesV2,
   options: ProviderRuntimeOptions = {}
 ): ProviderRuntime {
-  const runtime: ProviderRuntime = {
+  const base: ProviderRuntimeBase = {
     preset: connection.preset,
-    protocol: connection.protocol,
     textPromptFormat: connection.textPromptFormat ?? "raw",
     splitThinkTags: connection.splitThinkTags === true,
     auth: connection.auth,
@@ -157,9 +165,15 @@ export function providerRuntimeFromV2(
     keepReasoning: options.keepReasoning ?? true,
     continuationPromptLayout: continuationPromptLayoutForOptimization(options.continuationPromptOptimization),
     capabilities,
-    sampling: options.sampling ?? EMPTY_SAMPLING_V2,
-    ...(options.subscription === undefined ? {} : { subscription: options.subscription })
+    sampling: options.sampling ?? EMPTY_SAMPLING_V2
   };
+  const runtime: ProviderRuntime = isSubscriptionProtocolV2(connection.protocol)
+    ? {
+        ...base,
+        protocol: connection.protocol,
+        subscription: requireSubscriptionDependencies(options.subscription)
+      }
+    : { ...base, protocol: connection.protocol };
   if (options.environment !== undefined || options.storedSecrets !== undefined) {
     const slots = new Map<string, string>();
     for (const reference of credentialReferences(connection)) {
@@ -180,6 +194,15 @@ export function providerRuntimeFromV2(
     PROVIDER_CREDENTIALS.set(runtime, slots);
   }
   return runtime;
+}
+
+function requireSubscriptionDependencies(
+  value: SubscriptionRuntimeDependencies | undefined
+): SubscriptionRuntimeDependencies {
+  if (value === undefined) {
+    throw new ProviderError("Subscription credential storage is unavailable.");
+  }
+  return value;
 }
 
 export function resolveProviderHeaders(

--- a/server/provider-runtime.ts
+++ b/server/provider-runtime.ts
@@ -120,6 +120,18 @@ export type SubscriptionModelConnectionV2 = Omit<ModelConnectionV2, "protocol"> 
   readonly protocol: SubscriptionProtocolV2;
 };
 
+export function isSubscriptionModelConnectionV2(
+  connection: ModelConnectionV2
+): connection is SubscriptionModelConnectionV2 {
+  return isSubscriptionProtocolV2(connection.protocol);
+}
+
+export function isStandardModelConnectionV2(
+  connection: ModelConnectionV2
+): connection is StandardModelConnectionV2 {
+  return !isSubscriptionProtocolV2(connection.protocol);
+}
+
 /** Attach server-only runtime policy without changing the frozen JSON settings
  * contract. Enumerable symbols survive the small `{ ...settings }` budget
  * overrides used by generation, while JSON and Object.keys ignore them. */

--- a/server/provider-runtime.ts
+++ b/server/provider-runtime.ts
@@ -123,6 +123,15 @@ export function providerRuntimeFor(settings: GenerationSettings): ProviderRuntim
   return (settings as RuntimeSettings)[PROVIDER_RUNTIME] ?? legacyProviderRuntime(settings);
 }
 
+export function subscriptionRuntimeFor(
+  runtime: ProviderRuntime
+): SubscriptionRuntimeDependencies {
+  if (runtime.subscription === undefined) {
+    throw new ProviderError("Subscription credential storage is unavailable.");
+  }
+  return runtime.subscription;
+}
+
 export function hasProviderRuntime(settings: GenerationSettings): boolean {
   return (settings as RuntimeSettings)[PROVIDER_RUNTIME] !== undefined;
 }

--- a/server/provider-runtime.ts
+++ b/server/provider-runtime.ts
@@ -106,8 +106,19 @@ export interface ProviderRuntimeOptions {
   readonly reasoning?: ReasoningDisplayV2;
   readonly keepReasoning?: boolean;
   readonly continuationPromptOptimization?: ContinuationPromptOptimizationV2;
-  readonly subscription?: SubscriptionRuntimeDependencies;
 }
+
+export interface SubscriptionProviderRuntimeOptions extends ProviderRuntimeOptions {
+  readonly subscription: SubscriptionRuntimeDependencies;
+}
+
+export type StandardModelConnectionV2 = Omit<ModelConnectionV2, "protocol"> & {
+  readonly protocol: Exclude<SettingsProtocolV2, SubscriptionProtocolV2>;
+};
+
+export type SubscriptionModelConnectionV2 = Omit<ModelConnectionV2, "protocol"> & {
+  readonly protocol: SubscriptionProtocolV2;
+};
 
 /** Attach server-only runtime policy without changing the frozen JSON settings
  * contract. Enumerable symbols survive the small `{ ...settings }` budget
@@ -146,10 +157,28 @@ export function hasProviderRuntime(settings: GenerationSettings): boolean {
 }
 
 export function providerRuntimeFromV2(
+  connection: StandardModelConnectionV2,
+  effort: GenerationEffortV2,
+  capabilities: ModelCapabilitiesV2,
+  options?: ProviderRuntimeOptions
+): StandardProviderRuntime;
+export function providerRuntimeFromV2(
+  connection: SubscriptionModelConnectionV2,
+  effort: GenerationEffortV2,
+  capabilities: ModelCapabilitiesV2,
+  options: SubscriptionProviderRuntimeOptions
+): SubscriptionProviderRuntime;
+export function providerRuntimeFromV2(
   connection: ModelConnectionV2,
   effort: GenerationEffortV2,
   capabilities: ModelCapabilitiesV2,
-  options: ProviderRuntimeOptions = {}
+  options: SubscriptionProviderRuntimeOptions
+): ProviderRuntime;
+export function providerRuntimeFromV2(
+  connection: ModelConnectionV2,
+  effort: GenerationEffortV2,
+  capabilities: ModelCapabilitiesV2,
+  options: ProviderRuntimeOptions | SubscriptionProviderRuntimeOptions = {}
 ): ProviderRuntime {
   const base: ProviderRuntimeBase = {
     preset: connection.preset,
@@ -171,7 +200,7 @@ export function providerRuntimeFromV2(
     ? {
         ...base,
         protocol: connection.protocol,
-        subscription: requireSubscriptionDependencies(options.subscription)
+        subscription: subscriptionDependencies(options)
       }
     : { ...base, protocol: connection.protocol };
   if (options.environment !== undefined || options.storedSecrets !== undefined) {
@@ -196,13 +225,13 @@ export function providerRuntimeFromV2(
   return runtime;
 }
 
-function requireSubscriptionDependencies(
-  value: SubscriptionRuntimeDependencies | undefined
+function subscriptionDependencies(
+  options: ProviderRuntimeOptions | SubscriptionProviderRuntimeOptions
 ): SubscriptionRuntimeDependencies {
-  if (value === undefined) {
+  if (!("subscription" in options)) {
     throw new ProviderError("Subscription credential storage is unavailable.");
   }
-  return value;
+  return options.subscription;
 }
 
 export function resolveProviderHeaders(

--- a/server/settings-runtime-resolver.ts
+++ b/server/settings-runtime-resolver.ts
@@ -1,0 +1,169 @@
+import {
+  EMPTY_SAMPLING_V2,
+  type ModelCapabilitiesV2,
+  type ModelConnectionV2,
+  type SettingsDocumentV2,
+  type SettingsRoutePurpose
+} from "../shared/settings-v2-types.js";
+import type { GenerationSettings } from "../shared/types.js";
+import type { PromptCacheContext } from "./provider-cache-policy.js";
+import {
+  attachProviderRuntime,
+  isStandardModelConnectionV2,
+  isSubscriptionModelConnectionV2,
+  providerRuntimeFromV2,
+  type ProviderRuntime
+} from "./provider-runtime.js";
+import {
+  projectEffectiveGeneration,
+  type EffectiveMetadataV2
+} from "./settings-v2-conversion.js";
+import { SettingsFormatError } from "./settings-v2-scalars.js";
+import type { SubscriptionRuntimeDependencies } from "./subscription-runtime.js";
+
+export interface EffectiveGenerationRuntime {
+  readonly settings: GenerationSettings;
+  readonly promptCache: PromptCacheContext;
+  readonly providerRuntime: ProviderRuntime;
+}
+
+export interface SettingsRuntimeRequest {
+  readonly document: SettingsDocumentV2;
+  readonly purpose?: SettingsRoutePurpose;
+  readonly metadata?: EffectiveMetadataV2;
+  /** Provider checks and discovery do not require a generation-ready model ID. */
+  readonly allowBlankModel?: boolean;
+  readonly storedSecrets?: ReadonlyMap<string, string>;
+}
+
+export interface ProviderRuntimeResolutionRequest {
+  readonly connection: ModelConnectionV2;
+  readonly effort: SettingsDocumentV2["profiles"][string]["effort"];
+  readonly capabilities: ModelCapabilitiesV2;
+  readonly storedSecrets?: ReadonlyMap<string, string>;
+}
+
+/** Resolve settings through one machine-tier runtime composition root. */
+export interface SettingsRuntimeResolver {
+  readonly credentials: SubscriptionRuntimeDependencies["credentials"];
+  resolve(request: SettingsRuntimeRequest): EffectiveGenerationRuntime;
+  resolveConnection(request: ProviderRuntimeResolutionRequest): ProviderRuntime;
+}
+
+export interface SettingsRuntimeDependencies {
+  readonly environment: NodeJS.ProcessEnv;
+  readonly subscription: SubscriptionRuntimeDependencies;
+}
+
+export function createSettingsRuntimeResolver(
+  dependencies: SettingsRuntimeDependencies
+): SettingsRuntimeResolver {
+  return {
+    credentials: dependencies.subscription.credentials,
+    resolve: (request) => materializeEffectiveGenerationRuntime(
+      request,
+      dependencies.environment,
+      dependencies.subscription
+    ),
+    resolveConnection: (request) => resolveConnectionRuntime(
+      request,
+      dependencies.environment,
+      dependencies.subscription
+    )
+  };
+}
+
+/** Project one standard provider route without subscription infrastructure. */
+export function effectiveStandardGenerationRuntime(
+  document: SettingsDocumentV2,
+  purpose: SettingsRoutePurpose = "default",
+  metadata: EffectiveMetadataV2 = {},
+  environment?: NodeJS.ProcessEnv,
+  options: { readonly allowBlankModel?: boolean } = {},
+  storedSecrets?: ReadonlyMap<string, string>
+): EffectiveGenerationRuntime {
+  return materializeEffectiveGenerationRuntime({
+    document,
+    purpose,
+    metadata,
+    allowBlankModel: options.allowBlankModel,
+    storedSecrets
+  }, environment);
+}
+
+/** Project settings and cache policy from one parsed route snapshot. */
+function materializeEffectiveGenerationRuntime(
+  request: SettingsRuntimeRequest,
+  environment?: NodeJS.ProcessEnv,
+  subscription?: SubscriptionRuntimeDependencies
+): EffectiveGenerationRuntime {
+  const projection = projectEffectiveGeneration(
+    request.document,
+    request.purpose ?? "default",
+    request.metadata ?? {},
+    request.allowBlankModel === true
+  );
+  const { profile, model, connection } = projection.route;
+  const runtimeOptions = {
+    environment,
+    storedSecrets: request.storedSecrets,
+    sampling: profile.sampling ?? EMPTY_SAMPLING_V2,
+    tokenProbabilities: profile.tokenProbabilities ?? null,
+    reasoning: profile.reasoning ?? "marker",
+    keepReasoning: profile.discardReasoning !== true,
+    continuationPromptOptimization: profile.continuationPromptOptimization
+  };
+  let providerRuntime: ProviderRuntime;
+  if (isSubscriptionModelConnectionV2(connection)) {
+    if (subscription === undefined) {
+      throw new SettingsFormatError(
+        "A subscription route requires a subscription-aware runtime resolver."
+      );
+    }
+    providerRuntime = providerRuntimeFromV2(
+      connection,
+      profile.effort,
+      model.capabilities,
+      { ...runtimeOptions, subscription }
+    );
+  } else if (isStandardModelConnectionV2(connection)) {
+    providerRuntime = providerRuntimeFromV2(
+      connection,
+      profile.effort,
+      model.capabilities,
+      runtimeOptions
+    );
+  } else {
+    throw new SettingsFormatError("The selected provider protocol is unavailable.");
+  }
+  return {
+    promptCache: projection.promptCache,
+    providerRuntime,
+    settings: attachProviderRuntime(projection.settings, providerRuntime)
+  };
+}
+
+function resolveConnectionRuntime(
+  request: ProviderRuntimeResolutionRequest,
+  environment: NodeJS.ProcessEnv,
+  subscription: SubscriptionRuntimeDependencies
+): ProviderRuntime {
+  const options = { environment, storedSecrets: request.storedSecrets };
+  if (isSubscriptionModelConnectionV2(request.connection)) {
+    return providerRuntimeFromV2(
+      request.connection,
+      request.effort,
+      request.capabilities,
+      { ...options, subscription }
+    );
+  }
+  if (isStandardModelConnectionV2(request.connection)) {
+    return providerRuntimeFromV2(
+      request.connection,
+      request.effort,
+      request.capabilities,
+      options
+    );
+  }
+  throw new SettingsFormatError("The selected provider protocol is unavailable.");
+}

--- a/server/settings-v2-conversion.ts
+++ b/server/settings-v2-conversion.ts
@@ -12,7 +12,6 @@ import {
   resolveModelScalar,
   type ModelScalarMetadataSourcesV2
 } from "../shared/model-scalar-resolution.js";
-import { EMPTY_SAMPLING_V2 } from "../shared/settings-v2-types.js";
 import {
   defaultConnectionTimeouts,
   defaultModelCapabilities,
@@ -34,39 +33,8 @@ import {
   MAX_SETTINGS_NAME_SCALARS,
   SettingsFormatError
 } from "./settings-v2-scalars.js";
-import {
-  attachProviderRuntime,
-  isStandardModelConnectionV2,
-  isSubscriptionModelConnectionV2,
-  providerRuntimeFromV2,
-  type ProviderRuntime
-} from "./provider-runtime.js";
-import type { SubscriptionRuntimeDependencies } from "./subscription-runtime.js";
 
 export interface EffectiveMetadataV2 extends ModelScalarMetadataSourcesV2 {}
-
-export interface EffectiveGenerationRuntime {
-  readonly settings: GenerationSettings;
-  readonly promptCache: PromptCacheContext;
-  readonly providerRuntime: ProviderRuntime;
-}
-
-export interface EffectiveGenerationRuntimeOptions {
-  /** Provider checks and discovery do not require a generation-ready model ID. */
-  readonly allowBlankModel?: boolean;
-}
-
-/** Subscription-aware runtime projection owned by one storage composition root. */
-export interface EffectiveGenerationRuntimeProjector {
-  project(
-    value: SettingsDocumentV2,
-    purpose?: SettingsRoutePurpose,
-    metadata?: EffectiveMetadataV2,
-    environment?: NodeJS.ProcessEnv,
-    options?: EffectiveGenerationRuntimeOptions,
-    storedSecrets?: ReadonlyMap<string, string>
-  ): EffectiveGenerationRuntime;
-}
 
 export function convertGenerationSettingsV1(value: GenerationSettings): SettingsDocumentV2 {
   const settings = parseGenerationSettingsV1(value);
@@ -111,108 +79,7 @@ export function effectiveGenerationView(
   return projectEffectiveGeneration(value, purpose, metadata).settings;
 }
 
-/** Create one projector that owns the machine-tier subscription services. */
-export function createEffectiveGenerationRuntimeProjector(
-  subscription: SubscriptionRuntimeDependencies
-): EffectiveGenerationRuntimeProjector {
-  return {
-    project: (
-      value,
-      purpose = "default",
-      metadata = {},
-      environment,
-      options = {},
-      storedSecrets
-    ) => materializeEffectiveGenerationRuntime(
-      value,
-      purpose,
-      metadata,
-      environment,
-      options,
-      storedSecrets,
-      subscription
-    )
-  };
-}
-
-/** Project one standard provider route without subscription infrastructure. */
-export function effectiveStandardGenerationRuntime(
-  value: SettingsDocumentV2,
-  purpose: SettingsRoutePurpose = "default",
-  metadata: EffectiveMetadataV2 = {},
-  environment?: NodeJS.ProcessEnv,
-  options: EffectiveGenerationRuntimeOptions = {},
-  storedSecrets?: ReadonlyMap<string, string>
-): EffectiveGenerationRuntime {
-  return materializeEffectiveGenerationRuntime(
-    value,
-    purpose,
-    metadata,
-    environment,
-    options,
-    storedSecrets
-  );
-}
-
-/** Project settings and cache policy from one parsed route snapshot. Callers
- * must not combine independent reads: a settings activation between them could
- * otherwise pair one provider target with another target's cache contract. */
-function materializeEffectiveGenerationRuntime(
-  value: SettingsDocumentV2,
-  purpose: SettingsRoutePurpose,
-  metadata: EffectiveMetadataV2,
-  environment: NodeJS.ProcessEnv | undefined,
-  options: EffectiveGenerationRuntimeOptions,
-  storedSecrets: ReadonlyMap<string, string> | undefined,
-  subscription?: SubscriptionRuntimeDependencies
-): EffectiveGenerationRuntime {
-  const projection = projectEffectiveGeneration(
-    value,
-    purpose,
-    metadata,
-    options.allowBlankModel === true
-  );
-  const { profile, model, connection } = projection.route;
-  const runtimeOptions = {
-    environment,
-    storedSecrets,
-    sampling: profile.sampling ?? EMPTY_SAMPLING_V2,
-    tokenProbabilities: profile.tokenProbabilities ?? null,
-    reasoning: profile.reasoning ?? "marker",
-    keepReasoning: profile.discardReasoning !== true,
-    continuationPromptOptimization: profile.continuationPromptOptimization
-  };
-  let providerRuntime: ProviderRuntime;
-  if (isSubscriptionModelConnectionV2(connection)) {
-    if (subscription === undefined) {
-      throw new SettingsFormatError(
-        "A subscription route requires a subscription-aware runtime projector."
-      );
-    }
-    providerRuntime = providerRuntimeFromV2(
-      connection,
-      profile.effort,
-      model.capabilities,
-      { ...runtimeOptions, subscription }
-    );
-  } else if (isStandardModelConnectionV2(connection)) {
-    providerRuntime = providerRuntimeFromV2(
-      connection,
-      profile.effort,
-      model.capabilities,
-      runtimeOptions
-    );
-  } else {
-    throw new SettingsFormatError("The selected provider protocol is unavailable.");
-  }
-  return {
-    promptCache: projection.promptCache,
-    providerRuntime,
-    settings: attachProviderRuntime(projection.settings, providerRuntime)
-  };
-}
-
-function projectEffectiveGeneration(
+export function projectEffectiveGeneration(
   value: SettingsDocumentV2,
   purpose: SettingsRoutePurpose,
   metadata: EffectiveMetadataV2,

--- a/server/settings-v2-conversion.ts
+++ b/server/settings-v2-conversion.ts
@@ -36,6 +36,8 @@ import {
 } from "./settings-v2-scalars.js";
 import {
   attachProviderRuntime,
+  isStandardModelConnectionV2,
+  isSubscriptionModelConnectionV2,
   providerRuntimeFromV2,
   type ProviderRuntime
 } from "./provider-runtime.js";
@@ -52,8 +54,18 @@ export interface EffectiveGenerationRuntime {
 export interface EffectiveGenerationRuntimeOptions {
   /** Provider checks and discovery do not require a generation-ready model ID. */
   readonly allowBlankModel?: boolean;
-  /** Runtime-only subscription seams. They never enter the settings document. */
-  readonly subscription: SubscriptionRuntimeDependencies;
+}
+
+/** Subscription-aware runtime projection owned by one storage composition root. */
+export interface EffectiveGenerationRuntimeProjector {
+  project(
+    value: SettingsDocumentV2,
+    purpose?: SettingsRoutePurpose,
+    metadata?: EffectiveMetadataV2,
+    environment?: NodeJS.ProcessEnv,
+    options?: EffectiveGenerationRuntimeOptions,
+    storedSecrets?: ReadonlyMap<string, string>
+  ): EffectiveGenerationRuntime;
 }
 
 export function convertGenerationSettingsV1(value: GenerationSettings): SettingsDocumentV2 {
@@ -99,16 +111,60 @@ export function effectiveGenerationView(
   return projectEffectiveGeneration(value, purpose, metadata).settings;
 }
 
-/** Project settings and cache policy from one parsed route snapshot. Callers
- * must not combine independent reads: a settings activation between them could
- * otherwise pair one provider target with another target's cache contract. */
-export function effectiveGenerationRuntime(
+/** Create one projector that owns the machine-tier subscription services. */
+export function createEffectiveGenerationRuntimeProjector(
+  subscription: SubscriptionRuntimeDependencies
+): EffectiveGenerationRuntimeProjector {
+  return {
+    project: (
+      value,
+      purpose = "default",
+      metadata = {},
+      environment,
+      options = {},
+      storedSecrets
+    ) => materializeEffectiveGenerationRuntime(
+      value,
+      purpose,
+      metadata,
+      environment,
+      options,
+      storedSecrets,
+      subscription
+    )
+  };
+}
+
+/** Project one standard provider route without subscription infrastructure. */
+export function effectiveStandardGenerationRuntime(
   value: SettingsDocumentV2,
   purpose: SettingsRoutePurpose = "default",
   metadata: EffectiveMetadataV2 = {},
+  environment?: NodeJS.ProcessEnv,
+  options: EffectiveGenerationRuntimeOptions = {},
+  storedSecrets?: ReadonlyMap<string, string>
+): EffectiveGenerationRuntime {
+  return materializeEffectiveGenerationRuntime(
+    value,
+    purpose,
+    metadata,
+    environment,
+    options,
+    storedSecrets
+  );
+}
+
+/** Project settings and cache policy from one parsed route snapshot. Callers
+ * must not combine independent reads: a settings activation between them could
+ * otherwise pair one provider target with another target's cache contract. */
+function materializeEffectiveGenerationRuntime(
+  value: SettingsDocumentV2,
+  purpose: SettingsRoutePurpose,
+  metadata: EffectiveMetadataV2,
   environment: NodeJS.ProcessEnv | undefined,
   options: EffectiveGenerationRuntimeOptions,
-  storedSecrets?: ReadonlyMap<string, string>
+  storedSecrets: ReadonlyMap<string, string> | undefined,
+  subscription?: SubscriptionRuntimeDependencies
 ): EffectiveGenerationRuntime {
   const projection = projectEffectiveGeneration(
     value,
@@ -117,21 +173,38 @@ export function effectiveGenerationRuntime(
     options.allowBlankModel === true
   );
   const { profile, model, connection } = projection.route;
-  const providerRuntime = providerRuntimeFromV2(
-    connection,
-    profile.effort,
-    model.capabilities,
-    {
-      environment,
-      storedSecrets,
-      sampling: profile.sampling ?? EMPTY_SAMPLING_V2,
-      tokenProbabilities: profile.tokenProbabilities ?? null,
-      reasoning: profile.reasoning ?? "marker",
-      keepReasoning: profile.discardReasoning !== true,
-      continuationPromptOptimization: profile.continuationPromptOptimization,
-      subscription: options.subscription
+  const runtimeOptions = {
+    environment,
+    storedSecrets,
+    sampling: profile.sampling ?? EMPTY_SAMPLING_V2,
+    tokenProbabilities: profile.tokenProbabilities ?? null,
+    reasoning: profile.reasoning ?? "marker",
+    keepReasoning: profile.discardReasoning !== true,
+    continuationPromptOptimization: profile.continuationPromptOptimization
+  };
+  let providerRuntime: ProviderRuntime;
+  if (isSubscriptionModelConnectionV2(connection)) {
+    if (subscription === undefined) {
+      throw new SettingsFormatError(
+        "A subscription route requires a subscription-aware runtime projector."
+      );
     }
-  );
+    providerRuntime = providerRuntimeFromV2(
+      connection,
+      profile.effort,
+      model.capabilities,
+      { ...runtimeOptions, subscription }
+    );
+  } else if (isStandardModelConnectionV2(connection)) {
+    providerRuntime = providerRuntimeFromV2(
+      connection,
+      profile.effort,
+      model.capabilities,
+      runtimeOptions
+    );
+  } else {
+    throw new SettingsFormatError("The selected provider protocol is unavailable.");
+  }
   return {
     promptCache: projection.promptCache,
     providerRuntime,

--- a/server/settings-v2-conversion.ts
+++ b/server/settings-v2-conversion.ts
@@ -95,9 +95,16 @@ export function convertGenerationSettingsV1(value: GenerationSettings): Settings
 export function effectiveGenerationSettings(
   value: SettingsDocumentV2,
   purpose: SettingsRoutePurpose = "default",
-  metadata: EffectiveMetadataV2 = {}
+  metadata: EffectiveMetadataV2 = {},
+  options: EffectiveGenerationRuntimeOptions = {}
 ): GenerationSettings {
-  return effectiveGenerationRuntime(value, purpose, metadata).settings;
+  return effectiveGenerationRuntime(
+    value,
+    purpose,
+    metadata,
+    undefined,
+    options
+  ).settings;
 }
 
 /** Project settings and cache policy from one parsed route snapshot. Callers

--- a/server/settings-v2-conversion.ts
+++ b/server/settings-v2-conversion.ts
@@ -90,21 +90,13 @@ export function convertGenerationSettingsV1(value: GenerationSettings): Settings
   });
 }
 
-/** Project the selected v2 route into the unchanged provider runtime contract.
- * Unsupported v2-only semantics fail explicitly rather than being dropped. */
+/** Project one route into the serializable Generation Settings view. */
 export function effectiveGenerationSettings(
   value: SettingsDocumentV2,
   purpose: SettingsRoutePurpose = "default",
-  metadata: EffectiveMetadataV2 = {},
-  options: EffectiveGenerationRuntimeOptions = {}
+  metadata: EffectiveMetadataV2 = {}
 ): GenerationSettings {
-  return effectiveGenerationRuntime(
-    value,
-    purpose,
-    metadata,
-    undefined,
-    options
-  ).settings;
+  return projectEffectiveGeneration(value, purpose, metadata).settings;
 }
 
 /** Project settings and cache policy from one parsed route snapshot. Callers
@@ -118,6 +110,41 @@ export function effectiveGenerationRuntime(
   options: EffectiveGenerationRuntimeOptions = {},
   storedSecrets?: ReadonlyMap<string, string>
 ): EffectiveGenerationRuntime {
+  const projection = projectEffectiveGeneration(
+    value,
+    purpose,
+    metadata,
+    options.allowBlankModel === true
+  );
+  const { profile, model, connection } = projection.route;
+  const providerRuntime = providerRuntimeFromV2(
+    connection,
+    profile.effort,
+    model.capabilities,
+    {
+      environment,
+      storedSecrets,
+      sampling: profile.sampling ?? EMPTY_SAMPLING_V2,
+      tokenProbabilities: profile.tokenProbabilities ?? null,
+      reasoning: profile.reasoning ?? "marker",
+      keepReasoning: profile.discardReasoning !== true,
+      continuationPromptOptimization: profile.continuationPromptOptimization,
+      subscription: options.subscription
+    }
+  );
+  return {
+    promptCache: projection.promptCache,
+    providerRuntime,
+    settings: attachProviderRuntime(projection.settings, providerRuntime)
+  };
+}
+
+function projectEffectiveGeneration(
+  value: SettingsDocumentV2,
+  purpose: SettingsRoutePurpose,
+  metadata: EffectiveMetadataV2,
+  allowBlankModel = false
+) {
   const document = parseSettingsDocumentV2(value);
   const route = selectSettingsRoute(document, purpose);
   const { profile, model, connection } = route;
@@ -134,40 +161,25 @@ export function effectiveGenerationRuntime(
   const remoteId = effectiveRemoteId(
     provider,
     model.remoteId,
-    options.allowBlankModel === true
+    allowBlankModel
   );
   const contextWindow = resolveModelScalar(model, metadata, "contextWindow");
-  const providerRuntime = providerRuntimeFromV2(
-    connection,
-    profile.effort,
-    model.capabilities,
-    {
-      environment,
-      storedSecrets,
-      sampling: profile.sampling ?? EMPTY_SAMPLING_V2,
-      tokenProbabilities: profile.tokenProbabilities ?? null,
-      reasoning: profile.reasoning ?? "marker",
-      keepReasoning: profile.discardReasoning !== true,
-      continuationPromptOptimization: profile.continuationPromptOptimization,
-      subscription: options.subscription
-    }
-  );
-  const settings = attachProviderRuntime({
-      provider,
-      baseUrl: connection.baseUrl ?? "",
-      model: remoteId,
-      apiKeyEnv: effectiveApiKeyEnv(connection),
-      ...(isSubscriptionProtocolV2(connection.protocol)
-        ? { protocol: connection.protocol }
-        : {}),
-      temperature: profile.temperature,
-      maxTokens: clampMaxOutputTokensToModel(profile.maxOutputTokens, model, metadata),
-      systemPrompt: document.writing.defaultAuthorBrief,
-      contextWindow: contextWindow ?? null
-    }, providerRuntime);
+  const settings: GenerationSettings = {
+    provider,
+    baseUrl: connection.baseUrl ?? "",
+    model: remoteId,
+    apiKeyEnv: effectiveApiKeyEnv(connection),
+    ...(isSubscriptionProtocolV2(connection.protocol)
+      ? { protocol: connection.protocol }
+      : {}),
+    temperature: profile.temperature,
+    maxTokens: clampMaxOutputTokensToModel(profile.maxOutputTokens, model, metadata),
+    systemPrompt: document.writing.defaultAuthorBrief,
+    contextWindow: contextWindow ?? null
+  };
   return {
+    route,
     promptCache,
-    providerRuntime,
     settings
   };
 }

--- a/server/settings-v2-conversion.ts
+++ b/server/settings-v2-conversion.ts
@@ -53,7 +53,7 @@ export interface EffectiveGenerationRuntimeOptions {
   /** Provider checks and discovery do not require a generation-ready model ID. */
   readonly allowBlankModel?: boolean;
   /** Runtime-only subscription seams. They never enter the settings document. */
-  readonly subscription?: SubscriptionRuntimeDependencies;
+  readonly subscription: SubscriptionRuntimeDependencies;
 }
 
 export function convertGenerationSettingsV1(value: GenerationSettings): SettingsDocumentV2 {
@@ -90,22 +90,6 @@ export function convertGenerationSettingsV1(value: GenerationSettings): Settings
   });
 }
 
-/** Construct generation-ready settings with the selected provider runtime. */
-export function effectiveGenerationSettings(
-  value: SettingsDocumentV2,
-  purpose: SettingsRoutePurpose = "default",
-  metadata: EffectiveMetadataV2 = {},
-  options: EffectiveGenerationRuntimeOptions = {}
-): GenerationSettings {
-  return effectiveGenerationRuntime(
-    value,
-    purpose,
-    metadata,
-    undefined,
-    options
-  ).settings;
-}
-
 /** Project one route into the serializable Generation Settings view. */
 export function effectiveGenerationView(
   value: SettingsDocumentV2,
@@ -122,8 +106,8 @@ export function effectiveGenerationRuntime(
   value: SettingsDocumentV2,
   purpose: SettingsRoutePurpose = "default",
   metadata: EffectiveMetadataV2 = {},
-  environment?: NodeJS.ProcessEnv,
-  options: EffectiveGenerationRuntimeOptions = {},
+  environment: NodeJS.ProcessEnv | undefined,
+  options: EffectiveGenerationRuntimeOptions,
   storedSecrets?: ReadonlyMap<string, string>
 ): EffectiveGenerationRuntime {
   const projection = projectEffectiveGeneration(

--- a/server/settings-v2-conversion.ts
+++ b/server/settings-v2-conversion.ts
@@ -90,8 +90,24 @@ export function convertGenerationSettingsV1(value: GenerationSettings): Settings
   });
 }
 
-/** Project one route into the serializable Generation Settings view. */
+/** Construct generation-ready settings with the selected provider runtime. */
 export function effectiveGenerationSettings(
+  value: SettingsDocumentV2,
+  purpose: SettingsRoutePurpose = "default",
+  metadata: EffectiveMetadataV2 = {},
+  options: EffectiveGenerationRuntimeOptions = {}
+): GenerationSettings {
+  return effectiveGenerationRuntime(
+    value,
+    purpose,
+    metadata,
+    undefined,
+    options
+  ).settings;
+}
+
+/** Project one route into the serializable Generation Settings view. */
+export function effectiveGenerationView(
   value: SettingsDocumentV2,
   purpose: SettingsRoutePurpose = "default",
   metadata: EffectiveMetadataV2 = {}

--- a/server/settings-v2-runtime.ts
+++ b/server/settings-v2-runtime.ts
@@ -9,10 +9,8 @@ import type { GenerationSettings } from "../shared/types.js";
 import { checkModelServer } from "./server-check.js";
 import { ownedLoopbackHttpSupported } from "./provider-fetch.js";
 import { providerRuntimeFor } from "./provider-runtime.js";
-import {
-  effectiveGenerationView,
-  type EffectiveGenerationRuntimeProjector
-} from "./settings-v2-conversion.js";
+import { effectiveGenerationView } from "./settings-v2-conversion.js";
+import type { SettingsRuntimeResolver } from "./settings-runtime-resolver.js";
 import { classifyHttpHost, SettingsFormatError } from "./settings-v2-scalars.js";
 import { selectSettingsRoute } from "../shared/settings-route.js";
 import { continuationPromptLayoutForOptimization } from "../shared/continuation-prompt-optimization.js";
@@ -102,11 +100,11 @@ export function credentialReferencesResolve(
 
 export function assertRuntimeDocumentSupported(
   document: SettingsDocumentV2,
-  runtimeProjector: EffectiveGenerationRuntimeProjector
+  runtimeResolver: SettingsRuntimeResolver
 ): void {
   try {
     for (const purpose of SETTINGS_ROUTE_PURPOSE_VALUES) {
-      runtimeProjector.project(document, purpose);
+      runtimeResolver.resolve({ document, purpose });
     }
   } catch (error) {
     throw invalidSettingsMutation(error);

--- a/server/settings-v2-runtime.ts
+++ b/server/settings-v2-runtime.ts
@@ -13,6 +13,7 @@ import { effectiveGenerationSettings } from "./settings-v2-conversion.js";
 import { classifyHttpHost, SettingsFormatError } from "./settings-v2-scalars.js";
 import { selectSettingsRoute } from "../shared/settings-route.js";
 import { continuationPromptLayoutForOptimization } from "../shared/continuation-prompt-optimization.js";
+import type { SubscriptionRuntimeDependencies } from "./subscription-runtime.js";
 import { settingsStateRelation } from "./settings-state-validation.js";
 import {
   corruptSettingsStateReceipt,
@@ -20,7 +21,8 @@ import {
 } from "./settings-v2-mutation.js";
 
 export function settingsViewFromState(
-  state: SettingsStateV2
+  state: SettingsStateV2,
+  subscription?: SubscriptionRuntimeDependencies
 ): Extract<SettingsView, { dataFormat: 2 }> {
   // A committed activation is past its point of no return: the candidate is
   // the document generation already uses, so the view reports it as plainly
@@ -33,6 +35,7 @@ export function settingsViewFromState(
     ? activeSettingsDocument(state)
     : pendingSettingsDocument(state);
   const active = activeSettingsDocument(state);
+  const runtimeOptions = subscription === undefined ? {} : { subscription };
   return {
     dataFormat: 2,
     editable: true,
@@ -40,8 +43,8 @@ export function settingsViewFromState(
     activeRevision: effectiveActiveSettingsRevision(state),
     pendingRevision,
     document: shown,
-    effective: effectiveGenerationSettings(active),
-    effectiveProse: effectiveGenerationSettings(active, "prose"),
+    effective: effectiveGenerationSettings(active, "default", {}, runtimeOptions),
+    effectiveProse: effectiveGenerationSettings(active, "prose", {}, runtimeOptions),
     // Read from `active`, never `shown`: `effectiveProse` above already
     // resolves against the active (never pending) document, and this must
     // describe the same route, not whichever document a mid-activation
@@ -97,10 +100,14 @@ export function credentialReferencesResolve(
   return true;
 }
 
-export function assertRuntimeDocumentSupported(document: SettingsDocumentV2): void {
+export function assertRuntimeDocumentSupported(
+  document: SettingsDocumentV2,
+  subscription?: SubscriptionRuntimeDependencies
+): void {
   try {
+    const runtimeOptions = subscription === undefined ? {} : { subscription };
     for (const purpose of SETTINGS_ROUTE_PURPOSE_VALUES) {
-      effectiveGenerationSettings(document, purpose);
+      effectiveGenerationSettings(document, purpose, {}, runtimeOptions);
     }
   } catch (error) {
     throw invalidSettingsMutation(error);

--- a/server/settings-v2-runtime.ts
+++ b/server/settings-v2-runtime.ts
@@ -9,7 +9,10 @@ import type { GenerationSettings } from "../shared/types.js";
 import { checkModelServer } from "./server-check.js";
 import { ownedLoopbackHttpSupported } from "./provider-fetch.js";
 import { providerRuntimeFor } from "./provider-runtime.js";
-import { effectiveGenerationSettings } from "./settings-v2-conversion.js";
+import {
+  effectiveGenerationRuntime,
+  effectiveGenerationSettings
+} from "./settings-v2-conversion.js";
 import { classifyHttpHost, SettingsFormatError } from "./settings-v2-scalars.js";
 import { selectSettingsRoute } from "../shared/settings-route.js";
 import { continuationPromptLayoutForOptimization } from "../shared/continuation-prompt-optimization.js";
@@ -21,8 +24,7 @@ import {
 } from "./settings-v2-mutation.js";
 
 export function settingsViewFromState(
-  state: SettingsStateV2,
-  subscription?: SubscriptionRuntimeDependencies
+  state: SettingsStateV2
 ): Extract<SettingsView, { dataFormat: 2 }> {
   // A committed activation is past its point of no return: the candidate is
   // the document generation already uses, so the view reports it as plainly
@@ -35,7 +37,6 @@ export function settingsViewFromState(
     ? activeSettingsDocument(state)
     : pendingSettingsDocument(state);
   const active = activeSettingsDocument(state);
-  const runtimeOptions = subscription === undefined ? {} : { subscription };
   return {
     dataFormat: 2,
     editable: true,
@@ -43,8 +44,8 @@ export function settingsViewFromState(
     activeRevision: effectiveActiveSettingsRevision(state),
     pendingRevision,
     document: shown,
-    effective: effectiveGenerationSettings(active, "default", {}, runtimeOptions),
-    effectiveProse: effectiveGenerationSettings(active, "prose", {}, runtimeOptions),
+    effective: effectiveGenerationSettings(active),
+    effectiveProse: effectiveGenerationSettings(active, "prose"),
     // Read from `active`, never `shown`: `effectiveProse` above already
     // resolves against the active (never pending) document, and this must
     // describe the same route, not whichever document a mid-activation
@@ -102,12 +103,11 @@ export function credentialReferencesResolve(
 
 export function assertRuntimeDocumentSupported(
   document: SettingsDocumentV2,
-  subscription?: SubscriptionRuntimeDependencies
+  subscription: SubscriptionRuntimeDependencies
 ): void {
   try {
-    const runtimeOptions = subscription === undefined ? {} : { subscription };
     for (const purpose of SETTINGS_ROUTE_PURPOSE_VALUES) {
-      effectiveGenerationSettings(document, purpose, {}, runtimeOptions);
+      effectiveGenerationRuntime(document, purpose, {}, undefined, { subscription });
     }
   } catch (error) {
     throw invalidSettingsMutation(error);

--- a/server/settings-v2-runtime.ts
+++ b/server/settings-v2-runtime.ts
@@ -10,13 +10,12 @@ import { checkModelServer } from "./server-check.js";
 import { ownedLoopbackHttpSupported } from "./provider-fetch.js";
 import { providerRuntimeFor } from "./provider-runtime.js";
 import {
-  effectiveGenerationRuntime,
-  effectiveGenerationView
+  effectiveGenerationView,
+  type EffectiveGenerationRuntimeProjector
 } from "./settings-v2-conversion.js";
 import { classifyHttpHost, SettingsFormatError } from "./settings-v2-scalars.js";
 import { selectSettingsRoute } from "../shared/settings-route.js";
 import { continuationPromptLayoutForOptimization } from "../shared/continuation-prompt-optimization.js";
-import type { SubscriptionRuntimeDependencies } from "./subscription-runtime.js";
 import { settingsStateRelation } from "./settings-state-validation.js";
 import {
   corruptSettingsStateReceipt,
@@ -103,11 +102,11 @@ export function credentialReferencesResolve(
 
 export function assertRuntimeDocumentSupported(
   document: SettingsDocumentV2,
-  subscription: SubscriptionRuntimeDependencies
+  runtimeProjector: EffectiveGenerationRuntimeProjector
 ): void {
   try {
     for (const purpose of SETTINGS_ROUTE_PURPOSE_VALUES) {
-      effectiveGenerationRuntime(document, purpose, {}, undefined, { subscription });
+      runtimeProjector.project(document, purpose);
     }
   } catch (error) {
     throw invalidSettingsMutation(error);

--- a/server/settings-v2-runtime.ts
+++ b/server/settings-v2-runtime.ts
@@ -11,7 +11,7 @@ import { ownedLoopbackHttpSupported } from "./provider-fetch.js";
 import { providerRuntimeFor } from "./provider-runtime.js";
 import {
   effectiveGenerationRuntime,
-  effectiveGenerationSettings
+  effectiveGenerationView
 } from "./settings-v2-conversion.js";
 import { classifyHttpHost, SettingsFormatError } from "./settings-v2-scalars.js";
 import { selectSettingsRoute } from "../shared/settings-route.js";
@@ -44,8 +44,8 @@ export function settingsViewFromState(
     activeRevision: effectiveActiveSettingsRevision(state),
     pendingRevision,
     document: shown,
-    effective: effectiveGenerationSettings(active),
-    effectiveProse: effectiveGenerationSettings(active, "prose"),
+    effective: effectiveGenerationView(active),
+    effectiveProse: effectiveGenerationView(active, "prose"),
     // Read from `active`, never `shown`: `effectiveProse` above already
     // resolves against the active (never pending) document, and this must
     // describe the same route, not whichever document a mid-activation

--- a/server/settings-v2-save-bias-check.ts
+++ b/server/settings-v2-save-bias-check.ts
@@ -9,6 +9,7 @@ import { effectiveGenerationRuntime } from "./settings-v2-conversion.js";
 import { invalidSettingsMutation } from "./settings-v2-mutation.js";
 import { resolveSamplingBiasForSettings } from "./sampling-phrase-bias.js";
 import { validateSamplingRoute } from "./settings-v2-sampling-validation.js";
+import type { SubscriptionRuntimeDependencies } from "./subscription-runtime.js";
 
 /** How long the whole live-tokenize-probe bias-resolution phase of a save
  * gets, across every routed profile combined (see
@@ -61,6 +62,7 @@ export const SAMPLING_BIAS_SAVE_PROBE_DEADLINE_MS = 5_000;
 export async function assertSavedSamplingBiasResolves(
   document: SettingsDocumentV2,
   environment: NodeJS.ProcessEnv,
+  subscription: SubscriptionRuntimeDependencies,
   signal?: AbortSignal
 ): Promise<void> {
   const deadline = AbortSignal.timeout(SAMPLING_BIAS_SAVE_PROBE_DEADLINE_MS);
@@ -72,7 +74,13 @@ export async function assertSavedSamplingBiasResolves(
     resolvedProfileIds.add(route.profileId);
     let settings: GenerationSettings;
     try {
-      settings = effectiveGenerationRuntime(document, purpose, {}, environment).settings;
+      settings = effectiveGenerationRuntime(
+        document,
+        purpose,
+        {},
+        environment,
+        { subscription }
+      ).settings;
     } catch {
       continue;
     }

--- a/server/settings-v2-save-bias-check.ts
+++ b/server/settings-v2-save-bias-check.ts
@@ -5,7 +5,7 @@ import {
 import { selectSettingsRoute } from "../shared/settings-route.js";
 import type { GenerationSettings } from "../shared/types.js";
 import { ProviderError } from "./errors.js";
-import type { EffectiveGenerationRuntimeProjector } from "./settings-v2-conversion.js";
+import type { SettingsRuntimeResolver } from "./settings-runtime-resolver.js";
 import { invalidSettingsMutation } from "./settings-v2-mutation.js";
 import { resolveSamplingBiasForSettings } from "./sampling-phrase-bias.js";
 import { validateSamplingRoute } from "./settings-v2-sampling-validation.js";
@@ -54,14 +54,12 @@ export const SAMPLING_BIAS_SAVE_PROBE_DEADLINE_MS = 5_000;
  * verdict, only reach the same verdict sooner: there is nothing this budget
  * protects by running longer.
  *
- * `environment` is the store's own resolved `NodeJS.ProcessEnv` snapshot,
- * passed through rather than read from `process.env` here, so this check
- * resolves credentials exactly like the rest of the save path does.
+ * The runtime resolver owns the store's `NodeJS.ProcessEnv` snapshot, so this
+ * check resolves credentials exactly like the rest of the save path does.
  */
 export async function assertSavedSamplingBiasResolves(
   document: SettingsDocumentV2,
-  environment: NodeJS.ProcessEnv,
-  runtimeProjector: EffectiveGenerationRuntimeProjector,
+  runtimeResolver: SettingsRuntimeResolver,
   signal?: AbortSignal
 ): Promise<void> {
   const deadline = AbortSignal.timeout(SAMPLING_BIAS_SAVE_PROBE_DEADLINE_MS);
@@ -73,13 +71,7 @@ export async function assertSavedSamplingBiasResolves(
     resolvedProfileIds.add(route.profileId);
     let settings: GenerationSettings;
     try {
-      settings = runtimeProjector.project(
-        document,
-        purpose,
-        {},
-        environment,
-        {}
-      ).settings;
+      settings = runtimeResolver.resolve({ document, purpose }).settings;
     } catch {
       continue;
     }

--- a/server/settings-v2-save-bias-check.ts
+++ b/server/settings-v2-save-bias-check.ts
@@ -5,11 +5,10 @@ import {
 import { selectSettingsRoute } from "../shared/settings-route.js";
 import type { GenerationSettings } from "../shared/types.js";
 import { ProviderError } from "./errors.js";
-import { effectiveGenerationRuntime } from "./settings-v2-conversion.js";
+import type { EffectiveGenerationRuntimeProjector } from "./settings-v2-conversion.js";
 import { invalidSettingsMutation } from "./settings-v2-mutation.js";
 import { resolveSamplingBiasForSettings } from "./sampling-phrase-bias.js";
 import { validateSamplingRoute } from "./settings-v2-sampling-validation.js";
-import type { SubscriptionRuntimeDependencies } from "./subscription-runtime.js";
 
 /** How long the whole live-tokenize-probe bias-resolution phase of a save
  * gets, across every routed profile combined (see
@@ -62,7 +61,7 @@ export const SAMPLING_BIAS_SAVE_PROBE_DEADLINE_MS = 5_000;
 export async function assertSavedSamplingBiasResolves(
   document: SettingsDocumentV2,
   environment: NodeJS.ProcessEnv,
-  subscription: SubscriptionRuntimeDependencies,
+  runtimeProjector: EffectiveGenerationRuntimeProjector,
   signal?: AbortSignal
 ): Promise<void> {
   const deadline = AbortSignal.timeout(SAMPLING_BIAS_SAVE_PROBE_DEADLINE_MS);
@@ -74,12 +73,12 @@ export async function assertSavedSamplingBiasResolves(
     resolvedProfileIds.add(route.profileId);
     let settings: GenerationSettings;
     try {
-      settings = effectiveGenerationRuntime(
+      settings = runtimeProjector.project(
         document,
         purpose,
         {},
         environment,
-        { subscription }
+        {}
       ).settings;
     } catch {
       continue;

--- a/server/settings-v2-scalars.ts
+++ b/server/settings-v2-scalars.ts
@@ -2,6 +2,10 @@ import { StoryFormatError } from "./story-format-facts.js";
 import { unicodeScalarLength } from "../shared/unicode.js";
 import { MAX_AUTHOR_BRIEF_CHARS } from "../shared/author-brief.js";
 import {
+  MAX_SETTINGS_REMOTE_ID_SCALARS,
+  MAX_SETTINGS_TOKEN_COUNT
+} from "../shared/settings-scalar-policy.js";
+import {
   CREDENTIAL_ENV_PATTERN,
   CREDENTIAL_ENV_PATTERN_SOURCE,
   MAX_CREDENTIAL_NAMES_PER_DOCUMENT,
@@ -29,7 +33,7 @@ export const MAX_SETTINGS_CREDENTIAL_NAMES =
   MAX_CREDENTIAL_NAMES_PER_DOCUMENT;
 export const MAX_SETTINGS_ID_SCALARS = 128;
 export const MAX_SETTINGS_NAME_SCALARS = 256;
-export const MAX_SETTINGS_REMOTE_ID_SCALARS = 512;
+export { MAX_SETTINGS_REMOTE_ID_SCALARS, MAX_SETTINGS_TOKEN_COUNT };
 export const MAX_SETTINGS_URL_SCALARS = 4_096;
 /** The story-scoped Author Brief field shares this exact bound (`shared/author-brief.ts`),
  * so a single value governs both — see `MAX_AUTHOR_BRIEF_CHARS`. */
@@ -40,7 +44,6 @@ export const MAX_SETTINGS_TIMEOUT_MS = 86_400_000;
  *  it presents the domain the document accepts instead of guessing one from
  *  whatever unit it happens to display. */
 export const MIN_SETTINGS_TIMEOUT_MS = 1;
-export const MAX_SETTINGS_TOKEN_COUNT = 1_000_000_000;
 
 export const SETTINGS_ID_PATTERN_SOURCE = "[A-Za-z0-9][A-Za-z0-9._:-]{0,127}";
 export const SETTINGS_ID_PATTERN = new RegExp(`^(?:${SETTINGS_ID_PATTERN_SOURCE})$`, "u");

--- a/server/settings-v2-store.ts
+++ b/server/settings-v2-store.ts
@@ -26,9 +26,10 @@ import {
   hashSettingsStateV2
 } from "./settings-v2-codec.js";
 import {
-  effectiveGenerationRuntime,
+  createEffectiveGenerationRuntimeProjector,
   effectiveApiKeyEnv,
-  providerForProtocol
+  providerForProtocol,
+  type EffectiveGenerationRuntimeProjector
 } from "./settings-v2-conversion.js";
 import { providerRuntimeFromV2 } from "./provider-runtime.js";
 import { defaultModelCapabilities } from "../shared/settings-provider-defaults.js";
@@ -141,6 +142,7 @@ export class SettingsV2Store {
   private readonly secretsDir: string;
   private readonly prunesSecrets: boolean;
   private readonly subscription: SubscriptionRuntimeDependencies;
+  private readonly runtimeProjector: EffectiveGenerationRuntimeProjector;
 
   constructor(
     private readonly dataDir: string,
@@ -148,6 +150,7 @@ export class SettingsV2Store {
   ) {
     this.secretsDir = options.secretsDir ?? dataDir;
     this.subscription = createSubscriptionRuntime(this.secretsDir);
+    this.runtimeProjector = createEffectiveGenerationRuntimeProjector(this.subscription);
     // A shared machine tier holds every project's keys, and this store only
     // knows the IDs one project references. Pruning against that view would
     // delete another project's credentials, so garbage collection is confined
@@ -170,7 +173,7 @@ export class SettingsV2Store {
     // activate, or prune. Opening proves the state parses and its active
     // document supports a route, exactly like the writable path below.
     if (slot.kind === "v3") {
-      assertRuntimeDocumentSupported(activeSettingsDocument(slot.readOnlyView), this.subscription);
+      assertRuntimeDocumentSupported(activeSettingsDocument(slot.readOnlyView), this.runtimeProjector);
       settingsViewFromState(slot.readOnlyView);
       return;
     }
@@ -185,7 +188,7 @@ export class SettingsV2Store {
       await removeProviderSecretsScratch(this.secretsDir);
       await pruneProviderSecrets(this.secretsDir, providerSecretIdsToKeep(state));
     }
-    assertRuntimeDocumentSupported(activeSettingsDocument(state), this.subscription);
+    assertRuntimeDocumentSupported(activeSettingsDocument(state), this.runtimeProjector);
     settingsViewFromState(state);
   }
 
@@ -216,16 +219,16 @@ export class SettingsV2Store {
   async loadRuntime(purpose: SettingsRoutePurpose = "default") {
     const { slot, state, storedSecrets } = await this.readRuntimeSnapshot();
     const document = activeSettingsDocument(state);
-    const runtime = effectiveGenerationRuntime(
+    const runtime = this.runtimeProjector.project(
       document,
       purpose,
       {},
       this.environment,
-      { subscription: this.subscription },
+      {},
       storedSecrets
     );
     assertRuntimeGenerationSettingsSupported(runtime.settings);
-    // Same `document` object `effectiveGenerationRuntime` just resolved a
+    // Same `document` object the runtime projector just resolved a
     // route from, above — a second call to the same pure route-selection
     // function, not a second read. `selectSettingsRoute` is deterministic
     // given a document and a purpose, so this always names the same model
@@ -360,14 +363,13 @@ export class SettingsV2Store {
         );
       }
     }
-    const runtime = effectiveGenerationRuntime(
+    const runtime = this.runtimeProjector.project(
       document,
       purpose,
       {},
       this.environment,
       {
-        allowBlankModel: true,
-        subscription: this.subscription
+        allowBlankModel: true
       },
       resolvedSecrets
     );
@@ -488,11 +490,11 @@ export class SettingsV2Store {
     }
 
     if (operation.method === "saveSettings") {
-      assertRuntimeDocumentSupported(operation.document, this.subscription);
+      assertRuntimeDocumentSupported(operation.document, this.runtimeProjector);
       await assertSavedSamplingBiasResolves(
         operation.document,
         this.environment,
-        this.subscription,
+        this.runtimeProjector,
         signal
       );
     }
@@ -818,19 +820,19 @@ export class SettingsV2Store {
     }
     let candidateReady = false;
     try {
-      assertRuntimeDocumentSupported(candidate, this.subscription);
+      assertRuntimeDocumentSupported(candidate, this.runtimeProjector);
       const validatedConnections = new Set<string>();
       const probeTargets: GenerationSettings[] = [];
       for (const purpose of SETTINGS_ROUTE_PURPOSE_VALUES) {
         const route = selectSettingsRoute(candidate, purpose);
         if (validatedConnections.has(route.model.connectionId)) continue;
         validatedConnections.add(route.model.connectionId);
-        const effective = effectiveGenerationRuntime(
+        const effective = this.runtimeProjector.project(
           candidate,
           purpose,
           {},
           this.environment,
-          { subscription: this.subscription },
+          {},
           storedSecrets
         ).settings;
         if (providerRequestTransportAvailable(effective)) probeTargets.push(effective);

--- a/server/settings-v2-store.ts
+++ b/server/settings-v2-store.ts
@@ -26,12 +26,14 @@ import {
   hashSettingsStateV2
 } from "./settings-v2-codec.js";
 import {
-  createEffectiveGenerationRuntimeProjector,
   effectiveApiKeyEnv,
-  providerForProtocol,
-  type EffectiveGenerationRuntimeProjector
+  providerForProtocol
 } from "./settings-v2-conversion.js";
-import { providerRuntimeFromV2 } from "./provider-runtime.js";
+import {
+  createSettingsRuntimeResolver,
+  type SettingsRuntimeResolver
+} from "./settings-runtime-resolver.js";
+import type { ProviderRuntime } from "./provider-runtime.js";
 import { defaultModelCapabilities } from "../shared/settings-provider-defaults.js";
 import {
   isExactSettingsActivationSuccessor,
@@ -97,8 +99,7 @@ import {
   createSubscriptionRuntime,
   providerSecretIdsToKeep,
   storedSecretIdsInDocument,
-  storedSecretIdsInState,
-  type SubscriptionRuntimeDependencies
+  storedSecretIdsInState
 } from "./subscription-runtime.js";
 import { readSettingsView } from "./settings-v2-view-read.js";
 
@@ -141,16 +142,18 @@ export class SettingsV2Store {
   private readonly activationMode: SettingsActivationMode;
   private readonly secretsDir: string;
   private readonly prunesSecrets: boolean;
-  private readonly subscription: SubscriptionRuntimeDependencies;
-  private readonly runtimeProjector: EffectiveGenerationRuntimeProjector;
+  private readonly runtimeResolver: SettingsRuntimeResolver;
 
   constructor(
     private readonly dataDir: string,
     options: SettingsV2StoreOptions = {}
   ) {
     this.secretsDir = options.secretsDir ?? dataDir;
-    this.subscription = createSubscriptionRuntime(this.secretsDir);
-    this.runtimeProjector = createEffectiveGenerationRuntimeProjector(this.subscription);
+    this.environment = { ...(options.environment ?? process.env) };
+    this.runtimeResolver = createSettingsRuntimeResolver({
+      environment: this.environment,
+      subscription: createSubscriptionRuntime(this.secretsDir)
+    });
     // A shared machine tier holds every project's keys, and this store only
     // knows the IDs one project references. Pruning against that view would
     // delete another project's credentials, so garbage collection is confined
@@ -158,7 +161,6 @@ export class SettingsV2Store {
     this.prunesSecrets = this.secretsDir === dataDir;
     this.coordinator = options.coordinator ?? createMutationCoordinator();
     this.ledger = options.ledger ?? new MutationLedgerStore(dataDir);
-    this.environment = { ...(options.environment ?? process.env) };
     this.now = options.now ?? (() => new Date());
     this.validateCandidate = options.validateCandidate ?? defaultCandidateValidator;
     this.activationMode = options.activationMode ?? "activation-capable";
@@ -173,7 +175,7 @@ export class SettingsV2Store {
     // activate, or prune. Opening proves the state parses and its active
     // document supports a route, exactly like the writable path below.
     if (slot.kind === "v3") {
-      assertRuntimeDocumentSupported(activeSettingsDocument(slot.readOnlyView), this.runtimeProjector);
+      assertRuntimeDocumentSupported(activeSettingsDocument(slot.readOnlyView), this.runtimeResolver);
       settingsViewFromState(slot.readOnlyView);
       return;
     }
@@ -188,12 +190,12 @@ export class SettingsV2Store {
       await removeProviderSecretsScratch(this.secretsDir);
       await pruneProviderSecrets(this.secretsDir, providerSecretIdsToKeep(state));
     }
-    assertRuntimeDocumentSupported(activeSettingsDocument(state), this.runtimeProjector);
+    assertRuntimeDocumentSupported(activeSettingsDocument(state), this.runtimeResolver);
     settingsViewFromState(state);
   }
 
   loadView(): Promise<SettingsView> {
-    return readSettingsView(this.dataDir, this.subscription.credentials);
+    return readSettingsView(this.dataDir, this.runtimeResolver.credentials);
   }
 
   /** The route's runtime settings AND its stored image-input override,
@@ -219,16 +221,9 @@ export class SettingsV2Store {
   async loadRuntime(purpose: SettingsRoutePurpose = "default") {
     const { slot, state, storedSecrets } = await this.readRuntimeSnapshot();
     const document = activeSettingsDocument(state);
-    const runtime = this.runtimeProjector.project(
-      document,
-      purpose,
-      {},
-      this.environment,
-      {},
-      storedSecrets
-    );
+    const runtime = this.runtimeResolver.resolve({ document, purpose, storedSecrets });
     assertRuntimeGenerationSettingsSupported(runtime.settings);
-    // Same `document` object the runtime projector just resolved a
+    // Same `document` object the runtime resolver just resolved a
     // route from, above — a second call to the same pure route-selection
     // function, not a second read. `selectSettingsRoute` is deterministic
     // given a document and a purpose, so this always names the same model
@@ -280,13 +275,13 @@ export class SettingsV2Store {
     settings: GenerationSettings
   ): Promise<readonly {
     readonly connectionId: string;
-    readonly providerRuntime: ReturnType<typeof providerRuntimeFromV2>;
+    readonly providerRuntime: ProviderRuntime;
   }[]> {
     const { state, storedSecrets } = await this.readRuntimeSnapshot();
     const document = activeSettingsDocument(state);
     const exact: Array<{
       readonly connectionId: string;
-      readonly providerRuntime: ReturnType<typeof providerRuntimeFromV2>;
+      readonly providerRuntime: ProviderRuntime;
     }> = [];
     const fallback: typeof exact = [];
     for (const [connectionId, connection] of Object.entries(document.connections)) {
@@ -305,16 +300,12 @@ export class SettingsV2Store {
       const model = exactModel ?? models[0];
       const match = {
         connectionId,
-        providerRuntime: providerRuntimeFromV2(
+        providerRuntime: this.runtimeResolver.resolveConnection({
           connection,
-          "default",
-          model?.capabilities ?? defaultModelCapabilities(provider),
-          {
-            environment: this.environment,
-            storedSecrets,
-            subscription: this.subscription
-          }
-        )
+          effort: "default",
+          capabilities: model?.capabilities ?? defaultModelCapabilities(provider),
+          storedSecrets
+        })
       };
       (exactModel === undefined ? fallback : exact).push(match);
     }
@@ -363,16 +354,12 @@ export class SettingsV2Store {
         );
       }
     }
-    const runtime = this.runtimeProjector.project(
+    const runtime = this.runtimeResolver.resolve({
       document,
       purpose,
-      {},
-      this.environment,
-      {
-        allowBlankModel: true
-      },
-      resolvedSecrets
-    );
+      allowBlankModel: true,
+      storedSecrets: resolvedSecrets
+    });
     assertRuntimeGenerationSettingsSupported(runtime.settings);
     return runtime.settings;
   }
@@ -490,11 +477,10 @@ export class SettingsV2Store {
     }
 
     if (operation.method === "saveSettings") {
-      assertRuntimeDocumentSupported(operation.document, this.runtimeProjector);
+      assertRuntimeDocumentSupported(operation.document, this.runtimeResolver);
       await assertSavedSamplingBiasResolves(
         operation.document,
-        this.environment,
-        this.runtimeProjector,
+        this.runtimeResolver,
         signal
       );
     }
@@ -820,21 +806,18 @@ export class SettingsV2Store {
     }
     let candidateReady = false;
     try {
-      assertRuntimeDocumentSupported(candidate, this.runtimeProjector);
+      assertRuntimeDocumentSupported(candidate, this.runtimeResolver);
       const validatedConnections = new Set<string>();
       const probeTargets: GenerationSettings[] = [];
       for (const purpose of SETTINGS_ROUTE_PURPOSE_VALUES) {
         const route = selectSettingsRoute(candidate, purpose);
         if (validatedConnections.has(route.model.connectionId)) continue;
         validatedConnections.add(route.model.connectionId);
-        const effective = this.runtimeProjector.project(
-          candidate,
+        const effective = this.runtimeResolver.resolve({
+          document: candidate,
           purpose,
-          {},
-          this.environment,
-          {},
           storedSecrets
-        ).settings;
+        }).settings;
         if (providerRequestTransportAvailable(effective)) probeTargets.push(effective);
       }
       // Distinct connections validate concurrently, so the whole attempt is

--- a/server/settings-v2-store.ts
+++ b/server/settings-v2-store.ts
@@ -489,7 +489,12 @@ export class SettingsV2Store {
 
     if (operation.method === "saveSettings") {
       assertRuntimeDocumentSupported(operation.document, this.subscription);
-      await assertSavedSamplingBiasResolves(operation.document, this.environment, signal);
+      await assertSavedSamplingBiasResolves(
+        operation.document,
+        this.environment,
+        this.subscription,
+        signal
+      );
     }
     if (current.stateGeneration !== request.expectedAggregateVersion.stateGeneration) {
       throw new ServiceError(

--- a/server/settings-v2-store.ts
+++ b/server/settings-v2-store.ts
@@ -170,8 +170,8 @@ export class SettingsV2Store {
     // activate, or prune. Opening proves the state parses and its active
     // document supports a route, exactly like the writable path below.
     if (slot.kind === "v3") {
-      assertRuntimeDocumentSupported(activeSettingsDocument(slot.readOnlyView));
-      settingsViewFromState(slot.readOnlyView);
+      assertRuntimeDocumentSupported(activeSettingsDocument(slot.readOnlyView), this.subscription);
+      settingsViewFromState(slot.readOnlyView, this.subscription);
       return;
     }
     // Every authority that reaches here is schema 2: the branch above
@@ -185,12 +185,12 @@ export class SettingsV2Store {
       await removeProviderSecretsScratch(this.secretsDir);
       await pruneProviderSecrets(this.secretsDir, providerSecretIdsToKeep(state));
     }
-    assertRuntimeDocumentSupported(activeSettingsDocument(state));
-    settingsViewFromState(state);
+    assertRuntimeDocumentSupported(activeSettingsDocument(state), this.subscription);
+    settingsViewFromState(state, this.subscription);
   }
 
   loadView(): Promise<SettingsView> {
-    return readSettingsView(this.dataDir, this.subscription.credentials);
+    return readSettingsView(this.dataDir, this.subscription);
   }
 
   /** The route's runtime settings AND its stored image-input override,
@@ -488,7 +488,7 @@ export class SettingsV2Store {
     }
 
     if (operation.method === "saveSettings") {
-      assertRuntimeDocumentSupported(operation.document);
+      assertRuntimeDocumentSupported(operation.document, this.subscription);
       await assertSavedSamplingBiasResolves(operation.document, this.environment, signal);
     }
     if (current.stateGeneration !== request.expectedAggregateVersion.stateGeneration) {
@@ -813,7 +813,7 @@ export class SettingsV2Store {
     }
     let candidateReady = false;
     try {
-      assertRuntimeDocumentSupported(candidate);
+      assertRuntimeDocumentSupported(candidate, this.subscription);
       const validatedConnections = new Set<string>();
       const probeTargets: GenerationSettings[] = [];
       for (const purpose of SETTINGS_ROUTE_PURPOSE_VALUES) {

--- a/server/settings-v2-store.ts
+++ b/server/settings-v2-store.ts
@@ -171,7 +171,7 @@ export class SettingsV2Store {
     // document supports a route, exactly like the writable path below.
     if (slot.kind === "v3") {
       assertRuntimeDocumentSupported(activeSettingsDocument(slot.readOnlyView), this.subscription);
-      settingsViewFromState(slot.readOnlyView, this.subscription);
+      settingsViewFromState(slot.readOnlyView);
       return;
     }
     // Every authority that reaches here is schema 2: the branch above
@@ -186,11 +186,11 @@ export class SettingsV2Store {
       await pruneProviderSecrets(this.secretsDir, providerSecretIdsToKeep(state));
     }
     assertRuntimeDocumentSupported(activeSettingsDocument(state), this.subscription);
-    settingsViewFromState(state, this.subscription);
+    settingsViewFromState(state);
   }
 
   loadView(): Promise<SettingsView> {
-    return readSettingsView(this.dataDir, this.subscription);
+    return readSettingsView(this.dataDir, this.subscription.credentials);
   }
 
   /** The route's runtime settings AND its stored image-input override,

--- a/server/settings-v2-view-read.ts
+++ b/server/settings-v2-view-read.ts
@@ -1,4 +1,3 @@
-import type { CredentialStore } from "@earendil-works/pi-ai";
 import type { SettingsView } from "../shared/settings-v2-types.js";
 import { hashSettingsStateV2 } from "./settings-v2-codec.js";
 import { INITIAL_SETTINGS_STATE_V2_HASH } from "./settings-v2-initial-vectors.js";
@@ -7,20 +6,26 @@ import {
   settingsStateSlotReadOnlyView,
   type SettingsStateSlot
 } from "./settings-state-slot.js";
-import { readSubscriptionAuthState } from "./subscription-runtime.js";
+import {
+  readSubscriptionAuthState,
+  type SubscriptionRuntimeDependencies
+} from "./subscription-runtime.js";
 import { settingsViewFromState } from "./settings-v2-runtime.js";
 
 /** Read the settings view and its machine-tier subscription presentation. */
 export async function readSettingsView(
   dataDir: string,
-  credentials: Pick<CredentialStore, "read">
+  subscription: SubscriptionRuntimeDependencies
 ): Promise<SettingsView> {
   const slot = await readSettingsStateSlot(dataDir);
-  const view = settingsViewFromState(settingsStateSlotReadOnlyView(slot));
+  const view = settingsViewFromState(
+    settingsStateSlotReadOnlyView(slot),
+    subscription
+  );
   return {
     ...view,
     subscriptionAutoSelectEligible: exactInitialStateOwnedByThisRelease(slot),
-    subscriptionAuth: await readSubscriptionAuthState(credentials)
+    subscriptionAuth: await readSubscriptionAuthState(subscription.credentials)
   };
 }
 

--- a/server/settings-v2-view-read.ts
+++ b/server/settings-v2-view-read.ts
@@ -1,3 +1,4 @@
+import type { CredentialStore } from "@earendil-works/pi-ai";
 import type { SettingsView } from "../shared/settings-v2-types.js";
 import { hashSettingsStateV2 } from "./settings-v2-codec.js";
 import { INITIAL_SETTINGS_STATE_V2_HASH } from "./settings-v2-initial-vectors.js";
@@ -6,26 +7,20 @@ import {
   settingsStateSlotReadOnlyView,
   type SettingsStateSlot
 } from "./settings-state-slot.js";
-import {
-  readSubscriptionAuthState,
-  type SubscriptionRuntimeDependencies
-} from "./subscription-runtime.js";
+import { readSubscriptionAuthState } from "./subscription-runtime.js";
 import { settingsViewFromState } from "./settings-v2-runtime.js";
 
 /** Read the settings view and its machine-tier subscription presentation. */
 export async function readSettingsView(
   dataDir: string,
-  subscription: SubscriptionRuntimeDependencies
+  credentials: Pick<CredentialStore, "read">
 ): Promise<SettingsView> {
   const slot = await readSettingsStateSlot(dataDir);
-  const view = settingsViewFromState(
-    settingsStateSlotReadOnlyView(slot),
-    subscription
-  );
+  const view = settingsViewFromState(settingsStateSlotReadOnlyView(slot));
   return {
     ...view,
     subscriptionAutoSelectEligible: exactInitialStateOwnedByThisRelease(slot),
-    subscriptionAuth: await readSubscriptionAuthState(subscription.credentials)
+    subscriptionAuth: await readSubscriptionAuthState(credentials)
   };
 }
 

--- a/server/subscription-adapter.ts
+++ b/server/subscription-adapter.ts
@@ -25,7 +25,8 @@ import { ProviderError } from "./errors.js";
 import {
   createProviderStreamRedactor,
   providerRuntimeFor,
-  redactProviderSecrets
+  redactProviderSecrets,
+  subscriptionRuntimeFor
 } from "./provider-runtime.js";
 import { requireLogitBiasFamilyAvailable } from "./provider-sampling.js";
 import { createReasoningRelay } from "./provider-reasoning-relay.js";
@@ -36,7 +37,6 @@ import {
 import {
   subscriptionProviderForProtocol
 } from "./subscription-protocol.js";
-import type { SubscriptionRuntimeDependencies } from "./subscription-runtime.js";
 import type {
   GenerationRecordCollector
 } from "./generation-record-capture.js";
@@ -82,7 +82,7 @@ export async function* streamSubscription(
     throw new ProviderError("Subscription protocol is not supported.");
   }
   requireLogitBiasFamilyAvailable(settings, protocol, options.storySampling);
-  const dependencies = subscriptionDependencies(runtime);
+  const dependencies = subscriptionRuntimeFor(runtime);
   const providerId = subscriptionProviderForProtocol(protocol);
   const modelValue = dependencies.models.getModel(providerId, settings.model);
   if (modelValue === undefined) {
@@ -319,17 +319,8 @@ export async function* streamSubscription(
   }
 }
 
-function subscriptionDependencies(
-  runtime: ReturnType<typeof providerRuntimeFor>
-): SubscriptionRuntimeDependencies {
-  if (runtime.subscription === undefined) {
-    throw new ProviderError("Subscription credential storage is unavailable.");
-  }
-  return runtime.subscription;
-}
-
 async function resolveSubscriptionAuth(
-  dependencies: SubscriptionRuntimeDependencies,
+  dependencies: ReturnType<typeof subscriptionRuntimeFor>,
   model: Model<Api>,
   providerId: "openai-codex" | "anthropic",
   signal: AbortSignal

--- a/server/subscription-adapter.ts
+++ b/server/subscription-adapter.ts
@@ -10,8 +10,6 @@ import type {
   Models
 } from "@earendil-works/pi-ai";
 import { hasApi } from "@earendil-works/pi-ai";
-import type { SettingsProtocolV2 } from "../shared/settings-v2-types.js";
-import { isSubscriptionProtocolV2 } from "../shared/settings-v2-types.js";
 import type { GenerationSettings } from "../shared/types.js";
 import type { StorySamplingBias } from "./sampling-phrase-bias.js";
 import {
@@ -24,9 +22,10 @@ import { lowerPromptForProvider } from "./provider-request-body.js";
 import { ProviderError } from "./errors.js";
 import {
   createProviderStreamRedactor,
+  isSubscriptionProviderRuntime,
   providerRuntimeFor,
   redactProviderSecrets,
-  subscriptionRuntimeFor
+  type SubscriptionProviderRuntime
 } from "./provider-runtime.js";
 import { requireLogitBiasFamilyAvailable } from "./provider-sampling.js";
 import { createReasoningRelay } from "./provider-reasoning-relay.js";
@@ -77,12 +76,12 @@ export async function* streamSubscription(
   options: SubscriptionStreamOptions
 ): AsyncGenerator<string> {
   const runtime = providerRuntimeFor(settings);
-  const protocol = runtime.protocol as SettingsProtocolV2 | undefined;
-  if (protocol === undefined || !isSubscriptionProtocolV2(protocol)) {
+  if (!isSubscriptionProviderRuntime(runtime)) {
     throw new ProviderError("Subscription protocol is not supported.");
   }
+  const protocol = runtime.protocol;
   requireLogitBiasFamilyAvailable(settings, protocol, options.storySampling);
-  const dependencies = subscriptionRuntimeFor(runtime);
+  const dependencies = runtime.subscription;
   const providerId = subscriptionProviderForProtocol(protocol);
   const modelValue = dependencies.models.getModel(providerId, settings.model);
   if (modelValue === undefined) {
@@ -320,7 +319,7 @@ export async function* streamSubscription(
 }
 
 async function resolveSubscriptionAuth(
-  dependencies: ReturnType<typeof subscriptionRuntimeFor>,
+  dependencies: SubscriptionProviderRuntime["subscription"],
   model: Model<Api>,
   providerId: "openai-codex" | "anthropic",
   signal: AbortSignal

--- a/server/subscription-models.ts
+++ b/server/subscription-models.ts
@@ -22,13 +22,3 @@ export function createSubscriptionModels(
   models.setProvider(anthropicProvider());
   return models;
 }
-
-/** Build the same fixed coordinator for catalog-only demo reads. */
-export function createSubscriptionCatalog(): Models {
-  return createSubscriptionModels({
-    read: async () => undefined,
-    list: async () => [],
-    modify: async (_providerId, update) => await update(undefined),
-    delete: async () => {}
-  });
-}

--- a/server/subscription-models.ts
+++ b/server/subscription-models.ts
@@ -22,3 +22,13 @@ export function createSubscriptionModels(
   models.setProvider(anthropicProvider());
   return models;
 }
+
+/** Build the same fixed coordinator for catalog-only demo reads. */
+export function createSubscriptionCatalog(): Models {
+  return createSubscriptionModels({
+    read: async () => undefined,
+    list: async () => [],
+    modify: async (_providerId, update) => await update(undefined),
+    delete: async () => {}
+  });
+}

--- a/shared/build-identity.ts
+++ b/shared/build-identity.ts
@@ -67,10 +67,13 @@ export const AI_1667_PRODUCT = "1667" as const;
  * continuation layout in the Settings view. A v21 client would reject that
  * additive closed-record field. v23 carries machine-tier subscription sign-in
  * state in the Settings view. A v22 client would reject that additive field
- * before it can use the rest of Settings. */
-export const HTTP_API_PROTOCOL_VERSION = 23;
-export const HTTP_MIN_CLIENT_PROTOCOL_VERSION = 23;
-export const HTTP_MAX_CLIENT_PROTOCOL_VERSION = 23;
+ * before it can use the rest of Settings. v24 adds `pi-catalog` to the closed
+ * model-discovery source enum. A v23 client would reject a subscription model
+ * list from a v24 server. A v24 client would accept a v23 response but receive
+ * the old empty subscription catalog. */
+export const HTTP_API_PROTOCOL_VERSION = 24;
+export const HTTP_MIN_CLIENT_PROTOCOL_VERSION = 24;
+export const HTTP_MAX_CLIENT_PROTOCOL_VERSION = 24;
 
 export type ArtifactTarget = "source" | BuiltArtifactTarget;
 

--- a/shared/model-discovery-catalog.ts
+++ b/shared/model-discovery-catalog.ts
@@ -1,0 +1,105 @@
+import type {
+  DiscoveredModelV2,
+  ModelDiscoverySourceV2
+} from "./settings-v2-types.js";
+import {
+  MAX_SETTINGS_REMOTE_ID_SCALARS,
+  MAX_SETTINGS_TOKEN_COUNT
+} from "./settings-scalar-policy.js";
+import { hasUnpairedSurrogate, unicodeScalarLength } from "./unicode.js";
+
+export const MAX_DISCOVERED_MODELS = 256;
+
+export interface ModelDiscoveryCandidate {
+  readonly remoteId: unknown;
+  readonly name: unknown;
+  readonly contextWindow: readonly unknown[];
+  readonly maxOutputTokens: readonly unknown[];
+}
+
+/** The typed part of a bundled model that discovery publishes. */
+export interface BundledCatalogModel {
+  readonly id: string;
+  readonly name: string;
+  readonly contextWindow: number;
+  readonly maxTokens: number;
+}
+
+/** Apply one discovery policy after a source adapter projects its fields. */
+export function sanitizeDiscoveredModels<T>(
+  entries: readonly T[],
+  source: ModelDiscoverySourceV2,
+  candidateFor: (entry: T) => ModelDiscoveryCandidate | null
+): readonly DiscoveredModelV2[] {
+  const result: DiscoveredModelV2[] = [];
+  const seen = new Set<string>();
+  for (const entry of entries) {
+    const candidate = candidateFor(entry);
+    if (candidate === null) continue;
+    const remoteId = safeModelId(candidate.remoteId);
+    if (remoteId === null || seen.has(remoteId)) continue;
+    seen.add(remoteId);
+    result.push({
+      remoteId,
+      name: safeModelName(candidate.name, remoteId),
+      contextWindow: firstSafeModelScalar(candidate.contextWindow),
+      maxOutputTokens: firstSafeModelScalar(candidate.maxOutputTokens),
+      source
+    });
+    if (result.length === MAX_DISCOVERED_MODELS) break;
+  }
+  return result;
+}
+
+/** Project a typed bundled catalog through the shared discovery policy. */
+export function discoverBundledModels(
+  models: readonly BundledCatalogModel[]
+): readonly DiscoveredModelV2[] {
+  return sanitizeDiscoveredModels(models, "pi-catalog", (model) => ({
+    remoteId: model.id,
+    name: model.name,
+    contextWindow: [model.contextWindow],
+    maxOutputTokens: [model.maxTokens]
+  }));
+}
+
+function safeModelId(value: unknown): string | null {
+  if (
+    typeof value !== "string"
+    || value.length === 0
+    || value.trim() !== value
+    || hasUnpairedSurrogate(value)
+    || value.normalize("NFC") !== value
+  ) return null;
+  return unicodeScalarLength(value, MAX_SETTINGS_REMOTE_ID_SCALARS)
+    <= MAX_SETTINGS_REMOTE_ID_SCALARS
+    ? value
+    : null;
+}
+
+function safeModelName(value: unknown, fallback: string): string {
+  const safe = typeof value !== "string"
+    || value.trim().length === 0
+    || hasUnpairedSurrogate(value)
+    || value.normalize("NFC") !== value
+    ? fallback
+    : value;
+  return Array.from(safe).slice(0, 256).join("");
+}
+
+function safeModelScalar(value: unknown): number | null {
+  return typeof value === "number"
+    && Number.isSafeInteger(value)
+    && value > 0
+    && value <= MAX_SETTINGS_TOKEN_COUNT
+    ? value
+    : null;
+}
+
+function firstSafeModelScalar(values: readonly unknown[]): number | null {
+  for (const value of values) {
+    const scalar = safeModelScalar(value);
+    if (scalar !== null) return scalar;
+  }
+  return null;
+}

--- a/shared/model-discovery-catalog.ts
+++ b/shared/model-discovery-catalog.ts
@@ -3,12 +3,13 @@ import type {
   ModelDiscoverySourceV2
 } from "./settings-v2-types.js";
 import {
+  MAX_DISCOVERED_MODELS,
   MAX_SETTINGS_REMOTE_ID_SCALARS,
   MAX_SETTINGS_TOKEN_COUNT
 } from "./settings-scalar-policy.js";
 import { hasUnpairedSurrogate, unicodeScalarLength } from "./unicode.js";
 
-export const MAX_DISCOVERED_MODELS = 256;
+export { MAX_DISCOVERED_MODELS };
 
 export interface ModelDiscoveryCandidate {
   readonly remoteId: unknown;

--- a/shared/settings-response-decoder.ts
+++ b/shared/settings-response-decoder.ts
@@ -14,6 +14,7 @@ import {
   type SubscriptionProtocolV2
 } from "./settings-v2-types.js";
 import { CONTINUATION_PROMPT_LAYOUTS } from "./continuation-prompt-optimization.js";
+import { MAX_DISCOVERED_MODELS } from "./settings-scalar-policy.js";
 import type { GenerationSettings, Provider } from "./types.js";
 
 export type SettingsDocumentResponseDecoder = (value: unknown) => SettingsDocumentV2;
@@ -216,7 +217,7 @@ export function decodeModelDiscoveryResult(value: unknown): ModelDiscoveryResult
   const response = closedRecord(value, "model discovery result", ["observedAt", "models"]);
   const observedAt = stringValue(response.observedAt, "model discovery result.observedAt");
   if (!isCanonicalDate(observedAt) || !Array.isArray(response.models)
-    || response.models.length > 256) {
+    || response.models.length > MAX_DISCOVERED_MODELS) {
     invalid("model discovery result");
   }
   return {

--- a/shared/settings-response-decoder.ts
+++ b/shared/settings-response-decoder.ts
@@ -1,9 +1,9 @@
 import {
+  MODEL_DISCOVERY_SOURCE_V2_VALUES,
   REASONING_DISPLAY_V2_VALUES,
   SETTINGS_ACTIVATION_ERROR_CODE_V2_VALUES,
   SETTINGS_SUBSCRIPTION_PROTOCOL_V2_VALUES,
   type ModelDiscoveryResultV2,
-  type ModelDiscoverySourceV2,
   type ReasoningDisplayV2,
   type SettingsActivationOutcomeV2,
   type SettingsDocumentV2,
@@ -236,8 +236,9 @@ export function decodeModelDiscoveryResult(value: unknown): ModelDiscoveryResult
           model.maxOutputTokens,
           `model discovery result.models[${index}].maxOutputTokens`
         ),
-        source: discoverySource(
+        source: oneOf(
           model.source,
+          MODEL_DISCOVERY_SOURCE_V2_VALUES,
           `model discovery result.models[${index}].source`
         )
       };
@@ -296,13 +297,6 @@ function positiveSafeInteger(value: unknown, label: string): number {
 
 function nullablePositiveSafeInteger(value: unknown, label: string): number | null {
   return value === null ? null : positiveSafeInteger(value, label);
-}
-
-function discoverySource(value: unknown, label: string): ModelDiscoverySourceV2 {
-  if (value !== "anthropic-models" && value !== "openai-models"
-    && value !== "lm-studio-models" && value !== "ollama-tags"
-    && value !== "pi-catalog") invalid(label);
-  return value;
 }
 
 function oneOf<const T extends readonly string[]>(

--- a/shared/settings-response-decoder.ts
+++ b/shared/settings-response-decoder.ts
@@ -300,7 +300,8 @@ function nullablePositiveSafeInteger(value: unknown, label: string): number | nu
 
 function discoverySource(value: unknown, label: string): ModelDiscoverySourceV2 {
   if (value !== "anthropic-models" && value !== "openai-models"
-    && value !== "lm-studio-models" && value !== "ollama-tags") invalid(label);
+    && value !== "lm-studio-models" && value !== "ollama-tags"
+    && value !== "pi-catalog") invalid(label);
   return value;
 }
 

--- a/shared/settings-scalar-policy.ts
+++ b/shared/settings-scalar-policy.ts
@@ -1,0 +1,3 @@
+/** Shared limits for model identifiers and token counts in Settings. */
+export const MAX_SETTINGS_REMOTE_ID_SCALARS = 512;
+export const MAX_SETTINGS_TOKEN_COUNT = 1_000_000_000;

--- a/shared/settings-scalar-policy.ts
+++ b/shared/settings-scalar-policy.ts
@@ -1,3 +1,4 @@
 /** Shared limits for model identifiers and token counts in Settings. */
+export const MAX_DISCOVERED_MODELS = 256;
 export const MAX_SETTINGS_REMOTE_ID_SCALARS = 512;
 export const MAX_SETTINGS_TOKEN_COUNT = 1_000_000_000;

--- a/shared/settings-v2-types.ts
+++ b/shared/settings-v2-types.ts
@@ -366,12 +366,14 @@ export interface SettingsDocumentV3 {
   };
 }
 
-export type ModelDiscoverySourceV2 =
-  | "anthropic-models"
-  | "openai-models"
-  | "lm-studio-models"
-  | "ollama-tags"
-  | "pi-catalog";
+export const MODEL_DISCOVERY_SOURCE_V2_VALUES = [
+  "anthropic-models",
+  "openai-models",
+  "lm-studio-models",
+  "ollama-tags",
+  "pi-catalog"
+] as const;
+export type ModelDiscoverySourceV2 = (typeof MODEL_DISCOVERY_SOURCE_V2_VALUES)[number];
 
 export interface DiscoveredModelV2 {
   readonly remoteId: string;

--- a/shared/settings-v2-types.ts
+++ b/shared/settings-v2-types.ts
@@ -370,7 +370,8 @@ export type ModelDiscoverySourceV2 =
   | "anthropic-models"
   | "openai-models"
   | "lm-studio-models"
-  | "ollama-tags";
+  | "ollama-tags"
+  | "pi-catalog";
 
 export interface DiscoveredModelV2 {
   readonly remoteId: string;

--- a/test/build-identity.test.ts
+++ b/test/build-identity.test.ts
@@ -41,12 +41,13 @@ test("source identity is explicit and cannot masquerade as a packaged build", ()
   // `internal`, so it cannot tell a writer that a Draft Lease expired. v21
   // adds Aside routes, Aside failure codes, and the Markdown export fidelity
   // contract. v22 adds the active prose continuation layout to Settings. v23
-  // adds machine-tier subscription sign-in state to Settings. An older peer
-  // must fail at preflight.
+  // adds machine-tier subscription sign-in state to Settings. v24 adds the
+  // closed `pi-catalog` model-discovery source. An older peer must fail at
+  // preflight.
   assert.equal(
     HTTP_API_PROTOCOL_VERSION,
-    23,
-    "Aside routes, failure codes, export fidelity, active prompt layout, and subscription auth require HTTP API v23"
+    24,
+    "Subscription model catalogs require HTTP API v24"
   );
   const source = createSourceBuildIdentity("1.2.3");
   assert.deepEqual(source, {

--- a/test/continuation-prompt-layout.test.ts
+++ b/test/continuation-prompt-layout.test.ts
@@ -3,8 +3,7 @@ import test from "node:test";
 import { assembleContinuation } from "../server/continuation-assembly.js";
 import { continuationRecordEntries } from "../server/generation-record-prompt.js";
 import { buildOpenAiChatRequestBody } from "../server/provider-request-body.js";
-import { effectiveGenerationRuntime } from "../server/settings-v2-conversion.js";
-import { createSubscriptionRuntime } from "../server/subscription-runtime.js";
+import { effectiveStandardGenerationRuntime } from "../server/settings-v2-conversion.js";
 import {
   INITIAL_SETTINGS_DOCUMENT_V2,
   INITIAL_SETTINGS_DOCUMENT_V2_TEXT
@@ -35,19 +34,12 @@ const APPEND_CONTRACT = [
   "Return only the new characters after that boundary; do not repeat, restart, quote, or summarize existing text."
 ].join(" ");
 const PREFILL_CONTINUITY_GUARD = "Preserve the established point of view and tense.";
-const SUBSCRIPTION_RUNTIME = createSubscriptionRuntime(process.cwd());
 
 function generationRuntime(
   document: SettingsDocumentV2,
   purpose: "default" | "prose" = "default"
 ) {
-  return effectiveGenerationRuntime(
-    document,
-    purpose,
-    {},
-    undefined,
-    { subscription: SUBSCRIPTION_RUNTIME }
-  );
+  return effectiveStandardGenerationRuntime(document, purpose);
 }
 
 test("compatibility is the default continuation prompt layout", () => {

--- a/test/continuation-prompt-layout.test.ts
+++ b/test/continuation-prompt-layout.test.ts
@@ -4,6 +4,7 @@ import { assembleContinuation } from "../server/continuation-assembly.js";
 import { continuationRecordEntries } from "../server/generation-record-prompt.js";
 import { buildOpenAiChatRequestBody } from "../server/provider-request-body.js";
 import { effectiveGenerationRuntime } from "../server/settings-v2-conversion.js";
+import { createSubscriptionRuntime } from "../server/subscription-runtime.js";
 import {
   INITIAL_SETTINGS_DOCUMENT_V2,
   INITIAL_SETTINGS_DOCUMENT_V2_TEXT
@@ -34,6 +35,20 @@ const APPEND_CONTRACT = [
   "Return only the new characters after that boundary; do not repeat, restart, quote, or summarize existing text."
 ].join(" ");
 const PREFILL_CONTINUITY_GUARD = "Preserve the established point of view and tense.";
+const SUBSCRIPTION_RUNTIME = createSubscriptionRuntime(process.cwd());
+
+function generationRuntime(
+  document: SettingsDocumentV2,
+  purpose: "default" | "prose" = "default"
+) {
+  return effectiveGenerationRuntime(
+    document,
+    purpose,
+    {},
+    undefined,
+    { subscription: SUBSCRIPTION_RUNTIME }
+  );
+}
 
 test("compatibility is the default continuation prompt layout", () => {
   const parts = storyParts();
@@ -114,11 +129,11 @@ test("enabled Retake uses the exact v0.9.0 final user contract and route snapsho
     routing: { ...INITIAL_SETTINGS_DOCUMENT_V2.routing, prose: "prose" }
   };
   assert.equal(
-    effectiveGenerationRuntime(splitProfiles, "default").providerRuntime.continuationPromptLayout,
+    generationRuntime(splitProfiles, "default").providerRuntime.continuationPromptLayout,
     "compatibility"
   );
   assert.equal(
-    effectiveGenerationRuntime(splitProfiles, "prose").providerRuntime.continuationPromptLayout,
+    generationRuntime(splitProfiles, "prose").providerRuntime.continuationPromptLayout,
     "late-cache-stable"
   );
 });
@@ -158,7 +173,7 @@ test("late-cache-stable keeps its v0.9.0 final contracts and guards only prefill
   });
   assert.equal(echoContinue.leftAnchor, "n filled the flagstones.");
   const echoBody = await buildOpenAiChatRequestBody(
-    effectiveGenerationRuntime(withContinuationPromptOptimization(INITIAL_SETTINGS_DOCUMENT_V2), "prose").settings,
+    generationRuntime(withContinuationPromptOptimization(INITIAL_SETTINGS_DOCUMENT_V2), "prose").settings,
     echoContinue.prompt,
     { kind: "omit", reason: "policy-off" }
   );
@@ -261,7 +276,7 @@ async function continuationBody(
   document: SettingsDocumentV2,
   appendLast: boolean
 ): Promise<Record<string, unknown>> {
-  const runtime = effectiveGenerationRuntime(document, "prose");
+  const runtime = generationRuntime(document, "prose");
   const story = {
     chapterBreaks: [],
     nodes: [
@@ -287,7 +302,7 @@ async function continuationPlanFor(
   document: SettingsDocumentV2,
   appendLast: boolean
 ): Promise<ContinuationPlan> {
-  const runtime = effectiveGenerationRuntime(document, "prose");
+  const runtime = generationRuntime(document, "prose");
   const story = { chapterBreaks: [], nodes: [node("p1", "Open gate", "Hinges groaned")] };
   return assembleContinuation({
     story,

--- a/test/continuation-prompt-layout.test.ts
+++ b/test/continuation-prompt-layout.test.ts
@@ -3,7 +3,7 @@ import test from "node:test";
 import { assembleContinuation } from "../server/continuation-assembly.js";
 import { continuationRecordEntries } from "../server/generation-record-prompt.js";
 import { buildOpenAiChatRequestBody } from "../server/provider-request-body.js";
-import { effectiveStandardGenerationRuntime } from "../server/settings-v2-conversion.js";
+import { effectiveStandardGenerationRuntime } from "../server/settings-runtime-resolver.js";
 import {
   INITIAL_SETTINGS_DOCUMENT_V2,
   INITIAL_SETTINGS_DOCUMENT_V2_TEXT

--- a/test/generation-profile-route-fit.integration.test.ts
+++ b/test/generation-profile-route-fit.integration.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { effectiveGenerationSettings } from "../server/settings-v2-conversion.js";
+import { effectiveGenerationView } from "../server/settings-v2-conversion.js";
 import { exportGenerationProfile, importProfileExport } from "../server/import-profile-export.js";
 import { validateSamplingRoute } from "../server/settings-v2-sampling-validation.js";
 import {
@@ -92,7 +92,7 @@ test("Profile transfer rejects Anthropic effort off through the exact route", ()
     reason: "Anthropic does not support generation effort set to off"
   });
   assert.throws(
-    () => effectiveGenerationSettings({
+    () => effectiveGenerationView({
       ...anthropic,
       profiles: {
         ...anthropic.profiles,
@@ -148,7 +148,7 @@ test("Profile transfer omits Mirostat when the selected route cannot use it", ()
       fitted.document.models[profile.modelId]!,
       fitted.document.connections[fitted.document.models[profile.modelId]!.connectionId]!
     );
-    assert.doesNotThrow(() => effectiveGenerationSettings(fitted.document));
+    assert.doesNotThrow(() => effectiveGenerationView(fitted.document));
   }
 });
 
@@ -175,7 +175,7 @@ test("Profile transfer caps maximum output with the runtime model limit policy",
   };
   const overrideFit = fitProfileToRoute(override, "default", candidate);
   assert.equal(overrideFit.document.profiles.default?.maxOutputTokens, 512);
-  assert.equal(effectiveGenerationSettings(overrideFit.document).maxTokens, 512);
+  assert.equal(effectiveGenerationView(overrideFit.document).maxTokens, 512);
   assert.deepEqual(overrideFit.fidelity, ["maximum output clamped to 512"]);
 
   const discovered = {
@@ -189,7 +189,7 @@ test("Profile transfer caps maximum output with the runtime model limit policy",
   };
   const discoveredFit = fitProfileToRoute(discovered, "default", candidate);
   assert.equal(discoveredFit.document.profiles.default?.maxOutputTokens, 1_024);
-  assert.equal(effectiveGenerationSettings(discoveredFit.document).maxTokens, 1_024);
+  assert.equal(effectiveGenerationView(discoveredFit.document).maxTokens, 1_024);
   assert.deepEqual(discoveredFit.fidelity, ["maximum output clamped to 1024"]);
 
   const unknown = {
@@ -203,7 +203,7 @@ test("Profile transfer caps maximum output with the runtime model limit policy",
   };
   const unknownFit = fitProfileToRoute(unknown, "default", candidate);
   assert.equal(unknownFit.document.profiles.default?.maxOutputTokens, 2_048);
-  assert.equal(effectiveGenerationSettings(unknownFit.document).maxTokens, 2_048);
+  assert.equal(effectiveGenerationView(unknownFit.document).maxTokens, 2_048);
   assert.deepEqual(unknownFit.fidelity, []);
 
   const runtimeMetadata = { runtime: { maxOutputTokens: 640 }, builtin: { maxOutputTokens: 320 } };
@@ -211,7 +211,7 @@ test("Profile transfer caps maximum output with the runtime model limit policy",
     modelMetadata: runtimeMetadata
   });
   assert.equal(runtimeFit.document.profiles.default?.maxOutputTokens, 640);
-  assert.equal(effectiveGenerationSettings(runtimeFit.document, "default", runtimeMetadata).maxTokens, 640);
+  assert.equal(effectiveGenerationView(runtimeFit.document, "default", runtimeMetadata).maxTokens, 640);
   assert.deepEqual(runtimeFit.fidelity, ["maximum output clamped to 640"]);
 
   const builtinMetadata = { builtin: { maxOutputTokens: 320 } };
@@ -219,7 +219,6 @@ test("Profile transfer caps maximum output with the runtime model limit policy",
     modelMetadata: builtinMetadata
   });
   assert.equal(builtinFit.document.profiles.default?.maxOutputTokens, 320);
-  assert.equal(effectiveGenerationSettings(builtinFit.document, "default", builtinMetadata).maxTokens, 320);
+  assert.equal(effectiveGenerationView(builtinFit.document, "default", builtinMetadata).maxTokens, 320);
   assert.deepEqual(builtinFit.fidelity, ["maximum output clamped to 320"]);
 });
-

--- a/test/generation-prompts.test.ts
+++ b/test/generation-prompts.test.ts
@@ -290,16 +290,10 @@ test("ChatGPT plan continuation uses a boundary user turn and exact echo", () =>
     systemPrompt: "Write.",
     contextWindow: null
   };
-  const runtime = providerRuntimeFor(settings);
-  const planSettings = attachProviderRuntime(settings, {
-    ...runtime,
-    preset: "chatgpt-plan",
-    protocol: "openai-codex-responses",
-    capabilities: {
-      ...runtime.capabilities,
-      assistantPrefill: "unknown"
-    }
-  });
+  const planSettings = {
+    ...settings,
+    protocol: "openai-codex-responses" as const
+  };
   assert.equal(supportsAssistantPrefill(planSettings), false);
 
   const parts = [part("Open the door.", "The latch was unlo")];
@@ -340,13 +334,11 @@ test("ChatGPT plan continuation uses a boundary user turn and exact echo", () =>
     systemPrompt: "Write.",
     contextWindow: null
   };
-  const claudeRuntime = providerRuntimeFor(claudeSettings);
   assert.equal(
-    supportsAssistantPrefill(attachProviderRuntime(claudeSettings, {
-      ...claudeRuntime,
-      preset: "claude-plan",
+    supportsAssistantPrefill({
+      ...claudeSettings,
       protocol: "anthropic-subscription-messages"
-    })),
+    }),
     false
   );
 });

--- a/test/model-discovery.test.ts
+++ b/test/model-discovery.test.ts
@@ -4,6 +4,7 @@ import { createServer } from "node:http";
 import test from "node:test";
 import { discoverProviderModels } from "../server/model-discovery.js";
 import { decodeModelDiscoveryResult } from "../shared/settings-response-decoder.js";
+import { MAX_DISCOVERED_MODELS } from "../shared/settings-scalar-policy.js";
 import {
   attachProviderRuntime,
   providerRuntimeFor,
@@ -488,7 +489,7 @@ test("model discovery wire decoder is closed and bounded", () => {
   assert.throws(
     () => decodeModelDiscoveryResult({
       observedAt: "2026-07-24T00:00:00.000Z",
-      models: Array.from({ length: 257 }, () => ({
+      models: Array.from({ length: MAX_DISCOVERED_MODELS + 1 }, () => ({
         remoteId: "fixture",
         name: "Fixture",
         contextWindow: null,

--- a/test/model-discovery.test.ts
+++ b/test/model-discovery.test.ts
@@ -469,9 +469,15 @@ test("model discovery wire decoder is closed and bounded", () => {
       name: "Fixture",
       contextWindow: 8_192,
       maxOutputTokens: null,
-      source: "openai-models"
+      source: "pi-catalog"
     }]
-  }).models[0]?.remoteId, "fixture");
+  }).models[0], {
+    remoteId: "fixture",
+    name: "Fixture",
+    contextWindow: 8_192,
+    maxOutputTokens: null,
+    source: "pi-catalog"
+  });
   assert.throws(
     () => decodeModelDiscoveryResult({
       observedAt: "not-a-date",

--- a/test/provider-cache-policy.test.ts
+++ b/test/provider-cache-policy.test.ts
@@ -12,7 +12,7 @@ import {
 import { parseSettingsDocumentV2 } from "../server/settings-v2-codec.js";
 import {
   convertGenerationSettingsV1,
-  effectiveGenerationSettings,
+  effectiveGenerationView,
   effectivePromptCacheContext
 } from "../server/settings-v2-conversion.js";
 import { promptCachePolicyPresentation } from "../shared/prompt-cache-capabilities.js";
@@ -259,25 +259,25 @@ test("runtime plans cache only stable boundaries and commit rolling state after 
 
 test("runtime admission accepts exact contracts and rejects unsupported policy precisely", () => {
   assert.equal(
-    effectiveGenerationSettings(
+    effectiveGenerationView(
       cacheDocument("openai-compatible", "openai", "supported", "auto", "gpt-5.6")
     ).model,
     "gpt-5.6"
   );
   assert.equal(
-    effectiveGenerationSettings(
+    effectiveGenerationView(
       cacheDocument("anthropic", "anthropic", "supported", "long", "claude-sonnet-4-6")
     ).model,
     "claude-sonnet-4-6"
   );
   assert.throws(
-    () => effectiveGenerationSettings(
+    () => effectiveGenerationView(
       cacheDocument("openai-compatible", "openai", "supported", "long", "gpt-5.6")
     ),
     /Long prompt-cache retention is unavailable/
   );
   assert.throws(
-    () => effectiveGenerationSettings(
+    () => effectiveGenerationView(
       cacheDocument("openai-compatible", "custom", "supported", "auto", "gpt-5.4")
     ),
     /Prompt caching is not supported by the selected provider/

--- a/test/provider-runtime-sampling.test.ts
+++ b/test/provider-runtime-sampling.test.ts
@@ -3,13 +3,12 @@ import test from "node:test";
 import {
   attachProviderRuntime,
   providerRuntimeFromV2,
-  resolveProviderHeaders
+  resolveProviderHeaders,
+  type StandardModelConnectionV2
 } from "../server/provider-runtime.js";
-import { createSubscriptionRuntime } from "../server/subscription-runtime.js";
 import {
   EMPTY_SAMPLING_V2,
-  type ModelCapabilitiesV2,
-  type ModelConnectionV2
+  type ModelCapabilitiesV2
 } from "../shared/settings-v2-types.js";
 import type { GenerationSettings } from "../shared/types.js";
 
@@ -20,10 +19,8 @@ const CAPABILITIES: ModelCapabilitiesV2 = {
   promptCaching: "unknown"
 };
 
-const SUBSCRIPTION_RUNTIME = createSubscriptionRuntime(process.cwd());
-
 test("v2 runtime accepts named credentials and sampling options", () => {
-  const connection: ModelConnectionV2 = {
+  const connection: StandardModelConnectionV2 = {
     name: "Compatibility fixture",
     preset: "custom",
     protocol: "openai-chat-completions",
@@ -55,8 +52,7 @@ test("v2 runtime accepts named credentials and sampling options", () => {
     {
       environment: { AI_1667_COMPAT_HEADER: "environment-secret" },
       storedSecrets: new Map([["compat-secret", "stored-secret"]]),
-      sampling,
-      subscription: SUBSCRIPTION_RUNTIME
+      sampling
     }
   );
 

--- a/test/provider-runtime-sampling.test.ts
+++ b/test/provider-runtime-sampling.test.ts
@@ -5,6 +5,7 @@ import {
   providerRuntimeFromV2,
   resolveProviderHeaders
 } from "../server/provider-runtime.js";
+import { createSubscriptionRuntime } from "../server/subscription-runtime.js";
 import {
   EMPTY_SAMPLING_V2,
   type ModelCapabilitiesV2,
@@ -18,6 +19,8 @@ const CAPABILITIES: ModelCapabilitiesV2 = {
   reasoningEffort: "unknown",
   promptCaching: "unknown"
 };
+
+const SUBSCRIPTION_RUNTIME = createSubscriptionRuntime(process.cwd());
 
 test("v2 runtime accepts named credentials and sampling options", () => {
   const connection: ModelConnectionV2 = {
@@ -52,7 +55,8 @@ test("v2 runtime accepts named credentials and sampling options", () => {
     {
       environment: { AI_1667_COMPAT_HEADER: "environment-secret" },
       storedSecrets: new Map([["compat-secret", "stored-secret"]]),
-      sampling
+      sampling,
+      subscription: SUBSCRIPTION_RUNTIME
     }
   );
 

--- a/test/provider-runtime.test.ts
+++ b/test/provider-runtime.test.ts
@@ -8,7 +8,8 @@ import {
   redactProviderBody,
   redactProviderSecrets,
   resolveProviderHeaders,
-  type ProviderRuntime
+  type ProviderRuntime,
+  type StandardProviderRuntime
 } from "../server/provider-runtime.js";
 import {
   BoundedProviderSseParser,
@@ -1775,7 +1776,7 @@ test("complete SSE frames may share a transport chunk larger than the partial-fr
 });
 
 function attached(
-  overrides: Partial<ProviderRuntime> = {},
+  overrides: Partial<StandardProviderRuntime> = {},
   settingsOverrides: Partial<GenerationSettings> = {}
 ): GenerationSettings {
   return attachProviderRuntime({ ...baseSettings(), ...settingsOverrides }, {

--- a/test/settings-activation-in-process.test.ts
+++ b/test/settings-activation-in-process.test.ts
@@ -7,7 +7,7 @@ import { SETTINGS_STATE_V2_NEXT_FILE } from "../server/data-directory-layout.js"
 import { readProviderSecrets } from "../server/provider-secret-store.js";
 import { resolveProviderHeaders } from "../server/provider-runtime.js";
 import { SettingsStore } from "../server/settings.js";
-import { effectiveGenerationSettings } from "../server/settings-v2-conversion.js";
+import { effectiveGenerationView } from "../server/settings-v2-conversion.js";
 import { INITIAL_SETTINGS_DOCUMENT_V2 } from "../server/settings-v2-default.js";
 import { reduceSettingsStateV2 } from "../server/settings-v2-reducer.js";
 import {
@@ -244,7 +244,7 @@ test("mid-activation states keep the old document effective until the commit edg
 
   for (const state of [staged, validating, prepared, promoted]) {
     assert.equal(
-      effectiveGenerationSettings(activeSettingsDocument(state)).provider,
+      effectiveGenerationView(activeSettingsDocument(state)).provider,
       "dry-run",
       "a reversible activation state never exposes the candidate to readers"
     );
@@ -256,7 +256,7 @@ test("mid-activation states keep the old document effective until the commit edg
   // Commit is the durable point of no return: recovery only completes it, so
   // the candidate reads as plainly active — never as its own pending revision.
   assert.equal(
-    effectiveGenerationSettings(activeSettingsDocument(committed)).provider,
+    effectiveGenerationView(activeSettingsDocument(committed)).provider,
     "openai-compatible"
   );
   const committedView = settingsViewFromState(committed);

--- a/test/settings-basic-draft.test.ts
+++ b/test/settings-basic-draft.test.ts
@@ -14,6 +14,7 @@ import {
   providerRuntimeFromV2,
   resolveProviderHeaders
 } from "../server/provider-runtime.js";
+import { createSubscriptionRuntime } from "../server/subscription-runtime.js";
 import {
   EMPTY_SAMPLING_V2,
   type SamplingSettingsV2,
@@ -22,6 +23,8 @@ import {
 import { INITIAL_SETTINGS_DOCUMENT_V2 } from "../server/settings-v2-default.js";
 import { validateSettingsDocumentV2 } from "../server/settings-v2-validation.js";
 import { selectSettingsRoute } from "../shared/settings-route.js";
+
+const SUBSCRIPTION_RUNTIME = createSubscriptionRuntime(process.cwd());
 
 test("discovery metadata stays separate from manual context overrides", () => {
   const selected = applyBasicSettingsDraft(DOCUMENT, {
@@ -525,7 +528,8 @@ function resolvedStoredHeaders(
         model.capabilities,
         {
           environment: {},
-          storedSecrets: new Map([[auth.secretId, secret]])
+          storedSecrets: new Map([[auth.secretId, secret]]),
+          subscription: SUBSCRIPTION_RUNTIME
         }
       ),
       true

--- a/test/settings-basic-draft.test.ts
+++ b/test/settings-basic-draft.test.ts
@@ -11,10 +11,10 @@ import { imageInputForModelChangeV3 } from "../tui/src/settings-text.js";
 import { applySamplingSettings } from "../shared/sampling-capabilities.js";
 import {
   attachProviderRuntime,
+  isStandardModelConnectionV2,
   providerRuntimeFromV2,
   resolveProviderHeaders
 } from "../server/provider-runtime.js";
-import { createSubscriptionRuntime } from "../server/subscription-runtime.js";
 import {
   EMPTY_SAMPLING_V2,
   type SamplingSettingsV2,
@@ -23,8 +23,6 @@ import {
 import { INITIAL_SETTINGS_DOCUMENT_V2 } from "../server/settings-v2-default.js";
 import { validateSettingsDocumentV2 } from "../server/settings-v2-validation.js";
 import { selectSettingsRoute } from "../shared/settings-route.js";
-
-const SUBSCRIPTION_RUNTIME = createSubscriptionRuntime(process.cwd());
 
 test("discovery metadata stays separate from manual context overrides", () => {
   const selected = applyBasicSettingsDraft(DOCUMENT, {
@@ -519,6 +517,9 @@ function resolvedStoredHeaders(
   if (auth.type !== "bearer-stored" && auth.type !== "header-stored") {
     throw new Error("test document must use stored auth");
   }
+  if (!isStandardModelConnectionV2(connection)) {
+    throw new Error("test document must use a standard provider");
+  }
   return resolveProviderHeaders(
     attachProviderRuntime(
       basicSettingsFromDocument(document),
@@ -528,8 +529,7 @@ function resolvedStoredHeaders(
         model.capabilities,
         {
           environment: {},
-          storedSecrets: new Map([[auth.secretId, secret]]),
-          subscription: SUBSCRIPTION_RUNTIME
+          storedSecrets: new Map([[auth.secretId, secret]])
         }
       ),
       true

--- a/test/settings-runtime-prerequisites.test.ts
+++ b/test/settings-runtime-prerequisites.test.ts
@@ -14,7 +14,7 @@ import { MutationLedgerStore } from "../server/mutation-ledger-store.js";
 import { SettingsStore } from "../server/settings.js";
 import {
   applyEffectiveGenerationSettings,
-  effectiveGenerationSettings
+  effectiveGenerationView
 } from "../server/settings-v2-conversion.js";
 import {
   INITIAL_SETTINGS_DOCUMENT_V2,
@@ -85,7 +85,7 @@ test("direct saves validate cache policy on utility and prose routes", async (t)
   );
   const store = new SettingsStore(dataDir, { now: () => FIXED_TIME });
   await store.init(2);
-  const initial = effectiveGenerationSettings(INITIAL_SETTINGS_DOCUMENT_V2);
+  const initial = effectiveGenerationView(INITIAL_SETTINGS_DOCUMENT_V2);
   const document = applyEffectiveGenerationSettings(
     INITIAL_SETTINGS_DOCUMENT_V2,
     {
@@ -138,7 +138,7 @@ test("externally persisted invalid selected routes fail initialization and runti
 });
 
 function invalidRuntimePrerequisites(): readonly RuntimePrerequisiteCase[] {
-  const initialEffective = effectiveGenerationSettings(INITIAL_SETTINGS_DOCUMENT_V2);
+  const initialEffective = effectiveGenerationView(INITIAL_SETTINGS_DOCUMENT_V2);
   const openAi = applyEffectiveGenerationSettings(
     INITIAL_SETTINGS_DOCUMENT_V2,
     {

--- a/test/settings-schema-successor.test.ts
+++ b/test/settings-schema-successor.test.ts
@@ -7,7 +7,7 @@ import { SETTINGS_STATE_V2_FILE } from "../server/data-directory-layout.js";
 import { hashSettingsStateV2, parseSettingsStateV2Bytes } from "../server/settings-v2-codec.js";
 import {
   applyEffectiveGenerationSettings,
-  effectiveGenerationSettings
+  effectiveGenerationView
 } from "../server/settings-v2-conversion.js";
 import { INITIAL_SETTINGS_DOCUMENT_V2 } from "../server/settings-v2-default.js";
 import {
@@ -144,7 +144,7 @@ function withModelCapabilities(
  *  IDs, and the OpenAI-compatible fixture cannot name one. */
 function anthropicCredentialedDocument(environmentName: string, remoteId: string): SettingsDocumentV2 {
   return applyEffectiveGenerationSettings(INITIAL_SETTINGS_DOCUMENT_V2, {
-    ...effectiveGenerationSettings(INITIAL_SETTINGS_DOCUMENT_V2),
+    ...effectiveGenerationView(INITIAL_SETTINGS_DOCUMENT_V2),
     provider: "anthropic",
     baseUrl: "https://api.anthropic.com",
     model: remoteId,

--- a/test/settings-store-fixtures.ts
+++ b/test/settings-store-fixtures.ts
@@ -15,7 +15,7 @@ import type {
 import { hashSettingsStateV2 } from "../server/settings-v2-codec.js";
 import {
   applyEffectiveGenerationSettings,
-  effectiveGenerationSettings
+  effectiveGenerationView
 } from "../server/settings-v2-conversion.js";
 import {
   INITIAL_SETTINGS_DOCUMENT_V2,
@@ -56,7 +56,7 @@ export function writingDocument(brief: string): SettingsDocumentV2 {
 
 export function credentialedDocument(environmentName: string): SettingsDocumentV2 {
   return applyEffectiveGenerationSettings(INITIAL_SETTINGS_DOCUMENT_V2, {
-    ...effectiveGenerationSettings(INITIAL_SETTINGS_DOCUMENT_V2),
+    ...effectiveGenerationView(INITIAL_SETTINGS_DOCUMENT_V2),
     provider: "openai-compatible",
     baseUrl: "https://api.openai.com/v1",
     model: "test-model",

--- a/test/settings-store-release-a.test.ts
+++ b/test/settings-store-release-a.test.ts
@@ -8,7 +8,7 @@ import {
 import { SettingsStore } from "../server/settings.js";
 import {
   convertGenerationSettingsV1,
-  effectiveGenerationSettings
+  effectiveGenerationView
 } from "../server/settings-v2-conversion.js";
 import { INITIAL_SETTINGS_DOCUMENT_V2 } from "../server/settings-v2-default.js";
 import { readSettingsState } from "../server/settings-state-file.js";
@@ -418,7 +418,7 @@ test("migrated plaintext presets use owned loopback only on supported targets", 
     });
     await first.init(2);
     const migrated = convertGenerationSettingsV1({
-      ...effectiveGenerationSettings(INITIAL_SETTINGS_DOCUMENT_V2),
+      ...effectiveGenerationView(INITIAL_SETTINGS_DOCUMENT_V2),
       provider: "openai-compatible",
       baseUrl,
       model: `${preset}-model`

--- a/test/settings-subscription-settings.test.ts
+++ b/test/settings-subscription-settings.test.ts
@@ -1,10 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
-  createEffectiveGenerationRuntimeProjector,
   convertGenerationSettingsV1,
   providerForProtocol
 } from "../server/settings-v2-conversion.js";
+import { createSettingsRuntimeResolver } from "../server/settings-runtime-resolver.js";
 import { parseSettingsDocumentV2 } from "../server/settings-v2-codec.js";
 import { settingsViewFromState } from "../server/settings-v2-runtime.js";
 import { createSubscriptionRuntime } from "../server/subscription-runtime.js";
@@ -18,7 +18,10 @@ import type {
 
 test("subscription presets keep their fixed connection shape and runtime route", () => {
   const subscription = createSubscriptionRuntime(process.cwd());
-  const runtimeProjector = createEffectiveGenerationRuntimeProjector(subscription);
+  const runtimeResolver = createSettingsRuntimeResolver({
+    environment: process.env,
+    subscription
+  });
   const base = convertGenerationSettingsV1({
     provider: "openai-compatible",
     baseUrl: "https://api.openai.com/v1",
@@ -41,7 +44,7 @@ test("subscription presets keep their fixed connection shape and runtime route",
     assert.deepEqual(connection.auth, { type: "none" });
     assert.deepEqual(connection.headers, []);
     assert.equal(providerForProtocol(connection.protocol), provider);
-    const runtime = runtimeProjector.project(document);
+    const runtime = runtimeResolver.resolve({ document });
     assert.equal(runtime.settings.provider, provider);
     assert.equal(runtime.settings.baseUrl, "");
     assert.equal(runtime.settings.apiKeyEnv, null);

--- a/test/settings-subscription-settings.test.ts
+++ b/test/settings-subscription-settings.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
-  effectiveGenerationRuntime,
+  createEffectiveGenerationRuntimeProjector,
   convertGenerationSettingsV1,
   providerForProtocol
 } from "../server/settings-v2-conversion.js";
@@ -18,6 +18,7 @@ import type {
 
 test("subscription presets keep their fixed connection shape and runtime route", () => {
   const subscription = createSubscriptionRuntime(process.cwd());
+  const runtimeProjector = createEffectiveGenerationRuntimeProjector(subscription);
   const base = convertGenerationSettingsV1({
     provider: "openai-compatible",
     baseUrl: "https://api.openai.com/v1",
@@ -40,13 +41,7 @@ test("subscription presets keep their fixed connection shape and runtime route",
     assert.deepEqual(connection.auth, { type: "none" });
     assert.deepEqual(connection.headers, []);
     assert.equal(providerForProtocol(connection.protocol), provider);
-    const runtime = effectiveGenerationRuntime(
-      document,
-      "default",
-      {},
-      undefined,
-      { subscription }
-    );
+    const runtime = runtimeProjector.project(document);
     assert.equal(runtime.settings.provider, provider);
     assert.equal(runtime.settings.baseUrl, "");
     assert.equal(runtime.settings.apiKeyEnv, null);

--- a/test/settings-subscription-settings.test.ts
+++ b/test/settings-subscription-settings.test.ts
@@ -7,6 +7,7 @@ import {
 } from "../server/settings-v2-conversion.js";
 import { parseSettingsDocumentV2 } from "../server/settings-v2-codec.js";
 import { settingsViewFromState } from "../server/settings-v2-runtime.js";
+import { createSubscriptionRuntime } from "../server/subscription-runtime.js";
 import { supportsAssistantPrefill } from "../shared/continuation-plan.js";
 import { decodeSettingsViewResponse } from "../shared/settings-response-decoder.js";
 import { INITIAL_SETTINGS_STATE_V2 } from "../server/settings-v2-default.js";
@@ -16,6 +17,7 @@ import type {
 } from "../shared/settings-v2-types.js";
 
 test("subscription presets keep their fixed connection shape and runtime route", () => {
+  const subscription = createSubscriptionRuntime(process.cwd());
   const base = convertGenerationSettingsV1({
     provider: "openai-compatible",
     baseUrl: "https://api.openai.com/v1",
@@ -38,7 +40,13 @@ test("subscription presets keep their fixed connection shape and runtime route",
     assert.deepEqual(connection.auth, { type: "none" });
     assert.deepEqual(connection.headers, []);
     assert.equal(providerForProtocol(connection.protocol), provider);
-    const runtime = effectiveGenerationRuntime(document);
+    const runtime = effectiveGenerationRuntime(
+      document,
+      "default",
+      {},
+      undefined,
+      { subscription }
+    );
     assert.equal(runtime.settings.provider, provider);
     assert.equal(runtime.settings.baseUrl, "");
     assert.equal(runtime.settings.apiKeyEnv, null);
@@ -48,7 +56,7 @@ test("subscription presets keep their fixed connection shape and runtime route",
       JSON.parse(JSON.stringify(settingsViewFromState({
         ...INITIAL_SETTINGS_STATE_V2,
         documents: { "1": document }
-      }))),
+      }, subscription))),
       parseSettingsDocumentV2
     );
     assert.equal(decoded.effectiveProse.protocol, protocol);

--- a/test/settings-subscription-settings.test.ts
+++ b/test/settings-subscription-settings.test.ts
@@ -56,7 +56,7 @@ test("subscription presets keep their fixed connection shape and runtime route",
       JSON.parse(JSON.stringify(settingsViewFromState({
         ...INITIAL_SETTINGS_STATE_V2,
         documents: { "1": document }
-      }, subscription))),
+      }))),
       parseSettingsDocumentV2
     );
     assert.equal(decoded.effectiveProse.protocol, protocol);

--- a/test/settings-v2-codec.test.ts
+++ b/test/settings-v2-codec.test.ts
@@ -25,9 +25,9 @@ import {
 import {
   applyEffectiveGenerationSettings,
   convertGenerationSettingsV1,
-  effectiveStandardGenerationRuntime,
   effectiveGenerationView
 } from "../server/settings-v2-conversion.js";
+import { effectiveStandardGenerationRuntime } from "../server/settings-runtime-resolver.js";
 import {
   INITIAL_SETTINGS_DOCUMENT_V2,
   INITIAL_SETTINGS_DOCUMENT_V2_HASH,

--- a/test/settings-v2-codec.test.ts
+++ b/test/settings-v2-codec.test.ts
@@ -25,9 +25,9 @@ import {
 import {
   applyEffectiveGenerationSettings,
   convertGenerationSettingsV1,
+  effectiveGenerationRuntime,
   effectiveGenerationSettings
 } from "../server/settings-v2-conversion.js";
-import { providerRuntimeFor } from "../server/provider-runtime.js";
 import {
   INITIAL_SETTINGS_DOCUMENT_V2,
   INITIAL_SETTINGS_DOCUMENT_V2_HASH,
@@ -175,7 +175,7 @@ test("sampling parses as a closed optional profile object and projects to runtim
     }
   });
   assert.deepEqual(document.profiles.default?.sampling, sampling);
-  assert.deepEqual(providerRuntimeFor(effectiveGenerationSettings(document)).sampling, sampling);
+  assert.deepEqual(effectiveGenerationRuntime(document).providerRuntime.sampling, sampling);
   assert.deepEqual(
     parseSettingsDocumentV2Text(formatSettingsDocumentV2(document)),
     document
@@ -395,7 +395,7 @@ test("reasoning and discardReasoning parse as closed optional profile fields and
   assert.equal(document.profiles.default?.reasoning, "open");
   assert.equal(document.profiles.default?.discardReasoning, true);
   assert.deepEqual(parseSettingsDocumentV2Text(formatSettingsDocumentV2(document)), document);
-  const runtime = providerRuntimeFor(effectiveGenerationSettings(document));
+  const runtime = effectiveGenerationRuntime(document).providerRuntime;
   assert.equal(runtime.reasoning, "open");
   assert.equal(runtime.keepReasoning, false);
 });
@@ -410,7 +410,7 @@ test("reasoning and discardReasoning stay absent through a document round trip w
   assert.equal(Object.hasOwn(document.profiles.default!, "discardReasoning"), false);
   assert.equal(formatSettingsDocumentV2(document), INITIAL_SETTINGS_DOCUMENT_V2_TEXT);
   assert.equal(hashSettingsDocumentV2(document), INITIAL_SETTINGS_DOCUMENT_V2_HASH);
-  const runtime = providerRuntimeFor(effectiveGenerationSettings(document));
+  const runtime = effectiveGenerationRuntime(document).providerRuntime;
   assert.equal(runtime.reasoning, "marker");
   assert.equal(runtime.keepReasoning, true);
 });
@@ -891,7 +891,7 @@ test("Anthropic runtime lowering preserves exact authentication references", () 
     });
     const effective = effectiveGenerationSettings(document);
     assert.equal(effective.apiKeyEnv, "ANTHROPIC_API_KEY");
-    assert.deepEqual(providerRuntimeFor(effective).auth, auth);
+    assert.deepEqual(effectiveGenerationRuntime(document).providerRuntime.auth, auth);
   }
   for (const auth of [
     { type: "bearer-stored" as const, secretId: "migrated:connection" },
@@ -914,7 +914,7 @@ test("Anthropic runtime lowering preserves exact authentication references", () 
     );
     const effective = effectiveGenerationSettings(document);
     assert.equal(effective.apiKeyEnv, null);
-    assert.deepEqual(providerRuntimeFor(effective).auth, auth);
+    assert.deepEqual(effectiveGenerationRuntime(document).providerRuntime.auth, auth);
   }
   const customHeaderDocument = parseSettingsDocumentV2({
     ...base,
@@ -932,7 +932,7 @@ test("Anthropic runtime lowering preserves exact authentication references", () 
   });
   const effective = effectiveGenerationSettings(customHeaderDocument);
   assert.equal(effective.apiKeyEnv, null);
-  assert.deepEqual(providerRuntimeFor(effective).headers, [{
+  assert.deepEqual(effectiveGenerationRuntime(customHeaderDocument).providerRuntime.headers, [{
     name: "x-api-key",
     value: { type: "env", env: "ANTHROPIC_API_KEY" }
   }]);

--- a/test/settings-v2-codec.test.ts
+++ b/test/settings-v2-codec.test.ts
@@ -26,8 +26,9 @@ import {
   applyEffectiveGenerationSettings,
   convertGenerationSettingsV1,
   effectiveGenerationRuntime,
-  effectiveGenerationSettings
+  effectiveGenerationView
 } from "../server/settings-v2-conversion.js";
+import { createSubscriptionRuntime } from "../server/subscription-runtime.js";
 import {
   INITIAL_SETTINGS_DOCUMENT_V2,
   INITIAL_SETTINGS_DOCUMENT_V2_HASH,
@@ -83,6 +84,7 @@ const schemaText = readFileSync(path.join(ROOT, "schema", "settings-v2.schema.js
 const corpusText = readFileSync(path.join(ROOT, "schema", "settings-v2.corpus.json"), "utf8");
 const vectorsText = readFileSync(path.join(ROOT, "schema", "settings-v2.hash-vectors.json"), "utf8");
 const corpus = JSON.parse(corpusText) as { schemaVersion: number; cases: CorpusCase[] };
+const SUBSCRIPTION_RUNTIME = createSubscriptionRuntime(process.cwd());
 
 test("settings schema, corpus, and hash vectors are canonical and identity-pinned", () => {
   const schema = JSON.parse(schemaText) as Record<string, unknown>;
@@ -175,7 +177,13 @@ test("sampling parses as a closed optional profile object and projects to runtim
     }
   });
   assert.deepEqual(document.profiles.default?.sampling, sampling);
-  assert.deepEqual(effectiveGenerationRuntime(document).providerRuntime.sampling, sampling);
+  assert.deepEqual(effectiveGenerationRuntime(
+    document,
+    "default",
+    {},
+    undefined,
+    { subscription: SUBSCRIPTION_RUNTIME }
+  ).providerRuntime.sampling, sampling);
   assert.deepEqual(
     parseSettingsDocumentV2Text(formatSettingsDocumentV2(document)),
     document
@@ -395,7 +403,13 @@ test("reasoning and discardReasoning parse as closed optional profile fields and
   assert.equal(document.profiles.default?.reasoning, "open");
   assert.equal(document.profiles.default?.discardReasoning, true);
   assert.deepEqual(parseSettingsDocumentV2Text(formatSettingsDocumentV2(document)), document);
-  const runtime = effectiveGenerationRuntime(document).providerRuntime;
+  const runtime = effectiveGenerationRuntime(
+    document,
+    "default",
+    {},
+    undefined,
+    { subscription: SUBSCRIPTION_RUNTIME }
+  ).providerRuntime;
   assert.equal(runtime.reasoning, "open");
   assert.equal(runtime.keepReasoning, false);
 });
@@ -410,7 +424,13 @@ test("reasoning and discardReasoning stay absent through a document round trip w
   assert.equal(Object.hasOwn(document.profiles.default!, "discardReasoning"), false);
   assert.equal(formatSettingsDocumentV2(document), INITIAL_SETTINGS_DOCUMENT_V2_TEXT);
   assert.equal(hashSettingsDocumentV2(document), INITIAL_SETTINGS_DOCUMENT_V2_HASH);
-  const runtime = effectiveGenerationRuntime(document).providerRuntime;
+  const runtime = effectiveGenerationRuntime(
+    document,
+    "default",
+    {},
+    undefined,
+    { subscription: SUBSCRIPTION_RUNTIME }
+  ).providerRuntime;
   assert.equal(runtime.reasoning, "marker");
   assert.equal(runtime.keepReasoning, true);
 });
@@ -686,7 +706,7 @@ test("v1 conversion preserves provider request fields for all shipped preset URL
     const document = convertGenerationSettingsV1(settings);
     const connection = document.connections["migrated:connection"]!;
     assert.equal(connection.preset, expectedPreset);
-    const projected = effectiveGenerationSettings(document);
+    const projected = effectiveGenerationView(document);
     assert.deepEqual(projected, {
       ...settings,
       baseUrl: settings.baseUrl.replace(/\/+$/u, ""),
@@ -718,7 +738,7 @@ test("effective scalar resolution shares exact precedence and caps the profile o
     builtin: { contextWindow: 20_000, maxOutputTokens: 2_000 }
   };
   assert.deepEqual(
-    scalarProjection(effectiveGenerationSettings(fullyPopulated, "prose", allMetadata)),
+    scalarProjection(effectiveGenerationView(fullyPopulated, "prose", allMetadata)),
     { contextWindow: 60_000, maxTokens: 6_000 },
     "explicit overrides win and an absent prose route falls back to default"
   );
@@ -733,12 +753,12 @@ test("effective scalar resolution shares exact precedence and caps the profile o
     }
   });
   assert.deepEqual(
-    scalarProjection(effectiveGenerationSettings(runtimeWins, "utility", allMetadata)),
+    scalarProjection(effectiveGenerationView(runtimeWins, "utility", allMetadata)),
     { contextWindow: 50_000, maxTokens: 5_000 },
     "runtime metadata wins when no override exists"
   );
   assert.deepEqual(
-    scalarProjection(effectiveGenerationSettings(runtimeWins, "default", {
+    scalarProjection(effectiveGenerationView(runtimeWins, "default", {
       builtin: allMetadata.builtin
     })),
     { contextWindow: 30_000, maxTokens: 3_000 },
@@ -755,14 +775,14 @@ test("effective scalar resolution shares exact precedence and caps the profile o
     }
   });
   assert.deepEqual(
-    scalarProjection(effectiveGenerationSettings(builtinWins, "default", {
+    scalarProjection(effectiveGenerationView(builtinWins, "default", {
       builtin: allMetadata.builtin
     })),
     { contextWindow: 20_000, maxTokens: 2_000 },
     "built-in metadata wins only after override, runtime, and discovery"
   );
   assert.deepEqual(
-    scalarProjection(effectiveGenerationSettings(builtinWins)),
+    scalarProjection(effectiveGenerationView(builtinWins)),
     { contextWindow: null, maxTokens: 10_000 },
     "unknown model limits leave context unknown and preserve the profile budget"
   );
@@ -777,7 +797,7 @@ test("effective scalar resolution shares exact precedence and caps the profile o
     }
   });
   assert.equal(
-    effectiveGenerationSettings(profileCapsOutput, "default", allMetadata).maxTokens,
+    effectiveGenerationView(profileCapsOutput, "default", allMetadata).maxTokens,
     1_500,
     "a model maximum above the requested profile budget does not raise the request"
   );
@@ -822,7 +842,7 @@ test("selected network runtime lowering rejects blank model IDs without normaliz
     }
   });
   assert.equal(
-    effectiveGenerationSettings(document).model,
+    effectiveGenerationView(document).model,
     "  exact/model-id  ",
     "the provider receives the exact admitted nonblank identifier"
   );
@@ -838,7 +858,7 @@ test("selected network runtime lowering rejects blank model IDs without normaliz
     }
   });
   assert.throws(
-    () => effectiveGenerationSettings(blankSelected),
+    () => effectiveGenerationView(blankSelected),
     /nonblank model remote ID/
   );
 });
@@ -852,7 +872,7 @@ test("Anthropic runtime lowering preserves exact authentication references", () 
   ));
   const connection = base.connections["migrated:connection"]!;
   const model = base.models["migrated:model"]!;
-  assert.equal(effectiveGenerationSettings(base).apiKeyEnv, "ANTHROPIC_API_KEY");
+  assert.equal(effectiveGenerationView(base).apiKeyEnv, "ANTHROPIC_API_KEY");
   const unselected = parseSettingsDocumentV2({
     ...INITIAL_SETTINGS_DOCUMENT_V2,
     connections: {
@@ -871,7 +891,7 @@ test("Anthropic runtime lowering preserves exact authentication references", () 
     }
   });
   assert.equal(
-    effectiveGenerationSettings(unselected).provider,
+    effectiveGenerationView(unselected).provider,
     "dry-run",
     "runtime-only Anthropic authentication constraints do not reject an unselected record"
   );
@@ -889,9 +909,15 @@ test("Anthropic runtime lowering preserves exact authentication references", () 
         }
       }
     });
-    const effective = effectiveGenerationSettings(document);
+    const effective = effectiveGenerationView(document);
     assert.equal(effective.apiKeyEnv, "ANTHROPIC_API_KEY");
-    assert.deepEqual(effectiveGenerationRuntime(document).providerRuntime.auth, auth);
+    assert.deepEqual(effectiveGenerationRuntime(
+      document,
+      "default",
+      {},
+      undefined,
+      { subscription: SUBSCRIPTION_RUNTIME }
+    ).providerRuntime.auth, auth);
   }
   for (const auth of [
     { type: "bearer-stored" as const, secretId: "migrated:connection" },
@@ -912,9 +938,15 @@ test("Anthropic runtime lowering preserves exact authentication references", () 
       parseSettingsDocumentV2Text(formatSettingsDocumentV2(document)),
       document
     );
-    const effective = effectiveGenerationSettings(document);
+    const effective = effectiveGenerationView(document);
     assert.equal(effective.apiKeyEnv, null);
-    assert.deepEqual(effectiveGenerationRuntime(document).providerRuntime.auth, auth);
+    assert.deepEqual(effectiveGenerationRuntime(
+      document,
+      "default",
+      {},
+      undefined,
+      { subscription: SUBSCRIPTION_RUNTIME }
+    ).providerRuntime.auth, auth);
   }
   const customHeaderDocument = parseSettingsDocumentV2({
     ...base,
@@ -930,9 +962,15 @@ test("Anthropic runtime lowering preserves exact authentication references", () 
       }
     }
   });
-  const effective = effectiveGenerationSettings(customHeaderDocument);
+  const effective = effectiveGenerationView(customHeaderDocument);
   assert.equal(effective.apiKeyEnv, null);
-  assert.deepEqual(effectiveGenerationRuntime(customHeaderDocument).providerRuntime.headers, [{
+  assert.deepEqual(effectiveGenerationRuntime(
+    customHeaderDocument,
+    "default",
+    {},
+    undefined,
+    { subscription: SUBSCRIPTION_RUNTIME }
+  ).providerRuntime.headers, [{
     name: "x-api-key",
     value: { type: "env", env: "ANTHROPIC_API_KEY" }
   }]);
@@ -966,7 +1004,7 @@ test("Anthropic runtime lowering rejects normalized effort off without a wire ma
   };
 
   assert.throws(
-    () => effectiveGenerationSettings(document),
+    () => effectiveGenerationView(document),
     /Anthropic does not support generation effort set to off\./
   );
 });
@@ -982,7 +1020,7 @@ test("routed profiles reject unsupported temperature and undeclared effort", () 
   const profile = base.profiles.default!;
 
   assert.throws(
-    () => effectiveGenerationSettings({
+    () => effectiveGenerationView({
       ...base,
       models: {
         ...base.models,
@@ -998,7 +1036,7 @@ test("routed profiles reject unsupported temperature and undeclared effort", () 
     /sets temperature for an unsupported model/
   );
   assert.throws(
-    () => effectiveGenerationSettings({
+    () => effectiveGenerationView({
       ...base,
       profiles: {
         ...base.profiles,
@@ -1024,7 +1062,7 @@ test("basic compatibility mapper preserves stable IDs and unrelated records", ()
     }
   });
   const edited = applyEffectiveGenerationSettings(document, {
-    ...effectiveGenerationSettings(document),
+    ...effectiveGenerationView(document),
     provider: "openai-compatible",
     baseUrl: "https://api.openai.com/v1",
     model: "new-model",

--- a/test/settings-v2-codec.test.ts
+++ b/test/settings-v2-codec.test.ts
@@ -25,10 +25,9 @@ import {
 import {
   applyEffectiveGenerationSettings,
   convertGenerationSettingsV1,
-  effectiveGenerationRuntime,
+  effectiveStandardGenerationRuntime,
   effectiveGenerationView
 } from "../server/settings-v2-conversion.js";
-import { createSubscriptionRuntime } from "../server/subscription-runtime.js";
 import {
   INITIAL_SETTINGS_DOCUMENT_V2,
   INITIAL_SETTINGS_DOCUMENT_V2_HASH,
@@ -84,7 +83,6 @@ const schemaText = readFileSync(path.join(ROOT, "schema", "settings-v2.schema.js
 const corpusText = readFileSync(path.join(ROOT, "schema", "settings-v2.corpus.json"), "utf8");
 const vectorsText = readFileSync(path.join(ROOT, "schema", "settings-v2.hash-vectors.json"), "utf8");
 const corpus = JSON.parse(corpusText) as { schemaVersion: number; cases: CorpusCase[] };
-const SUBSCRIPTION_RUNTIME = createSubscriptionRuntime(process.cwd());
 
 test("settings schema, corpus, and hash vectors are canonical and identity-pinned", () => {
   const schema = JSON.parse(schemaText) as Record<string, unknown>;
@@ -177,13 +175,10 @@ test("sampling parses as a closed optional profile object and projects to runtim
     }
   });
   assert.deepEqual(document.profiles.default?.sampling, sampling);
-  assert.deepEqual(effectiveGenerationRuntime(
-    document,
-    "default",
-    {},
-    undefined,
-    { subscription: SUBSCRIPTION_RUNTIME }
-  ).providerRuntime.sampling, sampling);
+  assert.deepEqual(
+    effectiveStandardGenerationRuntime(document).providerRuntime.sampling,
+    sampling
+  );
   assert.deepEqual(
     parseSettingsDocumentV2Text(formatSettingsDocumentV2(document)),
     document
@@ -403,13 +398,7 @@ test("reasoning and discardReasoning parse as closed optional profile fields and
   assert.equal(document.profiles.default?.reasoning, "open");
   assert.equal(document.profiles.default?.discardReasoning, true);
   assert.deepEqual(parseSettingsDocumentV2Text(formatSettingsDocumentV2(document)), document);
-  const runtime = effectiveGenerationRuntime(
-    document,
-    "default",
-    {},
-    undefined,
-    { subscription: SUBSCRIPTION_RUNTIME }
-  ).providerRuntime;
+  const runtime = effectiveStandardGenerationRuntime(document).providerRuntime;
   assert.equal(runtime.reasoning, "open");
   assert.equal(runtime.keepReasoning, false);
 });
@@ -424,13 +413,7 @@ test("reasoning and discardReasoning stay absent through a document round trip w
   assert.equal(Object.hasOwn(document.profiles.default!, "discardReasoning"), false);
   assert.equal(formatSettingsDocumentV2(document), INITIAL_SETTINGS_DOCUMENT_V2_TEXT);
   assert.equal(hashSettingsDocumentV2(document), INITIAL_SETTINGS_DOCUMENT_V2_HASH);
-  const runtime = effectiveGenerationRuntime(
-    document,
-    "default",
-    {},
-    undefined,
-    { subscription: SUBSCRIPTION_RUNTIME }
-  ).providerRuntime;
+  const runtime = effectiveStandardGenerationRuntime(document).providerRuntime;
   assert.equal(runtime.reasoning, "marker");
   assert.equal(runtime.keepReasoning, true);
 });
@@ -911,13 +894,10 @@ test("Anthropic runtime lowering preserves exact authentication references", () 
     });
     const effective = effectiveGenerationView(document);
     assert.equal(effective.apiKeyEnv, "ANTHROPIC_API_KEY");
-    assert.deepEqual(effectiveGenerationRuntime(
-      document,
-      "default",
-      {},
-      undefined,
-      { subscription: SUBSCRIPTION_RUNTIME }
-    ).providerRuntime.auth, auth);
+    assert.deepEqual(
+      effectiveStandardGenerationRuntime(document).providerRuntime.auth,
+      auth
+    );
   }
   for (const auth of [
     { type: "bearer-stored" as const, secretId: "migrated:connection" },
@@ -940,13 +920,10 @@ test("Anthropic runtime lowering preserves exact authentication references", () 
     );
     const effective = effectiveGenerationView(document);
     assert.equal(effective.apiKeyEnv, null);
-    assert.deepEqual(effectiveGenerationRuntime(
-      document,
-      "default",
-      {},
-      undefined,
-      { subscription: SUBSCRIPTION_RUNTIME }
-    ).providerRuntime.auth, auth);
+    assert.deepEqual(
+      effectiveStandardGenerationRuntime(document).providerRuntime.auth,
+      auth
+    );
   }
   const customHeaderDocument = parseSettingsDocumentV2({
     ...base,
@@ -964,12 +941,8 @@ test("Anthropic runtime lowering preserves exact authentication references", () 
   });
   const effective = effectiveGenerationView(customHeaderDocument);
   assert.equal(effective.apiKeyEnv, null);
-  assert.deepEqual(effectiveGenerationRuntime(
-    customHeaderDocument,
-    "default",
-    {},
-    undefined,
-    { subscription: SUBSCRIPTION_RUNTIME }
+  assert.deepEqual(effectiveStandardGenerationRuntime(
+    customHeaderDocument
   ).providerRuntime.headers, [{
     name: "x-api-key",
     value: { type: "env", env: "ANTHROPIC_API_KEY" }

--- a/test/settings-v2-performance.test.ts
+++ b/test/settings-v2-performance.test.ts
@@ -17,7 +17,7 @@ import {
 } from "../server/settings-v2-codec.js";
 import {
   applyEffectiveGenerationSettings,
-  effectiveGenerationSettings
+  effectiveGenerationView
 } from "../server/settings-v2-conversion.js";
 import {
   INITIAL_SETTINGS_DOCUMENT_V2,
@@ -90,7 +90,7 @@ test("settings v2 pure operations stay comfortably bounded", {
   await t.test("500 staged whole-path preflights and bounded recoveries", (context) => {
     const iterations = 500;
     const candidate = applyEffectiveGenerationSettings(INITIAL_SETTINGS_DOCUMENT_V2, {
-      ...effectiveGenerationSettings(INITIAL_SETTINGS_DOCUMENT_V2),
+      ...effectiveGenerationView(INITIAL_SETTINGS_DOCUMENT_V2),
       provider: "openai-compatible",
       baseUrl: "https://api.openai.com/v1",
       model: "performance-model",

--- a/test/settings-v2-reducer.test.ts
+++ b/test/settings-v2-reducer.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   applyEffectiveGenerationSettings,
-  effectiveGenerationSettings
+  effectiveGenerationView
 } from "../server/settings-v2-conversion.js";
 import {
   INITIAL_SETTINGS_DOCUMENT_V2,
@@ -32,7 +32,7 @@ const POINTER_B = { receiptKind: "user", mutationId: MUTATION_B, phase: "prepare
 
 test("non-credential edit replaces active immediately and advances each counter once", () => {
   const document = applyEffectiveGenerationSettings(INITIAL_SETTINGS_DOCUMENT_V2, {
-    ...effectiveGenerationSettings(INITIAL_SETTINGS_DOCUMENT_V2),
+    ...effectiveGenerationView(INITIAL_SETTINGS_DOCUMENT_V2),
     systemPrompt: "A changed writing brief."
   });
   const state = reduceSettingsStateV2(INITIAL_SETTINGS_STATE_V2, {
@@ -354,7 +354,7 @@ function credentialedDocument(
   apiKeyEnv = "OPENAI_API_KEY"
 ): SettingsDocumentV2 {
   return applyEffectiveGenerationSettings(INITIAL_SETTINGS_DOCUMENT_V2, {
-    ...effectiveGenerationSettings(INITIAL_SETTINGS_DOCUMENT_V2),
+    ...effectiveGenerationView(INITIAL_SETTINGS_DOCUMENT_V2),
     provider: "openai-compatible",
     baseUrl: "https://api.openai.com/v1",
     model: "test-model",

--- a/test/subscription-runtime-probes.integration.test.ts
+++ b/test/subscription-runtime-probes.integration.test.ts
@@ -6,43 +6,61 @@ import { discoverProviderModels } from "../server/model-discovery.js";
 import { checkModelServer } from "../server/server-check.js";
 import { EMPTY_SAMPLING_V2 } from "../shared/settings-v2-types.js";
 
-test("subscription probes use the fixed runtime without an HTTP URL", async (t) => {
+test("subscription probes use bundled catalogs without an HTTP URL", async (t) => {
   const originalFetch = globalThis.fetch;
   globalThis.fetch = (() => {
     throw new Error("subscription probe attempted HTTP");
   }) as typeof fetch;
   t.after(() => { globalThis.fetch = originalFetch; });
-  const settings = attachProviderRuntime({
-    provider: "anthropic",
-    baseUrl: "",
-    model: "fixture-model",
-    apiKeyEnv: null,
-    temperature: 0,
-    maxTokens: 128,
-    systemPrompt: "",
-    contextWindow: null
-  }, {
-    preset: "claude-plan",
-    protocol: "anthropic-subscription-messages",
-    auth: { type: "none" },
-    headers: [],
-    timeouts: { responseHeaderMs: 1_000, firstTokenMs: 1_000, idleMs: 1_000, totalMs: 2_000 },
-    allowInsecureHttp: false,
-    effort: "default",
-    tokenProbabilities: null,
-    capabilities: {
-      temperature: "supported",
-      assistantPrefill: "unknown",
-      reasoningEffort: "unknown",
-      promptCaching: "unknown"
+  for (const fixture of [
+    {
+      provider: "openai-compatible" as const,
+      preset: "chatgpt-plan" as const,
+      protocol: "openai-codex-responses" as const,
+      model: "gpt-5.4"
     },
-    sampling: EMPTY_SAMPLING_V2
-  }, true);
+    {
+      provider: "anthropic" as const,
+      preset: "claude-plan" as const,
+      protocol: "anthropic-subscription-messages" as const,
+      model: "claude-sonnet-4-6"
+    }
+  ]) {
+    const settings = attachProviderRuntime({
+      provider: fixture.provider,
+      baseUrl: "",
+      model: fixture.model,
+      apiKeyEnv: null,
+      temperature: 0,
+      maxTokens: 128,
+      systemPrompt: "",
+      contextWindow: null
+    }, {
+      preset: fixture.preset,
+      protocol: fixture.protocol,
+      auth: { type: "none" },
+      headers: [],
+      timeouts: { responseHeaderMs: 1_000, firstTokenMs: 1_000, idleMs: 1_000, totalMs: 2_000 },
+      allowInsecureHttp: false,
+      effort: "default",
+      tokenProbabilities: null,
+      capabilities: {
+        temperature: "supported",
+        assistantPrefill: "unknown",
+        reasoningEffort: "unknown",
+        promptCaching: "unknown"
+      },
+      sampling: EMPTY_SAMPLING_V2
+    }, true);
 
-  assert.equal((await checkModelServer(settings)).state, "ready");
-  assert.deepEqual(
-    await discoverProviderModels(settings, () => new Date("2026-08-18T00:00:00.000Z")),
-    { observedAt: "2026-08-18T00:00:00.000Z", models: [] }
-  );
-  assert.equal(await probeContextWindow(settings), null);
+    assert.equal((await checkModelServer(settings)).state, "ready");
+    const discovery = await discoverProviderModels(
+      settings,
+      () => new Date("2026-08-18T00:00:00.000Z")
+    );
+    assert.equal(discovery.observedAt, "2026-08-18T00:00:00.000Z");
+    assert.ok(discovery.models.some((model) => model.remoteId === fixture.model));
+    assert.ok(discovery.models.every((model) => model.source === "pi-catalog"));
+    assert.equal(await probeContextWindow(settings), null);
+  }
 });

--- a/test/subscription-runtime-probes.integration.test.ts
+++ b/test/subscription-runtime-probes.integration.test.ts
@@ -3,13 +3,32 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
+import type { Models } from "@earendil-works/pi-ai";
 import { attachProviderRuntime } from "../server/provider-runtime.js";
 import { probeContextWindow } from "../server/context-probe.js";
 import { discoverProviderModels } from "../server/model-discovery.js";
 import { checkModelServer } from "../server/server-check.js";
 import { subscriptionProviderForProtocol } from "../server/subscription-protocol.js";
-import { createSubscriptionRuntime } from "../server/subscription-runtime.js";
+import {
+  createSubscriptionRuntime,
+  type SubscriptionRuntimeDependencies
+} from "../server/subscription-runtime.js";
 import { EMPTY_SAMPLING_V2 } from "../shared/settings-v2-types.js";
+
+const PLAN_FIXTURES = [
+  {
+    provider: "openai-compatible" as const,
+    preset: "chatgpt-plan" as const,
+    protocol: "openai-codex-responses" as const,
+    model: "gpt-5.4"
+  },
+  {
+    provider: "anthropic" as const,
+    preset: "claude-plan" as const,
+    protocol: "anthropic-subscription-messages" as const,
+    model: "claude-sonnet-4-6"
+  }
+] as const;
 
 test("subscription probes use bundled catalogs without an HTTP URL", async (t) => {
   const secretsDir = await mkdtemp(path.join(tmpdir(), "1667-model-catalog-"));
@@ -20,47 +39,8 @@ test("subscription probes use bundled catalogs without an HTTP URL", async (t) =
     throw new Error("subscription probe attempted HTTP");
   }) as typeof fetch;
   t.after(() => { globalThis.fetch = originalFetch; });
-  for (const fixture of [
-    {
-      provider: "openai-compatible" as const,
-      preset: "chatgpt-plan" as const,
-      protocol: "openai-codex-responses" as const,
-      model: "gpt-5.4"
-    },
-    {
-      provider: "anthropic" as const,
-      preset: "claude-plan" as const,
-      protocol: "anthropic-subscription-messages" as const,
-      model: "claude-sonnet-4-6"
-    }
-  ]) {
-    const settings = attachProviderRuntime({
-      provider: fixture.provider,
-      baseUrl: "",
-      model: fixture.model,
-      apiKeyEnv: null,
-      temperature: 0,
-      maxTokens: 128,
-      systemPrompt: "",
-      contextWindow: null
-    }, {
-      preset: fixture.preset,
-      protocol: fixture.protocol,
-      auth: { type: "none" },
-      headers: [],
-      timeouts: { responseHeaderMs: 1_000, firstTokenMs: 1_000, idleMs: 1_000, totalMs: 2_000 },
-      allowInsecureHttp: false,
-      effort: "default",
-      tokenProbabilities: null,
-      capabilities: {
-        temperature: "supported",
-        assistantPrefill: "unknown",
-        reasoningEffort: "unknown",
-        promptCaching: "unknown"
-      },
-      sampling: EMPTY_SAMPLING_V2,
-      subscription
-    }, true);
+  for (const fixture of PLAN_FIXTURES) {
+    const settings = subscriptionProbeSettings(fixture, subscription);
 
     assert.equal((await checkModelServer(settings)).state, "ready");
     const discovery = await discoverProviderModels(
@@ -80,3 +60,71 @@ test("subscription probes use bundled catalogs without an HTTP URL", async (t) =
     assert.equal(await probeContextWindow(settings), null);
   }
 });
+
+test("subscription catalogs use the durable discovery sanitizer", async () => {
+  const catalog = [
+    {
+      id: " invalid",
+      name: "Invalid",
+      contextWindow: 1,
+      maxTokens: 1
+    },
+    ...Array.from({ length: 256 }, (_, index) => ({
+      id: `valid-${index}`,
+      name: index === 0 ? "e\u0301" : `Valid ${index}`,
+      contextWindow: index === 0 ? 0 : 32_768,
+      maxTokens: index === 0 ? Number.MAX_SAFE_INTEGER : 4_096
+    }))
+  ];
+  const subscription = {
+    credentials: {} as SubscriptionRuntimeDependencies["credentials"],
+    models: { getModels: () => catalog } as unknown as Models
+  };
+
+  const discovery = await discoverProviderModels(
+    subscriptionProbeSettings(PLAN_FIXTURES[0], subscription)
+  );
+
+  assert.equal(discovery.models.length, 256);
+  assert.deepEqual(discovery.models[0], {
+    remoteId: "valid-0",
+    name: "valid-0",
+    contextWindow: null,
+    maxOutputTokens: null,
+    source: "pi-catalog"
+  });
+  assert.equal(discovery.models.at(-1)?.remoteId, "valid-255");
+});
+
+function subscriptionProbeSettings(
+  fixture: (typeof PLAN_FIXTURES)[number],
+  subscription: SubscriptionRuntimeDependencies
+) {
+  return attachProviderRuntime({
+    provider: fixture.provider,
+    baseUrl: "",
+    model: fixture.model,
+    apiKeyEnv: null,
+    temperature: 0,
+    maxTokens: 128,
+    systemPrompt: "",
+    contextWindow: null
+  }, {
+    preset: fixture.preset,
+    protocol: fixture.protocol,
+    auth: { type: "none" },
+    headers: [],
+    timeouts: { responseHeaderMs: 1_000, firstTokenMs: 1_000, idleMs: 1_000, totalMs: 2_000 },
+    allowInsecureHttp: false,
+    effort: "default",
+    tokenProbabilities: null,
+    capabilities: {
+      temperature: "supported",
+      assistantPrefill: "unknown",
+      reasoningEffort: "unknown",
+      promptCaching: "unknown"
+    },
+    sampling: EMPTY_SAMPLING_V2,
+    subscription
+  }, true);
+}

--- a/test/subscription-runtime-probes.integration.test.ts
+++ b/test/subscription-runtime-probes.integration.test.ts
@@ -14,6 +14,7 @@ import {
   type SubscriptionRuntimeDependencies
 } from "../server/subscription-runtime.js";
 import { EMPTY_SAMPLING_V2 } from "../shared/settings-v2-types.js";
+import { MAX_DISCOVERED_MODELS } from "../shared/settings-scalar-policy.js";
 
 const PLAN_FIXTURES = [
   {
@@ -52,7 +53,7 @@ test("subscription probes use bundled catalogs without an HTTP URL", async (t) =
       discovery.models.map((model) => model.remoteId),
       subscription.models
         .getModels(subscriptionProviderForProtocol(fixture.protocol))
-        .slice(0, 256)
+        .slice(0, MAX_DISCOVERED_MODELS)
         .map((model) => model.id)
     );
     assert.ok(discovery.models.some((model) => model.remoteId === fixture.model));
@@ -69,7 +70,7 @@ test("subscription catalogs use the durable discovery sanitizer", async () => {
       contextWindow: 1,
       maxTokens: 1
     },
-    ...Array.from({ length: 256 }, (_, index) => ({
+    ...Array.from({ length: MAX_DISCOVERED_MODELS }, (_, index) => ({
       id: `valid-${index}`,
       name: index === 0 ? "e\u0301" : `Valid ${index}`,
       contextWindow: index === 0 ? 0 : 32_768,
@@ -85,7 +86,7 @@ test("subscription catalogs use the durable discovery sanitizer", async () => {
     subscriptionProbeSettings(PLAN_FIXTURES[0], subscription)
   );
 
-  assert.equal(discovery.models.length, 256);
+  assert.equal(discovery.models.length, MAX_DISCOVERED_MODELS);
   assert.deepEqual(discovery.models[0], {
     remoteId: "valid-0",
     name: "valid-0",
@@ -93,7 +94,10 @@ test("subscription catalogs use the durable discovery sanitizer", async () => {
     maxOutputTokens: null,
     source: "pi-catalog"
   });
-  assert.equal(discovery.models.at(-1)?.remoteId, "valid-255");
+  assert.equal(
+    discovery.models.at(-1)?.remoteId,
+    `valid-${MAX_DISCOVERED_MODELS - 1}`
+  );
 });
 
 function subscriptionProbeSettings(

--- a/test/subscription-runtime-probes.integration.test.ts
+++ b/test/subscription-runtime-probes.integration.test.ts
@@ -1,12 +1,20 @@
 import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import test from "node:test";
 import { attachProviderRuntime } from "../server/provider-runtime.js";
 import { probeContextWindow } from "../server/context-probe.js";
 import { discoverProviderModels } from "../server/model-discovery.js";
 import { checkModelServer } from "../server/server-check.js";
+import { subscriptionProviderForProtocol } from "../server/subscription-protocol.js";
+import { createSubscriptionRuntime } from "../server/subscription-runtime.js";
 import { EMPTY_SAMPLING_V2 } from "../shared/settings-v2-types.js";
 
 test("subscription probes use bundled catalogs without an HTTP URL", async (t) => {
+  const secretsDir = await mkdtemp(path.join(tmpdir(), "1667-model-catalog-"));
+  t.after(async () => { await rm(secretsDir, { recursive: true, force: true }); });
+  const subscription = createSubscriptionRuntime(secretsDir);
   const originalFetch = globalThis.fetch;
   globalThis.fetch = (() => {
     throw new Error("subscription probe attempted HTTP");
@@ -50,7 +58,8 @@ test("subscription probes use bundled catalogs without an HTTP URL", async (t) =
         reasoningEffort: "unknown",
         promptCaching: "unknown"
       },
-      sampling: EMPTY_SAMPLING_V2
+      sampling: EMPTY_SAMPLING_V2,
+      subscription
     }, true);
 
     assert.equal((await checkModelServer(settings)).state, "ready");
@@ -59,6 +68,13 @@ test("subscription probes use bundled catalogs without an HTTP URL", async (t) =
       () => new Date("2026-08-18T00:00:00.000Z")
     );
     assert.equal(discovery.observedAt, "2026-08-18T00:00:00.000Z");
+    assert.deepEqual(
+      discovery.models.map((model) => model.remoteId),
+      subscription.models
+        .getModels(subscriptionProviderForProtocol(fixture.protocol))
+        .slice(0, 256)
+        .map((model) => model.id)
+    );
     assert.ok(discovery.models.some((model) => model.remoteId === fixture.model));
     assert.ok(discovery.models.every((model) => model.source === "pi-catalog"));
     assert.equal(await probeContextWindow(settings), null);

--- a/test/text-completion-e2e.test.ts
+++ b/test/text-completion-e2e.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { createServer, type IncomingMessage, type Server } from "node:http";
 import test from "node:test";
 import { effectiveGenerationRuntime } from "../server/settings-v2-conversion.js";
+import { createSubscriptionRuntime } from "../server/subscription-runtime.js";
 import { INITIAL_SETTINGS_DOCUMENT_V2 } from "../server/settings-v2-default.js";
 import {
   streamCompletion,
@@ -54,6 +55,8 @@ const PROMPT: PromptPlan = {
   ]
 };
 
+const SUBSCRIPTION_RUNTIME = createSubscriptionRuntime(process.cwd());
+
 test("OpenAI-compatible text completions stream ChatML without changing the final boundary", async (t) => {
   const requests: ProviderRequest[] = [];
   const server = createServer(async (request, response) => {
@@ -70,9 +73,9 @@ test("OpenAI-compatible text completions stream ChatML without changing the fina
     ].join("\n"));
   });
   const origin = await listen(t, server);
-  const settings = effectiveGenerationRuntime(
+  const settings = runtimeSettings(
     textDocument(origin, "custom", "chatml")
-  ).settings;
+  );
   const outcome: StreamOutcome = {
     finishReason: null,
     providerTerminal: false
@@ -118,9 +121,9 @@ test("llama.cpp text completions derive the prompt from the server template", as
     ].join("\n"));
   });
   const origin = await listen(t, server);
-  const settings = effectiveGenerationRuntime(
+  const settings = runtimeSettings(
     textDocument(origin, "llama-cpp", "server-template")
-  ).settings;
+  );
   const outcome: StreamOutcome = {
     finishReason: null,
     providerTerminal: false
@@ -173,7 +176,7 @@ test("KoboldCpp text completions use its native stream and sampler names", async
       stop: ["END"]
     }
   );
-  const settings = effectiveGenerationRuntime(document).settings;
+  const settings = runtimeSettings(document);
   const outcome: StreamOutcome = {
     finishReason: null,
     providerTerminal: false
@@ -231,9 +234,9 @@ test("KoboldCpp text rejects a provider error after partial output", async (t) =
     ].join("\n"));
   });
   const origin = await listen(t, server);
-  const settings = effectiveGenerationRuntime(
+  const settings = runtimeSettings(
     textDocument(origin, "koboldcpp", "raw")
-  ).settings;
+  );
   const received: string[] = [];
 
   await assert.rejects(async () => {
@@ -263,9 +266,9 @@ test("a short delta the redactor still holds when the stream fails still hands o
       ""
     ].join("\n"), { headers: { "content-type": "text/event-stream" } })) as typeof fetch;
   t.after(() => { globalThis.fetch = originalFetch; });
-  const settings = effectiveGenerationRuntime(
+  const settings = runtimeSettings(
     textDocument("https://models.example", "koboldcpp", "raw", secretEnv)
-  ).settings;
+  );
   const collector: GenerationRecordCollector = { effective: null };
   const received: string[] = [];
 
@@ -299,9 +302,9 @@ test("OpenAI-compatible text rejects content filtering after partial output", as
     ].join("\n"));
   });
   const origin = await listen(t, server);
-  const settings = effectiveGenerationRuntime(
+  const settings = runtimeSettings(
     textDocument(origin, "custom", "raw")
-  ).settings;
+  );
   const received: string[] = [];
 
   await assert.rejects(async () => {
@@ -328,9 +331,9 @@ test("OpenAI-compatible text rejects DONE without a successful finish reason", a
     ].join("\n"));
   });
   const origin = await listen(t, server);
-  const settings = effectiveGenerationRuntime(
+  const settings = runtimeSettings(
     textDocument(origin, "custom", "raw")
-  ).settings;
+  );
   const received: string[] = [];
 
   await assert.rejects(async () => {
@@ -375,6 +378,16 @@ function textDocument(
       }
     }
   };
+}
+
+function runtimeSettings(document: SettingsDocumentV2) {
+  return effectiveGenerationRuntime(
+    document,
+    "default",
+    {},
+    undefined,
+    { subscription: SUBSCRIPTION_RUNTIME }
+  ).settings;
 }
 
 interface ProviderRequest {

--- a/test/text-completion-e2e.test.ts
+++ b/test/text-completion-e2e.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { createServer, type IncomingMessage, type Server } from "node:http";
 import test from "node:test";
-import { effectiveStandardGenerationRuntime } from "../server/settings-v2-conversion.js";
+import { effectiveStandardGenerationRuntime } from "../server/settings-runtime-resolver.js";
 import { INITIAL_SETTINGS_DOCUMENT_V2 } from "../server/settings-v2-default.js";
 import {
   streamCompletion,

--- a/test/text-completion-e2e.test.ts
+++ b/test/text-completion-e2e.test.ts
@@ -1,8 +1,7 @@
 import assert from "node:assert/strict";
 import { createServer, type IncomingMessage, type Server } from "node:http";
 import test from "node:test";
-import { effectiveGenerationRuntime } from "../server/settings-v2-conversion.js";
-import { createSubscriptionRuntime } from "../server/subscription-runtime.js";
+import { effectiveStandardGenerationRuntime } from "../server/settings-v2-conversion.js";
 import { INITIAL_SETTINGS_DOCUMENT_V2 } from "../server/settings-v2-default.js";
 import {
   streamCompletion,
@@ -54,8 +53,6 @@ const PROMPT: PromptPlan = {
     }
   ]
 };
-
-const SUBSCRIPTION_RUNTIME = createSubscriptionRuntime(process.cwd());
 
 test("OpenAI-compatible text completions stream ChatML without changing the final boundary", async (t) => {
   const requests: ProviderRequest[] = [];
@@ -381,13 +378,7 @@ function textDocument(
 }
 
 function runtimeSettings(document: SettingsDocumentV2) {
-  return effectiveGenerationRuntime(
-    document,
-    "default",
-    {},
-    undefined,
-    { subscription: SUBSCRIPTION_RUNTIME }
-  ).settings;
+  return effectiveStandardGenerationRuntime(document).settings;
 }
 
 interface ProviderRequest {

--- a/test/text-completion-e2e.test.ts
+++ b/test/text-completion-e2e.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { createServer, type IncomingMessage, type Server } from "node:http";
 import test from "node:test";
-import { effectiveGenerationSettings } from "../server/settings-v2-conversion.js";
+import { effectiveGenerationRuntime } from "../server/settings-v2-conversion.js";
 import { INITIAL_SETTINGS_DOCUMENT_V2 } from "../server/settings-v2-default.js";
 import {
   streamCompletion,
@@ -70,9 +70,9 @@ test("OpenAI-compatible text completions stream ChatML without changing the fina
     ].join("\n"));
   });
   const origin = await listen(t, server);
-  const settings = effectiveGenerationSettings(
+  const settings = effectiveGenerationRuntime(
     textDocument(origin, "custom", "chatml")
-  );
+  ).settings;
   const outcome: StreamOutcome = {
     finishReason: null,
     providerTerminal: false
@@ -118,9 +118,9 @@ test("llama.cpp text completions derive the prompt from the server template", as
     ].join("\n"));
   });
   const origin = await listen(t, server);
-  const settings = effectiveGenerationSettings(
+  const settings = effectiveGenerationRuntime(
     textDocument(origin, "llama-cpp", "server-template")
-  );
+  ).settings;
   const outcome: StreamOutcome = {
     finishReason: null,
     providerTerminal: false
@@ -173,7 +173,7 @@ test("KoboldCpp text completions use its native stream and sampler names", async
       stop: ["END"]
     }
   );
-  const settings = effectiveGenerationSettings(document);
+  const settings = effectiveGenerationRuntime(document).settings;
   const outcome: StreamOutcome = {
     finishReason: null,
     providerTerminal: false
@@ -231,9 +231,9 @@ test("KoboldCpp text rejects a provider error after partial output", async (t) =
     ].join("\n"));
   });
   const origin = await listen(t, server);
-  const settings = effectiveGenerationSettings(
+  const settings = effectiveGenerationRuntime(
     textDocument(origin, "koboldcpp", "raw")
-  );
+  ).settings;
   const received: string[] = [];
 
   await assert.rejects(async () => {
@@ -263,9 +263,9 @@ test("a short delta the redactor still holds when the stream fails still hands o
       ""
     ].join("\n"), { headers: { "content-type": "text/event-stream" } })) as typeof fetch;
   t.after(() => { globalThis.fetch = originalFetch; });
-  const settings = effectiveGenerationSettings(
+  const settings = effectiveGenerationRuntime(
     textDocument("https://models.example", "koboldcpp", "raw", secretEnv)
-  );
+  ).settings;
   const collector: GenerationRecordCollector = { effective: null };
   const received: string[] = [];
 
@@ -299,9 +299,9 @@ test("OpenAI-compatible text rejects content filtering after partial output", as
     ].join("\n"));
   });
   const origin = await listen(t, server);
-  const settings = effectiveGenerationSettings(
+  const settings = effectiveGenerationRuntime(
     textDocument(origin, "custom", "raw")
-  );
+  ).settings;
   const received: string[] = [];
 
   await assert.rejects(async () => {
@@ -328,9 +328,9 @@ test("OpenAI-compatible text rejects DONE without a successful finish reason", a
     ].join("\n"));
   });
   const origin = await listen(t, server);
-  const settings = effectiveGenerationSettings(
+  const settings = effectiveGenerationRuntime(
     textDocument(origin, "custom", "raw")
-  );
+  ).settings;
   const received: string[] = [];
 
   await assert.rejects(async () => {

--- a/test/tokenize-probe.test.ts
+++ b/test/tokenize-probe.test.ts
@@ -10,6 +10,7 @@ import {
   EMPTY_SAMPLING_V2,
   type SettingsPresetV2,
   type SettingsProtocolV2,
+  type SubscriptionProtocolV2,
   type TextPromptFormatV2
 } from "../shared/settings-v2-types.js";
 import { MAX_COUNTED_PROMPT_CHARS } from "../shared/tokenize-source.js";
@@ -507,7 +508,7 @@ function settings(options: {
   readonly baseUrl?: string;
   readonly model?: string;
   readonly timeouts?: ProviderRuntime["timeouts"];
-  readonly protocol?: SettingsProtocolV2;
+  readonly protocol?: Exclude<SettingsProtocolV2, SubscriptionProtocolV2>;
   readonly textPromptFormat?: TextPromptFormatV2;
 }): GenerationSettings {
   const value: GenerationSettings = {

--- a/tui/src/demo-model-discovery.ts
+++ b/tui/src/demo-model-discovery.ts
@@ -48,7 +48,7 @@ export function discoverDemoModels(
   const settings = route === null
     ? target
     : basicSettingsFromDocument(target.document, route.profileId);
-  const protocol = route?.connection.protocol ?? null;
+  const protocol = route?.connection.protocol ?? settings.protocol ?? null;
   const subscription = protocol !== null && isSubscriptionProtocolV2(protocol);
   const anthropic = settings.provider === "anthropic";
   const source: ModelDiscoverySourceV2 = subscription

--- a/tui/src/demo-model-discovery.ts
+++ b/tui/src/demo-model-discovery.ts
@@ -1,3 +1,4 @@
+import type { Models } from "@earendil-works/pi-ai";
 import { basicSettingsFromDocument } from "../../shared/settings-basic-draft.js";
 import {
   isSubscriptionProtocolV2,
@@ -7,6 +8,10 @@ import {
   type ProviderProbeTarget
 } from "../../shared/settings-v2-types.js";
 import { selectSettingsRoute } from "../../shared/settings-route.js";
+import { discoverSubscriptionCatalog } from "../../server/model-discovery.js";
+import { createSubscriptionCatalog } from "../../server/subscription-models.js";
+
+const SUBSCRIPTION_MODELS = createSubscriptionCatalog();
 
 const OPENAI_MODELS = [
   {
@@ -38,9 +43,10 @@ const ANTHROPIC_MODELS = [
   }
 ] satisfies readonly Omit<DiscoveredModelV2, "source">[];
 
-/** Return deterministic provider-specific model fixtures for the demo API. */
+/** Return API fixtures or the bundled plan catalog for the demo API. */
 export function discoverDemoModels(
-  target: ProviderProbeTarget
+  target: ProviderProbeTarget,
+  subscriptionModels: Pick<Models, "getModels"> = SUBSCRIPTION_MODELS
 ): ModelDiscoveryResultV2 {
   const route = "kind" in target
     ? selectSettingsRoute(target.document, target.purpose)
@@ -49,13 +55,16 @@ export function discoverDemoModels(
     ? target
     : basicSettingsFromDocument(target.document, route.profileId);
   const protocol = route?.connection.protocol ?? settings.protocol ?? null;
-  const subscription = protocol !== null && isSubscriptionProtocolV2(protocol);
+  if (protocol !== null && isSubscriptionProtocolV2(protocol)) {
+    return {
+      observedAt: "2026-01-01T00:00:00.000Z",
+      models: discoverSubscriptionCatalog(subscriptionModels, protocol)
+    };
+  }
   const anthropic = settings.provider === "anthropic";
-  const source: ModelDiscoverySourceV2 = subscription
-    ? "pi-catalog"
-    : anthropic
-      ? "anthropic-models"
-      : "openai-models";
+  const source: ModelDiscoverySourceV2 = anthropic
+    ? "anthropic-models"
+    : "openai-models";
   const catalog = anthropic ? ANTHROPIC_MODELS : OPENAI_MODELS;
   return {
     observedAt: "2026-01-01T00:00:00.000Z",

--- a/tui/src/demo-model-discovery.ts
+++ b/tui/src/demo-model-discovery.ts
@@ -42,12 +42,13 @@ const ANTHROPIC_MODELS = [
 export function discoverDemoModels(
   target: ProviderProbeTarget
 ): ModelDiscoveryResultV2 {
-  const settings = "kind" in target
-    ? basicSettingsFromDocument(target.document)
-    : target;
-  const protocol = "kind" in target
-    ? selectSettingsRoute(target.document, target.purpose).connection.protocol
+  const route = "kind" in target
+    ? selectSettingsRoute(target.document, target.purpose)
     : null;
+  const settings = route === null
+    ? target
+    : basicSettingsFromDocument(target.document, route.profileId);
+  const protocol = route?.connection.protocol ?? null;
   const subscription = protocol !== null && isSubscriptionProtocolV2(protocol);
   const anthropic = settings.provider === "anthropic";
   const source: ModelDiscoverySourceV2 = subscription

--- a/tui/src/demo-model-discovery.ts
+++ b/tui/src/demo-model-discovery.ts
@@ -10,18 +10,18 @@ import {
   type DiscoveredModelV2,
   type ModelDiscoveryResultV2,
   type ModelDiscoverySourceV2,
-  type ProviderProbeTarget
+  type ProviderProbeTarget,
+  type SubscriptionProtocolV2
 } from "../../shared/settings-v2-types.js";
 import { selectSettingsRoute } from "../../shared/settings-route.js";
 
-export interface DemoSubscriptionCatalogs {
-  readonly chatgpt: readonly BundledCatalogModel[];
-  readonly claude: readonly BundledCatalogModel[];
-}
+export type DemoSubscriptionCatalogs = Readonly<
+  Record<SubscriptionProtocolV2, readonly BundledCatalogModel[]>
+>;
 
 const SUBSCRIPTION_CATALOGS: DemoSubscriptionCatalogs = {
-  chatgpt: Object.values(PI_OPENAI_CODEX_MODELS),
-  claude: Object.values(PI_ANTHROPIC_MODELS)
+  "openai-codex-responses": Object.values(PI_OPENAI_CODEX_MODELS),
+  "anthropic-subscription-messages": Object.values(PI_ANTHROPIC_MODELS)
 };
 
 const OPENAI_MODELS = [
@@ -72,9 +72,7 @@ export function discoverDemoModels(
   if (protocol !== null && isSubscriptionProtocolV2(protocol)) {
     return {
       observedAt: "2026-01-01T00:00:00.000Z",
-      models: discoverBundledModels(protocol === "openai-codex-responses"
-        ? subscriptionCatalogs.chatgpt
-        : subscriptionCatalogs.claude)
+      models: discoverBundledModels(subscriptionCatalogs[protocol])
     };
   }
   const anthropic = settings.provider === "anthropic";

--- a/tui/src/demo-model-discovery.ts
+++ b/tui/src/demo-model-discovery.ts
@@ -1,5 +1,10 @@
-import type { Models } from "@earendil-works/pi-ai";
+import { ANTHROPIC_MODELS as PI_ANTHROPIC_MODELS } from "@earendil-works/pi-ai/providers/anthropic.models";
+import { OPENAI_CODEX_MODELS as PI_OPENAI_CODEX_MODELS } from "@earendil-works/pi-ai/providers/openai-codex.models";
 import { basicSettingsFromDocument } from "../../shared/settings-basic-draft.js";
+import {
+  discoverBundledModels,
+  type BundledCatalogModel
+} from "../../shared/model-discovery-catalog.js";
 import {
   isSubscriptionProtocolV2,
   type DiscoveredModelV2,
@@ -8,10 +13,16 @@ import {
   type ProviderProbeTarget
 } from "../../shared/settings-v2-types.js";
 import { selectSettingsRoute } from "../../shared/settings-route.js";
-import { discoverSubscriptionCatalog } from "../../server/model-discovery.js";
-import { createSubscriptionCatalog } from "../../server/subscription-models.js";
 
-const SUBSCRIPTION_MODELS = createSubscriptionCatalog();
+export interface DemoSubscriptionCatalogs {
+  readonly chatgpt: readonly BundledCatalogModel[];
+  readonly claude: readonly BundledCatalogModel[];
+}
+
+const SUBSCRIPTION_CATALOGS: DemoSubscriptionCatalogs = {
+  chatgpt: Object.values(PI_OPENAI_CODEX_MODELS),
+  claude: Object.values(PI_ANTHROPIC_MODELS)
+};
 
 const OPENAI_MODELS = [
   {
@@ -46,19 +57,24 @@ const ANTHROPIC_MODELS = [
 /** Return API fixtures or the bundled plan catalog for the demo API. */
 export function discoverDemoModels(
   target: ProviderProbeTarget,
-  subscriptionModels: Pick<Models, "getModels"> = SUBSCRIPTION_MODELS
+  subscriptionCatalogs: DemoSubscriptionCatalogs = SUBSCRIPTION_CATALOGS
 ): ModelDiscoveryResultV2 {
-  const route = "kind" in target
-    ? selectSettingsRoute(target.document, target.purpose)
-    : null;
-  const settings = route === null
-    ? target
-    : basicSettingsFromDocument(target.document, route.profileId);
-  const protocol = route?.connection.protocol ?? settings.protocol ?? null;
+  let settings;
+  let protocol;
+  if ("kind" in target) {
+    const route = selectSettingsRoute(target.document, target.purpose);
+    settings = basicSettingsFromDocument(target.document, route.profileId);
+    protocol = route.connection.protocol;
+  } else {
+    settings = target;
+    protocol = target.protocol ?? null;
+  }
   if (protocol !== null && isSubscriptionProtocolV2(protocol)) {
     return {
       observedAt: "2026-01-01T00:00:00.000Z",
-      models: discoverSubscriptionCatalog(subscriptionModels, protocol)
+      models: discoverBundledModels(protocol === "openai-codex-responses"
+        ? subscriptionCatalogs.chatgpt
+        : subscriptionCatalogs.claude)
     };
   }
   const anthropic = settings.provider === "anthropic";

--- a/tui/src/demo-model-discovery.ts
+++ b/tui/src/demo-model-discovery.ts
@@ -1,0 +1,63 @@
+import { basicSettingsFromDocument } from "../../shared/settings-basic-draft.js";
+import {
+  isSubscriptionProtocolV2,
+  type DiscoveredModelV2,
+  type ModelDiscoveryResultV2,
+  type ModelDiscoverySourceV2,
+  type ProviderProbeTarget
+} from "../../shared/settings-v2-types.js";
+import { selectSettingsRoute } from "../../shared/settings-route.js";
+
+const OPENAI_MODELS = [
+  {
+    remoteId: "gpt-5.4",
+    name: "GPT-5.4",
+    contextWindow: 1_000_000,
+    maxOutputTokens: 128_000
+  },
+  {
+    remoteId: "gpt-5-mini",
+    name: "GPT-5 mini",
+    contextWindow: 400_000,
+    maxOutputTokens: 128_000
+  }
+] satisfies readonly Omit<DiscoveredModelV2, "source">[];
+
+const ANTHROPIC_MODELS = [
+  {
+    remoteId: "claude-sonnet-4-6",
+    name: "Claude Sonnet 4.6",
+    contextWindow: 1_000_000,
+    maxOutputTokens: 64_000
+  },
+  {
+    remoteId: "claude-haiku-4-5",
+    name: "Claude Haiku 4.5",
+    contextWindow: 200_000,
+    maxOutputTokens: 64_000
+  }
+] satisfies readonly Omit<DiscoveredModelV2, "source">[];
+
+/** Return deterministic provider-specific model fixtures for the demo API. */
+export function discoverDemoModels(
+  target: ProviderProbeTarget
+): ModelDiscoveryResultV2 {
+  const settings = "kind" in target
+    ? basicSettingsFromDocument(target.document)
+    : target;
+  const protocol = "kind" in target
+    ? selectSettingsRoute(target.document, target.purpose).connection.protocol
+    : null;
+  const subscription = protocol !== null && isSubscriptionProtocolV2(protocol);
+  const anthropic = settings.provider === "anthropic";
+  const source: ModelDiscoverySourceV2 = subscription
+    ? "pi-catalog"
+    : anthropic
+      ? "anthropic-models"
+      : "openai-models";
+  const catalog = anthropic ? ANTHROPIC_MODELS : OPENAI_MODELS;
+  return {
+    observedAt: "2026-01-01T00:00:00.000Z",
+    models: catalog.map((model) => ({ ...model, source }))
+  };
+}

--- a/tui/src/demo.ts
+++ b/tui/src/demo.ts
@@ -45,6 +45,7 @@ import type { RemovedChapterBreak, StoryApi } from "./api.js";
 import type { AppSource } from "./app.js";
 import { normalizeUserConfig } from "./config.js";
 import { demoResolveSamplingBias } from "./demo-token-ids.js";
+import { discoverDemoModels } from "./demo-model-discovery.js";
 import { streamFake } from "./fake-stream.js";
 import {
   createDemoChapterBreak,
@@ -776,25 +777,8 @@ export function demoStoryApi(demo: DemoController): StoryApi {
     resolveSamplingBias: async (request) => demoResolveSamplingBias(request),
     // The demo has no provider behind it, so there is never a tokenize source.
     countPromptTokens: async () => ({ kind: "estimate", reason: "no-source" }),
-    discoverModels: async (): Promise<ModelDiscoveryResultV2> => ({
-      observedAt: "2026-01-01T00:00:00.000Z",
-      models: [
-        {
-          remoteId: "gpt-5.4",
-          name: "GPT-5.4",
-          contextWindow: 1_000_000,
-          maxOutputTokens: 128_000,
-          source: "openai-models"
-        },
-        {
-          remoteId: "gpt-5-mini",
-          name: "GPT-5 mini",
-          contextWindow: 400_000,
-          maxOutputTokens: 128_000,
-          source: "openai-models"
-        }
-      ]
-    }),
+    discoverModels: async (target): Promise<ModelDiscoveryResultV2> =>
+      discoverDemoModels(target),
     importSillyTavern: async () => unavailable("SillyTavern import"),
     importMarkdown: async () => unavailable("Markdown import"),
     importNovelAI: async () => unavailable("NovelAI import"),

--- a/tui/src/settings-model-discovery.ts
+++ b/tui/src/settings-model-discovery.ts
@@ -117,16 +117,12 @@ export async function discoverSettingsModels(
   overlay: SettingsOverlayState
 ): Promise<void> {
   clearStaleAutomaticModel(overlay);
-  if (settingsSubscriptionPreset(overlay) !== null) {
-    clearSettingsModelDiscovery(overlay);
-    return;
-  }
   const settings = overlay.view.editable
     ? overlay.draft.generation
     : overlay.view.effective;
   const identity = settingsModelDiscoveryIdentity(settings);
   clearSettingsModelDiscovery(overlay);
-  if (!canDiscoverModels(settings)) return;
+  if (!canDiscoverModels(settings, settingsSubscriptionPreset(overlay))) return;
   const controller = new AbortController();
   overlay.modelDiscoveryAbortController = controller;
   const request: ModelDiscoveryRequest = {
@@ -239,7 +235,11 @@ async function retryModelDiscoveryWhenIdle(
   }
 }
 
-function canDiscoverModels(settings: GenerationSettings): boolean {
+function canDiscoverModels(
+  settings: GenerationSettings,
+  subscriptionPreset: ReturnType<typeof settingsSubscriptionPreset>
+): boolean {
+  if (subscriptionPreset !== null) return true;
   if (settings.provider === "dry-run") return false;
   try {
     const protocol = new URL(settings.baseUrl).protocol;

--- a/tui/test/demo-model-discovery.test.ts
+++ b/tui/test/demo-model-discovery.test.ts
@@ -70,8 +70,8 @@ test("demo discovery resolves one non-default route for provider and source", as
 
 test("demo discovery keeps plan protocols on direct probe targets", async () => {
   const subscriptionCatalogs: DemoSubscriptionCatalogs = {
-    chatgpt: [catalogModel("gpt-fixture")],
-    claude: [catalogModel("claude-fixture")]
+    "openai-codex-responses": [catalogModel("gpt-fixture")],
+    "anthropic-subscription-messages": [catalogModel("claude-fixture")]
   };
   const cases = [
     {

--- a/tui/test/demo-model-discovery.test.ts
+++ b/tui/test/demo-model-discovery.test.ts
@@ -1,6 +1,8 @@
 import { expect, test } from "bun:test";
+import type { Api, Model, Models } from "@earendil-works/pi-ai";
 import type { SettingsDocumentV2 } from "../../shared/settings-v2-types.js";
 import { demoAppSource, DEMO_SETTINGS_DOCUMENT } from "../src/demo.js";
+import { discoverDemoModels } from "../src/demo-model-discovery.js";
 
 test("demo discovery resolves one non-default route for provider and source", async () => {
   const document: SettingsDocumentV2 = {
@@ -59,27 +61,32 @@ test("demo discovery resolves one non-default route for provider and source", as
   });
 
   expect(discovery.models.map((model) => model.remoteId))
-    .toEqual(["claude-sonnet-4-6", "claude-haiku-4-5"]);
+    .toContain("claude-sonnet-4-6");
   expect(discovery.models.every((model) => model.source === "pi-catalog"))
     .toBeTrue();
 });
 
 test("demo discovery keeps plan protocols on direct probe targets", async () => {
+  const subscriptionModels: Pick<Models, "getModels"> = {
+    getModels: (provider) => provider === "openai-codex"
+      ? [piModel("openai-codex", "gpt-fixture")]
+      : [piModel("anthropic", "claude-fixture")]
+  };
   const cases = [
     {
       provider: "openai-compatible" as const,
       protocol: "openai-codex-responses" as const,
-      expectedModels: ["gpt-5.4", "gpt-5-mini"]
+      expectedModels: ["gpt-fixture"]
     },
     {
       provider: "anthropic" as const,
       protocol: "anthropic-subscription-messages" as const,
-      expectedModels: ["claude-sonnet-4-6", "claude-haiku-4-5"]
+      expectedModels: ["claude-fixture"]
     }
   ];
 
   for (const fixture of cases) {
-    const discovery = await demoAppSource().api.discoverModels({
+    const discovery = discoverDemoModels({
       provider: fixture.provider,
       protocol: fixture.protocol,
       baseUrl: "",
@@ -89,7 +96,7 @@ test("demo discovery keeps plan protocols on direct probe targets", async () => 
       maxTokens: 2_048,
       systemPrompt: "Write plain prose.",
       contextWindow: null
-    });
+    }, subscriptionModels);
 
     expect(discovery.models.map((model) => model.remoteId))
       .toEqual(fixture.expectedModels);
@@ -97,3 +104,18 @@ test("demo discovery keeps plan protocols on direct probe targets", async () => 
       .toBeTrue();
   }
 });
+
+function piModel(provider: string, id: string): Model<Api> {
+  return {
+    id,
+    name: id,
+    api: provider === "anthropic" ? "anthropic-messages" : "openai-codex-responses",
+    provider,
+    baseUrl: "https://unused.invalid",
+    reasoning: true,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 32_768,
+    maxTokens: 4_096
+  };
+}

--- a/tui/test/demo-model-discovery.test.ts
+++ b/tui/test/demo-model-discovery.test.ts
@@ -1,0 +1,65 @@
+import { expect, test } from "bun:test";
+import type { SettingsDocumentV2 } from "../../shared/settings-v2-types.js";
+import { demoAppSource, DEMO_SETTINGS_DOCUMENT } from "../src/demo.js";
+
+test("demo discovery resolves one non-default route for provider and source", async () => {
+  const document: SettingsDocumentV2 = {
+    ...DEMO_SETTINGS_DOCUMENT,
+    connections: {
+      ...DEMO_SETTINGS_DOCUMENT.connections,
+      claude: {
+        name: "Claude plan",
+        preset: "claude-plan",
+        protocol: "anthropic-subscription-messages",
+        baseUrl: null,
+        auth: { type: "none" },
+        headers: [],
+        timeouts: {
+          responseHeaderMs: 120_000,
+          firstTokenMs: 120_000,
+          idleMs: 120_000,
+          totalMs: 1_800_000
+        }
+      }
+    },
+    models: {
+      ...DEMO_SETTINGS_DOCUMENT.models,
+      claude: {
+        connectionId: "claude",
+        remoteId: "claude-sonnet-4-6",
+        name: "Claude Sonnet 4.6",
+        discovered: { contextWindow: 1_000_000 },
+        overrides: {},
+        capabilities: {
+          temperature: "supported",
+          assistantPrefill: "unknown",
+          reasoningEffort: "unknown",
+          promptCaching: "unknown"
+        }
+      }
+    },
+    profiles: {
+      ...DEMO_SETTINGS_DOCUMENT.profiles,
+      utility: {
+        name: "Utility",
+        modelId: "claude",
+        temperature: 0.7,
+        maxOutputTokens: 2_048,
+        effort: "default",
+        cachePolicy: "off"
+      }
+    },
+    routing: { ...DEMO_SETTINGS_DOCUMENT.routing, utility: "utility" }
+  };
+
+  const discovery = await demoAppSource().api.discoverModels({
+    kind: "settings-document",
+    document,
+    purpose: "utility"
+  });
+
+  expect(discovery.models.map((model) => model.remoteId))
+    .toEqual(["claude-sonnet-4-6", "claude-haiku-4-5"]);
+  expect(discovery.models.every((model) => model.source === "pi-catalog"))
+    .toBeTrue();
+});

--- a/tui/test/demo-model-discovery.test.ts
+++ b/tui/test/demo-model-discovery.test.ts
@@ -63,3 +63,37 @@ test("demo discovery resolves one non-default route for provider and source", as
   expect(discovery.models.every((model) => model.source === "pi-catalog"))
     .toBeTrue();
 });
+
+test("demo discovery keeps plan protocols on direct probe targets", async () => {
+  const cases = [
+    {
+      provider: "openai-compatible" as const,
+      protocol: "openai-codex-responses" as const,
+      expectedModels: ["gpt-5.4", "gpt-5-mini"]
+    },
+    {
+      provider: "anthropic" as const,
+      protocol: "anthropic-subscription-messages" as const,
+      expectedModels: ["claude-sonnet-4-6", "claude-haiku-4-5"]
+    }
+  ];
+
+  for (const fixture of cases) {
+    const discovery = await demoAppSource().api.discoverModels({
+      provider: fixture.provider,
+      protocol: fixture.protocol,
+      baseUrl: "",
+      model: "",
+      apiKeyEnv: null,
+      temperature: 0.7,
+      maxTokens: 2_048,
+      systemPrompt: "Write plain prose.",
+      contextWindow: null
+    });
+
+    expect(discovery.models.map((model) => model.remoteId))
+      .toEqual(fixture.expectedModels);
+    expect(discovery.models.every((model) => model.source === "pi-catalog"))
+      .toBeTrue();
+  }
+});

--- a/tui/test/demo-model-discovery.test.ts
+++ b/tui/test/demo-model-discovery.test.ts
@@ -1,8 +1,10 @@
 import { expect, test } from "bun:test";
-import type { Api, Model, Models } from "@earendil-works/pi-ai";
 import type { SettingsDocumentV2 } from "../../shared/settings-v2-types.js";
 import { demoAppSource, DEMO_SETTINGS_DOCUMENT } from "../src/demo.js";
-import { discoverDemoModels } from "../src/demo-model-discovery.js";
+import {
+  discoverDemoModels,
+  type DemoSubscriptionCatalogs
+} from "../src/demo-model-discovery.js";
 
 test("demo discovery resolves one non-default route for provider and source", async () => {
   const document: SettingsDocumentV2 = {
@@ -67,10 +69,9 @@ test("demo discovery resolves one non-default route for provider and source", as
 });
 
 test("demo discovery keeps plan protocols on direct probe targets", async () => {
-  const subscriptionModels: Pick<Models, "getModels"> = {
-    getModels: (provider) => provider === "openai-codex"
-      ? [piModel("openai-codex", "gpt-fixture")]
-      : [piModel("anthropic", "claude-fixture")]
+  const subscriptionCatalogs: DemoSubscriptionCatalogs = {
+    chatgpt: [catalogModel("gpt-fixture")],
+    claude: [catalogModel("claude-fixture")]
   };
   const cases = [
     {
@@ -96,7 +97,7 @@ test("demo discovery keeps plan protocols on direct probe targets", async () => 
       maxTokens: 2_048,
       systemPrompt: "Write plain prose.",
       contextWindow: null
-    }, subscriptionModels);
+    }, subscriptionCatalogs);
 
     expect(discovery.models.map((model) => model.remoteId))
       .toEqual(fixture.expectedModels);
@@ -105,16 +106,10 @@ test("demo discovery keeps plan protocols on direct probe targets", async () => 
   }
 });
 
-function piModel(provider: string, id: string): Model<Api> {
+function catalogModel(id: string) {
   return {
     id,
     name: id,
-    api: provider === "anthropic" ? "anthropic-messages" : "openai-codex-responses",
-    provider,
-    baseUrl: "https://unused.invalid",
-    reasoning: true,
-    input: ["text"],
-    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
     contextWindow: 32_768,
     maxTokens: 4_096
   };

--- a/tui/test/settings-form.test.ts
+++ b/tui/test/settings-form.test.ts
@@ -512,7 +512,10 @@ describe("the settings row model stays one list", () => {
 
     expect(discoveryCalls).toBe(1);
     expect(settingsModelChoices(overlay).map((model) => model.remoteId))
-      .toEqual(["gpt-5.4", "gpt-5-mini"]);
+      .toContain("gpt-5.4");
+    expect(settingsModelChoices(overlay).every((model) =>
+      model.remoteId.startsWith("gpt-") && model.source === "pi-catalog"
+    )).toBeTrue();
     expect(probeCalls).toBe(0);
     expect(overlay.result?.message).toContain("ChatGPT plan is signed in.");
     expect(overlay.result?.message).not.toContain("auth login");
@@ -551,9 +554,10 @@ describe("the settings row model stays one list", () => {
     await discoverSettingsModels(state, source, context, overlay);
 
     expect(settingsModelChoices(overlay).map((model) => model.remoteId))
-      .toEqual(["claude-sonnet-4-6", "claude-haiku-4-5"]);
-    expect(settingsModelChoices(overlay).every((model) => model.source === "pi-catalog"))
-      .toBeTrue();
+      .toContain("claude-sonnet-4-6");
+    expect(settingsModelChoices(overlay).every((model) =>
+      model.remoteId.startsWith("claude-") && model.source === "pi-catalog"
+    )).toBeTrue();
   });
 
   test("subscription plans hide probe keys and ignore direct probe shortcuts", async () => {

--- a/tui/test/settings-form.test.ts
+++ b/tui/test/settings-form.test.ts
@@ -10,7 +10,8 @@ import {
 import { INITIAL_SETTINGS_DOCUMENT_V2_TEXT } from "../../server/settings-v2-initial-vectors.js";
 import {
   discoverSettingsModels,
-  publishCurrentSettingsModelDiscovery
+  publishCurrentSettingsModelDiscovery,
+  settingsModelChoices
 } from "../src/settings-model-discovery.js";
 import {
   checkSettings,
@@ -464,7 +465,7 @@ describe("the settings row model stays one list", () => {
       .toBe("In a terminal, run 1667 auth login claude to sign in. Claude plan support is experimental.");
   });
 
-  test("subscription plans skip legacy discovery and context probes", async () => {
+  test("subscription plans load catalogs and skip context probes", async () => {
     const { source, state, backend, press } = settingsHarness();
     await openSettings(press);
     const overlay = state.settings!;
@@ -509,7 +510,9 @@ describe("the settings row model stays one list", () => {
     await discoverSettingsModels(state, source, context, overlay);
     await detectSettingsContext(state, source, context, overlay);
 
-    expect(discoveryCalls).toBe(0);
+    expect(discoveryCalls).toBe(1);
+    expect(settingsModelChoices(overlay).map((model) => model.remoteId))
+      .toEqual(["gpt-5.4", "gpt-5-mini"]);
     expect(probeCalls).toBe(0);
     expect(overlay.result?.message).toContain("ChatGPT plan is signed in.");
     expect(overlay.result?.message).not.toContain("auth login");

--- a/tui/test/settings-form.test.ts
+++ b/tui/test/settings-form.test.ts
@@ -522,6 +522,40 @@ describe("the settings row model stays one list", () => {
     expect(overlay.result?.message).not.toContain("auth login");
   });
 
+  test("Claude plan discovery shows only Claude demo models", async () => {
+    const { source, state, backend, press } = settingsHarness();
+    await openSettings(press);
+    const overlay = state.settings!;
+    overlay.draft = settingsTextDraftWithSubscriptionPlan(
+      overlay.draft,
+      "claude-plan",
+      {
+        ...overlay.draft.generation,
+        provider: "anthropic",
+        baseUrl: "",
+        model: "claude-sonnet-4-6",
+        apiKeyEnv: null,
+        contextWindow: 1_000_000
+      }
+    );
+    overlay.base = overlay.draft;
+    const context = {
+      backend,
+      repaint: () => undefined,
+      cache: createWrapCache<ProseStyle>(),
+      renderer: null,
+      applyTheme: () => undefined,
+      previewTheme: () => undefined
+    };
+
+    await discoverSettingsModels(state, source, context, overlay);
+
+    expect(settingsModelChoices(overlay).map((model) => model.remoteId))
+      .toEqual(["claude-sonnet-4-6", "claude-haiku-4-5"]);
+    expect(settingsModelChoices(overlay).every((model) => model.source === "pi-catalog"))
+      .toBeTrue();
+  });
+
   test("subscription plans hide probe keys and ignore direct probe shortcuts", async () => {
     const { state, press } = settingsHarness();
     await openSettings(press);

--- a/tui/test/settings-inline.test.ts
+++ b/tui/test/settings-inline.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { parseSettingsDocumentV2 } from "../../server/settings-v2-codec.js";
-import { effectiveStandardGenerationRuntime } from "../../server/settings-v2-conversion.js";
+import { effectiveStandardGenerationRuntime } from "../../server/settings-runtime-resolver.js";
 import {
   applyBasicSettingsDraft,
   basicSettingsFromDocument

--- a/tui/test/settings-inline.test.ts
+++ b/tui/test/settings-inline.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { parseSettingsDocumentV2 } from "../../server/settings-v2-codec.js";
 import { effectiveGenerationRuntime } from "../../server/settings-v2-conversion.js";
+import { createSubscriptionRuntime } from "../../server/subscription-runtime.js";
 import {
   applyBasicSettingsDraft,
   basicSettingsFromDocument
@@ -40,6 +41,8 @@ import {
   selectRow,
   settingsHarness as harness
 } from "./settings-test-harness.js";
+
+const SUBSCRIPTION_RUNTIME = createSubscriptionRuntime(process.cwd());
 
 describe("inline settings menu", () => {
   test("up/down selects every row; Enter edits text and advances closed choices", async () => {
@@ -799,7 +802,10 @@ describe("inline settings menu", () => {
           target.purpose,
           {},
           {},
-          { allowBlankModel: true }
+          {
+            allowBlankModel: true,
+            subscription: SUBSCRIPTION_RUNTIME
+          }
         );
         expect(runtime.settings.model).toBe("");
         expect(runtime.providerRuntime.preset).toBe(expected.id);

--- a/tui/test/settings-inline.test.ts
+++ b/tui/test/settings-inline.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { parseSettingsDocumentV2 } from "../../server/settings-v2-codec.js";
-import { effectiveGenerationRuntime } from "../../server/settings-v2-conversion.js";
-import { createSubscriptionRuntime } from "../../server/subscription-runtime.js";
+import { effectiveStandardGenerationRuntime } from "../../server/settings-v2-conversion.js";
 import {
   applyBasicSettingsDraft,
   basicSettingsFromDocument
@@ -41,8 +40,6 @@ import {
   selectRow,
   settingsHarness as harness
 } from "./settings-test-harness.js";
-
-const SUBSCRIPTION_RUNTIME = createSubscriptionRuntime(process.cwd());
 
 describe("inline settings menu", () => {
   test("up/down selects every row; Enter edits text and advances closed choices", async () => {
@@ -797,15 +794,12 @@ describe("inline settings menu", () => {
       source.api.probeContextWindow = async (target) => {
         probes += 1;
         if (!("kind" in target)) throw new Error("expected a settings document");
-        const runtime = effectiveGenerationRuntime(
+        const runtime = effectiveStandardGenerationRuntime(
           parseSettingsDocumentV2(target.document),
           target.purpose,
           {},
           {},
-          {
-            allowBlankModel: true,
-            subscription: SUBSCRIPTION_RUNTIME
-          }
+          { allowBlankModel: true }
         );
         expect(runtime.settings.model).toBe("");
         expect(runtime.providerRuntime.preset).toBe(expected.id);

--- a/tui/test/settings-profiles.test.ts
+++ b/tui/test/settings-profiles.test.ts
@@ -319,7 +319,7 @@ describe("Generation Profile settings", () => {
         await press(key("right"));
       }
       expect(overlay.draft.document!.profiles[profileId]!.effort).toBe("low");
-      await draftRow(press, state, "model", `${plan.model}-edited`);
+      await editSubscriptionModel(press, state, `${plan.model}-edited`);
 
       const route = resolveSettingsProfile(overlay.draft.document!, profileId);
       expect(route.model.capabilities.reasoningEffort).toBe("supported");
@@ -986,3 +986,23 @@ describe("Generation Profile settings", () => {
   });
 
 });
+
+async function editSubscriptionModel(
+  press: ReturnType<typeof settingsHarness>["press"],
+  state: ReturnType<typeof settingsHarness>["state"],
+  value: string
+): Promise<void> {
+  await selectRow(press, state, "model");
+  await press(key("return"));
+  const overlay = state.settings!;
+  if (overlay.modelPicker !== null) {
+    for (const character of value) {
+      await press(key(character, { sequence: character }));
+    }
+    await press(key("return"));
+    return;
+  }
+  if (overlay.edit?.kind !== "inline") throw new Error("model row did not open");
+  setComposerText(overlay.edit.composer, value);
+  await press(key("return"));
+}


### PR DESCRIPTION
## Outcome

ChatGPT and Claude plan connections now show the bundled Pi model catalog in Settings. A user can select a model or enter a model ID manually.

## Changes

- Return bundled model metadata for subscription-plan discovery.
- Let the Settings model row load and show subscription-plan choices.
- Keep context-window probes disabled for subscription plans.
- Apply one bounded catalog policy to production, demo, and decoding paths.
- Resolve subscription runtimes through one machine-tier composition root.

## Verification

- `npm run typecheck`
- `cd tui && bun run typecheck`
- `npm test` (2,551 passed; 226 skipped)
- `cd tui && bun test --timeout 30000` (2,061 passed; 2 skipped)
- `$autoreview` branch review (clean, 0.91)
- `$thermo-nuclear-code-quality-review` branch review; concrete findings fixed, scope-expanding findings rejected after inspection

## Risk

The bundled catalog changes only when the pinned Pi dependency changes. Manual model ID entry remains available.

Tracks #282