### PR TITLE
fix(aside): polish selected turns and status

### DIFF
--- a/tui/src/aside-actions.ts
+++ b/tui/src/aside-actions.ts
@@ -23,6 +23,7 @@ import {
 } from "./aside-surface.js";
 import {
   asideChatLayout as renderAsideV2ChatLayout,
+  hydrateAsideAnchor,
   asideSessionsFromResponse,
   asideV2HeaderLines,
   type AsideChatRowKind,
@@ -647,7 +648,7 @@ export async function openAside(
     const responseAnchor = responseRecord !== null
       && Object.prototype.hasOwnProperty.call(responseRecord, "anchor")
       ? normalizeAsideAnchor(responseRecord.anchor) : openingAnchor;
-    const selectedAnchor = responseAnchor;
+    const selectedAnchor = hydrateAsideAnchor(responseAnchor, model.anchors, openingAnchor);
     state.aside = createAsideSurface(
       requestedStoryId,
       state.payload.title,
@@ -823,7 +824,10 @@ export async function sendAsideQuestion(
         {
           storyId: surface.storyId,
           question: trimmed,
-          anchor: surface.anchor,
+          anchor: surface.anchor === null ? null : {
+            partId: surface.anchor.partId,
+            takeId: surface.anchor.takeId
+          },
           // Keep an empty persisted session addressable after `/clear`.
           // Client-created ids are also stable mutation inputs, so the first
           // ask can persist that exact id without a second local identity.

--- a/tui/src/aside-v2-layout.ts
+++ b/tui/src/aside-v2-layout.ts
@@ -31,6 +31,33 @@ function dimension(value: number, fallback: number): number {
   return Number.isFinite(value) ? Math.max(1, Math.floor(value)) : fallback;
 }
 
+function sameAnchor(left: AsideSessionAnchor, right: AsideSessionAnchor): boolean {
+  return left.partId === right.partId && left.takeId === right.takeId;
+}
+
+/** Restore display-only position fields without changing the wire address. */
+export function hydrateAsideAnchor(
+  anchor: AsideSessionAnchor | null,
+  anchors: readonly AsideAnchorView[],
+  fallback: AsideSessionAnchor | null = null
+): AsideSessionAnchor | null {
+  if (anchor === null) return null;
+  const presence = anchors.find((entry) =>
+    entry.unanchored !== true && sameAnchor(entry, anchor)
+  );
+  const fallbackMatch = fallback !== null && sameAnchor(fallback, anchor)
+    ? fallback : undefined;
+  const partNumber = presence?.partNumber ?? fallbackMatch?.partNumber ?? anchor.partNumber;
+  const takeIndex = presence?.takeIndex ?? fallbackMatch?.takeIndex ?? anchor.takeIndex;
+  const takeCount = presence?.takeCount ?? fallbackMatch?.takeCount ?? anchor.takeCount;
+  return {
+    ...anchor,
+    ...(partNumber === undefined ? {} : { partNumber }),
+    ...(takeIndex === undefined ? {} : { takeIndex }),
+    ...(takeCount === undefined ? {} : { takeCount })
+  };
+}
+
 interface WrappedAsideRow {
   text: string;
   start: number;
@@ -162,7 +189,11 @@ export function asideSessionsFromResponse(
       unanchored: true
     });
   }
-  return { sessions, anchors };
+  const hydratedSessions = sessions.map((session) => ({
+    ...session,
+    anchor: hydrateAsideAnchor(session.anchor, anchors, fallbackAnchor)
+  }));
+  return { sessions: hydratedSessions, anchors };
 }
 
 export function asideHopStrip(surface: AsideSessionSurfaceState): string {

--- a/tui/src/aside-v2-settlement.ts
+++ b/tui/src/aside-v2-settlement.ts
@@ -14,7 +14,7 @@ import {
   type AsideSessionSurfaceState,
   type AsideSessionView
 } from "./aside-surface.js";
-import { asideSessionsFromResponse } from "./aside-v2-layout.js";
+import { asideSessionsFromResponse, hydrateAsideAnchor } from "./aside-v2-layout.js";
 
 type AsideSingleSessionResponse = AsideAskResponse | AsideSessionMutationResponse;
 
@@ -145,7 +145,10 @@ function applySingleSession(
 ): void {
   const normalized = normalizeAsideSession(response, surface.sessions.length);
   if (normalized === null) return;
-  const session: AsideSessionView = normalized;
+  const session: AsideSessionView = {
+    ...normalized,
+    anchor: hydrateAsideAnchor(normalized.anchor, surface.anchors, surface.anchor)
+  };
   const currentIndex = surface.sessionIndex;
   const matching = surface.sessions.findIndex((entry) => entry.id === session.id);
   const sessionIndex = matching >= 0 ? matching : surface.sessions.length;

--- a/tui/src/screens/story/aside-screen.ts
+++ b/tui/src/screens/story/aside-screen.ts
@@ -193,7 +193,11 @@ function renderAsideV2Screen(
       renderAsideV2HistoryLine(
         text,
         history.rowKinds[index] ?? "plain",
-        historyLayout.rowAnswerSources[history.start + index]
+        historyLayout.rowAnswerSources[history.start + index],
+        turnsFocus
+          && !surface.busy
+          && historyLayout.rowKinds[history.start + index] === "question"
+          && historyLayout.rowTurnIndex[history.start + index] === surface.turnCursor
       )),
     ...composerLines,
     ...footerLines.map((line) => [segment(line, "chrome")]),
@@ -266,14 +270,20 @@ function renderQuestionHistoryLine(
 function renderAsideV2HistoryLine(
   text: string,
   kind: AsideChatRowKind,
-  answerSource?: AsideAnswerSource | null
+  answerSource?: AsideAnswerSource | null,
+  focusedQuestion = false
 ): FrameLine {
   if (kind === "question") {
     if (text.startsWith("▸ › ")) {
       return renderQuestionHistoryLine(text, "▸ › ", "focus / accent", "prose");
     }
     if (text.startsWith("  › ")) {
-      return renderQuestionHistoryLine(text, "  › ", "accent · deep", "prose · dim");
+      return renderQuestionHistoryLine(
+        text,
+        "  › ",
+        "accent · deep",
+        focusedQuestion ? "prose" : "prose · dim"
+      );
     }
     // Older layouts can leave a decorated continuation without the repeated
     // marker. Keep its body role aligned with the labelled question row.

--- a/tui/src/screens/story/aside-screen.ts
+++ b/tui/src/screens/story/aside-screen.ts
@@ -52,11 +52,13 @@ import {
 } from "./frame.js";
 import { renderComposerLayout } from "./composer.js";
 import type { StoryScreenFrame } from "../story.js";
+import { lightWorkKeyword, streamLivenessMark } from "../work-light.js";
 
 function renderAsideV2Status(
   state: StoryScreenState,
   surface: AsideSessionSurfaceState,
-  width: number
+  width: number,
+  deadlines?: FrameDeadlineCollector
 ): FrameLine {
   const resetConfirmation = surface.confirmReset !== null
     && surface.confirmReset.turnIndex >= 0;
@@ -82,11 +84,18 @@ function renderAsideV2Status(
     segment(width < 100 ? `  ${position}` : `  ${surface.storyTitle} · ${position}`, "chrome")
   ];
   const rightText = surface.busy
-    ? surface.streamPhase ?? "thinking"
+    ? `${streamLivenessMark(state.now, deadlines)} ${surface.streamPhase ?? "thinking"}`
     : width < 100 ? "utility route" : `utility route · ${state.model}`;
-  const right = segment(` ${rightText} `, surface.busy ? "focus / accent" : "chrome");
+  const right: FrameLine = surface.busy
+    ? lightWorkKeyword(
+      [segment(` ${rightText} `, "focus / accent")],
+      surface.streamPhase ?? "thinking",
+      state.now,
+      deadlines
+    )
+    : [segment(` ${rightText} `, "chrome")];
   const rightWidth = visibleWidth(rightText) + 2;
-  return [...fitLine(left, Math.max(1, width - rightWidth)), right];
+  return [...fitLine(left, Math.max(1, width - rightWidth)), ...right];
 }
 
 function renderAsideV2Composer(
@@ -174,7 +183,7 @@ function renderAsideV2Screen(
   deadlines?: FrameDeadlineCollector
 ): StoryScreenFrame {
   const composerLines = renderAsideV2Composer(state, surface, width, height);
-  const status = renderAsideV2Status(state, surface, width);
+  const status = renderAsideV2Status(state, surface, width, deadlines);
   const turnsFocus = surface.focus === "turns" || surface.focus === "notes";
   const standaloneFooter = turnsFocus || surface.busy;
   const footerLines = standaloneFooter

--- a/tui/src/screens/story/gutter.ts
+++ b/tui/src/screens/story/gutter.ts
@@ -16,32 +16,13 @@ import {
   asidePresenceGutterRows,
   type AsidePresence
 } from "../../aside-presence.js";
-import { lightWorkKeyword } from "../work-light.js";
+import { lightWorkKeyword, streamLivenessMark } from "../work-light.js";
 import {
   focusedFoldedThoughtLine,
   ghostThoughtMark,
   thinkingGutterLine0,
   thinkingGutterLine1
 } from "./thought-block.js";
-
-/** The complete braille cycle. The dots travel once around the cell and arrive
- *  back where they started, so the mark reads as one turn. Four of these ten
- *  marks carry the dots a quarter of the way around and then snap back to the
- *  top, which reads as a stall rather than as progress. */
-const STREAM_LIVENESS_MARKS = [
-  "⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"
-] as const;
-const STREAM_LIVENESS_FRAME_MS = 250;
-
-/** One indicator owns both stream labels and their next visible frame. */
-export function streamLivenessMark(
-  now: number,
-  deadlines?: FrameDeadlineCollector
-): string {
-  const frame = Math.floor(now / STREAM_LIVENESS_FRAME_MS);
-  deadlines?.at((frame + 1) * STREAM_LIVENESS_FRAME_MS);
-  return STREAM_LIVENESS_MARKS[frame % STREAM_LIVENESS_MARKS.length]!;
-}
 
 export interface GutterVerb { token: string | null; label: string; action: KeyAction }
 

--- a/tui/src/screens/story/row-layout.ts
+++ b/tui/src/screens/story/row-layout.ts
@@ -37,10 +37,10 @@ import {
   actionHint,
   gutterFor,
   gutterRowsFor,
-  streamingGutterRows,
-  streamLivenessMark
+  streamingGutterRows
 } from "./gutter.js";
 import { asideBoundaryLabel, asidePresenceForPart } from "../../aside-presence.js";
+import { streamLivenessMark } from "../work-light.js";
 
 export interface StoryRowLayout {
   height: number;

--- a/tui/src/screens/work-light.ts
+++ b/tui/src/screens/work-light.ts
@@ -3,6 +3,20 @@ import type { DisplayRole, FrameLine, FrameSegment } from "./story/frame.js";
 
 const WORK_LIGHT_FRAME_MS = 120;
 const WORK_LIGHT_EDGE_FRAMES = 2;
+const STREAM_LIVENESS_MARKS = [
+  "⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"
+] as const;
+const STREAM_LIVENESS_FRAME_MS = 250;
+
+/** Move the liveness dots once around their cell before the cycle repeats. */
+export function streamLivenessMark(
+  now: number,
+  deadlines?: FrameDeadlineCollector
+): string {
+  const frame = Math.floor(now / STREAM_LIVENESS_FRAME_MS);
+  deadlines?.at((frame + 1) * STREAM_LIVENESS_FRAME_MS);
+  return STREAM_LIVENESS_MARKS[frame % STREAM_LIVENESS_MARKS.length]!;
+}
 
 /** Move one light band through a visible work-state keyword. */
 export function lightWorkKeyword(

--- a/tui/test/animation-deadline.test.ts
+++ b/tui/test/animation-deadline.test.ts
@@ -8,6 +8,7 @@ import {
 } from "../src/animation-deadline.js";
 import { initialState } from "../src/app.js";
 import { demoAppSource } from "../src/demo.js";
+import { createAsideSurface } from "../src/aside-surface.js";
 import { createStoryViewModel, rowIndexForNode } from "../src/model.js";
 import { renderConnectionBanner } from "../src/screens/connection-banner.js";
 import { renderStoryScreen } from "../src/screens/story.js";
@@ -176,6 +177,46 @@ describe("animation deadlines", () => {
       "streaming", "focus / accent", "brass dim"
     ]);
     expect(thinkingDeadlines.next()).toBe(360);
+  });
+
+  test("Aside v2 writing status animates and schedules its next frame", () => {
+    const state = initialState(demoAppSource(false), false);
+    const surface = createAsideSurface(
+      state.payload.id,
+      state.payload.title,
+      [],
+      null,
+      null,
+      { v2: true }
+    );
+    state.aside = surface;
+    state.mode = "ASIDE";
+    surface.busy = true;
+    surface.streamPhase = "writing";
+    state.now = 0;
+    const first = renderStoryScreen(state, {
+      width: 120,
+      height: 36
+    });
+    expect(plainLine(first.lines.at(-1)!)).toContain("⠋ writing");
+
+    state.now = 250;
+    const deadlines = createFrameDeadlineCollector(state.now);
+
+    const frame = renderStoryScreen(state, {
+      width: 120,
+      height: 36,
+      deadlines
+    });
+    const status = frame.lines.at(-1)!;
+    const writing = keywordSegments(status, "writing");
+
+    expect(plainLine(status)).toContain("⠙ writing");
+    expect(writing.map((part) => part.text).join("")).toBe("writing");
+    expect(writing.slice(0, 3).map((part) => part.role)).toEqual([
+      "streaming", "focus / accent", "brass dim"
+    ]);
+    expect(deadlines.next()).toBe(360);
   });
 
   test("the liveness mark travels a whole turn before it repeats", () => {

--- a/tui/test/aside-readability.test.ts
+++ b/tui/test/aside-readability.test.ts
@@ -103,6 +103,23 @@ describe("Aside readability and navigation", () => {
     expect(frame.lines.every((line) => visibleWidth(plainLine(line)) <= 32)).toBeTrue();
   });
 
+  test("fully highlights every wrapped row of the selected question", () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const question = "selected-question ".repeat(40).trim();
+    const surface = v2Surface(state, question, "answer");
+    const frame = renderAsideScreen(state, surface, 32, 80);
+    const questionRows = frame.lines.filter((line) =>
+      plainLine(line).includes("selected-question")
+    );
+
+    const continuationRows = questionRows.slice(1);
+    expect(continuationRows.length).toBeGreaterThan(0);
+    expect(continuationRows.every((line) => line.some((part) =>
+      part.text.includes("selected-question") && part.role === "prose"
+    ))).toBeTrue();
+  });
+
   test("labels the turns exit action as esc exit", () => {
     const source = demoAppSource();
     const state = initialState(source, false);

--- a/tui/test/aside-v2.test.ts
+++ b/tui/test/aside-v2.test.ts
@@ -149,6 +149,77 @@ describe("Aside v2 surface", () => {
     });
   });
 
+  test("hydrates the opening take position for the Aside status and header", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const view = createStoryViewModel(state.payload);
+    const openingPart = view.parts.at(-1)!;
+    state.focusIndex = rowIndexForNode(view, openingPart.id);
+    let askRequest: unknown;
+    const api = {
+      ...source.api,
+      getAsideV2: async (request: { anchor: { partId: string; takeId: string } }) => ({
+        schemaVersion: 2 as const,
+        anchor: request.anchor,
+        sessions: [{
+          id: "s1",
+          anchor: request.anchor,
+          title: "why the lantern",
+          turns: [{ q: "Why?", a: "Because." }]
+        }],
+        anchors: [{
+          ...request.anchor,
+          partNumber: openingPart.number,
+          takeIndex: openingPart.takeIndex,
+          takeCount: openingPart.siblingCount,
+          sessionCount: 1
+        }],
+        unanchoredCount: 0
+      }),
+      askAsideV2: async (request: unknown) => {
+        askRequest = request;
+        return {
+          schemaVersion: 2 as const,
+          id: "s1",
+          anchor: { partId: openingPart.id, takeId: openingPart.id },
+          title: "why the lantern",
+          turns: [
+            { q: "Why?", a: "Because." },
+            { q: "Next?", a: "Next answer." }
+          ]
+        };
+      }
+    } as unknown as StoryApi;
+
+    await openAside(state, api);
+
+    const aside = state.aside;
+    if (aside === null || !isAsideV2(aside)) {
+      throw new Error("expected an Aside session surface");
+    }
+    expect(aside.anchor).toEqual({
+      partId: openingPart.id,
+      takeId: openingPart.id,
+      partNumber: openingPart.number,
+      takeIndex: openingPart.takeIndex,
+      takeCount: openingPart.siblingCount
+    });
+    const text = frameText(renderAsideScreen(state, aside, 120, 24).lines);
+    expect(text).toContain(
+      `¶ ${openingPart.number} · take ${openingPart.takeIndex}/${openingPart.siblingCount}`
+    );
+    expect(text).not.toContain("take ?/?");
+
+    await sendAsideQuestion(state, api, "Next?");
+    expect(askRequest).toEqual({
+      storyId: state.payload.id,
+      question: "Next?",
+      anchor: { partId: openingPart.id, takeId: openingPart.id },
+      sessionId: "s1"
+    });
+    expect(frameText(renderAsideScreen(state, aside, 120, 24).lines)).not.toContain("take ?/?");
+  });
+
   test("keeps an empty unanchored canonical session in the v2 renderer", () => {
     const model = asideSessionsFromResponse({
       schemaVersion: 2,
@@ -676,15 +747,14 @@ describe("Aside v2 surface", () => {
     expect(request).toEqual({
       storyId: state.payload.id,
       question: "First?",
-      anchor: openingAnchor
+      anchor: { partId: openingAnchor.partId, takeId: openingAnchor.takeId }
     });
     expect(surface.anchors).toEqual([{
       ...openingAnchor,
       sessionCount: 1
     }]);
     expect(surface.anchor).toEqual({
-      partId: openingAnchor.partId,
-      takeId: openingAnchor.takeId
+      ...openingAnchor
     });
     expect(surface.anchorIndex).toBe(0);
   });
@@ -740,7 +810,12 @@ describe("Aside v2 surface", () => {
     expect(surface.anchors).toHaveLength(3);
     expect(surface.anchors.map((entry) => [entry.partId, entry.takeId, entry.sessionCount]))
       .toEqual(anchors.map((entry) => [entry.partId, entry.takeId, entry.sessionCount]));
-    expect(surface.anchor).toEqual(currentAnchor);
+    expect(surface.anchor).toEqual({
+      ...currentAnchor,
+      partNumber: 1,
+      takeIndex: 1,
+      takeCount: 3
+    });
 
     surface.sessions[1] = {
       ...surface.sessions[1]!,


### PR DESCRIPTION
## Outcome

Fix the remaining Aside v2 readability and status defects found in beta testing.

## Changes

- Keep every wrapped line of the selected question highlighted.
- Animate the Aside writing and thinking status with the shared liveness indicators.
- Restore part and take labels from exact matching display metadata.
- Preserve canonical ID-only anchors on transport requests.

## Verification

- `bun test test/aside-v2.test.ts test/aside-transport.test.ts test/animation-deadline.test.ts test/aside-readability.test.ts test/aside-presence.test.ts test/aside-scale.test.ts`
- `bun run typecheck`
- Claude/Fable design review: pass
- `$autoreview`: clean after one accepted transport-boundary fix
- Thermo-nuclear code-quality review: clean after one shared-helper ownership fix

## Risk and follow-up

Legacy Side Notes and unanchored Aside sessions remain compatible. Keep issue #331 open until a stable release contains the change.

Tracks #331