### PR TITLE
fix: gate clipboard image paste

### DIFF
--- a/shared/image-input-release.ts
+++ b/shared/image-input-release.ts
@@ -1,7 +1,7 @@
 /**
  * The one switch that decides whether this build WRITES the successor story
- * document that Image Input needs, and opens every user-facing image entry
- * point.
+ * document that Image Input needs, and opens its stable user-facing entry
+ * points.
  *
  * 1667 releases a schema in two steps. A release learns to read and validate
  * a successor document and refuses to mutate it before any release writes
@@ -10,10 +10,10 @@
  * version without losing a story.
  *
  * This release writes the successor STORY document: a story upgrades the
- * moment it gains an Image Attachment, and every entry point that can
- * produce one (`attach image`, the attach panel, a clipboard image paste,
- * the staging and release routes, a Continue request naming a Draft Image)
- * is open while this constant is true.
+ * moment it gains an Image Attachment. The `attach image` panel, the staging
+ * and release routes, and a Continue request that names a Draft Image are
+ * open while this constant is true. Clipboard image paste has a separate
+ * release switch because it is not ready for production.
  *
  * This release does NOT write the successor SETTINGS document. There is no
  * successor settings writer in this build at all, and no switch that could
@@ -40,10 +40,9 @@ export function resolveImageInputActivation(option?: boolean): boolean {
 }
 
 /**
- * Whether a user-facing image entry point may run at all: the `attach
- * image` palette command, the attach panel, a clipboard image paste, the
- * staging and release HTTP routes and worker methods, and a Continue
- * request that names a Draft Image.
+ * Whether a stable image entry point may run at all: the `attach image`
+ * palette command, the attach panel, the staging and release HTTP routes and
+ * worker methods, and a Continue request that names a Draft Image.
  *
  * Reads the same release switch as the document writers above, so a single
  * flip opens every entry point together. A caller that passes nothing gets
@@ -54,4 +53,14 @@ export function resolveImageInputActivation(option?: boolean): boolean {
  */
 export function imageInputEntryPointsOpen(option?: boolean): boolean {
   return option ?? IMAGE_INPUT_ACTIVATED;
+}
+
+/** Keep clipboard image paste unavailable until its platform behavior is
+ *  ready for production. Text clipboard operations do not use this switch. */
+export const IMAGE_CLIPBOARD_ACTIVATED = false;
+
+/** Resolve clipboard image paste separately from stable Image Input. An
+ *  explicit option lets tests operate the inactive behavior. */
+export function imageClipboardEntryPointOpen(option?: boolean): boolean {
+  return option ?? (imageInputEntryPointsOpen() && IMAGE_CLIPBOARD_ACTIVATED);
 }

--- a/tui/src/clipboard.ts
+++ b/tui/src/clipboard.ts
@@ -6,6 +6,7 @@ import {
 } from "../../shared/image-attachment.js";
 import { readClipboardImageMacOS } from "./clipboard-macos.js";
 import { isWslHost, readClipboardImageWindows } from "./clipboard-windows.js";
+import { imageClipboardEntryPointOpen } from "../../shared/image-input-release.js";
 
 const ESC = String.fromCharCode(27);
 const BEL = String.fromCharCode(7);
@@ -82,11 +83,12 @@ export async function copyToClipboard(
  *  still enters through OpenTUI's paste event, which is always text — see
  *  `keys.ts`'s `pasteInto`.
  *
- * Negotiates a type before falling back to text: on Wayland it lists the
- * offered types, on X11 it reads `TARGETS`, on macOS and Windows/WSL a
- * bounded platform helper answers directly. Every image path bounds bytes
- * before this function ever constructs the `Uint8Array` it returns — see
- * each platform reader's own doc comment.
+ * When the clipboard image release switch is open, this function negotiates
+ * a type before it falls back to text. On Wayland it lists the offered types.
+ * On X11 it reads `TARGETS`. On macOS and Windows/WSL, a bounded platform
+ * helper answers directly. Every image path bounds bytes before this function
+ * constructs the `Uint8Array` that it returns. See each platform reader's
+ * doc comment.
  *
  * The story composer's own paste path (`compose-clipboard.ts`) and the
  * shared composer-backed field paste path (`composer-surface-action.ts`)
@@ -94,13 +96,17 @@ export async function copyToClipboard(
  * composer-backed surface (settings values, Sampling fields, Generation
  * Profile import, a rename field) is plain text and reads `readFromClipboard`
  * below instead, unchanged from before Image Input existed. */
-export async function readClipboardContent(): Promise<ClipboardContent | null> {
+export async function readClipboardContent(
+  imageClipboardOpen: boolean = imageClipboardEntryPointOpen()
+): Promise<ClipboardContent | null> {
   // Platform readers address the host running 1667, not the terminal
   // client's clipboard. Remote sessions use the remembered in-app copy.
   const remembered = sessionClipboard.beforePlatformRead(isRemoteSession());
   if (remembered.handled) return remembered.content;
-  const image = await readClipboardImage(process.platform);
-  if (image !== null) return image;
+  if (imageClipboardOpen) {
+    const image = await readClipboardImage(process.platform);
+    if (image !== null) return image;
+  }
   for (const command of clipboardReadCommands(process.platform)) {
     const text = await readClipboardCommand(command);
     if (text !== null) return { type: "text", text };

--- a/tui/src/compose-clipboard.ts
+++ b/tui/src/compose-clipboard.ts
@@ -5,7 +5,7 @@ import { insertComposerText, type ComposerState } from "./composer-model.js";
 import { attachDraftImage, draftImagesFor, MAX_DRAFT_IMAGES } from "./draft-image.js";
 import { currentImageInputCapability, imageInputRefusalMessage } from "./image-input-runtime.js";
 import { imageAttachmentLabel } from "../../shared/image-attachment.js";
-import { imageInputEntryPointsOpen } from "../../shared/image-input-release.js";
+import { imageClipboardEntryPointOpen } from "../../shared/image-input-release.js";
 import { sanitizePastedText } from "./keys.js";
 import type { RetakePromptSession } from "./state.js";
 
@@ -20,18 +20,18 @@ interface ComposeClipboardHost {
 /** Read the platform clipboard without applying a result to a changed draft.
  *  Text inserts into the draft exactly as before; an image stages and
  *  attaches as a Draft Image instead, never as marker text, but only once
- *  the release gate (shared/image-input-release.ts) is open. While it is
- *  closed, a clipboard image falls back to exactly the behavior it had
+ *  the clipboard image release gate (shared/image-input-release.ts) is open.
+ *  While it is closed, a clipboard image falls back to the behavior it had
  *  before Image Input existed: unreadable, the same as any other content
  *  `readFromClipboard` cannot turn into text.
  *
- *  `entryPointsOpen` defaults to the release constant; a test that needs to
- *  drive the image branch past the release gate passes an explicit value. */
+ *  `imageClipboardOpen` defaults to the release constant. A test can pass an
+ *  explicit value to operate the image branch behind the release gate. */
 export async function pasteClipboardIntoComposer(
   host: ComposeClipboardHost,
   source: AppSource,
   context: BackendActionContext,
-  entryPointsOpen: boolean = imageInputEntryPointsOpen()
+  imageClipboardOpen: boolean = imageClipboardEntryPointOpen()
 ): Promise<void> {
   const claim = {
     interactionVersion: host.interactionVersion,
@@ -48,14 +48,14 @@ export async function pasteClipboardIntoComposer(
     && host.composer.cursor === claim.cursor
     && host.composer.anchor === claim.anchor
     && host.composer.fullscreen === claim.fullscreen;
-  const content = await readClipboardContent();
+  const content = await readClipboardContent(imageClipboardOpen);
   if (!unchanged()) return;
   if (content === null) {
     host.toast = "clipboard unreadable · paste with ⌘V or ctrl+shift+v";
     return;
   }
   if (content.type === "image") {
-    if (!entryPointsOpen) {
+    if (!imageClipboardOpen) {
       // Same message and same outcome `readFromClipboard` gave for an image
       // before Image Input existed: unreadable, never an error.
       host.toast = "clipboard unreadable · paste with ⌘V or ctrl+shift+v";

--- a/tui/test/compose-clipboard.test.ts
+++ b/tui/test/compose-clipboard.test.ts
@@ -4,6 +4,7 @@ import { initialState } from "../src/app.js";
 import type { AppSource } from "../src/app.js";
 import { demoAppSource } from "../src/demo.js";
 import { draftImagesFor } from "../src/draft-image.js";
+import { composeAction } from "../src/story-actions.js";
 import { createWrapCache, type ProseStyle } from "../src/wrap.js";
 import type { RuntimeState } from "../src/state.js";
 import type { SettingsDocumentV2, SettingsProtocolV2 } from "../../shared/settings-v2-types.js";
@@ -31,7 +32,11 @@ const { pasteClipboardIntoComposer } = await import("../src/compose-clipboard.js
 function backendContext(state: RuntimeState) {
   return {
     cache: createWrapCache<ProseStyle>(),
-    backend: new ActionRuntime(state, () => undefined)
+    backend: new ActionRuntime(state, () => undefined),
+    repaint: () => undefined,
+    renderer: null,
+    applyTheme: () => undefined,
+    previewTheme: () => undefined
   };
 }
 
@@ -53,7 +58,7 @@ function setRoute(source: AppSource, protocol: SettingsProtocolV2, remoteId: str
 }
 
 describe("a clipboard image and the release gate", () => {
-  test("falls back to the pre-Image-Input unreadable toast, never an error, while entry points are closed", async () => {
+  test("the production flag keeps clipboard image paste unavailable", async () => {
     clipboardContent = { type: "image", mediaType: "image/png", bytes: new Uint8Array([1, 2, 3]) };
     const source = demoAppSource();
     setRoute(source, "anthropic-messages", "claude-sonnet-5");
@@ -62,17 +67,19 @@ describe("a clipboard image and the release gate", () => {
     let staged = false;
     source.api.stageStoryImage = async () => { staged = true; throw new Error("must not stage while entry points are closed"); };
 
-    // This release's own default opens the gate (shared/image-input-release.ts),
-    // so a genuine predecessor's refusal needs the explicit override; the
-    // test right below drives the bare default instead.
-    await pasteClipboardIntoComposer(state, source, backendContext(state), false);
+    await composeAction(
+      { action: "paste-clipboard" },
+      state,
+      source,
+      backendContext(state)
+    );
 
     expect(staged).toBeFalse();
     expect(state.toast).toBe("clipboard unreadable · paste with ⌘V or ctrl+shift+v");
     expect(draftImagesFor(state.composer)).toHaveLength(0);
   });
 
-  test("attaches the clipboard image as a Draft Image once entry points are open", async () => {
+  test("attaches the clipboard image as a Draft Image when the flag is enabled", async () => {
     clipboardContent = { type: "image", mediaType: "image/png", bytes: new Uint8Array([1, 2, 3]) };
     const source = demoAppSource();
     setRoute(source, "anthropic-messages", "claude-sonnet-5");


### PR DESCRIPTION
Summary

- Add a release flag for clipboard image paste.
- Keep the flag off for production.
- Keep text clipboard operations available.

Tests

- npm run typecheck
- npm test
- cd tui && bun run typecheck
- cd tui && bun test --timeout 30000
- autoreview --mode local --stream-engine-output

Tracks #327