### PR TITLE
chore(release): prepare 0.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ This file records notable changes to 1667. Product terms use the definitions in
 
 ## Unreleased
 
+## 0.10.2 - 2026-08-23
+
+- **This release has no additional product changes.** It contains the same
+  behavior as 0.10.2-rc.2.
+
 ## 0.10.2-rc.2 - 2026-08-23
 
 - **The command palette opens each Settings control.** Search for a Settings

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "1667-workspace",
-  "version": "0.10.2-rc.2",
+  "version": "0.10.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "1667-workspace",
-      "version": "0.10.2-rc.2",
+      "version": "0.10.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@earendil-works/pi-ai": "0.84.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667-workspace",
-  "version": "0.10.2-rc.2",
+  "version": "0.10.2",
   "private": true,
   "description": "Source workspace for the 1667 terminal writing environment",
   "license": "Apache-2.0",

--- a/shared/release-notes.ts
+++ b/shared/release-notes.ts
@@ -11,6 +11,11 @@ export interface ReleaseNote {
  *  a release, and is not included. */
 export const RELEASE_NOTES: readonly ReleaseNote[] = [
   {
+    version: "0.10.2",
+    date: "2026-08-23",
+    body: "- **This release has no additional product changes.** It contains the same\n  behavior as 0.10.2-rc.2."
+  },
+  {
     version: "0.10.2-rc.2",
     date: "2026-08-23",
     body: "- **The command palette opens each Settings control.** Search for a Settings\n  row or a Sampling control to open it directly. A hidden Advanced row opens\n  without changing the saved Settings view."

--- a/tui/package.json
+++ b/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667",
-  "version": "0.10.2-rc.2",
+  "version": "0.10.2",
   "private": true,
   "description": "A terminal environment for writing fiction with language models",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Outcome

Prepare stable 0.10.2 from the verified 0.10.2-rc.2 release.

## Changes

- Set the root, TUI, and lockfile versions to 0.10.2.
- Add the stable changelog entry.
- Generate the stable release notes.

## Verification

- `npm run build`
- `npm test` (2730 passed, 226 skipped)
- `bun run typecheck`
- `bun test` (2167 passed, 2 skipped)
- `bun bench/perf.ts`
- `bun run build:standalone`

## Risk

Low. This pull request changes only release metadata. Product behavior is the same as 0.10.2-rc.2.

Tracks #318.
