### PR TITLE
feat(tui): add Settings palette shortcuts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This file records notable changes to 1667. Product terms use the definitions in
 
 ## Unreleased
 
+- **The command palette opens each Settings control.** Search for a Settings
+  row or a Sampling control to open it directly. A hidden Advanced row opens
+  without changing the saved Settings view.
+
 ## 0.10.2-rc.1 - 2026-08-22
 
 - **Settings now controls the guidance for each writing action.** The simple

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ repository contains the terminal user interface (TUI) and its backend runtime.
 - Override the Default Author Brief for one story.
 - Set the Default Author Brief and the Default Continue direction in Settings.
 - Set Rewrite, Title, Summary, and Aside guidance in Advanced view.
+- Open each Settings row and Sampling control from the command palette.
 - Use keys to include a Fact only when the request context matches it.
 - Order, rank, and budget Facts so a full context window drops low-value ones first.
 - Inspect the next provider request in the request viewer.

--- a/docs/model-providers.md
+++ b/docs/model-providers.md
@@ -321,6 +321,12 @@ Advanced view.
 Press `,` to open Settings. Press `m` to switch between Simple view and
 Advanced view. 1667 remembers your choice for your next session.
 
+Press `Ctrl+P` or `:` and type a Settings row name to open that row. The
+command palette also lists each Sampling control. If a row needs Advanced
+view, 1667 opens Advanced view for this visit. It does not change your saved
+view. If a row does not apply to the selected provider, 1667 selects the
+provider row and reports that the requested row is not available.
+
 ## Provider support
 
 1667 supports these provider protocols:

--- a/tui/src/command-model.ts
+++ b/tui/src/command-model.ts
@@ -3,8 +3,13 @@ import { imageInputEntryPointsOpen } from "../../shared/image-input-release.js";
 import { asideEntryPointsOpen } from "../../shared/aside-release.js";
 import { THEME_NAMES, type ThemeName } from "./config.js";
 import { fuzzyMatch } from "./fuzzy.js";
+import {
+  SETTINGS_COMMAND_DEFINITIONS,
+  type SettingsCommandId,
+  type SettingsCommandTarget
+} from "./settings-command-catalog.js";
 
-export type CommandSectionId = "suggested" | "story" | "take" | "view" | "system";
+export type CommandSectionId = "suggested" | "story" | "take" | "view" | "system" | "settings";
 export type CommandId =
   | "export" | "summary" | "tag-line"
   | "switch-story" | "rename-story" | "folder" | "autoname" | "import-card" | "import-archive"
@@ -13,7 +18,8 @@ export type CommandId =
   | "direct-take" | "retake" | "rewrite-selection" | "prune" | "attach-image"
   | "tags" | "chapters" | "chapter" | "prompts"
   | "next-request" | "token-probabilities" | "generation-records"
-  | "settings" | "reconnect" | "disconnect" | "export-profile" | "theme";
+  | "settings" | "reconnect" | "disconnect" | "export-profile" | "theme"
+  | SettingsCommandId;
 
 export type CommandSelectionId = Exclude<CommandId, "theme"> | `theme:${ThemeName}`;
 
@@ -35,6 +41,10 @@ export interface PaletteCommand {
   /** Extra live gate beyond demo/mutating, e.g. rewrite-selection needing a
    *  selection this build can actually rewrite. Absent means always allowed. */
   requires?: (context: CommandPaletteContext) => boolean;
+  /** Target for a generated Settings shortcut. */
+  settingsTarget?: SettingsCommandTarget;
+  /** Extra terms used for literal and fuzzy search without changing the label. */
+  searchTerms?: readonly string[];
 }
 
 export interface CommandMatch {
@@ -88,7 +98,8 @@ const SECTIONS: ReadonlyArray<{ id: CommandSectionId; label: string }> = [
   { id: "story", label: "Story" },
   { id: "take", label: "Take" },
   { id: "view", label: "View" },
-  { id: "system", label: "System" }
+  { id: "system", label: "System" },
+  { id: "settings", label: "Settings" }
 ];
 
 const COMMANDS: readonly PaletteCommand[] = [
@@ -157,7 +168,8 @@ const COMMANDS: readonly PaletteCommand[] = [
     description: "switch the palette · persists per user"
   })),
   { id: "export-profile", section: "system", name: "export generation profile", description: "write the routed profile as shareable JSON" },
-  { id: "disconnect", section: "system", name: "simulate disconnect", description: "demo-only connection banner fixture", demoOnly: true }
+  { id: "disconnect", section: "system", name: "simulate disconnect", description: "demo-only connection banner fixture", demoOnly: true },
+  ...SETTINGS_COMMAND_DEFINITIONS
 ];
 
 export function commandContext(
@@ -196,7 +208,8 @@ export function commandPaletteModel(
   const literal = needle.length === 0 ? candidates : candidates.filter(({ command }) =>
     command.name.toLocaleLowerCase().includes(needle)
     || command.description.toLocaleLowerCase().includes(needle)
-    || command.shortcut?.toLocaleLowerCase() === needle);
+    || command.shortcut?.toLocaleLowerCase() === needle
+    || command.searchTerms?.some((term) => term.toLocaleLowerCase() === needle) === true);
   const matched = literal.length > 0 ? literal : candidates;
   const sections: CommandPaletteSection[] = [];
   const selectable: CommandMatch[] = [];
@@ -228,7 +241,12 @@ export function commandPaletteModel(
   };
 
   function matchCommand(command: PaletteCommand): CommandMatch | null {
-    const match = fuzzyMatch(`${command.name} ${command.description} ${command.shortcut ?? ""}`, query);
+    const match = fuzzyMatch([
+      command.name,
+      command.description,
+      command.shortcut ?? "",
+      ...(command.searchTerms ?? [])
+    ].join(" "), query);
     if (match === null) return null;
     const nameLength = [...command.name].length;
     return {
@@ -246,6 +264,22 @@ export function commandMatches(
   context: CommandPaletteContext = DEFAULT_CONTEXT
 ): CommandMatch[] {
   return commandPaletteModel(query, demo, context).selectable;
+}
+
+/** Prefer an exact destination name, alias, or shortcut without changing the
+ * grouped render order. Earlier sections can still contain incidental prose
+ * matches, but Enter should open the destination the writer named. */
+export function commandQueryCursor(
+  matches: readonly CommandMatch[],
+  query: string
+): number {
+  const needle = query.trim().toLocaleLowerCase();
+  if (needle.length === 0) return 0;
+  const exact = matches.findIndex(({ command }) =>
+    command.name.toLocaleLowerCase() === needle
+    || command.shortcut?.toLocaleLowerCase() === needle
+    || command.searchTerms?.some((term) => term.toLocaleLowerCase() === needle) === true);
+  return exact >= 0 ? exact : 0;
 }
 
 export interface RetainedCommandSelection {

--- a/tui/src/overlay-actions.ts
+++ b/tui/src/overlay-actions.ts
@@ -1,6 +1,7 @@
 import {
   commandContext,
   commandMatches,
+  commandQueryCursor,
   retainCommandSelection,
   type CommandMatch,
   type PaletteCommand
@@ -514,7 +515,7 @@ async function commandsAction(resolved: ResolvedKey, state: RuntimeState, source
     matches = liveCommandMatches(
       state, overlay.query, undefined, context.asideEntryPointsOpen
     );
-    selectCommand(overlay, matches, 0);
+    selectCommand(overlay, matches, commandQueryCursor(matches, overlay.query));
   }
   else if (resolved.action === "open-selected") {
     const command = matches[overlay.cursor]?.command;
@@ -667,7 +668,10 @@ async function runCommand(command: PaletteCommand, state: RuntimeState, source: 
     if (plan === null) state.toast = "nothing to prune · every leaf is protected";
     else state.prune = plan;
   } else if (command.id === "prompts") { state.showInstructions = !state.showInstructions; state.toast = `directions ${state.showInstructions ? "shown" : "hidden"}`; }
-  else if (command.id === "settings") await openSettingsOverlay(state, source, context);
+  else if (command.settingsTarget !== undefined || command.id === "settings") {
+    await openSettingsOverlay(state, source, context, command.settingsTarget);
+    await synchronizeSettingsModelDiscovery(state, source, context);
+  }
   else if (command.id === "theme" && command.theme !== undefined) {
     context.applyTheme(command.theme);
     state.toast = `theme · ${command.theme}`;

--- a/tui/src/settings-command-catalog.ts
+++ b/tui/src/settings-command-catalog.ts
@@ -1,0 +1,147 @@
+import { samplingKnobLabel } from "../../shared/sampling-capabilities.js";
+import {
+  SAMPLING_LAYER_ROWS,
+  samplingLayerRowIdentity,
+  type SamplingListPanel,
+  type SamplingLayerRowSpec,
+  type SamplingScalarKnob
+} from "./sampling-model.js";
+import { samplingListPanelSpec } from "./sampling-panel-spec.js";
+import { SETTINGS_ROW_IDS } from "./settings-row-navigation.js";
+
+/** Rows that have a first-class command-palette entry. This is deliberately
+ * derived from the Settings form registry so a new row cannot be added to the
+ * form without a corresponding shortcut. */
+export type SettingsShortcutRow = (typeof SETTINGS_ROW_IDS)[number];
+
+export interface SettingsRowCommandTarget {
+  readonly kind: "row";
+  readonly row: SettingsShortcutRow;
+}
+
+export interface SamplingCommandTarget {
+  readonly kind: "sampling";
+  readonly row: SamplingLayerRowSpec;
+}
+
+export type SettingsCommandTarget = SettingsRowCommandTarget | SamplingCommandTarget;
+
+export type SamplingCommandId =
+  | `setting:sampling:scalar:${SamplingScalarKnob}`
+  | `setting:sampling:list:${SamplingListPanel}`;
+
+export type SettingsCommandId = `setting:${SettingsShortcutRow}` | SamplingCommandId;
+
+export interface SettingsCommandCatalogEntry {
+  readonly name: string;
+  readonly description: string;
+  /** Terms that should find this command without changing its visible name. */
+  readonly searchTerms?: readonly string[];
+}
+
+/** The one metadata table for top-level Settings shortcuts. `satisfies` is
+ * intentional: it turns a missing row into a compile-time error. */
+export const SETTINGS_COMMAND_CATALOG = {
+  theme: { name: "theme", description: "change the application colors" },
+  "compose-focus": { name: "focus mode", description: "dim the story while writing" },
+  "word-wrap": { name: "word wrap", description: "keep whole words together on wrapped lines" },
+  "update-checks": { name: "update checks", description: "choose whether to check for newer versions" },
+  "default-author-brief": {
+    name: "default author brief",
+    description: "set the machine-wide brief for prose and story names",
+    searchTerms: ["system prompt", "default authors note", "default author's note"]
+  },
+  "default-continue-direction": {
+    name: "default continue direction",
+    description: "set the direction for a new empty Continue request"
+  },
+  "rewrite-guidance": { name: "rewrite guidance", description: "set standing Rewrite guidance" },
+  "title-guidance": { name: "title guidance", description: "set standing Title guidance" },
+  "summary-guidance": { name: "summary guidance", description: "set standing Summary guidance" },
+  "aside-guidance": { name: "aside guidance", description: "set standing Aside guidance" },
+  provider: { name: "provider", description: "choose the service that runs the model" },
+  "text-prompt-format": {
+    name: "prompt format",
+    description: "choose the format for text-completion prompts"
+  },
+  "split-think-tags": {
+    name: "split thoughts",
+    description: "keep provider reasoning separate from story prose"
+  },
+  "base-url": { name: "base URL", description: "edit the model service address" },
+  "allow-insecure-http": {
+    name: "plain HTTP",
+    description: "allow plain HTTP for a service you control"
+  },
+  "api-key": { name: "API key", description: "edit the saved service credential" },
+  "timeout-headers": {
+    name: "headers timeout",
+    description: "set the response-header timeout"
+  },
+  "timeout-idle": { name: "idle timeout", description: "set the response idle timeout" },
+  "timeout-total": { name: "total timeout", description: "set the total generation timeout" },
+  profile: { name: "profile", description: "choose the active generation profile" },
+  model: { name: "model", description: "choose the model" },
+  "image-input": { name: "image input", description: "configure image input for the model" },
+  temperature: { name: "temperature", description: "set response randomness" },
+  "max-tokens": { name: "max tokens", description: "set the response length limit" },
+  sampling: { name: "sampling", description: "open word-choice and repetition controls" },
+  "context-window": { name: "context size", description: "set how much story context the model reads" },
+  effort: { name: "effort", description: "choose the model reasoning effort" },
+  "cache-policy": { name: "prompt cache", description: "choose the prompt cache policy" },
+  "continuation-prompt": { name: "prompt layout", description: "choose the continuation prompt layout" },
+  "token-probabilities": { name: "alternatives", description: "choose whether to request token alternatives" },
+  reasoning: { name: "reasoning", description: "choose how model reasoning is handled" },
+  "keep-thoughts": { name: "save thoughts", description: "choose whether to save model reasoning" },
+  "default-route": { name: "default route", description: "choose the fallback generation profile" },
+  "prose-route": { name: "prose route", description: "choose the profile for story prose" },
+  "utility-route": { name: "utility route", description: "choose the profile for support tasks" }
+} as const satisfies Readonly<Record<SettingsShortcutRow, SettingsCommandCatalogEntry>>;
+
+export interface SettingsCommandDefinition {
+  readonly id: SettingsCommandId;
+  readonly section: "settings";
+  readonly name: string;
+  readonly description: string;
+  readonly searchTerms?: readonly string[];
+  readonly settingsTarget: SettingsCommandTarget;
+}
+
+export function settingsCommandId(row: SettingsShortcutRow): `setting:${SettingsShortcutRow}` {
+  return `setting:${row}`;
+}
+
+export function samplingCommandId(row: SamplingLayerRowSpec): SamplingCommandId {
+  return `setting:${samplingLayerRowIdentity(row)}` as SamplingCommandId;
+}
+
+export function settingsCommandTargetIdentity(target: SettingsCommandTarget): string {
+  return target.kind === "row"
+    ? target.row
+    : samplingLayerRowIdentity(target.row);
+}
+
+function samplingCommandEntry(row: SamplingLayerRowSpec): SettingsCommandDefinition {
+  const label = row.kind === "scalar"
+    ? samplingKnobLabel(row.knob)
+    : samplingKnobLabel(samplingListPanelSpec(row.panel).knob);
+  return {
+    id: samplingCommandId(row),
+    section: "settings",
+    name: `sampling ${label}`,
+    description: `open the Sampling control for ${label}`,
+    settingsTarget: { kind: "sampling", row }
+  };
+}
+
+/** Canonical order: every top-level Settings row, followed by every Sampling
+ * focus stop. The registries above own both completeness and ordering. */
+export const SETTINGS_COMMAND_DEFINITIONS: readonly SettingsCommandDefinition[] = [
+  ...SETTINGS_ROW_IDS.map((row): SettingsCommandDefinition => ({
+    id: settingsCommandId(row),
+    section: "settings",
+    ...SETTINGS_COMMAND_CATALOG[row],
+    settingsTarget: { kind: "row", row }
+  })),
+  ...SAMPLING_LAYER_ROWS.map(samplingCommandEntry)
+];

--- a/tui/src/settings-overlay-actions.ts
+++ b/tui/src/settings-overlay-actions.ts
@@ -27,7 +27,6 @@ import { apiErrorCode } from "./api.js";
 import { insertComposerText } from "./composer-model.js";
 import { applyComposerEdit } from "./composer-editing.js";
 import { samplingOverlayAction } from "./sampling-actions.js";
-import { resolveSamplingBias } from "./sampling-bias-resolution.js";
 import { readFromClipboard } from "./clipboard.js";
 import { applyTextKey, sanitizePastedText, type ResolvedKey } from "./keys.js";
 import { inlineEditorAction } from "./editor-action.js";
@@ -102,6 +101,11 @@ import {
 } from "./settings-selector-actions.js";
 import { settingsSubscriptionPreset } from "./settings-subscription.js";
 import { toggleSettingsViewMode } from "./settings-view-mode.js";
+import type { SettingsCommandTarget } from "./settings-command-catalog.js";
+import {
+  focusSettingsTarget,
+  initializeSamplingOverlay
+} from "./settings-target-navigation.js";
 
 import type {
   RuntimeState,
@@ -114,7 +118,7 @@ export async function openSettingsOverlay(
   state: RuntimeState,
   source: AppSource,
   context: ActionContext,
-  row?: SettingsRowId,
+  rowOrTarget?: SettingsRowId | SettingsCommandTarget,
   profilePurpose?: SettingsRoutePurpose
 ): Promise<void> {
   const selectedProfileId = profilePurpose !== undefined && source.settingsView.editable
@@ -126,20 +130,27 @@ export async function openSettingsOverlay(
     selectedProfileId
   );
   const overlay = state.settings;
-  if (row !== undefined) {
-    const at = settingsRowIndex(row, overlay);
-    if (at >= 0) overlay.cursor = at;
+  const target: SettingsCommandTarget | undefined = rowOrTarget !== undefined
+    && typeof rowOrTarget !== "string" ? rowOrTarget : undefined;
+  if (typeof rowOrTarget === "string") {
+    const index = settingsRowIndex(rowOrTarget, overlay);
+    if (index >= 0) overlay.cursor = index;
   }
   state.mode = "SETTINGS";
   context.repaint();
-  if (state.connection.down) return;
-  await context.backend.run("refreshing settings", async (task) => {
-    try {
-      const settings = await source.api.getSettings();
-      if (!task.owns()) return;
-      publishSettingsView(state, source, settings);
-    } catch { /* connection decorator owns the banner */ }
-  });
+  if (!state.connection.down) {
+    await context.backend.run("refreshing settings", async (task) => {
+      try {
+        const settings = await source.api.getSettings();
+        if (!task.owns()) return;
+        publishSettingsView(state, source, settings);
+      } catch { /* connection decorator owns the banner */ }
+    });
+  }
+  if (target !== undefined && state.settings === overlay) {
+    focusSettingsTarget(target, state, overlay, source, context);
+    context.repaint();
+  }
 }
 
 export async function settingsOverlayAction(
@@ -248,16 +259,7 @@ export async function settingsOverlayAction(
     } else if (isWritingPromptRow(row)) {
       openWritingPromptEditor(state, row);
     } else if (row === "sampling") {
-      overlay.sampling = {
-        panel: "sampling",
-        cursor: 0,
-        logitBiasOrder: Object.keys(overlay.draft.sampling.logitBias),
-        edit: null,
-        result: null,
-        biasResolution: { kind: "idle" },
-        resolutionGeneration: 0
-      };
-      resolveSamplingBias(overlay, source, context);
+      initializeSamplingOverlay(overlay, source, context);
     } else {
       beginSettingsRowEdit(overlay, state.config);
     }

--- a/tui/src/settings-target-navigation.ts
+++ b/tui/src/settings-target-navigation.ts
@@ -1,0 +1,80 @@
+import type { AppSource } from "./app.js";
+import type { ActionContext } from "./action-context.js";
+import { resolveSamplingBias } from "./sampling-bias-resolution.js";
+import {
+  SETTINGS_COMMAND_CATALOG,
+  type SettingsCommandTarget
+} from "./settings-command-catalog.js";
+import {
+  samplingLayerRowIndex,
+  type SamplingLayerRowSpec
+} from "./sampling-model.js";
+import {
+  settingsRowIndex
+} from "./settings-row-navigation.js";
+import { settingsSubscriptionRowVisible } from "./settings-subscription.js";
+import { settingsSimpleModeRowVisible } from "./settings-view-mode.js";
+import type { RuntimeState, SettingsOverlayState } from "./state.js";
+
+/** Focus a command-palette destination without changing the saved Settings
+ * view. A provider-specific row that is not applicable falls back to Provider
+ * and reports why the requested destination cannot open. */
+export function focusSettingsTarget(
+  target: SettingsCommandTarget,
+  state: RuntimeState,
+  overlay: SettingsOverlayState,
+  source: AppSource,
+  context: ActionContext
+): void {
+  const row = target.kind === "row" ? target.row : "sampling";
+  if (!settingsSubscriptionRowVisible(overlay, row)) {
+    const provider = settingsRowIndex("provider", overlay);
+    if (provider >= 0) overlay.cursor = provider;
+    if (target.kind === "row") {
+      state.toast = `${SETTINGS_COMMAND_CATALOG[target.row].name} is unavailable for the selected provider`;
+    }
+    return;
+  }
+  let index = settingsRowIndex(row, overlay);
+  if (index < 0 && overlay.viewMode === "simple" && !settingsSimpleModeRowVisible(row)) {
+    overlay.viewMode = "advanced";
+    index = settingsRowIndex(row, overlay);
+  }
+  if (index < 0) {
+    const provider = settingsRowIndex("provider", overlay);
+    if (provider >= 0) overlay.cursor = provider;
+    if (target.kind === "row") {
+      state.toast = `${SETTINGS_COMMAND_CATALOG[target.row].name} is unavailable for the selected provider`;
+    }
+    return;
+  }
+  overlay.cursor = index;
+  if (target.kind === "sampling") {
+    initializeSamplingOverlay(overlay, source, context, target.row);
+  }
+}
+
+/** Start the nested Sampling surface in one place. Ordinary Enter and
+ * semantic palette destinations share the same state and resolution cycle. */
+export function initializeSamplingOverlay(
+  overlay: SettingsOverlayState,
+  source: AppSource,
+  context: ActionContext,
+  target?: SamplingLayerRowSpec
+): void {
+  overlay.sampling = {
+    panel: "sampling",
+    cursor: 0,
+    logitBiasOrder: Object.keys(overlay.draft.sampling.logitBias),
+    edit: null,
+    result: null,
+    biasResolution: { kind: "idle" },
+    resolutionGeneration: 0
+  };
+  if (target !== undefined) {
+    const targetValue = target.kind === "scalar" ? target.knob : target.panel;
+    const index = samplingLayerRowIndex(targetValue);
+    if (index >= 0) overlay.sampling.cursor = index;
+  }
+  resolveSamplingBias(overlay, source, context);
+}

--- a/tui/test/aside-command-live.test.ts
+++ b/tui/test/aside-command-live.test.ts
@@ -61,8 +61,7 @@ test("activated palette Aside refuses during a live generation", async () => {
     canRewriteSelection: false,
     asideEntryPointsOpen: true
   }).selectable;
-  expect(matches).toHaveLength(1);
-  expect(matches[0]!.command).toMatchObject({
+  expect(matches.find(({ command }) => command.id === "aside")?.command).toMatchObject({
     id: "aside",
     blockedByLiveStream: true
   });

--- a/tui/test/command-palette.test.ts
+++ b/tui/test/command-palette.test.ts
@@ -8,6 +8,15 @@ import {
   retainCommandSelection,
   type CommandSelectionId
 } from "../src/command-model.js";
+import {
+  SETTINGS_COMMAND_DEFINITIONS,
+  settingsCommandTargetIdentity
+} from "../src/settings-command-catalog.js";
+import {
+  SAMPLING_LAYER_ROWS,
+  samplingLayerRowIdentity
+} from "../src/sampling-model.js";
+import { SETTINGS_ROW_IDS } from "../src/settings-row-navigation.js";
 import { demoAppSource } from "../src/demo.js";
 import { hitAt, type HitRows } from "../src/hit.js";
 import { panelHorizontalGeometry } from "../src/screens/overlay.js";
@@ -16,10 +25,10 @@ import { plainLine, visibleWidth, type FrameLine } from "../src/screens/story/fr
 import { nextRequestEstimate } from "../src/request-projection.js";
 
 describe("grouped command palette model", () => {
-  test("builds five sections and one canonical selectable/render order", () => {
+  test("builds six sections and one canonical selectable/render order", () => {
     const model = commandPaletteModel("", false);
     expect(model.sections.map((section) => section.label)).toEqual([
-      "Suggested", "Story", "Take", "View", "System"
+      "Suggested", "Story", "Take", "View", "System", "Settings"
     ]);
     const ids = model.selectable.map((match) => match.command.id);
     for (const id of [
@@ -33,6 +42,29 @@ describe("grouped command palette model", () => {
     for (const [index, row] of model.renderRows.entries()) {
       expect(model.renderRowToSelectable[index]).toBe(row.kind === "section" ? null : row.selectableIndex);
     }
+  });
+
+  test("covers every Settings row and Sampling focus stop exactly once", () => {
+    const model = commandPaletteModel("", false);
+    const commands = model.selectable
+      .map(({ command }) => command)
+      .filter((command) => command.settingsTarget !== undefined);
+    const ids = commands.map((command) => command.id);
+    expect(ids).toHaveLength(SETTINGS_COMMAND_DEFINITIONS.length);
+    expect(new Set(ids).size).toBe(ids.length);
+
+    const rows = commands
+      .map((command) => command.settingsTarget!)
+      .filter((target): target is { kind: "row"; row: (typeof SETTINGS_ROW_IDS)[number] } =>
+        target.kind === "row")
+      .map((target) => target.row);
+    expect(rows).toEqual([...SETTINGS_ROW_IDS]);
+
+    const sampling = commands
+      .map((command) => command.settingsTarget!)
+      .filter((target) => target.kind === "sampling")
+      .map((target) => settingsCommandTargetIdentity(target));
+    expect(sampling).toEqual(SAMPLING_LAYER_ROWS.map(samplingLayerRowIdentity));
   });
 
   test("attach image is available once image input's entry points are open, this release's default", () => {
@@ -143,6 +175,34 @@ describe("grouped command palette model", () => {
     expect(brief?.shortcut).toBe(undefined);
   });
 
+  test("finds priority Settings rows and Default Author Brief aliases", () => {
+    for (const [query, row] of [
+      ["provider", "provider"],
+      ["model", "model"],
+      ["effort", "effort"],
+      ["default author brief", "default-author-brief"],
+      ["system prompt", "default-author-brief"],
+      ["default authors note", "default-author-brief"],
+      ["default author's note", "default-author-brief"]
+    ] as const) {
+      const match = commandMatches(query, false)
+        .find(({ command }) => command.settingsTarget?.kind === "row"
+          && command.settingsTarget.row === row);
+      expect(match?.command.settingsTarget).toEqual({ kind: "row", row });
+    }
+  });
+
+  test("keeps the Story Author's Note command distinct from the Default Author Brief alias", () => {
+    const story = commandMatches("author's note", false)
+      .find(({ command }) => command.id === "authors-note")?.command;
+    const brief = commandMatches("default author's note", false)
+      .find(({ command }) => command.settingsTarget?.kind === "row"
+        && command.settingsTarget.row === "default-author-brief")?.command;
+    expect(story).toMatchObject({ id: "authors-note", section: "story", shortcut: "n" });
+    expect(brief).toMatchObject({ section: "settings" });
+    expect(brief?.id).not.toBe(story?.id);
+  });
+
   test("retains command identity across live Suggested reordering", () => {
     const source = demoAppSource();
     const context = commandContext(source.payload, { connectionDown: false, requestActive: true, canRewriteSelection: false });
@@ -156,11 +216,10 @@ describe("grouped command palette model", () => {
     expect(retained.selectedId).toBe("switch-story");
   });
 
-  test("compact windows retain the selected command and its section header when possible", () => {
+  test("compact windows retain the selected command", () => {
     const model = commandPaletteModel("", false);
     const cursor = model.selectable.length - 1;
     const rows = commandPaletteWindow(model, cursor, 10);
-    expect(rows.some((row) => row.kind === "section" && row.section.label === "System")).toBeTrue();
     expect(rows.some((row) => row.selectableIndex === cursor)).toBeTrue();
     expect(rows.every((row) => row.kind !== "section" || row.selectableIndex === null)).toBeTrue();
   });
@@ -190,12 +249,11 @@ describe("grouped command palette rendering", () => {
     expect(panelText.trimEnd().endsWith("t")).toBeTrue();
   });
 
-  test("keeps the selected System command visible at 80×24", () => {
+  test("keeps the selected Settings command visible at 80×24", () => {
     const model = commandPaletteModel("", false);
     const cursor = model.selectable.length - 1;
     const selectedName = model.selectable[cursor]!.command.name;
     const { lines } = renderCommands(80, 24, cursor);
-    expect(lines.map(plainLine).join("\n")).toContain("System");
     expect(lines.map(plainLine).join("\n")).toContain(selectedName);
   });
 

--- a/tui/test/settings-command-shortcuts.test.ts
+++ b/tui/test/settings-command-shortcuts.test.ts
@@ -1,0 +1,170 @@
+import { expect, test } from "bun:test";
+import { basicSettingsFromDocument } from "../../shared/settings-basic-draft.js";
+import { writingPromptSettingsFromAuthorBrief } from "../../shared/settings-v5-writing.js";
+import { selectSettingsRoute } from "../../shared/settings-route.js";
+import type { SettingsView } from "../../shared/settings-v2-types.js";
+import {
+  settingsTextDraftForView,
+  settingsTextDraftWithGeneration,
+  settingsTextDraftWithSubscriptionPlan
+} from "../src/settings-text.js";
+import { samplingLayerRowIndex } from "../src/sampling-model.js";
+import { settingsCursorRowIdentity } from "../src/settings-row-navigation.js";
+import { deferred, settingsHarness, key } from "./settings-test-harness.js";
+
+/** Type through the real Ctrl+P route and accept the exact named destination. */
+async function choosePaletteCommand(
+  harness: ReturnType<typeof settingsHarness>,
+  query: string,
+  commandId: string
+): Promise<void> {
+  const { press, state } = harness;
+  await press(key("p", { ctrl: true }));
+  expect(state.mode).toBe("COMMANDS");
+  for (const character of query) {
+    await press(key(character, { sequence: character }));
+  }
+  expect(state.commands?.selectedId).toBe(commandId);
+  await press(key("return"));
+}
+
+function chatgptPlanView(current: SettingsView): SettingsView {
+  if (!current.editable) throw new Error("demo Settings fixture must be editable");
+  const draft = settingsTextDraftForView(current);
+  const planDraft = settingsTextDraftWithSubscriptionPlan(
+    draft,
+    "chatgpt-plan",
+    {
+      ...draft.generation,
+      provider: "openai-compatible",
+      baseUrl: "",
+      apiKeyEnv: null,
+      model: "gpt-5.4",
+      contextWindow: 272_000
+    }
+  );
+  if (planDraft.document === null) throw new Error("subscription draft has no document");
+  const effective = basicSettingsFromDocument(planDraft.document);
+  return {
+    ...current,
+    subscriptionAuth: { chatgpt: "signed-in", claude: "signed-out" },
+    document: planDraft.document,
+    effective,
+    effectiveProse: basicSettingsFromDocument(
+      planDraft.document,
+      selectSettingsRoute(planDraft.document, "prose").profileId
+    ),
+    activeWriting: writingPromptSettingsFromAuthorBrief(effective.systemPrompt)
+  };
+}
+
+test("Ctrl+P opens the Provider, Model, and Default Author Brief rows", async () => {
+  for (const [query, row] of [
+    ["provider", "provider"],
+    ["model", "model"],
+    ["default authors note", "default-author-brief"]
+  ] as const) {
+    const harness = settingsHarness();
+    await choosePaletteCommand(harness, query, `setting:${row}`);
+    expect(harness.state.mode).toBe("SETTINGS");
+    expect(settingsCursorRowIdentity(harness.state.settings!)).toBe(row);
+  }
+});
+
+test("an Advanced Settings shortcut expands only its overlay", async () => {
+  const harness = settingsHarness(undefined, { settingsViewMode: "simple" });
+  await choosePaletteCommand(harness, "effort", "setting:effort");
+
+  expect(harness.state.settings?.viewMode).toBe("advanced");
+  expect(harness.state.config.settingsViewMode).toBe("simple");
+  expect(harness.source.config.settingsViewMode).toBe("simple");
+  expect(settingsCursorRowIdentity(harness.state.settings!)).toBe("effort");
+});
+
+test("Ctrl+P reaches an Advanced-only writing prompt row", async () => {
+  const harness = settingsHarness(undefined, { settingsViewMode: "simple" });
+  await choosePaletteCommand(harness, "rewrite guidance", "setting:rewrite-guidance");
+
+  expect(harness.state.settings?.viewMode).toBe("advanced");
+  expect(settingsCursorRowIdentity(harness.state.settings!)).toBe("rewrite-guidance");
+});
+
+test("a Sampling shortcut opens the nested panel at its canonical row", async () => {
+  const harness = settingsHarness();
+  await choosePaletteCommand(harness, "sampling top p", "setting:sampling:scalar:topP");
+
+  expect(harness.state.mode).toBe("SETTINGS");
+  expect(harness.state.settings?.sampling?.panel).toBe("sampling");
+  expect(harness.state.settings?.sampling?.cursor).toBe(samplingLayerRowIndex("topP"));
+  expect(harness.state.settings?.sampling?.biasResolution.kind).toBeDefined();
+});
+
+test("a Sampling shortcut survives an authoritative Settings refresh", async () => {
+  const harness = settingsHarness();
+  const current = harness.source.settingsView;
+  if (!current.editable) throw new Error("demo Settings fixture must be editable");
+  const nextDraft = settingsTextDraftWithGeneration(
+    settingsTextDraftForView(current),
+    { ...current.effective, maxTokens: current.effective.maxTokens + 1 }
+  );
+  if (nextDraft.document === null) throw new Error("refreshed draft has no document");
+  const effective = basicSettingsFromDocument(nextDraft.document);
+  harness.source.api.getSettings = async () => ({
+    ...current,
+    stateGeneration: current.stateGeneration + 1,
+    activeRevision: current.activeRevision + 1,
+    document: nextDraft.document!,
+    effective,
+    effectiveProse: basicSettingsFromDocument(
+      nextDraft.document!,
+      selectSettingsRoute(nextDraft.document!, "prose").profileId
+    )
+  });
+
+  await choosePaletteCommand(harness, "sampling top p", "setting:sampling:scalar:topP");
+
+  expect(harness.state.settings?.sampling?.panel).toBe("sampling");
+  expect(harness.state.settings?.sampling?.cursor).toBe(samplingLayerRowIndex("topP"));
+});
+
+test("unavailable provider rows report the destination and focus Provider", async () => {
+  for (const [query, commandId, label] of [
+    ["base URL", "setting:base-url", "base URL"],
+    ["plain HTTP", "setting:allow-insecure-http", "plain HTTP"]
+  ] as const) {
+    const harness = settingsHarness(undefined, { settingsViewMode: "simple" });
+    harness.source.settingsView = chatgptPlanView(harness.source.settingsView);
+    harness.source.api.getSettings = async () => harness.source.settingsView;
+
+    await choosePaletteCommand(harness, query, commandId);
+
+    expect(harness.state.settings?.viewMode).toBe("simple");
+    expect(settingsCursorRowIdentity(harness.state.settings!)).toBe("provider");
+    expect(harness.state.toast).toBe(`${label} is unavailable for the selected provider`);
+  }
+});
+
+test("a refreshed subscription provider keeps an unavailable target in Simple view", async () => {
+  const harness = settingsHarness(undefined, { settingsViewMode: "simple" });
+  const refreshed = chatgptPlanView(harness.source.settingsView);
+  harness.source.api.getSettings = async () => refreshed;
+
+  await choosePaletteCommand(harness, "plain HTTP", "setting:allow-insecure-http");
+
+  expect(harness.state.settings?.viewMode).toBe("simple");
+  expect(settingsCursorRowIdentity(harness.state.settings!)).toBe("provider");
+  expect(harness.state.toast).toBe("plain HTTP is unavailable for the selected provider");
+});
+
+test("a Settings target opens while another backend task is busy", async () => {
+  const harness = settingsHarness(undefined, { settingsViewMode: "simple" });
+  const gate = deferred<void>();
+  const busy = harness.backend.run("generating prose", async () => gate.promise);
+
+  await choosePaletteCommand(harness, "effort", "setting:effort");
+  gate.resolve();
+  expect(await busy).toBe(true);
+
+  expect(harness.state.settings?.viewMode).toBe("advanced");
+  expect(settingsCursorRowIdentity(harness.state.settings!)).toBe("effort");
+});


### PR DESCRIPTION
## Outcome

Ctrl+P now opens each Settings row and each nested Sampling control directly.
This makes infrequent controls easier to find without adding global keys.

## Changes

- Generate Settings commands from the canonical row registries.
- Prefer exact command names and aliases in Ctrl+P search.
- Open Advanced-only destinations for the current overlay only.
- Focus Provider when a destination does not apply to the selected provider.
- Preserve semantic destinations across refresh, offline mode, and backend contention.
- Document the new navigation behavior.

## Verification

- `npm run build`
- `npm test`
- `cd tui && bun run typecheck`
- `cd tui && bun test` (2,166 passed; 2 platform-only tests skipped)
- `cd tui && bun bench/perf.ts`
- `cd tui && bun run build:standalone`
- Autoreview: green, no findings
- Thermo-nuclear code-quality review: green

## Risk

The change adds command metadata and navigation only. It does not change the
Settings schema or saved Settings values. CI provides the final platform gate.

Tracks #318
