### PR TITLE
chore(release): prepare 0.9.10-rc.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ This file records notable changes to 1667. Product terms use the definitions in
 
 ## Unreleased
 
+## 0.9.10-rc.5 - 2026-08-20
+
+- **Settings opens in a simple view.** The simple view shows the system
+  prompt, the provider, the model, and the context size. It also shows the
+  base URL and the API key when the provider needs them. Press `m` for the
+  advanced view, which shows every row. 1667 keeps your choice.
+
+- **A model change finds the context size.** When you select a model, 1667
+  asks the provider for the context size and sets it. A size that you type
+  stays. 1667 shows a message on the context size row when the request
+  fails.
+
 - **ChatGPT and Claude plans show their bundled model catalogs.** Select a
   model in Settings, or enter a model ID manually.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "1667-workspace",
-  "version": "0.9.10-rc.4",
+  "version": "0.9.10-rc.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "1667-workspace",
-      "version": "0.9.10-rc.4",
+      "version": "0.9.10-rc.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@earendil-works/pi-ai": "0.84.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667-workspace",
-  "version": "0.9.10-rc.4",
+  "version": "0.9.10-rc.5",
   "private": true,
   "description": "Source workspace for the 1667 terminal writing environment",
   "license": "Apache-2.0",

--- a/shared/release-notes.ts
+++ b/shared/release-notes.ts
@@ -11,6 +11,11 @@ export interface ReleaseNote {
  *  a release, and is not included. */
 export const RELEASE_NOTES: readonly ReleaseNote[] = [
   {
+    version: "0.9.10-rc.5",
+    date: "2026-08-20",
+    body: "- **Settings opens in a simple view.** The simple view shows the system\n  prompt, the provider, the model, and the context size. It also shows the\n  base URL and the API key when the provider needs them. Press `m` for the\n  advanced view, which shows every row. 1667 keeps your choice.\n\n- **A model change finds the context size.** When you select a model, 1667\n  asks the provider for the context size and sets it. A size that you type\n  stays. 1667 shows a message on the context size row when the request\n  fails.\n\n- **ChatGPT and Claude plans show their bundled model catalogs.** Select a\n  model in Settings, or enter a model ID manually."
+  },
+  {
     version: "0.9.10-rc.4",
     date: "2026-08-20",
     body: "- **The Shell Installer can update a Managed Installation.** Run the Installer\n  again to recover when an old 1667 version refuses a package with updated\n  legal notices. The Installer keeps the Installation ID and the previous\n  executable. It refuses an unmanaged executable and an automatic downgrade."

--- a/tui/package.json
+++ b/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667",
-  "version": "0.9.10-rc.4",
+  "version": "0.9.10-rc.5",
   "private": true,
   "description": "A terminal environment for writing fiction with language models",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Outcome

Prepare the 0.9.10-rc.5 beta release. This release gives testers the new simple Settings view, automatic context-size detection, and bundled plan model catalogs.

## Changes

- Set the workspace, lockfile, and TUI version to 0.9.10-rc.5.
- Add the 0.9.10-rc.5 changelog section.
- Regenerate the embedded release notes.

## Verification

- npm run build
- npm test
- tui: bun run typecheck
- tui: bun test (2,081 passed; 2 skipped)
- tui: bun bench/perf.ts
- tui: bun run build:standalone
- npm run notes:check-version -- 0.9.10-rc.5

## Risks and limitations

- This is a prerelease. The hosted workflow publishes it only to the beta channel.
- No stable-channel promotion is part of this change.

Tracks #282