### PR TITLE
chore(release): prepare 0.10.3-rc.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This file records notable changes to 1667. Product terms use the definitions in
 
 ## Unreleased
 
+## 0.10.3-rc.2 - 2026-08-26
+
 - **Aside keeps long chats readable and selectable.** Wrapped questions keep
   their question style. Scroll history without changing the selected turn,
   including while an answer streams. Highlight saved answer text and

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "1667-workspace",
-  "version": "0.10.3-rc.1",
+  "version": "0.10.3-rc.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "1667-workspace",
-      "version": "0.10.3-rc.1",
+      "version": "0.10.3-rc.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@earendil-works/pi-ai": "0.84.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667-workspace",
-  "version": "0.10.3-rc.1",
+  "version": "0.10.3-rc.2",
   "private": true,
   "description": "Source workspace for the 1667 terminal writing environment",
   "license": "Apache-2.0",

--- a/shared/release-notes.ts
+++ b/shared/release-notes.ts
@@ -11,6 +11,11 @@ export interface ReleaseNote {
  *  a release, and is not included. */
 export const RELEASE_NOTES: readonly ReleaseNote[] = [
   {
+    version: "0.10.3-rc.2",
+    date: "2026-08-26",
+    body: "- **Aside keeps long chats readable and selectable.** Wrapped questions keep\n  their question style. Scroll history without changing the selected turn,\n  including while an answer streams. Highlight saved answer text and\n  right-click to copy it or insert it into the composer, a new Fact, or the\n  story. The full-answer menu can also create a new Fact. Large Aside\n  histories stay responsive. Existing Side Notes remain available."
+  },
+  {
     version: "0.10.3-rc.1",
     date: "2026-08-26",
     body: "- **The tree map draws the whole story in lanes.** Rows are reading order. Each live story\n  line owns a two-column lane. A line that ends hands its lane back and the next fork reuses\n  it. Lane 0 is the reading line. Press `←` or `→` to jump to the nearest row in the next\n  lane. Press `tab` to hide the lanes and open the path view on the same part.\n\n- **The streaming gutter pair stays visible while a long take scrolls.** The\n  `writing · esc stops` and `thinking · esc stops · T peeks` lines stick to\n  the top of the visible part, the same way the focused verb menu does.\n\n- **Aside now keeps separate chats for story takes.** Use the session and\n  anchor controls to review each chat. Existing Side Notes remain available\n  in the unanchored bucket. Optional Thoughts stay visible only in Aside and\n  do not enter a later model request."

--- a/tui/package.json
+++ b/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667",
-  "version": "0.10.3-rc.1",
+  "version": "0.10.3-rc.2",
   "private": true,
   "description": "A terminal environment for writing fiction with language models",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Outcome

Prepare the `0.10.3-rc.2` beta release with the merged Aside readability and selection changes.

## Changes

- Set the root and TUI package versions to `0.10.3-rc.2`.
- Add the dated release section to `CHANGELOG.md`.
- Regenerate the embedded release notes.

## Verification

- `npm run notes:check-version -- 0.10.3-rc.2`
- `npm run typecheck`
- `git diff --check`

## Risk and follow-up

This prerelease publishes to the npm `beta` tag. Keep issue #331 open until a stable release contains the change.

Tracks #331