### PR TITLE
chore(release): prepare 0.10.2-rc.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This file records notable changes to 1667. Product terms use the definitions in
 
 ## Unreleased
 
+## 0.10.2-rc.2 - 2026-08-23
+
 - **The command palette opens each Settings control.** Search for a Settings
   row or a Sampling control to open it directly. A hidden Advanced row opens
   without changing the saved Settings view.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "1667-workspace",
-  "version": "0.10.2-rc.1",
+  "version": "0.10.2-rc.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "1667-workspace",
-      "version": "0.10.2-rc.1",
+      "version": "0.10.2-rc.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@earendil-works/pi-ai": "0.84.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667-workspace",
-  "version": "0.10.2-rc.1",
+  "version": "0.10.2-rc.2",
   "private": true,
   "description": "Source workspace for the 1667 terminal writing environment",
   "license": "Apache-2.0",

--- a/shared/release-notes.ts
+++ b/shared/release-notes.ts
@@ -11,6 +11,11 @@ export interface ReleaseNote {
  *  a release, and is not included. */
 export const RELEASE_NOTES: readonly ReleaseNote[] = [
   {
+    version: "0.10.2-rc.2",
+    date: "2026-08-23",
+    body: "- **The command palette opens each Settings control.** Search for a Settings\n  row or a Sampling control to open it directly. A hidden Advanced row opens\n  without changing the saved Settings view."
+  },
+  {
     version: "0.10.2-rc.1",
     date: "2026-08-22",
     body: "- **Settings now controls the guidance for each writing action.** The simple\n  view contains the Default Author Brief and Default Continue direction. The\n  advanced view also contains the Rewrite, Title, Summary, and Aside guidance.\n  Existing default values keep the previous model requests unchanged.\n\n- **A prompt opens in a full-screen editor.** Press Ctrl+S to keep an edited\n  prompt in the Settings draft. Save Settings to activate all draft changes.\n\n- **The first prompt save upgrades the Settings data.** An older 1667 release\n  refuses the new Settings schema. Use this beta only when that downgrade\n  limit is acceptable."

--- a/tui/package.json
+++ b/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667",
-  "version": "0.10.2-rc.1",
+  "version": "0.10.2-rc.2",
   "private": true,
   "description": "A terminal environment for writing fiction with language models",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Outcome

Prepare beta `0.10.2-rc.2` from the merged Settings palette change.

## Changes

- Align the root, TUI, and lockfile versions.
- Add the dated changelog section.
- Regenerate the embedded release notes.

## Verification

- `npm run notes:check-version -- 0.10.2-rc.2`
- `npm run build`
- `npm test` (2,730 passed; 226 skipped)
- `cd tui && bun run typecheck`
- `cd tui && bun test` (2,167 passed; 2 platform-only tests skipped)
- `cd tui && bun bench/perf.ts`
- `cd tui && bun run build:standalone`

## Risk

This commit changes release metadata only. The hosted release workflow builds,
checks, and publishes the six-package beta set after the release tag exists.

Tracks #318
