### PR TITLE
chore(release): prepare 0.10.3-rc.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ This file records notable changes to 1667. Product terms use the definitions in
 
 ## Unreleased
 
+## 0.10.3-rc.3 - 2026-08-26
+
+- **Aside shows selected turns and status clearly.** Wrapped lines in the
+  selected question keep their highlight. The writing and thinking labels
+  animate. Anchored sessions show the correct part and take after reads and
+  updates.
+
 ## 0.10.3-rc.2 - 2026-08-26
 
 - **Aside keeps long chats readable and selectable.** Wrapped questions keep

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "1667-workspace",
-  "version": "0.10.3-rc.2",
+  "version": "0.10.3-rc.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "1667-workspace",
-      "version": "0.10.3-rc.2",
+      "version": "0.10.3-rc.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@earendil-works/pi-ai": "0.84.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667-workspace",
-  "version": "0.10.3-rc.2",
+  "version": "0.10.3-rc.3",
   "private": true,
   "description": "Source workspace for the 1667 terminal writing environment",
   "license": "Apache-2.0",

--- a/shared/release-notes.ts
+++ b/shared/release-notes.ts
@@ -11,6 +11,11 @@ export interface ReleaseNote {
  *  a release, and is not included. */
 export const RELEASE_NOTES: readonly ReleaseNote[] = [
   {
+    version: "0.10.3-rc.3",
+    date: "2026-08-26",
+    body: "- **Aside shows selected turns and status clearly.** Wrapped lines in the\n  selected question keep their highlight. The writing and thinking labels\n  animate. Anchored sessions show the correct part and take after reads and\n  updates."
+  },
+  {
     version: "0.10.3-rc.2",
     date: "2026-08-26",
     body: "- **Aside keeps long chats readable and selectable.** Wrapped questions keep\n  their question style. Scroll history without changing the selected turn,\n  including while an answer streams. Highlight saved answer text and\n  right-click to copy it or insert it into the composer, a new Fact, or the\n  story. The full-answer menu can also create a new Fact. Large Aside\n  histories stay responsive. Existing Side Notes remain available."

--- a/tui/package.json
+++ b/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667",
-  "version": "0.10.3-rc.2",
+  "version": "0.10.3-rc.3",
   "private": true,
   "description": "A terminal environment for writing fiction with language models",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Outcome

Prepare the `0.10.3-rc.3` beta release with the merged Aside follow-up fixes.

## Changes

- Set the root and TUI package versions to `0.10.3-rc.3`.
- Add the dated release section to `CHANGELOG.md`.
- Regenerate the embedded release notes.

## Verification

- `npm run notes:check-version -- 0.10.3-rc.3`
- `npm run typecheck`
- `git diff --check`

## Risk and follow-up

This prerelease publishes to the npm `beta` tag. Keep issue #331 open until a stable release contains the change.

Tracks #331