### PR TITLE
fix(library): total words across branches

### DIFF
--- a/server/stories.ts
+++ b/server/stories.ts
@@ -100,7 +100,7 @@ import {
   type StoryMetadata,
   type StoredStorySlot
 } from "./story-storage-reader.js";
-import { buildStorySummary } from "./story-summary.js";
+import { buildStoryCatalogSummary } from "./story-summary.js";
 import { storySummaryFromLiveEnvelope } from "./story-v6-codec.js";
 import {
   applyProviderStoryEffect,
@@ -436,9 +436,9 @@ export class StoryStore {
     const ids = await catalogStoryIds(this.dir);
     const summaries = await mapWithConcurrency(ids, STORY_LIST_IO_CONCURRENCY, async (id) => this.withIo(id, async () => {
       const slot = await readStoredStorySlot(this.dir, id);
-      if (slot.kind === "legacy") return buildStorySummary(slot.story);
+      if (slot.kind === "legacy") return buildStoryCatalogSummary(slot.story);
       if (slot.kind === "v5") return {
-        ...buildStorySummary(slot.manifest),
+        ...buildStoryCatalogSummary(slot.manifest),
         aggregateVersion: aggregateVersionFromSlot(slot)
       };
       if (slot.kind === "v6-live" || slot.kind === "v8-live" || slot.kind === "v10-live") return {

--- a/server/story-catalog.ts
+++ b/server/story-catalog.ts
@@ -23,7 +23,7 @@ import {
   readStoredStorySlot,
   type StoredStorySlot
 } from "./story-storage-reader.js";
-import { buildStorySummary } from "./story-summary.js";
+import { buildStoryCatalogSummary } from "./story-summary.js";
 import { storySummaryFromLiveEnvelope } from "./story-v6-codec.js";
 import {
   isEphemeralBundleName,
@@ -372,10 +372,10 @@ function bytesRead(slot: StoredStorySlot): number {
 }
 
 function summaryFromSlot(slot: StoredStorySlot): StorySummary | null {
-  if (slot.kind === "legacy") return buildStorySummary(slot.story);
+  if (slot.kind === "legacy") return buildStoryCatalogSummary(slot.story);
   if (slot.kind === "v5") {
     return {
-      ...buildStorySummary(slot.manifest),
+      ...buildStoryCatalogSummary(slot.manifest),
       aggregateVersion: {
         kind: "v5",
         manifestHash: hashStoryV5ManifestBytes(slot.manifestBytes)

--- a/server/story-summary.ts
+++ b/server/story-summary.ts
@@ -1,4 +1,4 @@
-import { activePath, hasFork, leafCount } from "../shared/story-tree.js";
+import { activePath, hasFork, isChapterSummary, leafCount } from "../shared/story-tree.js";
 import type { Story, StorySummary } from "../shared/types.js";
 import { countWords } from "./story-codec.js";
 import type {
@@ -33,4 +33,37 @@ export function buildStorySummary(
     forked: hasFork(source),
     lineCount: leafCount(source)
   };
+}
+
+/** Build the summary shown by story catalogs. The persisted summary keeps
+ * the active-line word count for format compatibility. Catalogs show the
+ * words stored across all prose branches. */
+export function buildStoryCatalogSummary(
+  source: Story | StoryManifestV4 | StoryManifestV5 | StoryManifestV7 | StoryManifestV9
+): StorySummary {
+  return {
+    ...buildStorySummary(source),
+    words: catalogWordCount(source)
+  };
+}
+
+function catalogWordCount(
+  source: Story | StoryManifestV4 | StoryManifestV5 | StoryManifestV7 | StoryManifestV9
+): number {
+  if (!("schemaVersion" in source)) {
+    return source.nodes.reduce(
+      (sum, node) => sum + (isChapterSummary(node) ? 0 : countWords(node.text)),
+      0
+    );
+  }
+
+  let words = 0;
+  for (const node of source.nodes) {
+    if (isChapterSummary(node)) continue;
+    // Early V4 manifests did not store per-node word metadata. Keep their
+    // valid active-line count until the next ordinary save populates it.
+    if (node.words === undefined) return source.activeWordCount;
+    words += node.words;
+  }
+  return words;
 }

--- a/server/story-v6-codec.ts
+++ b/server/story-v6-codec.ts
@@ -14,7 +14,7 @@ import {
   type StoryManifestV9
 } from "./story-format.js";
 import { hasLegacyTopLevelSchemaVersion } from "./json-schema-version.js";
-import { buildStorySummary } from "./story-summary.js";
+import { buildStoryCatalogSummary, buildStorySummary } from "./story-summary.js";
 import {
   MAX_STORY_MANIFEST_BYTES,
   MAX_STORY_TITLE_CHARS,
@@ -219,7 +219,8 @@ export function requireV6Manifest(manifest: StoryEnvelopeManifest, context: stri
 }
 
 export function storySummaryFromLiveEnvelope(manifest: LiveStoryEnvelopeManifest): StorySummary {
-  const words = safeSummaryNumber(manifest.summary.words, "summary.words");
+  safeSummaryNumber(manifest.summary.words, "summary.words");
+  const words = buildStoryCatalogSummary(manifest.content).words;
   const lineCount = safeSummaryNumber(manifest.summary.lineCount, "summary.lineCount");
   return {
     id: manifest.summary.id,

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -694,6 +694,7 @@ export interface StorySummary {
   title: string;
   updatedAt: string;
   partCount: number;
+  /** Words stored across all prose branches. Shared ancestors count once. */
   words: number;
   forked: boolean;
   lineCount: number;

--- a/test/story-store.test.ts
+++ b/test/story-store.test.ts
@@ -39,7 +39,7 @@ import { summarySourceFingerprint, type SummaryPoint } from "../server/summary-t
 
 const NOW = "2026-01-01T00:00:00.000Z";
 
-test("story store: node create, edit, delete, and list summaries use active-path data", async (t) => {
+test("story store: list summaries total every prose branch", async (t) => {
   const { store } = await testStore(t);
   const story = fixture("crud", [node("root", null, "Opening")], "root");
   await store.save(story);
@@ -62,13 +62,16 @@ test("story store: node create, edit, delete, and list summaries use active-path
     (error: unknown) => error instanceof HttpError && error.status === 409
   );
 
+  const forked = await store.createNode(story.id, "root", "A quiet alternate ending", "Turn right");
+  const alternate = forked.nodes.at(-1)!;
+
   const summary = (await store.list()).find((entry) => entry.id === story.id)!;
   assert.equal(summary.partCount, 2);
-  assert.equal(summary.words, 5);
-  assert.equal(summary.lineCount, 1);
-  assert.equal(summary.forked, false);
+  assert.equal(summary.words, 9);
+  assert.equal(summary.lineCount, 2);
+  assert.equal(summary.forked, true);
   const deleted = await store.deleteNode(story.id, take.id, 1);
-  assert.deepEqual(deleted.nodes.map(({ id }) => id), ["root"]);
+  assert.deepEqual(deleted.nodes.map(({ id }) => id), ["root", alternate.id]);
 });
 
 test("story store: editing a node that fully reclaims its rewritten span deletes the field instead of storing an empty array", async (t) => {

--- a/test/story-v6-store.test.ts
+++ b/test/story-v6-store.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { access, mkdir, mkdtemp, readFile, readdir, rm, truncate, unlink, writeFile } from "node:fs/promises";
+import { access, chmod, mkdir, mkdtemp, readFile, readdir, rm, truncate, unlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -30,13 +30,19 @@ test("story V6 store: existing list, read, and export surfaces support live stat
   await service.init();
   t.after(async () => { await service.dispose(); await rm(dataDir, { recursive: true, force: true }); });
 
-  await service.stories.save(fixture("v5-story", "V5 prose"));
-  await service.stories.save(fixture("v6-story", "V6 prose"));
+  await service.stories.save(branchingFixture("v5-story", "V5 prose"));
+  await service.stories.save(branchingFixture("v6-story", "V6 prose"));
   await service.stories.save(fixture("deleted-story", "Deleted prose"));
   await promoteLive(path.join(dataDir, "stories"), "v6-story");
   await promoteDeleted(path.join(dataDir, "stories"), "deleted-story");
 
-  assert.deepEqual((await service.listStories()).map(({ id }) => id).sort(), ["v5-story", "v6-story"]);
+  const summaries = await service.listStories();
+  assert.deepEqual(summaries.map(({ id }) => id).sort(), ["v5-story", "v6-story"]);
+  assert.equal(summaries.find(({ id }) => id === "v5-story")?.words, 7);
+  assert.equal(summaries.find(({ id }) => id === "v6-story")?.words, 7);
+  const catalog = await service.listStoriesPage({ cursor: null, maxEntries: 64 });
+  assert.equal(catalog.items.find(({ id }) => id === "v5-story")?.words, 7);
+  assert.equal(catalog.items.find(({ id }) => id === "v6-story")?.words, 7);
   assert.equal((await service.loadStory("v6-story")).path[0]!.text, "V6 prose");
   assert.match((await service.exportStory("v6-story")).markdown, /V6 prose/);
   await assert.rejects(() => service.loadStory("deleted-story"), hasServiceError("not_found"));
@@ -290,6 +296,7 @@ async function promoteDeleted(root: string, id: string): Promise<void> {
     }
   };
   await writeFile(file, formatV6(manifest));
+  await chmod(file, 0o600);
 }
 
 function fixture(id: string, text: string): Story {
@@ -301,6 +308,22 @@ function fixture(id: string, text: string): Story {
     id, title: id, createdAt: NOW, updatedAt: NOW, nodes: [root], activeRootId: root.id,
     tags: [], recentNodeIds: [], facts: [], chapterBreaks: []
   };
+}
+
+function branchingFixture(id: string, text: string): Story {
+  const story = fixture(id, text);
+  const root = story.nodes[0]!;
+  const active: StoryNode = {
+    id: `${id}-active`, parentId: root.id, instruction: "Continue", text: "Active ending",
+    model: "test", createdAt: NOW, activeChildId: null
+  };
+  const alternate: StoryNode = {
+    id: `${id}-alternate`, parentId: root.id, instruction: "Continue", text: "Alternate path turns",
+    model: "test", createdAt: NOW, activeChildId: null
+  };
+  root.activeChildId = active.id;
+  story.nodes.push(active, alternate);
+  return story;
 }
 
 function uint64(value: number): string {

--- a/tui/src/demo.ts
+++ b/tui/src/demo.ts
@@ -515,11 +515,10 @@ function normalizeDemoFactMetadata(fact: Story["facts"][number]): void {
 }
 
 function storySummary(story: Story): StorySummary {
-  const line = activePath(story);
   const prose = story.nodes.filter((node) => !isChapterSummary(node));
   const leaves = prose.filter((node) => !prose.some((candidate) => candidate.parentId === node.id));
   return { id: story.id, title: story.title, updatedAt: story.updatedAt, partCount: prose.length,
-    words: line.reduce((sum, node) => sum + countWords(node.text), 0), forked: story.origin !== undefined, lineCount: leaves.length };
+    words: prose.reduce((sum, node) => sum + countWords(node.text), 0), forked: story.origin !== undefined, lineCount: leaves.length };
 }
 
 function payloadFrom(story: Story): StoryPayload {


### PR DESCRIPTION
The Library now shows the total words stored across all prose branches. Shared ancestors count once. This fixes totals that changed when the writer selected a different take.

Changes:

- Total branch words for legacy, V5, and revisioned stories.
- Keep the persisted active-line summary compatible.
- Match the behavior in demo mode.
- Add storage and catalog integration coverage.

Verification:

- `npm run typecheck`
- 118 story storage and format tests
- `cd tui && bun run typecheck`
- 57 Library and golden-panel tests
- Commit attribution check

Risk: Early V4 manifests without per-node word metadata keep their valid active-line count until the next ordinary save populates the metadata.

Tracks #299.