### PR TITLE
chore(release): prepare 0.10.3-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This file records notable changes to 1667. Product terms use the definitions in
 
 ## Unreleased
 
+## 0.10.3-rc.1 - 2026-08-26
+
 - **The tree map draws the whole story in lanes.** Rows are reading order. Each live story
   line owns a two-column lane. A line that ends hands its lane back and the next fork reuses
   it. Lane 0 is the reading line. Press `←` or `→` to jump to the nearest row in the next

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "1667-workspace",
-  "version": "0.10.2",
+  "version": "0.10.3-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "1667-workspace",
-      "version": "0.10.2",
+      "version": "0.10.3-rc.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@earendil-works/pi-ai": "0.84.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667-workspace",
-  "version": "0.10.2",
+  "version": "0.10.3-rc.1",
   "private": true,
   "description": "Source workspace for the 1667 terminal writing environment",
   "license": "Apache-2.0",

--- a/shared/release-notes.ts
+++ b/shared/release-notes.ts
@@ -11,6 +11,11 @@ export interface ReleaseNote {
  *  a release, and is not included. */
 export const RELEASE_NOTES: readonly ReleaseNote[] = [
   {
+    version: "0.10.3-rc.1",
+    date: "2026-08-26",
+    body: "- **The tree map draws the whole story in lanes.** Rows are reading order. Each live story\n  line owns a two-column lane. A line that ends hands its lane back and the next fork reuses\n  it. Lane 0 is the reading line. Press `←` or `→` to jump to the nearest row in the next\n  lane. Press `tab` to hide the lanes and open the path view on the same part.\n\n- **The streaming gutter pair stays visible while a long take scrolls.** The\n  `writing · esc stops` and `thinking · esc stops · T peeks` lines stick to\n  the top of the visible part, the same way the focused verb menu does.\n\n- **Aside now keeps separate chats for story takes.** Use the session and\n  anchor controls to review each chat. Existing Side Notes remain available\n  in the unanchored bucket. Optional Thoughts stay visible only in Aside and\n  do not enter a later model request."
+  },
+  {
     version: "0.10.2",
     date: "2026-08-23",
     body: "- **This release has no additional product changes.** It contains the same\n  behavior as 0.10.2-rc.2."

--- a/tui/package.json
+++ b/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667",
-  "version": "0.10.2",
+  "version": "0.10.3-rc.1",
   "private": true,
   "description": "A terminal environment for writing fiction with language models",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Outcome

Prepare `0.10.3-rc.1` for beta publication after the Aside redesign merge.

## Changes

- Set the root workspace, TUI package, and root lockfile to `0.10.3-rc.1`.
- Move current Unreleased notes into the dated prerelease section.
- Regenerate the embedded release notes.

## Verification

- `npm run notes:check-version -- 0.10.3-rc.1`
- `npm run typecheck`
- `git diff --check`

## Risks and follow-ups

- The prerelease version selects the npm `beta` channel.
- Publish only from the immutable `v0.10.3-rc.1` tag after this PR merges.

Tracks #331
