### PR TITLE
chore(release): prepare 0.10.2-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ This file records notable changes to 1667. Product terms use the definitions in
 
 ## Unreleased
 
+## 0.10.2-rc.1 - 2026-08-22
+
+- **Settings now controls the guidance for each writing action.** The simple
+  view contains the Default Author Brief and Default Continue direction. The
+  advanced view also contains the Rewrite, Title, Summary, and Aside guidance.
+  Existing default values keep the previous model requests unchanged.
+
+- **A prompt opens in a full-screen editor.** Press Ctrl+S to keep an edited
+  prompt in the Settings draft. Save Settings to activate all draft changes.
+
+- **The first prompt save upgrades the Settings data.** An older 1667 release
+  refuses the new Settings schema. Use this beta only when that downgrade
+  limit is acceptable.
+
 ## 0.10.1 - 2026-08-21
 
 - **This release has no additional product changes.** It contains the same

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "1667-workspace",
-  "version": "0.10.1",
+  "version": "0.10.2-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "1667-workspace",
-      "version": "0.10.1",
+      "version": "0.10.2-rc.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@earendil-works/pi-ai": "0.84.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667-workspace",
-  "version": "0.10.1",
+  "version": "0.10.2-rc.1",
   "private": true,
   "description": "Source workspace for the 1667 terminal writing environment",
   "license": "Apache-2.0",

--- a/shared/release-notes.ts
+++ b/shared/release-notes.ts
@@ -11,6 +11,11 @@ export interface ReleaseNote {
  *  a release, and is not included. */
 export const RELEASE_NOTES: readonly ReleaseNote[] = [
   {
+    version: "0.10.2-rc.1",
+    date: "2026-08-22",
+    body: "- **Settings now controls the guidance for each writing action.** The simple\n  view contains the Default Author Brief and Default Continue direction. The\n  advanced view also contains the Rewrite, Title, Summary, and Aside guidance.\n  Existing default values keep the previous model requests unchanged.\n\n- **A prompt opens in a full-screen editor.** Press Ctrl+S to keep an edited\n  prompt in the Settings draft. Save Settings to activate all draft changes.\n\n- **The first prompt save upgrades the Settings data.** An older 1667 release\n  refuses the new Settings schema. Use this beta only when that downgrade\n  limit is acceptable."
+  },
+  {
     version: "0.10.1",
     date: "2026-08-21",
     body: "- **This release has no additional product changes.** It contains the same\n  behavior as 0.10.1-rc.2."

--- a/tui/package.json
+++ b/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667",
-  "version": "0.10.1",
+  "version": "0.10.2-rc.1",
   "private": true,
   "description": "A terminal environment for writing fiction with language models",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Outcome

Prepare the first 0.10.2 beta release for configurable writing prompts.

Tracks #311.

## Changes

- Set the root, lockfile, and TUI versions to `0.10.2-rc.1`.
- Add the beta changelog section.
- Regenerate the embedded release notes.

## Verification

- `npm run build`
- `npm run prompt:check`
- `npm test`
- `bun run typecheck`
- `bun test`
- `bun bench/perf.ts`
- `bun run build:standalone`
- `npm run notes:check-version -- 0.10.2-rc.1`
- `git diff --check`

## Risk

Saving configurable prompts writes Settings schema 5. Older releases refuse that schema. The beta release notes state this downgrade limit.