### PR TITLE
docs: point README to refreshed demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 1667 also provides a direct connection to a selected model provider. This
 repository contains the terminal user interface (TUI) and its backend runtime.
 
-[![1667 in a terminal: a direction is composed, the model streams the next part, two sibling takes are compared, and the path map opens](https://1667.ai/demo-2.gif)](https://1667.ai)
+[![1667 in a terminal: a direction is composed, the model streams the next part, two sibling takes are compared, and the path map opens](https://1667.ai/demo-3.gif)](https://1667.ai)
 
 ## Features
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -140,9 +140,10 @@ nothing else connects the two. `DEMO_FONT` overrides the Berkeley Mono path.
 
 The GIF is served from 1667.ai rather than committed here. The README embeds an
 absolute URL because npmjs.com renders the same README for `@1667-ai/cli` and
-drops relative image paths. The name carries a revision, so a new recording is
-published as `demo-2.gif` and the README link moves: GitHub's camo proxy caches
-these images long enough that overwriting one in place does not reach readers.
+drops relative image paths. The name carries a revision. Publish each new
+recording with the next number, and move the README link. GitHub's camo proxy
+caches these images long enough that overwriting one in place does not reach
+readers.
 
 Publishing a new recording means copying the GIF into the homepage repository's
 `public/`, adding its `_headers` rule, deploying, then updating the README link


### PR DESCRIPTION
## Outcome

Show the updated 0.10.2 interface in the README demo.

Tracks #313.

## Changes

- Point the README image at the cache-safe `demo-3.gif` asset.
- Make the future revision instructions independent of a specific revision number.

## Verification

- `node --import tsx --import ./test/setup.ts --test test/demo-tape.test.ts`
- `git diff --check`

## Risk

The new image depends on the homepage deployment. Merge this pull request after `https://1667.ai/demo-3.gif` is available.