### PR TITLE
feat(tui): light the writing gutter

### DIFF
--- a/tui/src/screens/story/gutter.ts
+++ b/tui/src/screens/story/gutter.ts
@@ -11,6 +11,7 @@ import {
   type FrameSegment
 } from "./frame.js";
 import type { FrameDeadlineCollector } from "../../animation-deadline.js";
+import { lightWorkKeyword } from "../work-light.js";
 import {
   focusedFoldedThoughtLine,
   ghostThoughtMark,
@@ -170,7 +171,14 @@ export function gutterFor(
       if (lineIndex === 1) return thinkingGutterLine1(thought.hit);
       return [];
     }
-    if (lineIndex === 0) return [segment(`${streamLivenessMark(now, deadlines)} writing`, "focus / accent")];
+    if (lineIndex === 0) {
+      return lightWorkKeyword(
+        [segment(`${streamLivenessMark(now, deadlines)} writing`, "focus / accent")],
+        "writing",
+        now,
+        deadlines
+      );
+    }
     if (lineIndex === 1) return [actionHint("esc stops", "cancel")];
     return [];
   }

--- a/tui/src/screens/story/row-layout.ts
+++ b/tui/src/screens/story/row-layout.ts
@@ -345,22 +345,25 @@ function renderPartBody(
   }
   const streaming = stream !== null;
   const lines: FrameLine[] = [];
+  const gutterAt = (lineIndex: number): FrameLine => narrow
+    ? []
+    : gutterFor(part, streaming, lineIndex, thought, gutterRows, state.now, deadlines);
   if (compactLogo) {
     lines.push(prefixLine(
       narrow,
-      gutterFor(part, streaming, 0, thought, gutterRows, state.now, deadlines),
+      gutterAt(0),
       compactStarterLogo(focused)
     ));
   }
   for (const line of wrapped) {
     const lineIndex = lines.length;
-    lines.push(prefixLine(narrow, gutterFor(part, streaming, lineIndex, thought, gutterRows, state.now, deadlines),
+    lines.push(prefixLine(narrow, gutterAt(lineIndex),
       styledWrapped(line, focused ? "prose" : "prose · dim", focused ? "human edit" : "human edit dim",
         "rewritten", state, part, streaming && !appending, deadlines, sourceStart)));
   }
   const proseTip = lines.length - 1;
   for (let lineIndex = lines.length; lineIndex < gutterRowCount; lineIndex += 1) {
-    lines.push(prefixLine(narrow, gutterFor(part, streaming, lineIndex, thought, gutterRows, state.now, deadlines), []));
+    lines.push(prefixLine(narrow, gutterAt(lineIndex), []));
   }
   // Machine insertion stays visually distinct from the writer's solid block.
   if (streaming && proseTip >= 0) lines[proseTip]!.push(segment("▏", "chrome"));

--- a/tui/src/screens/work-light.ts
+++ b/tui/src/screens/work-light.ts
@@ -7,7 +7,7 @@ const WORK_LIGHT_EDGE_FRAMES = 2;
 /** Move one light band through a visible work-state keyword. */
 export function lightWorkKeyword(
   line: FrameLine,
-  keyword: "working" | "thinking",
+  keyword: "working" | "writing" | "thinking",
   now: number,
   deadlines?: FrameDeadlineCollector
 ): FrameLine {

--- a/tui/test/animation-deadline.test.ts
+++ b/tui/test/animation-deadline.test.ts
@@ -83,7 +83,7 @@ describe("animation deadlines", () => {
     expect(deadlines.next()).toBe(1_330);
   });
 
-  test("a silent stream advances one visible liveness mark per frame deadline", () => {
+  test("a silent stream advances its liveness mark and light band", () => {
     const state = initialState(demoAppSource(false), false);
     const leaf = state.payload.path.at(-1)!;
     state.focusIndex = rowIndexForNode(createStoryViewModel(state.payload), leaf.id);
@@ -107,10 +107,10 @@ describe("animation deadlines", () => {
 
     expect(first).toContain("⠋ writing");
     expect(second).toContain("⠙ writing");
-    expect(firstDeadlines.next()).toBe(250);
+    expect(firstDeadlines.next()).toBe(120);
   });
 
-  test("visible working and thinking words carry one light band", () => {
+  test("visible working, writing, and thinking words carry one light band", () => {
     const state = initialState(demoAppSource(false), false);
     state.backendTask = {
       id: 1,
@@ -133,7 +133,6 @@ describe("animation deadlines", () => {
 
     const leaf = state.payload.path.at(-1)!;
     state.backendTask = null;
-    state.reasoning = "marker";
     state.focusIndex = rowIndexForNode(createStoryViewModel(state.payload), leaf.id);
     state.stream = {
       targetId: leaf.id,
@@ -143,6 +142,21 @@ describe("animation deadlines", () => {
       instruction: "",
       ...emptyStreamText()
     };
+    state.now = 250;
+    const writingDeadlines = createFrameDeadlineCollector(state.now);
+    const writingFrame = renderStoryScreen(state, {
+      width: 120, height: 36, deadlines: writingDeadlines
+    });
+    const writingLine = writingFrame.lines.find((line) => plainLine(line).includes("writing"))!;
+    const writing = keywordSegments(writingLine, "writing");
+
+    expect(writing.map((part) => part.text).join("")).toBe("writing");
+    expect(writing.slice(0, 3).map((part) => part.role)).toEqual([
+      "streaming", "focus / accent", "brass dim"
+    ]);
+    expect(writingDeadlines.next()).toBe(360);
+
+    state.reasoning = "marker";
     appendStreamReasoning(state.stream, "Weighing routes", 12);
     const thinkingDeadlines = createFrameDeadlineCollector(state.now);
     const thinkingFrame = renderStoryScreen(state, {

--- a/tui/test/animation-deadline.test.ts
+++ b/tui/test/animation-deadline.test.ts
@@ -100,14 +100,20 @@ describe("animation deadlines", () => {
     const first = renderStoryScreen(state, {
       width: 120, height: 36, deadlines: firstDeadlines
     }).lines.map(plainLine).join("\n");
+    const narrowDeadlines = createFrameDeadlineCollector(state.now);
+    const narrow = renderStoryScreen(state, {
+      width: 80, height: 24, deadlines: narrowDeadlines
+    }).lines.map(plainLine).join("\n");
 
     state.now = 250;
     const second = renderStoryScreen(state, { width: 120, height: 36 })
       .lines.map(plainLine).join("\n");
 
     expect(first).toContain("⠋ writing");
+    expect(narrow).toContain("⠋ writing");
     expect(second).toContain("⠙ writing");
     expect(firstDeadlines.next()).toBe(120);
+    expect(narrowDeadlines.next()).toBe(250);
   });
 
   test("visible working, writing, and thinking words carry one light band", () => {


### PR DESCRIPTION
The left gutter now applies the existing moving light to the `writing` label. This gives writing and thinking the same active-work signal.

The narrow layout does not render this gutter. It now skips the hidden animation work and keeps its existing visible spinner cadence.

Verification:

- `npm run build`
- `npm test`
- `cd tui && bun run typecheck`
- `cd tui && bun test` — 2,141 pass, 2 platform skips
- `cd tui && bun bench/perf.ts`
- `cd tui && bun run build:standalone`
- `$autoreview` — clean after one accepted narrow-layout performance fix

Risk: low. The change reuses the existing work-light helper and does not move text or change layout.

Tracks #307