### PR TITLE
fix(tui): make Aside history readable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ This file records notable changes to 1667. Product terms use the definitions in
 
 ## Unreleased
 
+- **Aside keeps long chats readable and selectable.** Wrapped questions keep
+  their question style. Scroll history without changing the selected turn,
+  including while an answer streams. Highlight saved answer text and
+  right-click to copy it or insert it into the composer, a new Fact, or the
+  story. The full-answer menu can also create a new Fact. Large Aside
+  histories stay responsive. Existing Side Notes remain available.
+
 ## 0.10.3-rc.1 - 2026-08-26
 
 - **The tree map draws the whole story in lanes.** Rows are reading order. Each live story

--- a/tui/bench/perf.ts
+++ b/tui/bench/perf.ts
@@ -17,7 +17,8 @@ import { createWrapCache, wrapText, type ProseStyle, type WrapCache } from "../s
 import { createComposer } from "../src/composer-model.js";
 import { nextRequestEstimate } from "../src/request-projection.js";
 import { createAtlasLayout } from "../src/atlas-layout.js";
-import { renderMapTreeRow } from "../src/screens/map-tree-row.js";
+import { createLaneLayout } from "../src/lane-layout.js";
+import { renderLaneRow } from "../src/screens/map-lane-row.js";
 import {
   createStoryWrapBuild,
   storyFrameWrapPlans,
@@ -446,21 +447,21 @@ const rows: BenchRow[] = [];
   rows.push(time("loom cursor move on big tree", 4, () => movePathCursor(payload, "p100", 1, 0), 50));
 }
 
-// 4b · High-fanout atlas: topology must stay linear and paint only the window.
+// 4b · High-fanout lanes: topology must stay linear and paint only the window.
 {
   const payload = wideAtlasPayload(1_600);
-  rows.push(time("atlas layout+visible paint, 1.6k branches", 100, () => {
-    const layout = createAtlasLayout(payload, { now: Date.parse("2026-07-22T00:00:00Z"), maxRows: 30 });
-    for (const row of layout.rows) renderMapTreeRow(row, 120, null);
+  rows.push(time("lane layout+visible paint, 1.6k branches", 100, () => {
+    const layout = createLaneLayout(payload, { now: Date.parse("2026-07-22T00:00:00Z"), maxRows: 30 });
+    for (const row of layout.rows) renderLaneRow(row, layout, 120, null);
   }, 5));
 }
 
 // 4c · Deep forked atlas: traversal stays iterative at the 20k-node scale.
 {
   const payload = deepAtlasPayload(10_000);
-  rows.push(time("atlas layout, 19,999 nodes / 10k depth", 300, () => {
+  rows.push(time("atlas layout, 19,999 nodes / 10k rows", 300, () => {
     const layout = createAtlasLayout(payload, { now: Date.parse("2026-07-22T00:00:00Z"), maxRows: 30 });
-    if (layout.totalRows !== 19_999) throw new Error(`Deep atlas lost rows: ${layout.totalRows}`);
+    if (layout.totalRows !== 10_000) throw new Error(`Deep atlas lost rows: ${layout.totalRows}`);
   }, 3));
 }
 

--- a/tui/src/aside-actions.ts
+++ b/tui/src/aside-actions.ts
@@ -17,6 +17,8 @@ import {
   normalizeAsideAnchor,
   createAsideSurface,
   type AsideSessionAnchor,
+  type AsideSessionSurfaceState,
+  type AsideAnswerSource,
   type AsideSurfaceState
 } from "./aside-surface.js";
 import {
@@ -59,6 +61,8 @@ export interface AsideHistoryLayout {
   rowTurnIndex: readonly (number | null)[];
   /** Semantic v2 row ownership; prevents answer text from being parsed as chrome. */
   rowKinds: readonly AsideChatRowKind[];
+  /** Source ranges for saved answer rows; null for every other row. */
+  rowAnswerSources: readonly (AsideAnswerSource | null)[];
 }
 
 type AsideWrapCache = WrapCache<ProseStyle>;
@@ -84,10 +88,24 @@ function dimension(value: number, fallback: number): number {
   return Number.isFinite(value) ? Math.max(1, Math.floor(value)) : fallback;
 }
 
-function wrappedRows(text: string, width: number, prefix = ""): string[] {
+interface WrappedAsideRow {
+  text: string;
+  start: number;
+  end: number;
+}
+
+function wrappedRowsWithOffsets(text: string, width: number, prefix = ""): WrappedAsideRow[] {
   const prefixWidth = prefix.length;
   const wrapped = wrapText(text, [], Math.max(1, width - prefixWidth));
-  return wrapped.map((line, index) => `${index === 0 ? prefix : " ".repeat(prefixWidth)}${line.text}`);
+  return wrapped.map((line, index) => ({
+    text: `${index === 0 ? prefix : " ".repeat(prefixWidth)}${line.text}`,
+    start: line.start,
+    end: line.end
+  }));
+}
+
+function wrappedRows(text: string, width: number, prefix = ""): string[] {
+  return wrappedRowsWithOffsets(text, width, prefix).map((line) => line.text);
 }
 
 function legacyAsideNotes(value: unknown): { question: string; answer: string }[] {
@@ -210,12 +228,16 @@ export function asideHistoryLayout(surface: AsideSurfaceState, cols: number, now
   const noteStarts: number[] = [];
   const noteContentEnds: number[] = [];
   const rowNoteIndex: (number | null)[] = [];
+  const rowKinds: AsideChatRowKind[] = [];
+  const rowAnswerSources: (AsideAnswerSource | null)[] = [];
   const notes = asideNotes(surface);
   if (notes.length === 0
     && presentedAsideText(surface).length === 0
     && surface.inflightQuestion === null) {
     body.push("(no Side Notes yet)");
     rowNoteIndex.push(null);
+    rowKinds.push("plain");
+    rowAnswerSources.push(null);
   }
   // Focus-neutral prefixes: wrap never depends on which note is selected.
   // The visible window decorates the first on-screen row of the focused note.
@@ -226,16 +248,32 @@ export function asideHistoryLayout(surface: AsideSurfaceState, cols: number, now
     noteStarts.push(body.length);
     const questionRows = wrappedRows(note.question, width, questionPrefix);
     body.push(...questionRows);
-    for (let row = 0; row < questionRows.length; row += 1) rowNoteIndex.push(index);
+    for (let row = 0; row < questionRows.length; row += 1) {
+      rowNoteIndex.push(index);
+      rowKinds.push("question");
+      rowAnswerSources.push(null);
+    }
+    let answerOffset = 0;
     for (const paragraph of note.answer.split("\n")) {
-      const answerRows = wrappedRows(paragraph, width, answerPrefix);
-      body.push(...answerRows);
-      for (let row = 0; row < answerRows.length; row += 1) rowNoteIndex.push(index);
+      const answerRows = wrappedRowsWithOffsets(paragraph, width, answerPrefix);
+      body.push(...answerRows.map((row) => row.text));
+      for (const row of answerRows) {
+        rowNoteIndex.push(index);
+        rowKinds.push("answer");
+        rowAnswerSources.push({
+          key: `aside-answer:legacy:${index}`,
+          text: note.answer,
+          start: answerOffset + row.start
+        });
+      }
+      answerOffset += paragraph.length + 1;
     }
     noteContentEnds.push(body.length);
     // Separator blank is not note content for visibility / focus.
     body.push("");
     rowNoteIndex.push(null);
+    rowKinds.push("plain");
+    rowAnswerSources.push(null);
   }
   const streamText = presentedAsideText(surface);
   if (surface.inflightQuestion !== null || streamText.length > 0) {
@@ -243,8 +281,15 @@ export function asideHistoryLayout(surface: AsideSurfaceState, cols: number, now
     const inflightQ = wrappedRows(surface.inflightQuestion ?? "", width, questionPrefix);
     const inflightA = wrappedRows(streamText, width, answerPrefix);
     body.push(...inflightQ, ...inflightA);
-    for (let row = 0; row < inflightQ.length + inflightA.length; row += 1) {
+    for (let row = 0; row < inflightQ.length; row += 1) {
       rowNoteIndex.push(null);
+      rowKinds.push("question");
+      rowAnswerSources.push(null);
+    }
+    for (let row = 0; row < inflightA.length; row += 1) {
+      rowNoteIndex.push(null);
+      rowKinds.push("answer");
+      rowAnswerSources.push(null);
     }
   }
   return {
@@ -256,7 +301,8 @@ export function asideHistoryLayout(surface: AsideSurfaceState, cols: number, now
     turnStarts: [],
     turnContentEnds: [],
     rowTurnIndex: [],
-    rowKinds: body.map(() => "plain")
+    rowKinds,
+    rowAnswerSources
   };
 }
 
@@ -332,9 +378,9 @@ export function asideFooterHint(surface: AsideSurfaceState): string {
         ? "⌫ reset here" : "r retake";
       const hops = surface.anchors.length > 1
         ? " · [ ] hop asides · g go to this take" : "";
-      return `↑↓ turn · ←→ session · n new · ↵ use · ${reset} · x delete · t Thoughts · tab ask · esc read${hops}`;
+      return `↑↓ turn · ←→ session · n new · ↵ use · ${reset} · x delete · t Thoughts · tab ask · esc exit${hops}`;
     }
-    return "↵ ask · ⇧↵ newline · tab turns · esc read";
+    return "↵ ask · ⇧↵ newline · tab turns · esc exit";
   }
   if (surface.confirmClear) return "Clear all Side Notes? Enter confirms · Esc cancels";
   if (surface.busy && surface.inflightQuestion === null) return "Clearing…";
@@ -348,6 +394,18 @@ export function asideFooterHint(surface: AsideSurfaceState): string {
   // Keep both escape and Clear visible before optional navigation hints.
   const notesHint = asideNotes(surface).length > 0 ? " · Tab notes" : "";
   return `Esc write · /clear clear · Enter ask · Shift+Enter newline${notesHint} · PageUp/PageDown scroll`;
+}
+
+/** Number of standalone v2 footer rows painted below the history. */
+export function asideV2FooterHeight(
+  surface: AsideSessionSurfaceState,
+  cols: number,
+  toast?: string | null
+): number {
+  const turnsFocus = surface.focus === "turns" || surface.focus === "notes";
+  if (!turnsFocus && !surface.busy) return 0;
+  if (turnsFocus && toast !== undefined && toast !== null && toast.length > 0) return 1;
+  return cols >= 100 || surface.busy || surface.confirmReset !== null ? 1 : 2;
 }
 
 function asideFooterRows(surface: AsideSurfaceState, cols: number): string[] {
@@ -380,17 +438,20 @@ export function asideHistoryWindow(
 export interface AsideHistoryWindowWithKinds {
   lines: string[];
   rowKinds: readonly AsideChatRowKind[];
+  /** First layout-body row shown in `lines`. */
+  start: number;
 }
 
 export function asideHistoryWindowWithKinds(
   surface: AsideSurfaceState,
   cols: number,
   bodyRows: number,
-  now?: number
+  now?: number,
+  suppliedLayout?: AsideHistoryLayout
 ): AsideHistoryWindowWithKinds {
-  const layout = asideHistoryLayout(surface, cols, now);
+  const layout = suppliedLayout ?? asideHistoryLayout(surface, cols, now);
   const height = Math.max(0, Math.floor(bodyRows));
-  if (height === 0) return { lines: [], rowKinds: [] };
+  if (height === 0) return { lines: [], rowKinds: [], start: 0 };
   const max = Math.max(0, layout.body.length - height);
   const start = surface.scrollTop === null
     ? max
@@ -427,13 +488,14 @@ export function asideHistoryWindowWithKinds(
     rowKinds: [
       ...visibleKinds,
       ...Array.from({ length: padding }, () => "plain" as const)
-    ]
+    ],
+    start
   };
 }
 
 /**
  * Swap one pad space for ▸ without reflowing wrap. Labelled rows keep Q:/A:;
- * wrap continuations keep the remaining indent (prefix-width spaces).
+ * question continuations keep their four-cell gutter.
  */
 function decorateFocusedHistoryRow(line: string): string {
   if (line.startsWith(" ")) return `▸${line.slice(1)}`;
@@ -444,12 +506,21 @@ export function asideBodyHeight(
   surface: AsideSurfaceState,
   cols: number,
   rows: number,
-  composerRows?: number
+  composerRows?: number,
+  toast?: string | null
 ): number {
   const height = dimension(rows, 24);
-  const footerHeight = composerRows === undefined
+  const defaultFooterHeight = composerRows === undefined
     ? asideFooterRows(surface, cols).length
     : Math.max(1, Math.floor(composerRows));
+  // V2 turns use a compact one-row composer, one status row, and a standalone
+  // keyline. The predecessor-sized composer budget otherwise leaves several
+  // phantom rows in the history viewport, so the first scroll keys appear to
+  // do nothing until they absorb that gap.
+  const footerHeight = isAsideV2(surface)
+    && (surface.focus === "turns" || surface.focus === "notes" || surface.busy)
+    ? 1 + asideV2FooterHeight(surface, cols, toast) + 1
+    : defaultFooterHeight;
   const headerHeight = asideHeaderWindow(surface, cols, height - footerHeight).length;
   return Math.max(1, height - headerHeight - footerHeight);
 }
@@ -460,29 +531,19 @@ export function scrollAside(
   delta: number,
   cols: number,
   rows: number,
-  composerRows?: number
+  composerRows?: number,
+  toast?: string | null
 ): void {
-  // One layout + bodyRows for this action: max scroll, cursor follow, reveal.
+  // One layout + bodyRows for this action: clamp the display-only offset.
   const layout = asideHistoryLayout(surface, cols);
-  const bodyRows = asideBodyHeight(surface, cols, rows, composerRows);
+  const bodyRows = asideBodyHeight(surface, cols, rows, composerRows, toast);
   const max = Math.max(0, layout.body.length - bodyRows);
-  const current = surface.scrollTop ?? max;
+  const current = Math.max(0, Math.min(max, surface.scrollTop ?? max));
   const next = Math.max(0, Math.min(max, current + delta));
   surface.scrollTop = next === max ? null : next;
   // Notes focus: keep the selected Side Note visible, or move selection to a
   // note that is in the new viewport for this scroll direction.
-  if (isAsideV2(surface)
-    && (surface.focus === "turns" || surface.focus === "notes")
-    && currentAsideTurns(surface).length > 0 && delta !== 0) {
-    const turns = currentAsideTurns(surface);
-    const currentTurn = surface.turnCursor;
-    const direction = delta > 0 ? 1 : -1;
-    surface.turnCursor = Math.max(0, Math.min(
-      turns.length - 1,
-      currentTurn + direction * Math.max(1, Math.abs(delta))
-    ));
-    revealAsideFocusedNoteWithLayout(surface, layout, bodyRows);
-  } else if (!isAsideV2(surface)
+  if (!isAsideV2(surface)
     && surface.focus === "notes" && surface.notes.length > 0 && delta !== 0) {
     const notes = surface.notes;
     const nextCursor = noteCursorAfterHistoryScroll(
@@ -503,6 +564,18 @@ export function scrollAside(
     }
   }
 }
+
+/** Keep an in-flight Aside ask's restore fence behind display-only scrolling.
+ *  A real editor interaction still advances the shared epoch without calling
+ *  this helper, so it remains newer than the submitted question. */
+export function noteAsideDisplayScroll(state: RuntimeState): void {
+  const active = state.abort?.kind === "generation" ? state.abort : null;
+  if (active?.askInteractionVersion !== undefined
+    && state.interactionVersion === active.askInteractionVersion + 1) {
+    active.askInteractionVersion = state.interactionVersion;
+  }
+}
+
 export async function openAside(
   state: RuntimeState,
   api: StoryApi,
@@ -708,6 +781,8 @@ export async function sendAsideQuestion(
     interactionCurrent()
     || active.stopInteractionVersion !== null
       && state.interactionVersion === active.stopInteractionVersion
+    || active.askInteractionVersion !== undefined
+      && state.interactionVersion === active.askInteractionVersion
   );
   try {
     const onDelta = (text: string) => {
@@ -772,12 +847,14 @@ export async function sendAsideQuestion(
     if (result === null) {
       // Cancelled or stopped: return the question to the input.
       const restore = mayRestore();
+      const preserveScroll = isAsideV2(surface) && surface.scrollTop !== null;
       if (restore) setComposerText(surface.composer, trimmed);
       clearAsideStream(surface);
-      if (restore) surface.scrollTop = null;
+      if (restore && !preserveScroll) surface.scrollTop = null;
       surface.busy = false;
       return;
     }
+    const preserveScroll = isAsideV2(surface) && surface.scrollTop !== null;
     applyAsideResult(surface, result);
     if (isAsideV2(surface)) {
       const turns = currentAsideTurns(surface);
@@ -787,7 +864,7 @@ export async function sendAsideQuestion(
     }
     clampAsideNoteCursor(surface);
     clearAsideStream(surface);
-    surface.scrollTop = null;
+    if (!preserveScroll) surface.scrollTop = null;
     surface.busy = false;
     // The Aside result is committed before this refresh. Keep the result
     // visible if the refresh fails; transports invalidate their optimistic
@@ -810,9 +887,10 @@ export async function sendAsideQuestion(
   } catch (error) {
     if (!current()) return;
     const restore = mayRestore();
+    const preserveScroll = isAsideV2(surface) && surface.scrollTop !== null;
     if (restore) setComposerText(surface.composer, trimmed);
     clearAsideStream(surface);
-    if (restore) surface.scrollTop = null;
+    if (restore && !preserveScroll) surface.scrollTop = null;
     surface.busy = false;
     state.toast = error instanceof Error ? error.message : String(error);
   } finally {

--- a/tui/src/aside-placement.ts
+++ b/tui/src/aside-placement.ts
@@ -212,7 +212,7 @@ export function openPlacementFromAside(state: RuntimeState): boolean {
   // Uncertain state is derived from the singular guard — no copy onto Placement.
   const sameStoryGuard = guard !== null && guard.storyId === state.payload.id;
   const placement: PlacementState = {
-    answer: note.answer,
+    answer: surface.useMenu.selectionText ?? note.answer,
     stops,
     cursor: initialPlacementCursor(stops, surface.openingPartId),
     returnAside: surface,

--- a/tui/src/aside-surface.ts
+++ b/tui/src/aside-surface.ts
@@ -15,6 +15,13 @@ export interface AsideNoteView {
   readonly answer: string;
 }
 
+/** Source range for one painted row of a saved Aside answer. */
+export interface AsideAnswerSource {
+  readonly key: string;
+  readonly text: string;
+  readonly start: number;
+}
+
 /** A linear v2 exchange. The wire names are deliberately short and stable. */
 export interface AsideTurnView {
   readonly id?: string;
@@ -56,6 +63,9 @@ export type AsideFocus = "composer" | "turns" | "notes";
 /** Use menu for one complete saved Side Note answer. */
 export interface AsideUseMenuState {
   noteIndex: number;
+  /** Exact terminal selection, when the menu came from a highlighted answer.
+   *  Undefined means the complete saved answer is the target. */
+  selectionText?: string;
   /** Index into the stage's use-menu action list. */
   cursor: number;
   /**

--- a/tui/src/aside-use.ts
+++ b/tui/src/aside-use.ts
@@ -5,18 +5,27 @@
 import { countWords } from "../../shared/story-text.js";
 import { closeAside } from "./aside-actions.js";
 import { openPlacementFromAside } from "./aside-placement.js";
+import { copyStoryText } from "./copy-actions.js";
 import { insertComposerText } from "./composer-model.js";
 import { openDirectComposer } from "./composer-ownership.js";
+import { openFactFromSelection } from "./editor-action.js";
 import {
   asideCursor,
   asideNotes,
+  currentAsideTurns,
   disarmAsideClear,
+  isAsideV2,
   setAsideCursor,
   type AsideSurfaceState
 } from "./aside-surface.js";
+import type { AsideTurnView } from "./aside-surface.js";
 import type { RuntimeState } from "./state.js";
 
-export type AsideUseActionId = "insert-into-compose" | "insert-into-story";
+export type AsideUseActionId =
+  | "copy"
+  | "insert-into-compose"
+  | "insert-into-story"
+  | "insert-as-new-fact";
 
 export interface AsideUseAction {
   readonly id: AsideUseActionId;
@@ -35,8 +44,86 @@ export const ASIDE_USE_ACTIONS: readonly AsideUseAction[] = [
     id: "insert-into-story",
     name: "insert into story…",
     description: "select a position, then confirm"
+  },
+  {
+    id: "insert-as-new-fact",
+    name: "insert as new Fact",
+    description: "edit the answer and optional tag"
   }
 ];
+
+const ASIDE_SELECTION_USE_ACTION: AsideUseAction = {
+  id: "copy",
+  name: "Copy",
+  description: "copy the highlighted text"
+};
+
+/** Protocol turns normally have no id. Keep their row identity in memory so
+ * deleting an earlier turn can rebase a click without retargeting a clone. */
+const asideTurnIdentity = new WeakMap<object, string>();
+let nextAsideTurnIdentity = 0;
+
+function asideTurnRowIdentity(turn: AsideTurnView): string {
+  if (turn.id !== undefined && turn.id.length > 0) return `id:${turn.id}`;
+  const object = turn as object;
+  const existing = asideTurnIdentity.get(object);
+  if (existing !== undefined) return `ref:${existing}`;
+  const identity = `turn-${++nextAsideTurnIdentity}`;
+  asideTurnIdentity.set(object, identity);
+  return `ref:${identity}`;
+}
+
+/** The selected-text menu adds Copy before the complete-answer actions. Keep
+ * the complete-answer list stable so existing keyboard and Placement paths
+ * retain their row order. */
+export function asideUseActions(
+  selectionText?: string
+): readonly AsideUseAction[] {
+  return selectionText === undefined
+    ? ASIDE_USE_ACTIONS
+    : [
+      ASIDE_SELECTION_USE_ACTION,
+      ASIDE_USE_ACTIONS.find(({ id }) => id === "insert-into-compose")!,
+      ASIDE_USE_ACTIONS.find(({ id }) => id === "insert-as-new-fact")!,
+      ASIDE_USE_ACTIONS.find(({ id }) => id === "insert-into-story")!
+    ];
+}
+
+function asideAnswerOwner(surface: AsideSurfaceState): string {
+  if (!isAsideV2(surface)) return "legacy";
+  return surface.sessions[surface.sessionIndex]?.id ?? `session-${surface.sessionIndex}`;
+}
+
+/** Stable row identity for a saved answer in one Aside session. */
+export function asideAnswerRowId(
+  surface: AsideSurfaceState,
+  noteIndex: number
+): string {
+  if (!isAsideV2(surface)) {
+    return `aside-answer:${asideAnswerOwner(surface)}:${noteIndex}`;
+  }
+  const turn = currentAsideTurns(surface)[noteIndex];
+  if (turn === undefined) return `aside-answer:${asideAnswerOwner(surface)}:unknown`;
+  return `aside-answer:${asideAnswerOwner(surface)}:${asideTurnRowIdentity(turn)}`;
+}
+
+/** Resolve a saved-answer row identity against the current Aside session. */
+export function asideAnswerIndexFromRowId(
+  rowId: string,
+  surface: AsideSurfaceState
+): number {
+  const prefix = `aside-answer:${asideAnswerOwner(surface)}:`;
+  if (!rowId.startsWith(prefix)) return -1;
+  const identity = rowId.slice(prefix.length);
+  if (!isAsideV2(surface)) {
+    const value = Number(identity);
+    return Number.isInteger(value) && value >= 0 ? value : -1;
+  }
+  if (!identity.startsWith("id:") && !identity.startsWith("ref:")) return -1;
+  return currentAsideTurns(surface).findIndex(
+    (turn) => asideTurnRowIdentity(turn) === identity
+  );
+}
 
 /** Hit-map / selection identity for one use-menu action in one menu session. */
 export function asideUseRowId(
@@ -49,34 +136,38 @@ export function asideUseRowId(
 /** Resolve a session-bound use-menu row id to its action index, or -1. */
 export function asideUseActionIndexFromRowId(
   rowId: string,
-  sessionId: string
+  sessionId: string,
+  selectionText?: string
 ): number {
   const prefix = `aside-use:${sessionId}:`;
   if (!rowId.startsWith(prefix)) return -1;
   const actionId = rowId.slice(prefix.length);
-  return ASIDE_USE_ACTIONS.findIndex((entry) => entry.id === actionId);
+  return asideUseActions(selectionText).findIndex((entry) => entry.id === actionId);
 }
 
-export function asideUseMenuTitle(answer: string): string {
-  const words = countWords(answer);
+export function asideUseMenuTitle(answer: string, selectionText?: string): string {
+  const words = countWords(selectionText ?? answer);
   const label = words === 1 ? "1 word" : `${words.toLocaleString("en-US")} words`;
-  return `use answer · ${label}`;
+  return `use ${selectionText === undefined ? "answer" : "selection"} · ${label}`;
 }
 
 export function openAsideUseMenu(
   surface: AsideSurfaceState,
   noteIndex: number,
-  cursor = 0
+  cursor = 0,
+  selectionText?: string
 ): boolean {
   if (surface.busy) return false;
   const notes = asideNotes(surface);
   if (noteIndex < 0 || noteIndex >= notes.length) return false;
+  const actions = asideUseActions(selectionText);
   disarmAsideClear(surface);
   surface.focus = "notes";
   setAsideCursor(surface, noteIndex);
   surface.useMenu = {
     noteIndex,
-    cursor: Math.max(0, Math.min(ASIDE_USE_ACTIONS.length - 1, cursor)),
+    ...(selectionText === undefined ? {} : { selectionText }),
+    cursor: Math.max(0, Math.min(actions.length - 1, cursor)),
     // New id every open so A→B menu clicks cannot reconcile on action alone.
     sessionId: crypto.randomUUID()
   };
@@ -93,9 +184,10 @@ export function moveAsideUseMenuCursor(
 ): void {
   const menu = surface.useMenu;
   if (menu === null) return;
+  const actions = asideUseActions(menu.selectionText);
   menu.cursor = Math.max(
     0,
-    Math.min(ASIDE_USE_ACTIONS.length - 1, menu.cursor + delta)
+    Math.min(actions.length - 1, menu.cursor + delta)
   );
 }
 
@@ -106,7 +198,8 @@ export function focusAsideUseMenuIndex(
 ): void {
   const menu = surface.useMenu;
   if (menu === null) return;
-  menu.cursor = Math.max(0, Math.min(ASIDE_USE_ACTIONS.length - 1, index));
+  const actions = asideUseActions(menu.selectionText);
+  menu.cursor = Math.max(0, Math.min(actions.length - 1, index));
 }
 
 /**
@@ -151,7 +244,8 @@ export function moveAsideNoteFocus(
  */
 export function insertAsideAnswerIntoCompose(
   state: RuntimeState,
-  noteIndex: number
+  noteIndex: number,
+  selectedText?: string
 ): boolean {
   const surface = state.aside;
   if (surface === null) return false;
@@ -161,7 +255,7 @@ export function insertAsideAnswerIntoCompose(
     state.toast = "stream running · esc stops it first";
     return false;
   }
-  const answer = note.answer;
+  const answer = selectedText ?? note.answer;
   closeAside(state);
   if (!openDirectComposer(state)) {
     state.toast = "stream running · esc stops it first";
@@ -172,17 +266,31 @@ export function insertAsideAnswerIntoCompose(
 }
 
 /** Apply the focused use-menu action. Returns which path ran, or false. */
-export function applyAsideUseMenu(
+export async function applyAsideUseMenu(
   state: RuntimeState
-): "compose" | "placement" | false {
+): Promise<"copy" | "compose" | "fact" | "placement" | false> {
   const surface = state.aside;
   if (surface === null || surface.useMenu === null) return false;
-  const action = ASIDE_USE_ACTIONS[surface.useMenu.cursor];
+  const menu = surface.useMenu;
+  const action = asideUseActions(menu.selectionText)[menu.cursor];
   if (action === undefined) return false;
-  const noteIndex = surface.useMenu.noteIndex;
+  const noteIndex = menu.noteIndex;
+  const note = asideNotes(surface)[noteIndex];
+  const text = menu.selectionText ?? note?.answer;
+  if (text === undefined) return false;
+  if (action.id === "copy") {
+    closeAsideUseMenu(surface);
+    await copyStoryText(state, { kind: "selection", text });
+    return "copy";
+  }
   if (action.id === "insert-into-compose") {
     closeAsideUseMenu(surface);
-    return insertAsideAnswerIntoCompose(state, noteIndex) ? "compose" : false;
+    return insertAsideAnswerIntoCompose(state, noteIndex, menu.selectionText) ? "compose" : false;
+  }
+  if (action.id === "insert-as-new-fact") {
+    closeAside(state);
+    openFactFromSelection(state, text);
+    return "fact";
   }
   // Placement owns closing the menu and Aside surface.
   return openPlacementFromAside(state) ? "placement" : false;

--- a/tui/src/aside-v2-actions.ts
+++ b/tui/src/aside-v2-actions.ts
@@ -45,6 +45,7 @@ type AsideContext = {
   readonly cache?: WrapCache<ProseStyle>;
   readonly repaint?: () => void;
   readonly renderer?: { readonly width: number; readonly height: number } | null;
+  readonly toast?: string | null;
 };
 
 function revealFocusedTurn(
@@ -57,7 +58,7 @@ function revealFocusedTurn(
   revealAsideFocusedNote(
     surface,
     width,
-    asideBodyHeight(surface, width, height, composerRows)
+    asideBodyHeight(surface, width, height, composerRows, context.toast)
   );
 }
 
@@ -446,7 +447,13 @@ export async function asideV2KeyAction(
     }
     return changed;
   }
-  if (surface.busy && resolved.action !== "cancel") return true;
+  const displayScroll = resolved.action === "scroll-line-down"
+    || resolved.action === "scroll-line-up"
+    || resolved.action === "scroll-down"
+    || resolved.action === "scroll-up";
+  // Streaming owns editing and navigation, but scrolling only changes the
+  // displayed history window and remains safe while the answer grows.
+  if (surface.busy && resolved.action !== "cancel" && !displayScroll) return true;
   if (resolved.action === "aside-session-next") return cycleAsideSession(surface, 1);
   if (resolved.action === "aside-session-previous") return cycleAsideSession(surface, -1);
   if (resolved.action === "aside-new-session") return newAsideSession(surface);

--- a/tui/src/aside-v2-layout.ts
+++ b/tui/src/aside-v2-layout.ts
@@ -7,6 +7,7 @@ import {
   currentAsideTurns,
   normalizeAsideSession,
   sessionFromAsideNotes,
+  type AsideAnswerSource,
   type AsideAnchorView,
   type AsideSessionAnchor,
   type AsideSessionSurfaceState,
@@ -21,6 +22,7 @@ export interface AsideChatLayout {
   turnStarts: readonly number[];
   turnContentEnds: readonly number[];
   rowTurnIndex: readonly (number | null)[];
+  rowAnswerSources: readonly (AsideAnswerSource | null)[];
 }
 
 export type AsideChatRowKind = "question" | "thought" | "status" | "answer" | "plain";
@@ -29,10 +31,35 @@ function dimension(value: number, fallback: number): number {
   return Number.isFinite(value) ? Math.max(1, Math.floor(value)) : fallback;
 }
 
-function wrappedRows(text: string, width: number, prefix = ""): string[] {
+interface WrappedAsideRow {
+  text: string;
+  start: number;
+  end: number;
+}
+
+function wrappedRowsWithOffsets(
+  text: string,
+  width: number,
+  prefix = "",
+  continuationPrefix = " ".repeat(prefix.length)
+): WrappedAsideRow[] {
   const prefixWidth = prefix.length;
   const wrapped = wrapText(text, [], Math.max(1, width - prefixWidth));
-  return wrapped.map((line, index) => `${index === 0 ? prefix : " ".repeat(prefixWidth)}${line.text}`);
+  return wrapped.map((line, index) => ({
+    text: `${index === 0 ? prefix : continuationPrefix}${line.text}`,
+    start: line.start,
+    end: line.end
+  }));
+}
+
+function wrappedRows(
+  text: string,
+  width: number,
+  prefix = "",
+  continuationPrefix = " ".repeat(prefix.length)
+): string[] {
+  return wrappedRowsWithOffsets(text, width, prefix, continuationPrefix)
+    .map((line) => line.text);
 }
 
 function anchorLabel(anchor: AsideSessionAnchor | null): string {
@@ -183,17 +210,27 @@ export function asideV2HeaderLines(surface: AsideSessionSurfaceState, width: num
 function questionRows(turn: AsideTurnView, width: number, focused: boolean, now?: number): string[] {
   const prefix = focused ? "▸ › " : "  › ";
   const timestamp = relativeTimestamp(turn.updatedAt ?? turn.createdAt, now);
-  const rows = wrappedRows(turn.q, width, prefix);
+  // Keep the four-cell question gutter on every visual row. Decoration adds
+  // the focus marker to the first visible row after scrolling.
+  const rows = wrappedRows(turn.q, width, prefix, "  › ");
   if (timestamp.length === 0 || rows.length !== 1) return rows;
   const available = Math.max(0, width - rows[0]!.length - timestamp.length - 1);
   if (available > 0) rows[0] = `${rows[0]}${" ".repeat(available + 1)}${timestamp}`;
   return rows;
 }
 
-function answerRows(turn: AsideTurnView, width: number): string[] {
-  const rows: string[] = [];
-  for (const paragraph of turn.a.split("\n")) rows.push(...wrappedRows(paragraph, width, "  "));
-  return rows.length > 0 ? rows : ["  "];
+function answerRows(turn: AsideTurnView, width: number): WrappedAsideRow[] {
+  const rows: WrappedAsideRow[] = [];
+  let answerOffset = 0;
+  for (const paragraph of turn.a.split("\n")) {
+    rows.push(...wrappedRowsWithOffsets(paragraph, width, "  ").map((row) => ({
+      ...row,
+      start: answerOffset + row.start,
+      end: answerOffset + row.end
+    })));
+    answerOffset += paragraph.length + 1;
+  }
+  return rows.length > 0 ? rows : [{ text: "  ", start: 0, end: 0 }];
 }
 
 function thoughtRows(turn: AsideTurnView, width: number, visible: boolean, focused: boolean): string[] {
@@ -218,6 +255,7 @@ export function asideChatLayout(
   const turnContentEnds: number[] = [];
   const rowTurnIndex: (number | null)[] = [];
   const rowKinds: AsideChatRowKind[] = [];
+  const rowAnswerSources: (AsideAnswerSource | null)[] = [];
   const turns = currentAsideTurns(surface);
   for (let index = 0; index < turns.length; index += 1) {
     const turn = turns[index]!;
@@ -230,7 +268,7 @@ export function asideChatLayout(
     const rows = [
       ...questions,
       ...thoughts,
-      ...answers
+      ...answers.map((row) => row.text)
     ];
     body.push(...rows);
     const questionCount = questions.length;
@@ -241,24 +279,36 @@ export function asideChatLayout(
         row < questionCount ? "question"
           : row < questionCount + thoughtCount ? "thought" : "answer"
       );
+      rowAnswerSources.push(
+        row < questionCount + thoughtCount
+          ? null
+          : {
+            key: `aside-answer:${turn.id ?? `${surface.sessionIndex}-${index}`}:${index}`,
+            text: turn.a,
+            start: answers[row - questionCount - thoughtCount]!.start
+          }
+      );
     }
     turnContentEnds.push(body.length);
     body.push("");
     rowTurnIndex.push(null);
     rowKinds.push("plain");
+    rowAnswerSources.push(null);
   }
   if (surface.inflightQuestion !== null || presentedText.length > 0 || surface.busy) {
-    const question = wrappedRows(surface.inflightQuestion ?? "", width, "▸ › ");
+    const question = wrappedRows(surface.inflightQuestion ?? "", width, "▸ › ", "  › ");
     body.push(...question);
     for (let row = 0; row < question.length; row += 1) {
       rowTurnIndex.push(null);
       rowKinds.push("question");
+      rowAnswerSources.push(null);
     }
     if (surface.busy) {
       const tokens = surface.streamThoughtTokens > 0 ? ` · ${surface.streamThoughtTokens} tok` : "";
       body.push(`  ⟳ ${surface.streamPhase ?? "thinking"}${tokens} · esc stops`);
       rowTurnIndex.push(null);
       rowKinds.push("status");
+      rowAnswerSources.push(null);
       if (surface.thoughtsVisible && surface.streamThoughts.length > 0) {
         const thoughts = wrappedRows(surface.streamThoughts, width, "  ┊ ");
         thoughts[thoughts.length - 1] = `${thoughts[thoughts.length - 1]!}▏`;
@@ -266,6 +316,7 @@ export function asideChatLayout(
         for (let row = 0; row < thoughts.length; row += 1) {
           rowTurnIndex.push(null);
           rowKinds.push("thought");
+          rowAnswerSources.push(null);
         }
       }
     }
@@ -275,6 +326,7 @@ export function asideChatLayout(
       for (let row = 0; row < answer.length; row += 1) {
         rowTurnIndex.push(null);
         rowKinds.push("answer");
+        rowAnswerSources.push(null);
       }
     }
   }
@@ -282,6 +334,7 @@ export function asideChatLayout(
     body.push("(ask about this story)");
     rowTurnIndex.push(null);
     rowKinds.push("plain");
+    rowAnswerSources.push(null);
   }
   return {
     header: asideV2HeaderLines(surface, width),
@@ -289,6 +342,7 @@ export function asideChatLayout(
     rowKinds,
     turnStarts,
     turnContentEnds,
-    rowTurnIndex
+    rowTurnIndex,
+    rowAnswerSources
   };
 }

--- a/tui/src/hit.ts
+++ b/tui/src/hit.ts
@@ -45,6 +45,10 @@ export type HitTarget =
       composerEditable?: boolean;
     }
   /** Page behind an open panel: a click there dismisses the panel. */
+  /** A saved Aside answer row. Right-click uses the terminal selection when
+   * one exists, while the row identity supplies the answer's Placement
+   * anchor. */
+  | { kind: "aside-answer"; noteIndex: number; rowId: string }
   | { kind: "scrim" }
   /** Panel chrome — titles, headers, rules: visible but not actionable. */
   | { kind: "panel" };

--- a/tui/src/keys.ts
+++ b/tui/src/keys.ts
@@ -65,7 +65,7 @@ export type KeyAction =
   | "aside-session-next" | "aside-session-previous" | "aside-anchor-next" | "aside-anchor-previous"
   | "aside-go-anchor" | "aside-undo-delete"
   | "filter" | "cycle" | "check" | "detect-context" | "discard-pending" | "retry" | "continue"
-  | "scroll-down" | "scroll-up" | "scroll-line-down" | "scroll-line-up" | "toggle-rail" | "copy-part" | "copy-line" | "open-actions" | "focus-index"
+  | "scroll-down" | "scroll-up" | "scroll-line-down" | "scroll-line-up" | "toggle-rail" | "copy-part" | "copy-line" | "open-actions" | "focus-index" | "open-aside-use"
   | "open-chapters" | "create-chapter" | "summarize-chapter" | "chapter-previous" | "chapter-next"
   | "toggle-context-meter" | "open-search" | "toggle-search-case" | "open-request"
   | "complete" | "open-log" | "clear-log" | "row-action"

--- a/tui/src/mouse-actions.ts
+++ b/tui/src/mouse-actions.ts
@@ -343,6 +343,14 @@ export function mouseToAction(
   if (state.mode === "COMPOSE" && event.button === 2) return null;
 
   if (target.kind === "scrim") return { action: "cancel" };
+  if (target.kind === "aside-answer" && state.mode === "ASIDE" && event.button === 2
+    && state.aside?.useMenu === null) {
+    return {
+      action: "open-aside-use",
+      index: target.noteIndex,
+      rowId: target.rowId
+    };
+  }
   if (target.kind === "settings-row" && event.button === 0) {
     return {
       action: "open-settings",

--- a/tui/src/overlay-actions.ts
+++ b/tui/src/overlay-actions.ts
@@ -36,6 +36,7 @@ import {
   closeAside,
   openAside,
   revealAsideFocusedNote,
+  noteAsideDisplayScroll,
   scrollAside,
   sendAsideQuestion,
   stopAsideAsk
@@ -139,6 +140,17 @@ export async function handleOverlayAction(
       } else {
         openRequestViewer(state);
       }
+    }
+    return true;
+  }
+  if (resolved.action === "open-aside-use") {
+    if (state.mode === "ASIDE" && state.aside !== null) {
+      openAsideUseMenu(
+        state.aside,
+        resolved.index ?? asideCursor(state.aside),
+        0,
+        resolved.selectionText
+      );
     }
     return true;
   }
@@ -732,14 +744,15 @@ async function reconnect(state: RuntimeState, source: AppSource, context: Overla
 
 function asideViewportBodyRows(
   surface: NonNullable<RuntimeState["aside"]>,
-  context: OverlayActionContext
+  context: OverlayActionContext,
+  toast?: string | null
 ): { width: number; bodyRows: number } {
   const width = context.renderer?.width ?? 80;
   const height = context.renderer?.height ?? 24;
   const composerRows = asideComposerRows(height);
   return {
     width,
-    bodyRows: asideBodyHeight(surface, width, height, composerRows)
+    bodyRows: asideBodyHeight(surface, width, height, composerRows, toast)
   };
 }
 
@@ -782,7 +795,8 @@ async function asideKeyAction(
       backend: context.backend,
       cache: context.cache,
       repaint: context.repaint,
-      renderer: context.renderer
+      renderer: context.renderer,
+      toast: state.toast
   })) return;
   if (resolved.action === "cancel") {
     // A busy Aside owns Escape for cancellation. Check this before the
@@ -803,6 +817,10 @@ async function asideKeyAction(
       return;
     }
     if (surface.focus === "notes" || surface.focus === "turns") {
+      if (isAsideV2(surface)) {
+        closeAside(state);
+        return;
+      }
       surface.focus = "composer";
       return;
     }
@@ -833,7 +851,7 @@ async function asideKeyAction(
       return;
     }
     if (resolved.action === "apply" || resolved.action === "open-selected") {
-      applyAsideUseMenu(state);
+      await applyAsideUseMenu(state);
       return;
     }
     // Use menu owns the surface: scrim/cancel stay authoritative; compose does
@@ -844,7 +862,7 @@ async function asideKeyAction(
   if (resolved.action === "cycle") {
     if (cycleAsideFocus(surface)
       && (surface.focus === "notes" || surface.focus === "turns")) {
-      const { width, bodyRows } = asideViewportBodyRows(surface, context);
+      const { width, bodyRows } = asideViewportBodyRows(surface, context, state.toast);
       revealAsideFocusedNote(surface, width, bodyRows);
     }
     return;
@@ -854,11 +872,12 @@ async function asideKeyAction(
     const width = context.renderer?.width ?? 80;
     const height = context.renderer?.height ?? 24;
     const composerRows = asideComposerRows(height);
-    const page = asideBodyHeight(surface, width, height, composerRows);
+    const page = asideBodyHeight(surface, width, height, composerRows, state.toast);
     const delta = resolved.action === "scroll-line-down" || resolved.action === "scroll-down"
       ? resolved.action === "scroll-down" ? page : 1
       : resolved.action === "scroll-up" ? -page : -1;
-    scrollAside(surface, delta, width, height, composerRows);
+    scrollAside(surface, delta, width, height, composerRows, state.toast);
+    if (surface.busy) noteAsideDisplayScroll(state);
     return;
   }
   if (surface.focus === "notes" || surface.focus === "turns") {
@@ -870,14 +889,14 @@ async function asideKeyAction(
     }
     if (resolved.action === "focus-next" || resolved.action === "focus-previous") {
       moveAsideNoteFocus(surface, resolved.action === "focus-next" ? 1 : -1);
-      const { width, bodyRows } = asideViewportBodyRows(surface, context);
+      const { width, bodyRows } = asideViewportBodyRows(surface, context, state.toast);
       revealAsideFocusedNote(surface, width, bodyRows);
       return;
     }
     if (resolved.action === "open-selected" || resolved.action === "apply") {
       // Re-anchor under the current terminal size: a stale scrollTop from a
       // prior width/header layout can hide noteCursor while Enter still uses it.
-      const { width, bodyRows } = asideViewportBodyRows(surface, context);
+      const { width, bodyRows } = asideViewportBodyRows(surface, context, state.toast);
       revealAsideFocusedNote(surface, width, bodyRows);
       openAsideUseMenu(surface, asideCursor(surface));
       return;

--- a/tui/src/presented-mouse-action.ts
+++ b/tui/src/presented-mouse-action.ts
@@ -25,7 +25,8 @@ import {
 } from "./mouse-actions.js";
 import type { RuntimeState } from "./state.js";
 import {
-  ASIDE_USE_ACTIONS,
+  asideAnswerIndexFromRowId,
+  asideUseActions,
   asideUseActionIndexFromRowId,
   asideUseRowId
 } from "./aside-use.js";
@@ -144,12 +145,18 @@ function rebaseByStableIdentity(
       // Session-bound row id: same action on a later menu open does not match.
       const index = asideUseActionIndexFromRowId(
         action.rowId,
-        state.aside.useMenu.sessionId
+        state.aside.useMenu.sessionId,
+        state.aside.useMenu.selectionText
       );
       return index < 0 ? null : { ...action, index };
     }
     const index = createStoryViewModel(state.payload, state.stream).rows
       .findIndex((row) => row.id === action.rowId);
+    return index < 0 ? null : { ...action, index };
+  }
+  if (action.action === "open-aside-use" && action.rowId !== undefined
+    && state.mode === "ASIDE" && state.aside !== null) {
+    const index = asideAnswerIndexFromRowId(action.rowId, state.aside);
     return index < 0 ? null : { ...action, index };
   }
   return relativeMouseAction(action) ? action : null;
@@ -250,7 +257,7 @@ function listRowIdentity(state: MouseActionState, index: number | undefined): st
   if (state.textActions !== null) return availableTextActions(state.textActions)[index]?.id ?? null;
   if (state.mode === "ASIDE" && state.aside?.useMenu !== null
     && state.aside?.useMenu !== undefined) {
-    const entry = ASIDE_USE_ACTIONS[index];
+    const entry = asideUseActions(state.aside.useMenu.selectionText)[index];
     return entry === undefined
       ? null
       : asideUseRowId(state.aside.useMenu.sessionId, entry.id);
@@ -341,7 +348,7 @@ function selectedListIdentity(state: MouseActionState): string | null {
   }
   if (state.mode === "ASIDE" && state.aside?.useMenu !== null
     && state.aside?.useMenu !== undefined) {
-    const entry = ASIDE_USE_ACTIONS[state.aside.useMenu.cursor];
+    const entry = asideUseActions(state.aside.useMenu.selectionText)[state.aside.useMenu.cursor];
     return entry === undefined
       ? null
       : asideUseRowId(state.aside.useMenu.sessionId, entry.id);

--- a/tui/src/screens/story/aside-screen.ts
+++ b/tui/src/screens/story/aside-screen.ts
@@ -6,8 +6,9 @@ import {
   asideComposerRows,
   asideFooterHint,
   asideHeaderWindow,
-  asideHistoryWindow,
-  asideHistoryWindowWithKinds
+  asideHistoryLayout,
+  asideHistoryWindowWithKinds,
+  asideV2FooterHeight
 } from "../../aside-actions.js";
 import type { AsideChatRowKind } from "../../aside-v2-layout.js";
 import {
@@ -15,23 +16,33 @@ import {
   asideNotes,
   currentAsideTurns,
   isAsideV2,
+  type AsideAnswerSource,
   type AsideSessionSurfaceState,
   type AsideSurfaceState
 } from "../../aside-surface.js";
 import { resetAsideStatus } from "../../aside-v2-actions.js";
 import {
-  ASIDE_USE_ACTIONS,
+  asideAnswerRowId,
+  asideUseActions,
   asideUseMenuTitle,
   asideUseRowId
 } from "../../aside-use.js";
 import type { HitRows, HitTarget } from "../../hit.js";
 import {
-  buildComposerSelectionProjection
+  buildComposerSelectionProjection,
+  buildStorySelectionProjection
 } from "../../selection-projection.js";
 import type { StoryScreenState } from "../../state.js";
 import { renderConnectionBanner } from "../connection-banner.js";
-import { dimPage, panelHorizontalGeometry, placePanel, raisedSegment } from "../overlay.js";
-import { cellPad } from "../panel-table-layout.js";
+import {
+  dimPage,
+  panelContentRows,
+  panelHorizontalGeometry,
+  placePanel,
+  raisedSegment
+} from "../overlay.js";
+import { cellPad, panelRange, panelRowWindow } from "../panel-table-layout.js";
+import { wrapText } from "../../wrap.js";
 import {
   fitLine,
   segment,
@@ -129,14 +140,21 @@ function asideV2FooterHint(surface: AsideSessionSurfaceState, width: number): st
     const turns = currentAsideTurns(surface);
     const history = surface.turnCursor < Math.max(0, turns.length - 1)
       ? "⌫ reset" : "r retake";
-    return `↑↓ turn · ←→ session · n new · ↵ use · ${history} · x delete · t Thoughts · tab ask · [ ] hop · g go · esc read`;
+    return `↑↓ turn · ←→ session · n new · ↵ use · ${history} · x delete · t Thoughts · tab ask · [ ] hop · g go · esc exit`;
   }
-  return "↵ ask · ⇧↵ newline · tab turns · esc read";
+  return "↵ ask · ⇧↵ newline · tab turns · esc exit";
 }
 
-function asideV2StandaloneFooterLines(surface: AsideSessionSurfaceState, width: number): string[] {
-  if (width >= 100 || surface.busy || surface.confirmReset !== null
-    || (surface.focus !== "turns" && surface.focus !== "notes")) {
+function asideV2StandaloneFooterLines(
+  surface: AsideSessionSurfaceState,
+  width: number,
+  toast?: string | null
+): string[] {
+  const turnsFocus = surface.focus === "turns" || surface.focus === "notes";
+  if (turnsFocus && toast !== undefined && toast !== null && toast.length > 0) {
+    return [toast];
+  }
+  if (asideV2FooterHeight(surface, width, toast) !== 2) {
     return [asideV2FooterHint(surface, width)];
   }
   const turns = currentAsideTurns(surface);
@@ -144,7 +162,7 @@ function asideV2StandaloneFooterLines(surface: AsideSessionSurfaceState, width: 
     ? "⌫ reset" : "r retake";
   return [
     `↑↓ turn · ←→ session · n new · ↵ use · ${history} · x delete`,
-    "t Thoughts · tab ask · [ ] hop · g go · esc read"
+    "t Thoughts · tab ask · [ ] hop · g go · esc exit"
   ];
 }
 
@@ -159,18 +177,24 @@ function renderAsideV2Screen(
   const status = renderAsideV2Status(state, surface, width);
   const turnsFocus = surface.focus === "turns" || surface.focus === "notes";
   const standaloneFooter = turnsFocus || surface.busy;
-  const footerLines = !standaloneFooter ? []
-    : turnsFocus && typeof state.toast === "string" && state.toast.length > 0
-    ? [state.toast]
-    : asideV2StandaloneFooterLines(surface, width);
+  const footerLines = standaloneFooter
+    ? asideV2StandaloneFooterLines(surface, width, state.toast)
+    : [];
   const bottomRows = composerLines.length + footerLines.length + 1;
   const header = asideHeaderWindow(surface, width, Math.max(0, height - bottomRows));
   const historyRows = Math.max(0, height - header.length - bottomRows);
-  const history = asideHistoryWindowWithKinds(surface, width, historyRows, state.now);
+  const historyLayout = asideHistoryLayout(surface, width, state.now);
+  const history = asideHistoryWindowWithKinds(
+    surface, width, historyRows, state.now, historyLayout
+  );
   const lines: FrameLine[] = [
     ...header.map(renderAsideV2HeaderLine),
     ...history.lines.map((text, index) =>
-      renderAsideV2HistoryLine(text, history.rowKinds[index] ?? "plain")),
+      renderAsideV2HistoryLine(
+        text,
+        history.rowKinds[index] ?? "plain",
+        historyLayout.rowAnswerSources[history.start + index]
+      )),
     ...composerLines,
     ...footerLines.map((line) => [segment(line, "chrome")]),
     status
@@ -178,9 +202,19 @@ function renderAsideV2Screen(
   while (lines.length < height) lines.push([]);
   const composerStart = header.length + historyRows;
   const hitRows: HitRows = Array.from({ length: height }, (_, row) => {
+    if (row >= header.length && row < composerStart) {
+      const target = asideAnswerHitTarget(
+        surface,
+        historyLayout,
+        history.start,
+        row - header.length
+      );
+      if (target !== null) return { target, left: 0, right: width };
+    }
     if (row < composerStart || row >= composerStart + composerLines.length) return null;
     return { target: { kind: "composer" }, left: 0, right: width };
   });
+  const storySelectionProjection = buildStorySelectionProjection(lines, width);
   let renderedLines = lines.slice(0, height);
   if (surface.useMenu !== null) {
     renderedLines = renderAsideUseMenu(renderedLines, surface, width, height, hitRows);
@@ -202,7 +236,7 @@ function renderAsideV2Screen(
       keysScrollTop: 0,
       composerSelectionProjection: selectionInTurns
         ? null : buildComposerSelectionProjection(renderedLines, width),
-      storySelectionProjection: null,
+      storySelectionProjection,
       map: null,
       request: null,
       record: null
@@ -231,7 +265,8 @@ function renderQuestionHistoryLine(
 
 function renderAsideV2HistoryLine(
   text: string,
-  kind: AsideChatRowKind
+  kind: AsideChatRowKind,
+  answerSource?: AsideAnswerSource | null
 ): FrameLine {
   if (kind === "question") {
     if (text.startsWith("▸ › ")) {
@@ -239,6 +274,14 @@ function renderAsideV2HistoryLine(
     }
     if (text.startsWith("  › ")) {
       return renderQuestionHistoryLine(text, "  › ", "accent · deep", "prose · dim");
+    }
+    // Older layouts can leave a decorated continuation without the repeated
+    // marker. Keep its body role aligned with the labelled question row.
+    if (text.startsWith("▸ ")) {
+      return [segment("▸ ", "focus / accent"), segment(text.slice(2), "prose")];
+    }
+    if (text.startsWith("    ")) {
+      return [segment(text.slice(0, 4), "accent · deep"), segment(text.slice(4), "prose · dim")];
     }
   }
   if (kind === "thought" && text.startsWith("  ┊ ")) {
@@ -248,7 +291,68 @@ function renderAsideV2HistoryLine(
     const prefix = text.startsWith("▸") ? "▸ ⟳ " : "  ⟳ ";
     return [segment(prefix, "dimmed page"), segment(text.slice(prefix.length), "dimmed page")];
   }
+  if (kind === "answer") {
+    const prefix = text.startsWith("▸ ") ? "▸ " : text.startsWith("  ") ? "  " : "";
+    if (prefix.length > 0) {
+      return [
+        segment(prefix, "prose · dim"),
+        asideAnswerSegment(text.slice(prefix.length), "prose · dim", answerSource)
+      ];
+    }
+  }
   return [segment(text, "prose · dim")];
+}
+
+function renderLegacyHistoryLine(
+  text: string,
+  kind: AsideChatRowKind,
+  answerSource?: AsideAnswerSource | null
+): FrameLine {
+  if (kind === "question") {
+    if (text.startsWith("▸ Q: ")) {
+      return [segment("▸ Q: ", "focus / accent"), segment(text.slice(5), "prose")];
+    }
+    if (text.startsWith("  Q: ")) {
+      return [segment("  Q: ", "accent · deep"), segment(text.slice(5), "prose · dim")];
+    }
+    // Legacy rows use a five-cell Q: prefix. Keep continuation body roles
+    // aligned with the labelled question row.
+    if (text.startsWith("▸ ")) {
+      return [segment("▸ ", "focus / accent"), segment(text.slice(2), "prose")];
+    }
+    if (text.startsWith("     ")) {
+      return [segment(text.slice(0, 5), "accent · deep"), segment(text.slice(5), "prose · dim")];
+    }
+  }
+  if (kind === "answer") {
+    const prefix = text.startsWith("▸ A: ") || text.startsWith("▸    ")
+      ? "▸ A: ".length
+      : text.startsWith("  A: ") || text.startsWith("     ")
+        ? "  A: ".length : 0;
+    if (prefix > 0) {
+      const focused = text.startsWith("▸ ");
+      return [
+        segment(text.slice(0, prefix), focused ? "focus / accent" : "prose"),
+        asideAnswerSegment(text.slice(prefix), focused ? "focus / accent" : "prose", answerSource)
+      ];
+    }
+  }
+  const focused = text.startsWith("▸ ");
+  return [segment(text, focused ? "focus / accent" : "prose")];
+}
+
+function asideAnswerSegment(
+  text: string,
+  role: "focus / accent" | "prose" | "prose · dim",
+  source: AsideAnswerSource | null | undefined
+): FrameLine[number] {
+  return {
+    ...segment(text, role),
+    ...(source === null || source === undefined ? {} : {
+      storySource: source,
+      prose: true as const
+    })
+  };
 }
 
 function renderAsideV2HeaderLine(text: string): FrameLine {
@@ -309,6 +413,28 @@ function composerHitTarget(line: FrameLine | undefined): HitTarget {
   };
 }
 
+/** Map a visible history row back to its saved answer. Inflight answers are
+ * deliberately left without a target because Placement and Fact insertion
+ * need a settled turn/note. */
+function asideAnswerHitTarget(
+  surface: AsideSurfaceState,
+  layout: ReturnType<typeof asideHistoryLayout>,
+  start: number,
+  visibleRow: number
+): HitTarget | null {
+  const bodyRow = start + visibleRow;
+  if (layout.rowKinds[bodyRow] !== "answer") return null;
+  const noteIndex = isAsideV2(surface)
+    ? layout.rowTurnIndex[bodyRow]
+    : layout.rowNoteIndex[bodyRow];
+  if (noteIndex === null || noteIndex === undefined) return null;
+  return {
+    kind: "aside-answer",
+    noteIndex,
+    rowId: asideAnswerRowId(surface, noteIndex)
+  };
+}
+
 function renderAsideUseMenu(
   base: FrameLine[],
   surface: AsideSurfaceState,
@@ -320,26 +446,61 @@ function renderAsideUseMenu(
   if (menu === null) return base;
   const note = asideNotes(surface)[menu.noteIndex];
   if (note === undefined) return base;
-  const actions = ASIDE_USE_ACTIONS;
+  const actions = asideUseActions(menu.selectionText);
   const contentWidth = panelHorizontalGeometry(width, 56).contentWidth;
+  // placePanel reserves the last screen row for its bottom rule. Account for
+  // that low-height paint bound before windowing, or a two-line block could
+  // lose its final line when the panel reaches its minimum height.
+  const contentBudget = Math.max(1, Math.min(panelContentRows(height), height - 4));
   const leadWidth = Math.min(4, contentWidth);
   const widestName = Math.max(...actions.map((action) => visibleWidth(action.name)));
   const nameWidth = Math.min(widestName + 2, Math.max(0, contentWidth - leadWidth));
   const descriptionWidth = Math.max(0, contentWidth - leadWidth - nameWidth);
-  const content: FrameLine[] = actions.map((action, index): FrameLine => [
-    raisedSegment(cellPad(index === menu.cursor ? "  ▸ " : "", leadWidth),
-      index === menu.cursor ? "focus / accent" : "chrome"),
-    raisedSegment(cellPad(truncate(action.name, nameWidth), nameWidth),
-      index === menu.cursor ? "prose" : "prose · dim"),
-    raisedSegment(truncate(action.description, descriptionWidth), "chrome")
-  ]);
+  const overflowBlocks = new Set<number>();
+  const blocks = actions.map((action, index) => {
+    const initial = asideUseActionBlock(
+      action,
+      index,
+      menu.cursor,
+      contentWidth,
+      leadWidth,
+      nameWidth,
+      descriptionWidth
+    );
+    if (initial.length <= contentBudget) return initial;
+    const reflowed = asideUseActionBlockFullWidth(action, index, menu.cursor, contentWidth);
+    if (reflowed.length <= contentBudget) return reflowed;
+    overflowBlocks.add(index);
+    return [asideUseOverflowLine(index === menu.cursor, contentWidth)];
+  });
+  const window = panelRowWindow(
+    blocks.map((block) => block.length),
+    menu.cursor,
+    contentBudget
+  );
+  const content = blocks.slice(window.start, window.end).flat();
+  const targets = blocks.slice(window.start, window.end).flatMap((block, offset) =>
+    block.map((): HitTarget | null => overflowBlocks.has(window.start + offset)
+      ? null
+      : {
+        kind: "list",
+        index: window.start + offset,
+        rowId: asideUseRowId(menu.sessionId, actions[window.start + offset]!.id),
+        selected: window.start + offset === menu.cursor
+      })
+  );
   // Keep ↵ and esc complete at 20–21 columns; drop secondary words first.
   const footer = panelHorizontalGeometry(width, 56).footerWidth < visibleWidth("↑↓ · ↵ · esc notes")
     ? "↵ · esc"
     : "↑↓ · ↵ · esc notes";
+  const menuTitle = asideUseMenuTitle(note.answer, menu.selectionText);
+  const hasHiddenActions = window.start > 0 || window.end < actions.length;
+  const title = overflowBlocks.size > 0 || hasHiddenActions
+    ? `use ↑↓ · ${menuTitle.slice(menuTitle.indexOf(" · ") + 3)}`
+    : `${menuTitle}${panelRange(actions.length, window)}`;
   return placePanel(
     dimPage(base),
-    asideUseMenuTitle(note.answer),
+    title,
     content,
     footer,
     width,
@@ -347,18 +508,98 @@ function renderAsideUseMenu(
     56,
     {
       rows: hitRows,
-      targets: actions.map((action, index): HitTarget => ({
-        kind: "list",
-        index,
-        rowId: asideUseRowId(menu.sessionId, action.id),
-        selected: index === menu.cursor
-      })),
+      targets,
       footerActions: [
         { token: "↵", action: "apply" },
         { token: "esc", action: "cancel" }
       ]
     }
   ).lines;
+}
+
+const MIN_INLINE_DESCRIPTION_WIDTH = 12;
+
+function wrappedActionText(text: string, width: number): string[] {
+  return wrapText(text, [], Math.max(1, width)).map((line) => line.text);
+}
+
+/** Wrap one action without passing an ellipsis into the panel's cell fitter.
+ * Wide panels keep the aligned two-column layout. Narrow panels stack the
+ * label and description so both fields retain their complete text. */
+function asideUseActionBlock(
+  action: { name: string; description: string },
+  index: number,
+  cursor: number,
+  contentWidth: number,
+  leadWidth: number,
+  nameWidth: number,
+  descriptionWidth: number
+): FrameLine[] {
+  const selected = index === cursor;
+  if (descriptionWidth >= MIN_INLINE_DESCRIPTION_WIDTH && nameWidth > 0) {
+    const names = wrappedActionText(action.name, nameWidth);
+    const descriptions = wrappedActionText(action.description, descriptionWidth);
+    const rows = Math.max(names.length, descriptions.length);
+    return Array.from({ length: rows }, (_, row) => [
+      raisedSegment(cellPad(row === 0 && selected ? "  ▸ " : "", leadWidth),
+        row === 0 && selected ? "focus / accent" : "chrome"),
+      raisedSegment(cellPad(names[row] ?? "", nameWidth),
+        selected ? "prose" : "prose · dim"),
+      raisedSegment(descriptions[row] ?? "", "chrome")
+    ]);
+  }
+
+  const labelWidth = Math.max(1, contentWidth - Math.min(leadWidth, contentWidth));
+  const names = wrappedActionText(action.name, labelWidth);
+  const indent = Math.min(2, contentWidth);
+  const descriptionMeasure = Math.max(1, contentWidth - indent);
+  const descriptions = wrappedActionText(action.description, descriptionMeasure);
+  const labelRows = names.map((name, row): FrameLine => [
+    raisedSegment(cellPad(row === 0 && selected ? "  ▸ " : "", Math.min(leadWidth, contentWidth)),
+      row === 0 && selected ? "focus / accent" : "chrome"),
+    raisedSegment(cellPad(name, labelWidth), selected ? "prose" : "prose · dim")
+  ]);
+  const descriptionRows = descriptions.map((description): FrameLine => [
+    raisedSegment(" ".repeat(indent), "chrome"),
+    raisedSegment(description, "chrome")
+  ]);
+  return [...labelRows, ...descriptionRows];
+}
+
+/** Reflow a tall two-column block as one full-width stack before giving up to
+ * the viewport. This keeps the panel from painting the bottom half of an
+ * action when only a small body budget remains. */
+function asideUseActionBlockFullWidth(
+  action: { name: string; description: string },
+  index: number,
+  cursor: number,
+  contentWidth: number
+): FrameLine[] {
+  const selected = index === cursor;
+  const marker = selected ? "▸ " : "  ";
+  const nameWidth = Math.max(1, contentWidth - visibleWidth(marker));
+  const names = wrappedActionText(action.name, nameWidth);
+  const descriptions = wrappedActionText(action.description, contentWidth);
+  return [
+    ...names.map((name, row): FrameLine => [
+      raisedSegment(row === 0 ? marker : " ".repeat(visibleWidth(marker)),
+        row === 0 && selected ? "focus / accent" : "chrome"),
+      raisedSegment(name, selected ? "prose" : "prose · dim")
+    ]),
+    ...descriptions.map((description): FrameLine => [
+      raisedSegment(description, "chrome")
+    ])
+  ];
+}
+
+function asideUseOverflowLine(selected: boolean, contentWidth: number): FrameLine {
+  const marker = selected ? "▸ " : "  ";
+  const cue = "… use ↑↓";
+  const available = Math.max(1, contentWidth - visibleWidth(marker));
+  return [
+    raisedSegment(marker, selected ? "focus / accent" : "chrome"),
+    raisedSegment(truncate(cue, available), selected ? "prose" : "prose · dim")
+  ];
 }
 
 export function renderAsideScreen(
@@ -390,19 +631,32 @@ export function renderAsideScreen(
   });
   const header = asideHeaderWindow(surface, width, height - composer.lines.length);
   const historyRows = Math.max(0, height - header.length - composer.lines.length);
-  const history = asideHistoryWindow(surface, width, historyRows, state.now);
+  const historyLayout = asideHistoryLayout(surface, width, state.now);
+  const history = asideHistoryWindowWithKinds(
+    surface, width, historyRows, state.now, historyLayout
+  );
   const lines: FrameLine[] = [
     ...header.map((text) => [segment(text, "prose")]),
-    ...history.map((text) => {
-      const focused = text.startsWith("▸ ");
-      return [segment(text, focused ? "focus / accent" : "prose")];
-    }),
+    ...history.lines.map((text, index) => renderLegacyHistoryLine(
+      text,
+      history.rowKinds[index] ?? "plain",
+      historyLayout.rowAnswerSources[history.start + index]
+    )),
     ...composer.lines
   ];
   const composerStart = header.length + historyRows;
   while (lines.length < height) lines.push([]);
   const visibleLines = lines.slice(0, height).map((line) => fitLine(line, width));
   const hitRows: HitRows = Array.from({ length: height }, (_, row) => {
+    if (row >= header.length && row < composerStart) {
+      const target = asideAnswerHitTarget(
+        surface,
+        historyLayout,
+        history.start,
+        row - header.length
+      );
+      if (target !== null) return { target, left: 0, right: width };
+    }
     if (row < composerStart || row >= composerStart + composer.lines.length) return null;
     return { target: composerHitTarget(visibleLines[row]), left: 0, right: width };
   });
@@ -416,6 +670,7 @@ export function renderAsideScreen(
       renderedLines, { ...state, hitRows }, width, deadlines
     );
   }
+  const storySelectionProjection = buildStorySelectionProjection(visibleLines, width);
   return {
     lines: renderedLines,
     selectable: null,
@@ -430,7 +685,7 @@ export function renderAsideScreen(
       composerSelectionProjection: notesFocus
         ? null
         : buildComposerSelectionProjection(renderedLines, width),
-      storySelectionProjection: null,
+      storySelectionProjection,
       map: null,
       request: null,
       record: null

--- a/tui/src/selection-menu.ts
+++ b/tui/src/selection-menu.ts
@@ -13,7 +13,8 @@ import { composerRangeFromProjection } from "./selection-projection.js";
 type SelectionReader = Pick<CliRenderer, "clearSelection" | "getSelection">;
 
 /** Bind the selected prose before the menu repaint, then replace OpenTUI's
- * buffer-relative selection with semantic highlighting of the source text. */
+ * buffer-relative selection with semantic source text. Native text remains
+ * the fallback for surfaces without a projection. */
 export function selectionAwarePartMenuAction(
   event: MouseEvent,
   resolved: ResolvedKey | null,
@@ -24,7 +25,8 @@ export function selectionAwarePartMenuAction(
     && (renderer.getSelection()?.getSelectedText().length ?? 0) > 0) {
     return null;
   }
-  if (resolved?.action !== "open-actions" || event.type !== "down" || event.button !== 2) return resolved;
+  if ((resolved?.action !== "open-actions" && resolved?.action !== "open-aside-use")
+    || event.type !== "down" || event.button !== 2) return resolved;
   const rendered = renderer.getSelection()?.getSelectedText() ?? "";
   const selection = storySelectionFromRendererSelection(renderer, projection);
   const selectionText = selection?.text ?? rendered;

--- a/tui/src/state.ts
+++ b/tui/src/state.ts
@@ -702,7 +702,8 @@ export interface StoryScreenState extends OverlayState {
         controller: AbortController;
         /** Latest Stop interaction that can focus the settled take. */
         stopInteractionVersion: number | null;
-        /** Interaction epoch captured when an Aside ask started. */
+        /** Interaction epoch captured when an Aside ask started; display-only
+         *  Aside scrolling may advance this restoration/Stop fence. */
         askInteractionVersion?: number;
       }
     | { kind: "summary"; controller: AbortController }

--- a/tui/test/aside-readability.test.ts
+++ b/tui/test/aside-readability.test.ts
@@ -1,0 +1,403 @@
+import { describe, expect, test } from "bun:test";
+import { demoAppSource } from "../src/demo.js";
+import { dispatch, initialState } from "../src/app.js";
+import {
+  asideBodyHeight,
+  asideComposerRows,
+  sendAsideQuestion
+} from "../src/aside-actions.js";
+import {
+  createAsideSurface,
+  isAsideV2,
+  type AsideSessionSurfaceState
+} from "../src/aside-surface.js";
+import { handleOverlayAction } from "../src/overlay-actions.js";
+import { ActionRuntime, beginInteraction } from "../src/action-runtime.js";
+import type { StoryApi } from "../src/api.js";
+import { createWrapCache, type ProseStyle } from "../src/wrap.js";
+import { setComposerText } from "../src/composer-model.js";
+import { pasteInto } from "../src/keys.js";
+import { renderAsideScreen } from "../src/screens/story/aside-screen.js";
+import { frameText, plainLine, visibleWidth } from "../src/screens/story/frame.js";
+
+function v2Surface(
+  state: ReturnType<typeof initialState>,
+  question: string,
+  answer: string
+): AsideSessionSurfaceState {
+  const surface = createAsideSurface(
+    state.payload.id,
+    state.payload.title,
+    [{
+      id: "session-1",
+      title: "long turn",
+      anchor: null,
+      turns: [{ q: question, a: answer }]
+    }],
+    null,
+    null,
+    { v2: true }
+  );
+  if (!isAsideV2(surface)) throw new Error("expected a v2 Aside surface");
+  state.aside = surface;
+  state.mode = "ASIDE";
+  return surface;
+}
+
+function overlayContext(
+  state: ReturnType<typeof initialState>,
+  width: number,
+  height: number
+) {
+  return {
+    backend: new ActionRuntime(state, () => undefined),
+    cache: createWrapCache<ProseStyle>(),
+    repaint: () => undefined,
+    renderer: { width, height } as never,
+    applyTheme: () => undefined,
+    previewTheme: () => undefined
+  };
+}
+
+function dispatchAsideAction(
+  action: Parameters<typeof dispatch>[0],
+  state: ReturnType<typeof initialState>,
+  source: ReturnType<typeof demoAppSource>,
+  context: ReturnType<typeof overlayContext>
+): Promise<void> {
+  return dispatch(
+    action,
+    state,
+    source,
+    context.cache,
+    context.repaint,
+    async () => undefined,
+    () => undefined,
+    context.renderer,
+    context.applyTheme,
+    context.previewTheme,
+    context.backend
+  );
+}
+
+describe("Aside readability and navigation", () => {
+  test("keeps a question treatment on every wrapped question row", () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const question = "question-marker ".repeat(40).trim();
+    const answer = "answer-marker ".repeat(24).trim();
+    const surface = v2Surface(state, question, answer);
+    const frame = renderAsideScreen(state, surface, 32, 80);
+    const questionRows = frame.lines.filter((line) => plainLine(line).includes("question-marker"));
+    const answerRows = frame.lines.filter((line) => plainLine(line).includes("answer-marker"));
+
+    expect(questionRows.length).toBeGreaterThan(1);
+    expect(answerRows.length).toBeGreaterThan(1);
+    expect(questionRows.every((line) => plainLine(line).includes("›"))).toBeTrue();
+    expect(questionRows.every((line) => line.some((part) =>
+      part.role === "accent · deep" || part.role === "focus / accent"
+    ))).toBeTrue();
+    expect(answerRows.every((line) => line.every((part) =>
+      part.role !== "accent · deep" && part.role !== "focus / accent"
+    ))).toBeTrue();
+    expect(frame.lines.every((line) => visibleWidth(plainLine(line)) <= 32)).toBeTrue();
+  });
+
+  test("labels the turns exit action as esc exit", () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const surface = v2Surface(state, "Why?", "Because.");
+    const turnsText = frameText(renderAsideScreen(state, surface, 120, 24).lines);
+    expect(turnsText).toContain("esc exit");
+    expect(turnsText).not.toContain("esc read");
+
+    surface.focus = "composer";
+    const composerText = frameText(renderAsideScreen(state, surface, 120, 24).lines);
+    expect(composerText).toContain("esc exit");
+    expect(composerText).not.toContain("esc read");
+  });
+
+  test("scrolls a long turn from the tail to the start at small and large sizes", async () => {
+    const question = "question-start " + "question-word ".repeat(160) + "question-end";
+    const answer = "answer-start " + "answer-word ".repeat(600) + "answer-end";
+    for (const [width, height] of [[24, 10], [120, 36]] as const) {
+      const source = demoAppSource();
+      const state = initialState(source, false);
+      const surface = v2Surface(state, question, answer);
+      const context = overlayContext(state, width, height);
+
+      const renderText = () => frameText(renderAsideScreen(state, surface, width, height).lines);
+      const tail = renderText();
+      expect(tail).toContain("answer-end");
+
+      await handleOverlayAction({ action: "scroll-line-up" }, state, source, context);
+      expect(surface.scrollTop).not.toBeNull();
+      expect(renderText()).not.toBe(tail);
+
+      for (let page = 0; page < 300; page += 1) {
+        await handleOverlayAction({ action: "scroll-up" }, state, source, context);
+      }
+      const start = renderText();
+      expect(start).toContain("question-start");
+
+      await handleOverlayAction({ action: "scroll-line-down" }, state, source, context);
+      expect(surface.scrollTop).not.toBe(0);
+      for (let page = 0; page < 300; page += 1) {
+        await handleOverlayAction({ action: "scroll-down" }, state, source, context);
+      }
+      expect(surface.scrollTop).toBeNull();
+      expect(renderText()).toContain("answer-end");
+    }
+  });
+
+  test("line, page, and wheel scrolling keep the selected turn stable", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const question = "question-start " + "question-word ".repeat(80) + "question-end";
+    const answer = "answer-start " + "answer-word ".repeat(480) + "answer-end";
+    const surface = v2Surface(state, question, answer);
+    const session = surface.sessions[surface.sessionIndex]!;
+    surface.sessions[surface.sessionIndex] = {
+      ...session,
+      turns: [{ q: "earlier question", a: "earlier answer" }, ...session.turns]
+    };
+    surface.turnCursor = 1;
+    const context = overlayContext(state, 80, 24);
+    const selectedTurn = surface.turnCursor;
+    const page = asideBodyHeight(surface, 80, 24, asideComposerRows(24));
+
+    await handleOverlayAction({ action: "scroll-line-up" }, state, source, context);
+    const first = surface.scrollTop;
+    expect(first).not.toBeNull();
+    await handleOverlayAction({ action: "scroll-line-up" }, state, source, context);
+    expect(surface.scrollTop).toBe(first! - 1);
+    expect(surface.turnCursor).toBe(selectedTurn);
+
+    for (let step = 0; step < 20; step += 1) {
+      await handleOverlayAction({ action: "scroll-line-up" }, state, source, context);
+    }
+    const middle = surface.scrollTop!;
+    await handleOverlayAction({ action: "scroll-down" }, state, source, context);
+    expect(surface.scrollTop).toBe(middle + page);
+    expect(surface.turnCursor).toBe(selectedTurn);
+
+    await handleOverlayAction({ action: "scroll-line-down" }, state, source, context);
+    expect(surface.scrollTop).toBe(middle + page + 1);
+    expect(surface.turnCursor).toBe(selectedTurn);
+  });
+
+  test("busy v2 scrolling remains visible and survives settlement", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const question = "saved-question " + "saved-word ".repeat(80);
+    const answer = "saved-answer " + "saved-word ".repeat(480);
+    const surface = v2Surface(state, question, answer);
+    const savedSession = surface.sessions[surface.sessionIndex]!;
+    surface.sessions[surface.sessionIndex] = {
+      ...savedSession,
+      turns: [{ q: "earlier question", a: "earlier answer" }, ...savedSession.turns]
+    };
+    surface.turnCursor = 1;
+    let emit!: (text: string) => void;
+    let release!: (value: unknown) => void;
+    const pending = new Promise<unknown>((resolve) => { release = resolve; });
+    const api = {
+      ...source.api,
+      askAsideV2: async (
+        _request: unknown,
+        onDelta: (text: string) => void,
+        _callbacks: unknown,
+        _signal: AbortSignal
+      ) => {
+        emit = onDelta;
+        return await pending;
+      }
+    } as unknown as StoryApi;
+    const context = overlayContext(state, 80, 24);
+    const ask = sendAsideQuestion(state, api, "streamed question", {
+      cache: createWrapCache(),
+      repaint: () => undefined
+    });
+    await Promise.resolve();
+    expect(surface.busy).toBeTrue();
+    const selectedTurn = surface.turnCursor;
+
+    await handleOverlayAction({ action: "scroll-line-up" }, state, source, context);
+    const selectedTop = surface.scrollTop;
+    expect(selectedTop).not.toBeNull();
+    expect(surface.turnCursor).toBe(selectedTurn);
+    await handleOverlayAction({ action: "scroll-line-up" }, state, source, context);
+    expect(surface.scrollTop).toBe(selectedTop! - 1);
+
+    emit("stream-tail " + "stream-word ".repeat(200));
+    expect(surface.scrollTop).toBe(selectedTop! - 1);
+    const session = surface.sessions[surface.sessionIndex]!;
+    release({
+      schemaVersion: 2,
+      id: session.id,
+      anchor: session.anchor,
+      title: session.title,
+      turns: [...session.turns, { q: "streamed question", a: "stream answer" }],
+      payload: state.payload
+    });
+    await ask;
+    expect(surface.busy).toBeFalse();
+    expect(surface.scrollTop).toBe(selectedTop! - 1);
+  });
+
+  test("busy scroll then API failure restores the submitted question", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const surface = v2Surface(
+      state,
+      "saved-question " + "saved-word ".repeat(80),
+      "saved-answer " + "saved-word ".repeat(480)
+    );
+    surface.focus = "composer";
+    setComposerText(surface.composer, "failed question");
+    let rejectAsk!: (error: unknown) => void;
+    const pending = new Promise<never>((_resolve, reject) => { rejectAsk = reject; });
+    source.api = {
+      ...source.api,
+      askAsideV2: async (
+        _request: unknown,
+        _onDelta: (text: string) => void,
+        _callbacks: unknown,
+        _signal: AbortSignal
+      ) => await pending
+    } as unknown as StoryApi;
+    const context = overlayContext(state, 80, 24);
+
+    await dispatchAsideAction({ action: "send" }, state, source, context);
+    await Promise.resolve();
+    await dispatchAsideAction({ action: "scroll-line-up" }, state, source, context);
+    const selectedTop = surface.scrollTop;
+    rejectAsk(new Error("provider failed"));
+    await context.backend.whenIdle();
+
+    expect(surface.composer.text).toBe("failed question");
+    expect(surface.scrollTop).toBe(selectedTop);
+  });
+
+  test("busy scroll then Stop restores the submitted question", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const surface = v2Surface(
+      state,
+      "saved-question " + "saved-word ".repeat(80),
+      "saved-answer " + "saved-word ".repeat(480)
+    );
+    surface.focus = "composer";
+    setComposerText(surface.composer, "stopped question");
+    let requestSignal!: AbortSignal;
+    source.api = {
+      ...source.api,
+      askAsideV2: async (
+        _request: unknown,
+        _onDelta: (text: string) => void,
+        _callbacks: unknown,
+        signal: AbortSignal
+      ) => {
+        requestSignal = signal;
+        return await new Promise<null>((resolve) => {
+          signal.addEventListener("abort", () => resolve(null), { once: true });
+        });
+      }
+    } as unknown as StoryApi;
+    const context = overlayContext(state, 80, 24);
+
+    await dispatchAsideAction({ action: "send" }, state, source, context);
+    await Promise.resolve();
+    await dispatchAsideAction({ action: "scroll-line-up" }, state, source, context);
+    const selectedTop = surface.scrollTop;
+    await dispatchAsideAction({ action: "cancel" }, state, source, context);
+    expect(requestSignal.aborted).toBeTrue();
+    await context.backend.whenIdle();
+
+    expect(surface.composer.text).toBe("stopped question");
+    expect(surface.scrollTop).toBe(selectedTop);
+  });
+
+  test("newer draft survives API failure after a busy scroll", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const surface = v2Surface(
+      state,
+      "saved-question " + "saved-word ".repeat(80),
+      "saved-answer " + "saved-word ".repeat(480)
+    );
+    surface.focus = "composer";
+    setComposerText(surface.composer, "failed question");
+    let rejectAsk!: (error: unknown) => void;
+    const pending = new Promise<never>((_resolve, reject) => { rejectAsk = reject; });
+    source.api = {
+      ...source.api,
+      askAsideV2: async (
+        _request: unknown,
+        _onDelta: (text: string) => void,
+        _callbacks: unknown,
+        _signal: AbortSignal
+      ) => await pending
+    } as unknown as StoryApi;
+    const context = overlayContext(state, 80, 24);
+
+    await dispatchAsideAction({ action: "send" }, state, source, context);
+    await Promise.resolve();
+    expect(surface.busy).toBeTrue();
+    expect(pasteInto(state, "newer draft")).toBeTrue();
+    beginInteraction(state);
+    await dispatchAsideAction({ action: "scroll-line-up" }, state, source, context);
+    const selectedTop = surface.scrollTop;
+    expect(selectedTop).not.toBeNull();
+
+    rejectAsk(new Error("provider failed"));
+    await context.backend.whenIdle();
+    expect(surface.busy).toBeFalse();
+    expect(surface.composer.text).toBe("newer draft");
+    expect(surface.scrollTop).toBe(selectedTop);
+  });
+
+  test("newer draft survives Stop after a busy scroll", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const surface = v2Surface(
+      state,
+      "saved-question " + "saved-word ".repeat(80),
+      "saved-answer " + "saved-word ".repeat(480)
+    );
+    surface.focus = "composer";
+    setComposerText(surface.composer, "stopped question");
+    let requestSignal!: AbortSignal;
+    source.api = {
+      ...source.api,
+      askAsideV2: async (
+        _request: unknown,
+        _onDelta: (text: string) => void,
+        _callbacks: unknown,
+        signal: AbortSignal
+      ) => {
+        requestSignal = signal;
+        return await new Promise<null>((resolve) => {
+          signal.addEventListener("abort", () => resolve(null), { once: true });
+        });
+      }
+    } as unknown as StoryApi;
+    const context = overlayContext(state, 80, 24);
+
+    await dispatchAsideAction({ action: "send" }, state, source, context);
+    await Promise.resolve();
+    expect(surface.busy).toBeTrue();
+    expect(pasteInto(state, "newer draft")).toBeTrue();
+    beginInteraction(state);
+    await dispatchAsideAction({ action: "scroll-line-up" }, state, source, context);
+    const selectedTop = surface.scrollTop;
+    expect(selectedTop).not.toBeNull();
+
+    await dispatchAsideAction({ action: "cancel" }, state, source, context);
+    expect(requestSignal.aborted).toBeTrue();
+    await context.backend.whenIdle();
+    expect(surface.busy).toBeFalse();
+    expect(surface.composer.text).toBe("newer draft");
+    expect(surface.scrollTop).toBe(selectedTop);
+  });
+});

--- a/tui/test/aside-scale.test.ts
+++ b/tui/test/aside-scale.test.ts
@@ -1,0 +1,251 @@
+import { describe, expect, test } from "bun:test";
+import { initialState } from "../src/app.js";
+import { demoAppSource } from "../src/demo.js";
+import {
+  createAsideSurface,
+  isAsideV2,
+  type AsideAnchorView,
+  type AsideSessionAnchor,
+  type AsideSessionSurfaceState,
+  type AsideSessionView
+} from "../src/aside-surface.js";
+import { cycleAsideSession } from "../src/aside-v2-actions.js";
+import { applyAsideV2Settlement, reconcileAsidePresence } from "../src/aside-v2-settlement.js";
+import {
+  asideHopEntries,
+  asideHopStripText,
+  asideHopWindow,
+  moveAsideHopIndex,
+  orderAsideAnchors
+} from "../src/aside-hop.js";
+import { asideHistoryLayout } from "../src/aside-actions.js";
+import { renderAsideScreen } from "../src/screens/story/aside-screen.js";
+import { frameText, visibleWidth } from "../src/screens/story/frame.js";
+
+const SMALL_VIEW = { width: 12, height: 6 } as const;
+const NORMAL_VIEW = { width: 80, height: 24 } as const;
+
+function anchor(index: number, sessionCount = 1): AsideAnchorView {
+  return {
+    partId: `part-${index}`,
+    takeId: `take-${index}`,
+    partNumber: index + 1,
+    takeIndex: 0,
+    takeCount: 1,
+    sessionCount
+  };
+}
+
+function session(index: number, target: AsideSessionAnchor): AsideSessionView {
+  return {
+    id: `session-${index}`,
+    title: `session title ${index}`,
+    anchor: target,
+    turns: [{
+      id: `turn-${index}`,
+      q: `question-${index}`,
+      a: `answer-${index}`
+    }]
+  };
+}
+
+function asideFixture(
+  sessions: readonly AsideSessionView[],
+  anchors: readonly AsideAnchorView[],
+  sessionIndex: number,
+  currentAnchor: AsideSessionAnchor | null
+): {
+  state: ReturnType<typeof initialState>;
+  surface: AsideSessionSurfaceState;
+} {
+  const source = demoAppSource();
+  const state = initialState(source, false);
+  const surface = createAsideSurface(
+    state.payload.id,
+    state.payload.title,
+    sessions,
+    null,
+    null,
+    { v2: true, anchors, anchor: currentAnchor, sessionIndex }
+  );
+  if (!isAsideV2(surface)) throw new Error("expected an Aside session surface");
+  state.aside = surface;
+  state.mode = "ASIDE";
+  return { state, surface };
+}
+
+function assertFrameIsBounded(
+  frame: ReturnType<typeof renderAsideScreen>,
+  width: number,
+  height: number
+): void {
+  expect(frame.lines).toHaveLength(height);
+  expect(frame.derived.hitRows).toHaveLength(height);
+  const cells = frame.lines.reduce(
+    (total, line) => total + visibleWidth(line.map((part) => part.text).join("")),
+    0
+  );
+  expect(cells <= width * height).toBeTrue();
+}
+
+function renderAtSizes(
+  state: ReturnType<typeof initialState>,
+  surface: AsideSessionSurfaceState
+): void {
+  for (const size of [SMALL_VIEW, NORMAL_VIEW]) {
+    const frame = renderAsideScreen(state, surface, size.width, size.height);
+    assertFrameIsBounded(frame, size.width, size.height);
+  }
+}
+
+describe("Aside v2 bounded scale", () => {
+  test("renders and cycles hundreds of sessions on one take", () => {
+    const sessionCount = 512;
+    const sameTake = anchor(7, sessionCount);
+    const sessions = Array.from({ length: sessionCount }, (_, index) =>
+      session(index, sameTake)
+    );
+    const { state, surface } = asideFixture(
+      sessions,
+      [sameTake],
+      sessionCount - 1,
+      sameTake
+    );
+
+    renderAtSizes(state, surface);
+    const initialText = frameText(renderAsideScreen(
+      state, surface, NORMAL_VIEW.width, NORMAL_VIEW.height
+    ).lines);
+    expect(initialText).toContain(`session ${sessionCount}/${sessionCount}`);
+    expect(initialText).toContain("¶ 8");
+    expect(initialText).toContain(`answer-${sessionCount - 1}`);
+
+    expect(cycleAsideSession(surface, 1)).toBeTrue();
+    expect(surface.sessionIndex).toBe(0);
+    expect(frameText(renderAsideScreen(
+      state, surface, NORMAL_VIEW.width, NORMAL_VIEW.height
+    ).lines)).toContain("session 1/512");
+    expect(cycleAsideSession(surface, -1)).toBeTrue();
+    expect(surface.sessionIndex).toBe(sessionCount - 1);
+  });
+
+  test("keeps thousands of anchors and sessions bounded across render, navigation, and reconciliation", () => {
+    const itemCount = 2_048;
+    const anchors = Array.from({ length: itemCount }, (_, index) => anchor(index));
+    const sessions = anchors.map((entry, index) => session(index, entry));
+    const currentIndex = 1_024;
+    const currentAnchor = anchors[currentIndex]!;
+    const { state, surface } = asideFixture(
+      sessions,
+      anchors,
+      currentIndex,
+      currentAnchor
+    );
+
+    renderAtSizes(state, surface);
+    const normalFrame = renderAsideScreen(
+      state, surface, NORMAL_VIEW.width, NORMAL_VIEW.height
+    );
+    const normalText = frameText(normalFrame.lines);
+    expect(normalText).toContain(`session ${currentIndex + 1}/${itemCount}`);
+    expect(normalText).toContain("[ ¶ 1025 ×1 ]");
+    expect(asideHopStripText(anchors, currentAnchor, NORMAL_VIEW.width)).toContain(
+      "[ ¶ 1025 ×1 ]"
+    );
+
+    const entries = asideHopEntries(anchors, currentAnchor);
+    expect(entries).toHaveLength(itemCount);
+    const window = asideHopWindow(entries, surface.anchorIndex, 5);
+    expect(window.entries).toHaveLength(5);
+    expect(window.entries.some((entry) => entry.current)).toBeTrue();
+    expect(moveAsideHopIndex(surface.anchorIndex, 1, entries.length)).toBe(
+      surface.anchorIndex + 1
+    );
+    expect(moveAsideHopIndex(entries.length - 1, 1, entries.length)).toBe(0);
+    expect(orderAsideAnchors(anchors)[0]?.partNumber).toBe(1);
+
+    const beforeId = surface.sessions[surface.sessionIndex]?.id;
+    const reversedRead = {
+      schemaVersion: 2 as const,
+      anchor: currentAnchor,
+      sessions: [...sessions].reverse(),
+      anchors: [...anchors].reverse(),
+      unanchoredCount: 0
+    };
+    expect(applyAsideV2Settlement(surface, reversedRead)).toBeTrue();
+    expect(surface.sessions[surface.sessionIndex]?.id).toBe(beforeId);
+    expect(surface.anchorIndex).toBe(orderAsideAnchors(surface.anchors).findIndex(
+      (entry) => entry.takeId === currentAnchor.takeId
+    ));
+
+    const refreshedPresence = {
+      ...state.payload,
+      asidePresence: {
+        anchors: [...anchors].reverse().map((entry) => ({
+          ...entry,
+          sessionCount: entry.takeId === currentAnchor.takeId ? 2 : 1
+        })),
+        unanchoredCount: 0
+      }
+    };
+    reconcileAsidePresence(surface, refreshedPresence);
+    expect(surface.anchors).toHaveLength(itemCount);
+    expect(surface.anchors.find((entry) => entry.takeId === currentAnchor.takeId)?.sessionCount)
+      .toBe(2);
+    expect(surface.anchorIndex).toBe(orderAsideAnchors(surface.anchors).findIndex(
+      (entry) => entry.takeId === currentAnchor.takeId
+    ));
+
+    expect(cycleAsideSession(surface, 1)).toBeTrue();
+    expect(surface.sessionIndex).toBe(itemCount - currentIndex);
+    expect(cycleAsideSession(surface, -1)).toBeTrue();
+    expect(surface.sessions[surface.sessionIndex]?.id).toBe(beforeId);
+  });
+
+  test("keeps protocol-bound session counters exact in anchor labels", () => {
+    const maximum = 20_001;
+    const anchored = anchor(0, maximum);
+    const unanchored: AsideAnchorView = {
+      ...anchored,
+      partId: "__aside_unanchored__",
+      takeId: "__aside_unanchored__",
+      sessionCount: maximum,
+      unanchored: true
+    };
+
+    expect(asideHopEntries([anchored], anchored)[0]?.label).toBe("¶ 1 ×20001");
+    expect(asideHopEntries([unanchored], null)[0]?.label).toBe("· unanchored ×20001");
+  });
+
+  test("does not rebuild the full history layout once per visible answer row", () => {
+    const trackedAnchors = Array.from({ length: 2_048 }, (_, index) => anchor(index));
+    const sameTake = trackedAnchors[3]!;
+    const longAnswer = Array.from({ length: 320 }, (_, index) => `answer-word-${index}`).join(" ");
+    const sessions = [{
+      ...session(0, sameTake),
+      turns: [{ q: "long question", a: longAnswer }]
+    }];
+    const { state, surface } = asideFixture(sessions, trackedAnchors, 0, sameTake);
+    let anchorReads = 0;
+    const trackedSurface = new Proxy(surface, {
+      get(target, property, receiver) {
+        if (property === "anchors") anchorReads += 1;
+        return Reflect.get(target, property, receiver);
+      }
+    });
+    state.aside = trackedSurface;
+
+    const renderAndCount = (height: number): number => {
+      anchorReads = 0;
+      const frame = renderAsideScreen(state, trackedSurface, NORMAL_VIEW.width, height);
+      assertFrameIsBounded(frame, NORMAL_VIEW.width, height);
+      return anchorReads;
+    };
+    const shortFrameReads = renderAndCount(8);
+    const normalFrameReads = renderAndCount(NORMAL_VIEW.height);
+    expect(shortFrameReads).toBeGreaterThan(0);
+    expect(normalFrameReads).toBe(shortFrameReads);
+    expect(asideHistoryLayout(trackedSurface, NORMAL_VIEW.width).body.length)
+      .toBeGreaterThan(NORMAL_VIEW.height);
+  });
+});

--- a/tui/test/aside-use-menu-mouse.test.ts
+++ b/tui/test/aside-use-menu-mouse.test.ts
@@ -3,12 +3,21 @@
  */
 import { describe, expect, test } from "bun:test";
 import { createAsideSurface } from "../src/aside-surface.js";
+import { isAsideV2 } from "../src/aside-surface.js";
 import { demoAppSource } from "../src/demo.js";
 import { initialState } from "../src/app.js";
 import { handleOverlayAction } from "../src/overlay-actions.js";
 import { ActionRuntime } from "../src/action-runtime.js";
 import { createWrapCache, type ProseStyle } from "../src/wrap.js";
 import { renderStoryScreen } from "../src/screens/story.js";
+import { frameText, plainLine, visibleWidth } from "../src/screens/story/frame.js";
+import {
+  asideAnswerRowId,
+  asideUseActions,
+  focusAsideUseMenuIndex,
+  openAsideUseMenu
+} from "../src/aside-use.js";
+import { selectionAwarePartMenuAction } from "../src/selection-menu.js";
 import {
   captureMouseActionState,
   mouseToAction
@@ -36,7 +45,419 @@ function overlayContext(
   };
 }
 
+function installLegacyAside(
+  state: ReturnType<typeof initialState>,
+  answer: string
+) {
+  const surface = createAsideSurface(
+    state.payload.id,
+    state.payload.title,
+    [{ question: "Why?", answer }]
+  );
+  state.aside = surface;
+  state.mode = "ASIDE";
+  return surface;
+}
+
+function installV2Aside(
+  state: ReturnType<typeof initialState>,
+  answer: string
+) {
+  const surface = createAsideSurface(
+    state.payload.id,
+    state.payload.title,
+    [{
+      id: "session-1",
+      title: "session",
+      anchor: null,
+      turns: [{ id: "turn-1", q: "Why?", a: answer }]
+    }],
+    null,
+    null,
+    { v2: true }
+  );
+  if (!isAsideV2(surface)) throw new Error("expected v2 Aside surface");
+  state.aside = surface;
+  state.mode = "ASIDE";
+  return surface;
+}
+
+function selectionReader(
+  text: string,
+  range: { start: number; end: number }
+) {
+  let cleared = false;
+  let prevented = false;
+  const selection = {
+    getSelectedText: () => text,
+    selectedRenderables: [{ getSelection: () => range }]
+  };
+  return {
+    renderer: {
+      getSelection: () => selection,
+      clearSelection: () => { cleared = true; }
+    },
+    event: {
+      type: "down",
+      button: 2,
+      x: 0,
+      y: 0,
+      modifiers: { shift: false, alt: false, ctrl: false },
+      preventDefault: () => { prevented = true; }
+    },
+    wasCleared: () => cleared,
+    wasPrevented: () => prevented
+  };
+}
+
+function normalizedFrameText(lines: ReturnType<typeof renderStoryScreen>["lines"]): string {
+  const panel = lines.map((line) => line
+    .filter((part) => part.background === "raised" && part.role !== "compose accent")
+    .map((part) => part.text)
+    .join("\n"))
+    .join("\n");
+  return panel.length > 0 ? panel
+    .replace(/[┃┏┓┗━]/gu, " ")
+    .replace(/\s+/gu, " ") : frameText(lines)
+    .replace(/[┃┏┓┗━]/gu, " ")
+    .replace(/\s+/gu, " ");
+}
+
+function activateStoryStream(state: ReturnType<typeof initialState>): void {
+  state.stream = {
+    targetId: "streaming-part",
+    parentId: null,
+    append: true,
+    startedAt: "2026-08-26T00:00:00.000Z",
+    instruction: "",
+    text: "partial answer"
+  } as never;
+}
+
 describe("Aside use-menu mouse", () => {
+  test("right-clicking a wrapped answer uses exact source text in legacy and v2", async () => {
+    const answer = "alpha bravo charlie delta echo foxtrot golf hotel india juliet kilo lima";
+    const width = 36;
+    const height = 24;
+    for (const variant of ["legacy", "v2"] as const) {
+      const source = demoAppSource();
+      const state = initialState(source, false);
+      const surface = variant === "legacy"
+        ? installLegacyAside(state, answer)
+        : installV2Aside(state, answer);
+      const context = overlayContext(state, width, height);
+      const frame = renderStoryScreen(state, { width, height });
+      state.hitRows = frame.derived.hitRows;
+
+      const projection = frame.derived.storySelectionProjection;
+      expect(projection).not.toBeNull();
+      const stride = width + 1;
+      const mapped = projection!.flatMap((cell, index) => cell === null
+        ? [] : [{ cell, index }]);
+      const answerCells = mapped.filter(({ cell }) => cell.key.startsWith("aside-answer:"));
+      expect(answerCells.length).toBeGreaterThan(0);
+      const first = answerCells[0]!;
+      const firstRow = Math.floor(first.index / stride);
+      const secondRowCells = answerCells.filter(({ index }) =>
+        Math.floor(index / stride) > firstRow);
+      expect(secondRowCells.length).toBeGreaterThan(0);
+      const last = secondRowCells.at(-1)!;
+      const expected = first.cell.text.slice(first.cell.start, last.cell.end);
+      expect(expected).toBe(answer.slice(first.cell.start, last.cell.end));
+
+      const answerRow = state.hitRows.findIndex((row) => row?.target.kind === "aside-answer");
+      expect(answerRow).toBeGreaterThan(-1);
+      const raw = mouseToAction({
+        type: "down",
+        button: 2,
+        x: 4,
+        y: answerRow,
+        modifiers: { shift: false, alt: false, ctrl: false }
+      }, state);
+      expect(raw).toMatchObject({
+        action: "open-aside-use",
+        index: 0,
+        rowId: asideAnswerRowId(surface, 0)
+      });
+
+      // Native terminal selection text includes the painted gutter and the
+      // wrap newline. The semantic projection must remove both.
+      const native = selectionReader(`  ${expected.slice(0, 12)}\n     ${expected.slice(12)}`, {
+        start: first.index,
+        end: last.index + 1
+      });
+      const decorated = selectionAwarePartMenuAction(
+        native.event as never,
+        raw,
+        native.renderer as never,
+        projection
+      );
+      expect(decorated?.selectionText).toBe(expected);
+      expect(decorated?.selectionText).not.toContain("\n");
+      expect(/^\s/u.test(decorated?.selectionText ?? "")).toBeFalse();
+      expect(native.wasCleared()).toBeTrue();
+      expect(native.wasPrevented()).toBeTrue();
+
+      await handleOverlayAction(decorated!, state, source, context);
+      expect(surface.useMenu?.selectionText).toBe(expected);
+      expect(asideUseActions(surface.useMenu?.selectionText).map(({ id }) => id))
+        .toEqual(["copy", "insert-into-compose", "insert-as-new-fact", "insert-into-story"]);
+
+      // Copy owns the selected text, then the same menu can be reopened for
+      // the local Fact editor path without losing the exact target.
+      await handleOverlayAction({ action: "focus-index", index: 0 }, state, source, context);
+      await handleOverlayAction({ action: "apply" }, state, source, context);
+      expect(state.mode).toBe("ASIDE");
+      expect(surface.useMenu).toBeNull();
+      expect(state.toast).toMatch(/copied selection|no clipboard available/u);
+
+      await handleOverlayAction({
+        action: "open-aside-use",
+        index: 0,
+        rowId: asideAnswerRowId(surface, 0),
+        selectionText: expected
+      }, state, source, context);
+      activateStoryStream(state);
+      await handleOverlayAction({ action: "focus-index", index: 2 }, state, source, context);
+      await handleOverlayAction({ action: "apply" }, state, source, context);
+      expect(state.mode).toBe("EDITOR");
+      expect(state.editor?.kind).toBe("fact");
+      expect(state.editor?.kind === "fact" ? state.editor.composer.text : "")
+        .toBe(expected);
+    }
+  });
+
+  test("v2 answer identity follows an id-less turn after an earlier turn is deleted", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const surface = createAsideSurface(
+      state.payload.id,
+      state.payload.title,
+      [{
+        id: "session-1",
+        title: "session",
+        anchor: null,
+        turns: [
+          { q: "first", a: "first answer" },
+          { q: "later", a: "later answer" }
+        ]
+      }],
+      null,
+      null,
+      { v2: true }
+    );
+    if (!isAsideV2(surface)) throw new Error("expected v2 Aside surface");
+    state.aside = surface;
+    state.mode = "ASIDE";
+    const width = 80;
+    const height = 24;
+    const event: FrozenMouseEvent = {
+      type: "down",
+      button: 2,
+      x: 8,
+      y: 0,
+      modifiers: { shift: false, alt: false, ctrl: false }
+    };
+    const initialFrame = renderStoryScreen(state, { width, height });
+    state.hitRows = initialFrame.derived.hitRows;
+    const laterRow = state.hitRows.findIndex((row) =>
+      row?.target.kind === "aside-answer" && row.target.noteIndex === 1);
+    expect(laterRow).toBeGreaterThan(-1);
+    const capturedEvent = { ...event, y: laterRow };
+    const action = mouseToAction(capturedEvent, state);
+    expect(action).toMatchObject({ action: "open-aside-use", index: 1 });
+    expect(action?.rowId).toContain(":ref:");
+
+    const captured: PresentedInteraction = {
+      version: 1,
+      frameToken: 1,
+      interactive: true,
+      storyId: state.payload.id,
+      state: captureMouseActionState(state)
+    };
+    const session = surface.sessions[surface.sessionIndex]!;
+    const laterTurn = session.turns[1]!;
+    surface.sessions[surface.sessionIndex] = { ...session, turns: [laterTurn] };
+    state.hitRows = renderStoryScreen(state, { width, height }).derived.hitRows;
+    const presented: PresentedInteraction = {
+      version: 2,
+      frameToken: 2,
+      interactive: true,
+      storyId: state.payload.id,
+      state: captureMouseActionState(state)
+    };
+    const rebased = reconcilePresentedMouseAction({
+      action: action!,
+      event: capturedEvent,
+      captured,
+      presented,
+      state
+    });
+    expect(rebased).toMatchObject({
+      action: "open-aside-use",
+      index: 0,
+      rowId: action?.rowId
+    });
+    await handleOverlayAction(rebased!, state, source, overlayContext(state, width, height));
+    expect(surface.useMenu?.noteIndex).toBe(0);
+    expect(surface.useMenu?.selectionText).toBe(undefined);
+    expect(surface.sessions[surface.sessionIndex]?.turns[0]?.a).toBe("later answer");
+  });
+
+  test("v2 id-less answer click drops when its turn object is replaced", () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const surface = createAsideSurface(
+      state.payload.id,
+      state.payload.title,
+      [{
+        id: "session-1",
+        title: "session",
+        anchor: null,
+        turns: [
+          { q: "first", a: "first answer" },
+          { q: "later", a: "later answer" }
+        ]
+      }],
+      null,
+      null,
+      { v2: true }
+    );
+    if (!isAsideV2(surface)) throw new Error("expected v2 Aside surface");
+    state.aside = surface;
+    state.mode = "ASIDE";
+    const width = 80;
+    const height = 24;
+    const frame = renderStoryScreen(state, { width, height });
+    state.hitRows = frame.derived.hitRows;
+    const laterRow = state.hitRows.findIndex((row) =>
+      row?.target.kind === "aside-answer" && row.target.noteIndex === 1);
+    expect(laterRow).toBeGreaterThan(-1);
+    const event: FrozenMouseEvent = {
+      type: "down",
+      button: 2,
+      x: 8,
+      y: laterRow,
+      modifiers: { shift: false, alt: false, ctrl: false }
+    };
+    const action = mouseToAction(event, state);
+    expect(action?.action).toBe("open-aside-use");
+    const captured: PresentedInteraction = {
+      version: 1,
+      frameToken: 1,
+      interactive: true,
+      storyId: state.payload.id,
+      state: captureMouseActionState(state)
+    };
+    const session = surface.sessions[surface.sessionIndex]!;
+    surface.sessions[surface.sessionIndex] = {
+      ...session,
+      turns: [
+        session.turns[0]!,
+        { q: "later", a: "later answer" }
+      ]
+    };
+    state.hitRows = renderStoryScreen(state, { width, height }).derived.hitRows;
+    const presented: PresentedInteraction = {
+      version: 2,
+      frameToken: 2,
+      interactive: true,
+      storyId: state.payload.id,
+      state: captureMouseActionState(state)
+    };
+    const stale = reconcilePresentedMouseAction({
+      action: action!,
+      event,
+      captured,
+      presented,
+      state
+    });
+    expect(stale).toBeNull();
+    expect(surface.useMenu).toBeNull();
+  });
+
+  test("full-answer Fact action and wrapped menu rows fit narrow and wide views", async () => {
+    const actions = asideUseActions();
+    expect(actions.map(({ id }) => id)).toEqual([
+      "insert-into-compose", "insert-into-story", "insert-as-new-fact"
+    ]);
+    const answer = Array.from({ length: 900 }, () => "answer-word").join(" ");
+    for (const [width, height] of [[24, 16], [120, 24]] as const) {
+      const source = demoAppSource();
+      const state = initialState(source, false);
+      const surface = installLegacyAside(state, answer);
+      const context = overlayContext(state, width, height);
+      await handleOverlayAction({ action: "cycle" }, state, source, context);
+      await handleOverlayAction({ action: "open-selected" }, state, source, context);
+      expect(surface.useMenu).not.toBeNull();
+
+      for (const [index, action] of actions.entries()) {
+        focusAsideUseMenuIndex(surface, index);
+        const frame = renderStoryScreen(state, { width, height });
+        const text = normalizedFrameText(frame.lines);
+        expect(text).toContain(action.name);
+        expect(text).toContain(action.description);
+        expect(frame.lines.every((line) => visibleWidth(plainLine(line)) <= width)).toBeTrue();
+      }
+      if (width >= 100) {
+        const title = normalizedFrameText(renderStoryScreen(state, { width, height }).lines);
+        expect(title).toContain("use answer · 900 words");
+      }
+    }
+
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const surface = installLegacyAside(state, answer);
+    const context = overlayContext(state, 120, 24);
+    await handleOverlayAction({ action: "cycle" }, state, source, context);
+    await handleOverlayAction({ action: "open-selected" }, state, source, context);
+    activateStoryStream(state);
+    focusAsideUseMenuIndex(surface, 2);
+    await handleOverlayAction({ action: "apply" }, state, source, context);
+    expect(state.mode).toBe("EDITOR");
+    expect(state.editor?.kind).toBe("fact");
+    expect(state.editor?.kind === "fact" ? state.editor.composer.text : "")
+      .toBe(answer);
+  });
+
+  test("wraps a very large selected menu and windows whole blocks at tiny heights", () => {
+    const selected = Array.from({ length: 450 }, () => "selected-word").join(" ");
+    const actions = asideUseActions(selected);
+
+    for (const [width, height] of [[24, 16], [120, 24]] as const) {
+      const source = demoAppSource();
+      const state = initialState(source, false);
+      const surface = installLegacyAside(state, "short answer");
+      expect(openAsideUseMenu(surface, 0, 0, selected)).toBeTrue();
+
+      for (const [index, action] of actions.entries()) {
+        focusAsideUseMenuIndex(surface, index);
+        const frame = renderStoryScreen(state, { width, height });
+        const text = normalizedFrameText(frame.lines);
+        expect(text).toContain(action.name);
+        expect(text).toContain(action.description);
+        expect(frame.lines.every((line) => visibleWidth(plainLine(line)) <= width)).toBeTrue();
+      }
+      if (width >= 100) {
+        expect(normalizedFrameText(renderStoryScreen(state, { width, height }).lines))
+          .toContain("use selection · 450 words");
+      }
+    }
+
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const surface = installLegacyAside(state, "short answer");
+    expect(openAsideUseMenu(surface, 0, 0, selected)).toBeTrue();
+    const frame = renderStoryScreen(state, { width: 24, height: 8 });
+    const text = normalizedFrameText(frame.lines);
+    expect(text).toContain("use ↑↓");
+    expect(frame.lines.every((line) => visibleWidth(plainLine(line)) <= 24)).toBeTrue();
+    const listTargets = frame.derived.hitRows.flatMap((row) =>
+      row?.overrides?.map(({ target }) => target).filter((target) => target.kind === "list") ?? []);
+    expect(listTargets.length).toBeGreaterThan(0);
+    expect(listTargets.every((target) => target.kind === "list" && target.index === 0)).toBeTrue();
+  });
+
   test("use-menu mouse click selects insert into story then opens Placement", async () => {
     const source = demoAppSource();
     const state = initialState(source, false);

--- a/tui/test/aside-use-placement.test.ts
+++ b/tui/test/aside-use-placement.test.ts
@@ -117,9 +117,10 @@ describe("Aside use menu and Placement", () => {
     expect(menuFrame).toContain("use answer ·");
     expect(menuFrame).toContain("insert into compose");
     expect(menuFrame).toContain("insert into story…");
-    expect(menuFrame).toContain("insert at the composer cur");
+    expect(menuFrame).toContain("insert at the composer");
+    expect(menuFrame).toContain("cursor");
     expect(menuFrame).toContain("select a position");
-    expect(menuFrame).not.toContain("new fact");
+    expect(menuFrame).toContain("insert as new Fact");
     expect(menuFrame).not.toContain("delete note");
     expect(menuFrame).not.toContain("author's note");
 

--- a/tui/test/aside-v2.test.ts
+++ b/tui/test/aside-v2.test.ts
@@ -542,8 +542,6 @@ describe("Aside v2 surface", () => {
     await press("x");
     expect(currentAsideTurns(surface)).toEqual([{ q: "A?", a: "A." }]);
     await press("escape");
-    expect(surface.focus).toBe("composer");
-    await press("escape");
     expect(state.aside).toBeNull();
     await Promise.resolve();
     rejectDelete(new Error("delete failed"));
@@ -885,7 +883,7 @@ describe("Aside v2 surface", () => {
     expect(currentAsideTurns(surface)).toEqual([]);
   });
 
-  test("Esc returns from turns to the composer before closing and keeps its draft", async () => {
+  test("Esc exits Aside from turns while Tab returns to the composer", async () => {
     const { source, state, surface } = surfaceWithTurns([{ q: "Why?", a: "Because." }]);
     surface.focus = "composer";
     surface.composer.text = "unsent draft";
@@ -904,9 +902,11 @@ describe("Aside v2 surface", () => {
 
     await press("tab");
     expect(surface.focus).toBe("notes");
-    await press("escape");
+    await press("tab");
     expect(surface.focus).toBe("composer");
     expect(surface.composer.text).toBe("unsent draft");
+    await press("tab");
+    expect(surface.focus).toBe("notes");
     await press("escape");
     expect(state.mode).toBe("NAV");
     expect(state.aside).toBeNull();
@@ -1860,7 +1860,7 @@ describe("Aside v2 surface", () => {
     const { state, surface } = surfaceWithTurns([{ q: "Why?", a: "Because." }]);
     const text = frameText(renderAsideScreen(state, surface, 80, 24).lines);
     expect(text).toContain("↑↓ turn · ←→ session · n new · ↵ use · r retake · x delete");
-    expect(text).toContain("t Thoughts · tab ask · [ ] hop · g go · esc read");
+    expect(text).toContain("t Thoughts · tab ask · [ ] hop · g go · esc exit");
   });
 
   test("composer keyline does not advertise hop keys", () => {


### PR DESCRIPTION
## Outcome

Aside remains readable and usable with long content and large histories. Existing Side Notes remain available.

## Changes

- Keep wrapped questions visually distinct from answers.
- Make history scrolling independent from turn selection, including during streaming.
- Change the Aside footer from `esc read` to `esc exit`.
- Add a saved-answer selection menu for copy, composer insertion, new Fact insertion, and story insertion.
- Add new Fact insertion to the full-answer menu.
- Wrap action labels and descriptions without partial cutoff.
- Use stable turn identities for mouse actions.
- Bound rendering and navigation with hundreds of sessions and thousands of story anchors.
- Repair the map performance benchmark after the lane renderer change.

## Verification

- `npm test`
- `npm run build`
- `npm run typecheck`
- `bun test` in `tui`: 2,254 passed, 2 platform skips
- `bun run build:standalone`
- `bun bench/perf.ts`
- Small and large Aside geometry tests
- 512-session take scale test
- 2,048-session story scale test
- Claude/Fable design review
- Autoreview closeout
- Thermonuclear maintainability review

## Risk and follow-up

The change preserves the legacy Side Note projection and actions. The scale tests use bounded synthetic data. Keep issue #331 open until a stable release contains this change.

Tracks #331