### PR TITLE
Prepare 0.9.10-rc.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ This file records notable changes to 1667. Product terms use the definitions in
 
 ## Unreleased
 
+## 0.9.10-rc.7 - 2026-08-20
+
+- **This beta has no additional product changes.** It contains the same
+  behavior as 0.9.10-rc.6.
+
 ## 0.9.10-rc.6 - 2026-08-20
 
 - **1667 now reports available releases by default.** You can turn update

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "1667-workspace",
-  "version": "0.9.10-rc.6",
+  "version": "0.9.10-rc.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "1667-workspace",
-      "version": "0.9.10-rc.6",
+      "version": "0.9.10-rc.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@earendil-works/pi-ai": "0.84.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667-workspace",
-  "version": "0.9.10-rc.6",
+  "version": "0.9.10-rc.7",
   "private": true,
   "description": "Source workspace for the 1667 terminal writing environment",
   "license": "Apache-2.0",

--- a/shared/release-notes.ts
+++ b/shared/release-notes.ts
@@ -11,6 +11,11 @@ export interface ReleaseNote {
  *  a release, and is not included. */
 export const RELEASE_NOTES: readonly ReleaseNote[] = [
   {
+    version: "0.9.10-rc.7",
+    date: "2026-08-20",
+    body: "- **This beta has no additional product changes.** It contains the same\n  behavior as 0.9.10-rc.6."
+  },
+  {
     version: "0.9.10-rc.6",
     date: "2026-08-20",
     body: "- **1667 now reports available releases by default.** You can turn update\n  checks off in Settings. The check stays silent when the network is not\n  available. Existing config files use the new default. A Managed Installation\n  notice shows the checked version and channel in the upgrade command. Other\n  notices show only the new version.\n\n- **Managed installations at 0.9.9 can upgrade to this release.** The npm\n  packages keep the notice that 0.9.9 accepts. Each SPDX SBOM contains the\n  current notice. Future notice changes do not break this upgrade path.\n\n- **Subscription plans use one model picker action.** Press Enter to open the\n  model picker for a ChatGPT Plan or a Claude Plan. Left Arrow and Right Arrow\n  do not change these models.\n\n- **The Settings mode action shows its destination.** The action says\n  `m advanced` in simple mode. It says `m simple` in advanced mode."

--- a/tui/package.json
+++ b/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667",
-  "version": "0.9.10-rc.6",
+  "version": "0.9.10-rc.7",
   "private": true,
   "description": "A terminal environment for writing fiction with language models",
   "license": "Apache-2.0",


### PR DESCRIPTION
Tracks #288

## Outcome

Prepare 0.9.10-rc.7 as the skip-upgrade beta. A fresh 0.9.9 installation must be able to upgrade directly to it after rc.6 is no longer the beta tag.

## Changes

- Set the workspace and TUI versions to 0.9.10-rc.7.
- Record that this beta has no additional product changes.
- Regenerate the embedded release notes.

## Verification

- npm run build
- cd tui && bun run typecheck
- npm run notes:check-version -- 0.9.10-rc.7
- git diff --check

## Risk

This PR changes release metadata only. Issue 288 stays open until the fix is in a stable release.