### PR TITLE
chore(release): prepare 0.9.11-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ This file records notable changes to 1667. Product terms use the definitions in
 
 ## Unreleased
 
+## 0.9.11-rc.1 - 2026-08-21
+
+- **Fast model responses now appear at a steady reading pace.** 1667 presents
+  large stream batches in small steps. Slow streams stay responsive. Stop and
+  story storage continue to use the complete received response.
+
+- **The Library word count includes every story branch.** It counts prose from
+  all takes and counts each shared part once. Selecting a different take no
+  longer changes the stored total.
+
+- **Active work labels now show a moving light.** The `working` and `thinking`
+  labels animate while work is active. The text and layout do not move.
+
 ## 0.9.10 - 2026-08-20
 
 - **This release has no additional product changes.** It contains the same

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "1667-workspace",
-  "version": "0.9.10",
+  "version": "0.9.11-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "1667-workspace",
-      "version": "0.9.10",
+      "version": "0.9.11-rc.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@earendil-works/pi-ai": "0.84.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667-workspace",
-  "version": "0.9.10",
+  "version": "0.9.11-rc.1",
   "private": true,
   "description": "Source workspace for the 1667 terminal writing environment",
   "license": "Apache-2.0",

--- a/shared/release-notes.ts
+++ b/shared/release-notes.ts
@@ -11,6 +11,11 @@ export interface ReleaseNote {
  *  a release, and is not included. */
 export const RELEASE_NOTES: readonly ReleaseNote[] = [
   {
+    version: "0.9.11-rc.1",
+    date: "2026-08-21",
+    body: "- **Fast model responses now appear at a steady reading pace.** 1667 presents\n  large stream batches in small steps. Slow streams stay responsive. Stop and\n  story storage continue to use the complete received response.\n\n- **The Library word count includes every story branch.** It counts prose from\n  all takes and counts each shared part once. Selecting a different take no\n  longer changes the stored total.\n\n- **Active work labels now show a moving light.** The `working` and `thinking`\n  labels animate while work is active. The text and layout do not move."
+  },
+  {
     version: "0.9.10",
     date: "2026-08-20",
     body: "- **This release has no additional product changes.** It contains the same\n  behavior as 0.9.10-rc.7."

--- a/tui/package.json
+++ b/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667",
-  "version": "0.9.10",
+  "version": "0.9.11-rc.1",
   "private": true,
   "description": "A terminal environment for writing fiction with language models",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Outcome

Prepare `0.9.11-rc.1` as a beta release. The hosted release workflow will publish the prerelease with the `beta` npm tag.

## Changes

- Set workspace and TUI versions to `0.9.11-rc.1`.
- Add the `0.9.11-rc.1` changelog section.
- Generate the embedded release notes.

## Verification

- `npm run notes:check-version -- 0.9.11-rc.1`
- `npm run build`
- `cd tui && bun run typecheck`
- `cd tui && bun bench/perf.ts`
- `cd tui && bun run build:standalone`
- `npx tsx scripts/check-commit-attribution.ts --range origin/main..HEAD`
- `git diff --check`

## Risk

Metadata only. Publication remains gated by the hosted release workflow.

Tracks #296
Tracks #298
Tracks #299