### PR TITLE
chore(release): prepare 0.9.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ This file records notable changes to 1667. Product terms use the definitions in
 
 ## Unreleased
 
+## 0.9.10 - 2026-08-20
+
+- **This release has no additional product changes.** It contains the same
+  behavior as 0.9.10-rc.7.
+
 ## 0.9.10-rc.7 - 2026-08-20
 
 - **This beta has no additional product changes.** It contains the same

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "1667-workspace",
-  "version": "0.9.10-rc.7",
+  "version": "0.9.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "1667-workspace",
-      "version": "0.9.10-rc.7",
+      "version": "0.9.10",
       "license": "Apache-2.0",
       "dependencies": {
         "@earendil-works/pi-ai": "0.84.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667-workspace",
-  "version": "0.9.10-rc.7",
+  "version": "0.9.10",
   "private": true,
   "description": "Source workspace for the 1667 terminal writing environment",
   "license": "Apache-2.0",

--- a/shared/release-notes.ts
+++ b/shared/release-notes.ts
@@ -11,6 +11,11 @@ export interface ReleaseNote {
  *  a release, and is not included. */
 export const RELEASE_NOTES: readonly ReleaseNote[] = [
   {
+    version: "0.9.10",
+    date: "2026-08-20",
+    body: "- **This release has no additional product changes.** It contains the same\n  behavior as 0.9.10-rc.7."
+  },
+  {
     version: "0.9.10-rc.7",
     date: "2026-08-20",
     body: "- **This beta has no additional product changes.** It contains the same\n  behavior as 0.9.10-rc.6."

--- a/tui/package.json
+++ b/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667",
-  "version": "0.9.10-rc.7",
+  "version": "0.9.10",
   "private": true,
   "description": "A terminal environment for writing fiction with language models",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Outcome

Prepare 0.9.10 as the stable release. The hosted release workflow will publish this non-prerelease version to the `latest` npm tag.

## Changes

- Set the root, lockfile, and TUI versions to 0.9.10.
- Add the 0.9.10 changelog section.
- Regenerate embedded release notes.

## Verification

- `npm run notes:write`
- `npm run notes:check-version -- 0.9.10`
- `git diff --check`
- `npm run build`
- `cd tui && bun run typecheck`

## Risk

This commit changes release metadata only. Publication remains gated by the hosted release workflow.

Tracks #288