### PR TITLE
chore(release): prepare 0.10.1-rc.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ This file records notable changes to 1667. Product terms use the definitions in
 
 ## Unreleased
 
+## 0.10.1-rc.2 - 2026-08-21
+
+- **The left story gutter now lights the active `writing` label.** It uses the
+  same moving light as `thinking`. Narrow layouts do not schedule hidden
+  gutter frames.
+
 ## 0.10.1-rc.1 - 2026-08-21
 
 - **This beta has no additional product changes.** It contains the same

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "1667-workspace",
-  "version": "0.10.1-rc.1",
+  "version": "0.10.1-rc.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "1667-workspace",
-      "version": "0.10.1-rc.1",
+      "version": "0.10.1-rc.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@earendil-works/pi-ai": "0.84.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667-workspace",
-  "version": "0.10.1-rc.1",
+  "version": "0.10.1-rc.2",
   "private": true,
   "description": "Source workspace for the 1667 terminal writing environment",
   "license": "Apache-2.0",

--- a/shared/release-notes.ts
+++ b/shared/release-notes.ts
@@ -11,6 +11,11 @@ export interface ReleaseNote {
  *  a release, and is not included. */
 export const RELEASE_NOTES: readonly ReleaseNote[] = [
   {
+    version: "0.10.1-rc.2",
+    date: "2026-08-21",
+    body: "- **The left story gutter now lights the active `writing` label.** It uses the\n  same moving light as `thinking`. Narrow layouts do not schedule hidden\n  gutter frames."
+  },
+  {
     version: "0.10.1-rc.1",
     date: "2026-08-21",
     body: "- **This beta has no additional product changes.** It contains the same\n  behavior as 0.10.0."

--- a/tui/package.json
+++ b/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667",
-  "version": "0.10.1-rc.1",
+  "version": "0.10.1-rc.2",
   "private": true,
   "description": "A terminal environment for writing fiction with language models",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Outcome

Prepare `0.10.1-rc.2` as the next beta release. The hosted release workflow will publish it with the `beta` npm tag.

## Changes

- Set workspace and TUI versions to `0.10.1-rc.2`.
- Add the `0.10.1-rc.2` changelog section.
- Generate the embedded release notes.

## Verification

- `npm run build`
- `cd tui && bun run typecheck`
- `cd tui && bun run build:standalone`
- `npm run notes:check-version -- 0.10.1-rc.2`
- `npx tsx scripts/check-commit-attribution.ts --range origin/main..HEAD`
- `git diff --check`

The exact product code passed the full local and hosted PR #306 gates.

## Risk

Metadata only. Publication remains gated by the hosted release workflow.

Tracks #307