### PR TITLE
feat(tui): animate work-state labels

### DIFF
--- a/tui/src/screens/map.ts
+++ b/tui/src/screens/map.ts
@@ -17,6 +17,7 @@ import { createMapPathRow, renderMapPathRow, type MapPathRow } from "./map-path-
 import { tagGlyph, tagRole, formatMapWords, formatMapWordsBare } from "./map-row-labels.js";
 import { mapTreeFoldFootnote, renderMapTreeRow } from "./map-tree-row.js";
 import { renderSurfaceBreadcrumb } from "./surface-breadcrumb.js";
+import { lightWorkKeyword } from "./work-light.js";
 import {
   fitLine,
   plainLine,
@@ -74,7 +75,7 @@ export function renderMapScreen(
     ...shown,
     ...Array.from({ length: Math.max(0, bodyHeight - shown.length) }, (): FrameLine => []),
     [segment("─".repeat(Math.max(0, width)), "dimmed page")],
-    renderBreadcrumb(visualState, map, body.crumb, width)
+    renderBreadcrumb(visualState, map, body.crumb, width, deadlines)
   ].slice(0, height).map((line) => fitLine(line, width));
 
   hitRows.length = height;
@@ -318,11 +319,22 @@ function mapTitleHits(): HitRegion[] {
   });
 }
 
-function renderBreadcrumb(state: StoryScreenState, map: MapState, crumb: string, width: number): FrameLine {
+function renderBreadcrumb(
+  state: StoryScreenState,
+  map: MapState,
+  crumb: string,
+  width: number,
+  deadlines?: FrameDeadlineCollector
+): FrameLine {
   if (state.prune != null) return renderPruneBreadcrumb(pruneConfirmText(state.prune), width);
   if (state.toast !== null && state.toast !== undefined) return renderMapNotice(state.toast, width);
   if (state.backendTask !== null && state.backendTask !== undefined) {
-    return renderMapNotice(`working · ${state.backendTask.label}`, width);
+    return lightWorkKeyword(
+      renderMapNotice(`working · ${state.backendTask.label}`, width),
+      "working",
+      state.now,
+      deadlines
+    );
   }
   const payload = state.payload;
   const view = map.view;

--- a/tui/src/screens/story.ts
+++ b/tui/src/screens/story.ts
@@ -293,7 +293,14 @@ export function renderStoryScreen(state: StoryScreenState, options: StoryScreenO
   // terminal's right edge.
   const surfaceRows = Math.max(0, height - 1);
   const status = fitLine(
-    renderStoryStatus(state, view, frameLayout.railRight ?? frameLayout.fullWidth, narrow, estimate),
+    renderStoryStatus(
+      state,
+      view,
+      frameLayout.railRight ?? frameLayout.fullWidth,
+      narrow,
+      estimate,
+      options.deadlines
+    ),
     frameLayout.fullWidth
   );
   let lines: FrameLine[] = [
@@ -755,7 +762,9 @@ function renderFullscreenComposer(
     softWrap: state.config.wordWrap === "on"
   });
   const withImages = spliceDraftImageRows(composer, draftImagesFor(state.composer), "");
-  const lines = [...withImages.lines, renderStoryStatus(state, view, width, width < 100, estimate)]
+  const lines = [...withImages.lines, renderStoryStatus(
+    state, view, width, width < 100, estimate, deadlines
+  )]
     .slice(0, height)
     .map((line) => fitLine(line, width));
   const hitRows: HitRows = Array.from({ length: height }, (_, row): HitRow | null => row < height - 1
@@ -894,7 +903,9 @@ function renderEditorLayoutFrame(
   layout: ComposerLayout,
   deadlines?: FrameDeadlineCollector
 ): StoryScreenFrame {
-  const base = [...layout.lines, renderStoryStatus(state, view, width, width < 100, estimate)]
+  const base = [...layout.lines, renderStoryStatus(
+    state, view, width, width < 100, estimate, deadlines
+  )]
     .slice(0, height)
     .map((line) => fitLine(line, width));
   const hitRows: HitRows = Array.from({ length: height }, (_, row): HitRow | null => row < height - 1
@@ -944,9 +955,10 @@ function renderStoryStatus(
   view: StoryViewModel,
   width: number,
   narrow: boolean,
-  estimate: NextRequestEstimate
+  estimate: NextRequestEstimate,
+  deadlines?: FrameDeadlineCollector
 ): FrameLine {
-  const status = renderCanonicalStatus(state, view, width, narrow, estimate);
+  const status = renderCanonicalStatus(state, view, width, narrow, estimate, deadlines);
   const prompt = state.mode === "COMPOSE" ? state.retakePrompt : null;
   if (prompt === null) return status;
   const [modeBlock, ...rest] = status;

--- a/tui/src/screens/story/gutter.ts
+++ b/tui/src/screens/story/gutter.ts
@@ -166,7 +166,7 @@ export function gutterFor(
     // `thought.thinking` is already false in both cases (see
     // `thoughtGutterContext`).
     if (thought.kind === "shown" && thought.thinking) {
-      if (lineIndex === 0) return thinkingGutterLine0(thought.resolved.tokenCount);
+      if (lineIndex === 0) return thinkingGutterLine0(thought.resolved.tokenCount, now, deadlines);
       if (lineIndex === 1) return thinkingGutterLine1(thought.hit);
       return [];
     }

--- a/tui/src/screens/story/status.ts
+++ b/tui/src/screens/story/status.ts
@@ -16,6 +16,8 @@ import {
   placementStopLabel
 } from "../../aside-placement.js";
 import type { StoryScreenState } from "../../state.js";
+import type { FrameDeadlineCollector } from "../../animation-deadline.js";
+import { lightWorkKeyword } from "../work-light.js";
 import {
   fitLine,
   plainLine,
@@ -32,7 +34,8 @@ export function renderStatus(
   view: StoryViewModel,
   width: number,
   narrow: boolean,
-  estimate: NextRequestEstimate
+  estimate: NextRequestEstimate,
+  deadlines?: FrameDeadlineCollector
 ): FrameLine {
   const payload = view.visiblePayload;
   const focused = rowPart(view, state.focusIndex);
@@ -176,12 +179,19 @@ export function renderStatus(
       ? tagged
       : state.chapterSummary != null ? compactSummaryRight : wideRight(false);
   const rightWidth = visibleWidth(plainLine(right));
-  if (rightWidth >= width) return fitLine(right, width);
+  if (rightWidth >= width) {
+    return lightWorkKeyword(fitLine(right, width), "working", state.now, deadlines);
+  }
   const leftWidth = width - rightWidth;
   const responsiveLeft = visibleWidth(plainLine(left)) <= leftWidth
     ? left
     : compactStatusIdentity(modeBlock, payload.title, lineIdentity, location, leftWidth);
-  return [...fitLine(responsiveLeft, leftWidth), ...right];
+  return lightWorkKeyword(
+    [...fitLine(responsiveLeft, leftWidth), ...right],
+    "working",
+    state.now,
+    deadlines
+  );
 }
 
 function renderPruneStatus(block: FrameSegment, text: string, width: number): FrameLine {

--- a/tui/src/screens/story/thought-block.ts
+++ b/tui/src/screens/story/thought-block.ts
@@ -2,6 +2,8 @@ import type { HitTarget } from "../../hit.js";
 import { formatTokensScaled } from "../../rail.js";
 import type { ResolvedThought } from "../../reasoning-model.js";
 import { wrapText } from "../../wrap.js";
+import type { FrameDeadlineCollector } from "../../animation-deadline.js";
+import { lightWorkKeyword } from "../work-light.js";
 import { segment, visibleWidth, type FrameLine } from "./frame.js";
 
 /** Ghost role for every thought affordance — settings §13's "marker is a
@@ -39,9 +41,13 @@ export function focusedFoldedThoughtLine(hit: HitTarget): FrameLine {
  *  the `writing` branch it stands in for) and adds `T peeks` in the same
  *  role, since this line is a status line, not the ghost-margin affordance
  *  the folded/unfolded marks are. */
-export function thinkingGutterLine0(tokenCount: number | null): FrameLine {
+export function thinkingGutterLine0(
+  tokenCount: number | null,
+  now = 0,
+  deadlines?: FrameDeadlineCollector
+): FrameLine {
   const label = tokenCount === null ? "⟳ thinking" : `⟳ thinking · ${tokenCount} tok`;
-  return [segment(label, "focus / accent")];
+  return lightWorkKeyword([segment(label, "focus / accent")], "thinking", now, deadlines);
 }
 
 export function thinkingGutterLine1(hit: HitTarget): FrameLine {

--- a/tui/src/screens/token-probabilities.ts
+++ b/tui/src/screens/token-probabilities.ts
@@ -60,7 +60,7 @@ export function renderTokenProbabilitiesScreen(
         : populatedBody(probs, part, probs.record, width, barCellsFor(width));
   const header = headerLine(state, view, part, probs, width);
   const keys = keylineRow(width);
-  const status = fitLine(renderStatus(state, view, width, narrow, estimate), width);
+  const status = fitLine(renderStatus(state, view, width, narrow, estimate, deadlines), width);
   const rows: FrameLine[] = [header, [], ...body, [], keys, status];
   const padded = rows.slice(0, height);
   while (padded.length < height) padded.push([]);

--- a/tui/src/screens/work-light.ts
+++ b/tui/src/screens/work-light.ts
@@ -1,0 +1,44 @@
+import type { FrameDeadlineCollector } from "../animation-deadline.js";
+import type { DisplayRole, FrameLine, FrameSegment } from "./story/frame.js";
+
+const WORK_LIGHT_FRAME_MS = 120;
+const WORK_LIGHT_EDGE_FRAMES = 2;
+
+/** Move one light band through a visible work-state keyword. */
+export function lightWorkKeyword(
+  line: FrameLine,
+  keyword: "working" | "thinking",
+  now: number,
+  deadlines?: FrameDeadlineCollector
+): FrameLine {
+  const partIndex = line.findIndex((part) => part.text.includes(keyword));
+  if (partIndex < 0) return line;
+  const part = line[partIndex]!;
+  const keywordStart = part.text.indexOf(keyword);
+  const frame = Math.floor(now / WORK_LIGHT_FRAME_MS);
+  const cycle = keyword.length + WORK_LIGHT_EDGE_FRAMES * 2;
+  const head = frame % cycle - WORK_LIGHT_EDGE_FRAMES;
+  deadlines?.at((frame + 1) * WORK_LIGHT_FRAME_MS);
+
+  const lit = Array.from(keyword, (character, index): FrameSegment => ({
+    ...part,
+    text: character,
+    role: workLightRole(Math.abs(index - head))
+  }));
+  return [
+    ...line.slice(0, partIndex),
+    ...(keywordStart === 0 ? [] : [{ ...part, text: part.text.slice(0, keywordStart) }]),
+    ...lit,
+    ...(keywordStart + keyword.length === part.text.length
+      ? []
+      : [{ ...part, text: part.text.slice(keywordStart + keyword.length) }]),
+    ...line.slice(partIndex + 1)
+  ];
+}
+
+function workLightRole(distance: number): DisplayRole {
+  if (distance === 0) return "streaming";
+  if (distance === 1) return "focus / accent";
+  if (distance === 2) return "brass dim";
+  return "chrome";
+}

--- a/tui/test/animation-deadline.test.ts
+++ b/tui/test/animation-deadline.test.ts
@@ -11,8 +11,8 @@ import { demoAppSource } from "../src/demo.js";
 import { createStoryViewModel, rowIndexForNode } from "../src/model.js";
 import { renderConnectionBanner } from "../src/screens/connection-banner.js";
 import { renderStoryScreen } from "../src/screens/story.js";
-import { plainLine } from "../src/screens/story/frame.js";
-import { emptyStreamText } from "../src/stream-text.js";
+import { plainLine, type FrameLine } from "../src/screens/story/frame.js";
+import { appendStreamReasoning, emptyStreamText } from "../src/stream-text.js";
 
 function fakeClock(start = 0) {
   let now = start;
@@ -110,6 +110,54 @@ describe("animation deadlines", () => {
     expect(firstDeadlines.next()).toBe(250);
   });
 
+  test("visible working and thinking words carry one light band", () => {
+    const state = initialState(demoAppSource(false), false);
+    state.backendTask = {
+      id: 1,
+      kind: "action",
+      label: "stalled mutation",
+      storyId: state.payload.id
+    };
+    state.now = 240;
+    const workingDeadlines = createFrameDeadlineCollector(state.now);
+    const workingLine = renderStoryScreen(state, {
+      width: 120, height: 36, deadlines: workingDeadlines
+    }).lines.at(-1)!;
+    const working = keywordSegments(workingLine, "working");
+
+    expect(working.map((part) => part.text).join("")).toBe("working");
+    expect(working.slice(0, 3).map((part) => part.role)).toEqual([
+      "streaming", "focus / accent", "brass dim"
+    ]);
+    expect(workingDeadlines.next()).toBe(360);
+
+    const leaf = state.payload.path.at(-1)!;
+    state.backendTask = null;
+    state.reasoning = "marker";
+    state.focusIndex = rowIndexForNode(createStoryViewModel(state.payload), leaf.id);
+    state.stream = {
+      targetId: leaf.id,
+      parentId: leaf.parentId,
+      append: true,
+      startedAt: "2026-07-22T00:00:00.000Z",
+      instruction: "",
+      ...emptyStreamText()
+    };
+    appendStreamReasoning(state.stream, "Weighing routes", 12);
+    const thinkingDeadlines = createFrameDeadlineCollector(state.now);
+    const thinkingFrame = renderStoryScreen(state, {
+      width: 120, height: 36, deadlines: thinkingDeadlines
+    });
+    const thinkingLine = thinkingFrame.lines.find((line) => plainLine(line).includes("thinking"))!;
+    const thinking = keywordSegments(thinkingLine, "thinking");
+
+    expect(thinking.map((part) => part.text).join("")).toBe("thinking");
+    expect(thinking.slice(0, 3).map((part) => part.role)).toEqual([
+      "streaming", "focus / accent", "brass dim"
+    ]);
+    expect(thinkingDeadlines.next()).toBe(360);
+  });
+
   test("the liveness mark travels a whole turn before it repeats", () => {
     const state = initialState(demoAppSource(false), false);
     const leaf = state.payload.path.at(-1)!;
@@ -182,3 +230,11 @@ describe("animation deadlines", () => {
     )).toBe(touched + 14 * 86_400_000);
   });
 });
+
+function keywordSegments(line: FrameLine, keyword: string): FrameLine {
+  const start = line.findIndex((part, index) => line
+    .slice(index, index + keyword.length)
+    .map((candidate) => candidate.text)
+    .join("") === keyword);
+  return start < 0 ? [] : line.slice(start, start + keyword.length);
+}


### PR DESCRIPTION
The `working` and `thinking` keywords now show a restrained moving light band while work is active. The animation keeps the exact text and layout. It uses the existing deadline scheduler, so it requests frames only while an indicator is visible.

Changes:

- Add one shared work-state light helper.
- Apply it to story status, MAP status, reasoning status, and token-probability status.
- Use existing theme roles and the existing animation clock.
- Add render-level deadline and styling coverage.

Verification:

- `cd tui && bun run typecheck`
- 122 render, MAP, reasoning, golden, and end-to-end tests
- Commit attribution check
- `git diff --check`

Risk: The indicator adds one scheduled frame every 120 ms only while `working` or `thinking` is visible. It does not add a continuous render loop.

Tracks #298.