### PR TITLE
chore(release): prepare 0.10.1-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ This file records notable changes to 1667. Product terms use the definitions in
 
 ## Unreleased
 
+## 0.10.1-rc.1 - 2026-08-21
+
+- **This beta has no additional product changes.** It contains the same
+  behavior as 0.10.0.
+
 ## 0.10.0 - 2026-08-21
 
 - **1667 prepares separate controls for Generation Effort and Thinking Mode.**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "1667-workspace",
-  "version": "0.10.0",
+  "version": "0.10.1-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "1667-workspace",
-      "version": "0.10.0",
+      "version": "0.10.1-rc.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@earendil-works/pi-ai": "0.84.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667-workspace",
-  "version": "0.10.0",
+  "version": "0.10.1-rc.1",
   "private": true,
   "description": "Source workspace for the 1667 terminal writing environment",
   "license": "Apache-2.0",

--- a/shared/release-notes.ts
+++ b/shared/release-notes.ts
@@ -11,6 +11,11 @@ export interface ReleaseNote {
  *  a release, and is not included. */
 export const RELEASE_NOTES: readonly ReleaseNote[] = [
   {
+    version: "0.10.1-rc.1",
+    date: "2026-08-21",
+    body: "- **This beta has no additional product changes.** It contains the same\n  behavior as 0.10.0."
+  },
+  {
     version: "0.10.0",
     date: "2026-08-21",
     body: "- **1667 prepares separate controls for Generation Effort and Thinking Mode.**\n  This release reads and runs the successor Settings schema. It refuses to\n  change that schema. A later release can write it and show the new controls\n  without making this release lose a setting.\n\n- **Fast model responses now appear at a steady reading pace.** 1667 presents\n  large stream batches in small steps. Slow streams stay responsive. Stop and\n  story storage continue to use the complete received response.\n\n- **The Library word count includes every story branch.** It counts prose from\n  all takes and counts each shared part once. Selecting a different take no\n  longer changes the stored total.\n\n- **Active work labels now show a moving light.** The `working` and `thinking`\n  labels animate while work is active. The text and layout do not move."

--- a/tui/package.json
+++ b/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667",
-  "version": "0.10.0",
+  "version": "0.10.1-rc.1",
   "private": true,
   "description": "A terminal environment for writing fiction with language models",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Outcome

Prepare `0.10.1-rc.1` as the next beta release. The hosted release workflow will publish it with the `beta` npm tag.

## Changes

- Set workspace and TUI versions to `0.10.1-rc.1`.
- Add the `0.10.1-rc.1` changelog section.
- Generate the embedded release notes.

## Verification

- `npm run build`
- `cd tui && bun run typecheck`
- `cd tui && bun run build:standalone`
- `npm run notes:check-version -- 0.10.1-rc.1`
- `npx tsx scripts/check-commit-attribution.ts --range origin/main..HEAD`
- `git diff --check`

The exact product code passed the full local and hosted `0.10.0` gates.

## Risk

Metadata only. Publication remains gated by the hosted release workflow.

Tracks #295