### PR TITLE
fix(aside): preserve selection and turn context

### DIFF
--- a/tui/src/aside-actions.ts
+++ b/tui/src/aside-actions.ts
@@ -334,15 +334,19 @@ function revealAsideFocusedNoteWithLayout(
     if (surface.focus !== "turns" && surface.focus !== "notes") return;
     const height = Math.max(0, Math.floor(bodyRows));
     if (height === 0) return;
-    const noteStart = layout.turnStarts[surface.turnCursor];
-    if (noteStart === undefined) return;
+    const turnStart = layout.turnStarts[surface.turnCursor];
+    if (turnStart === undefined) return;
+    const turnEnd = layout.turnContentEnds[surface.turnCursor] ?? turnStart;
     const max = Math.max(0, layout.body.length - height);
     const current = surface.scrollTop === null
       ? max
       : Math.max(0, Math.min(max, surface.scrollTop));
     let next = current;
-    if (noteStart < current) next = noteStart;
-    else if (noteStart >= current + height) next = noteStart - height + 1;
+    // Keep the selected turn's useful context together. The prior bottom-edge
+    // anchor showed only the first wrapped question row when the next turn was
+    // below the viewport. A turn that does not fit must start at its question;
+    // a short turn stays put only when its complete content is already visible.
+    if (turnStart < current || turnEnd > current + height) next = turnStart;
     next = Math.max(0, Math.min(max, next));
     surface.scrollTop = next === max ? null : next;
     return;

--- a/tui/src/aside-surface.ts
+++ b/tui/src/aside-surface.ts
@@ -9,6 +9,7 @@ import type { ComposerState } from "./composer-model.js";
 import { createComposer } from "./composer-model.js";
 import type { TextPresentation } from "./text-presentation.js";
 import { asideHopAnchorIndex } from "./aside-hop.js";
+import type { StorySelectionSpan } from "./selection-projection.js";
 
 export interface AsideNoteView {
   readonly question: string;
@@ -31,6 +32,37 @@ export interface AsideTurnView {
   readonly thoughtTokens?: number;
   readonly createdAt?: string;
   readonly updatedAt?: string;
+}
+
+/** Protocol turns normally have no id. Keep their display identity in memory
+ * so queued input and semantic selection survive an earlier turn's removal. */
+const asideTurnIdentity = new WeakMap<object, string>();
+let nextAsideTurnIdentity = 0;
+
+export function asideTurnRowIdentity(turn: AsideTurnView): string {
+  if (turn.id !== undefined && turn.id.length > 0) return `id:${turn.id}`;
+  const object = turn as object;
+  const existing = asideTurnIdentity.get(object);
+  if (existing !== undefined) return `ref:${existing}`;
+  const identity = `turn-${++nextAsideTurnIdentity}`;
+  asideTurnIdentity.set(object, identity);
+  return `ref:${identity}`;
+}
+
+/** A single-session mutation keeps turn order. Carry an allocated identity to
+ * the fresh protocol objects returned by its settlement. */
+export function inheritAsideTurnRowIdentities(
+  previous: readonly AsideTurnView[],
+  next: readonly AsideTurnView[]
+): void {
+  const length = Math.min(previous.length, next.length);
+  for (let index = 0; index < length; index += 1) {
+    const before = previous[index]!;
+    const after = next[index]!;
+    if (before.id !== undefined || after.id !== undefined) continue;
+    const identity = asideTurnIdentity.get(before as object);
+    if (identity !== undefined) asideTurnIdentity.set(after as object, identity);
+  }
 }
 
 export interface AsideSessionAnchor {
@@ -66,6 +98,8 @@ export interface AsideUseMenuState {
   /** Exact terminal selection, when the menu came from a highlighted answer.
    *  Undefined means the complete saved answer is the target. */
   selectionText?: string;
+  /** Semantic answer spans to repaint after the native selection is cleared. */
+  selectionSpans?: readonly StorySelectionSpan[];
   /** Index into the stage's use-menu action list. */
   cursor: number;
   /**
@@ -394,6 +428,42 @@ export function currentAsideSession(surface: AsideSurfaceState): AsideSessionVie
 
 export function currentAsideTurns(surface: AsideSurfaceState): readonly AsideTurnView[] {
   return currentAsideSession(surface)?.turns ?? [];
+}
+
+function asideAnswerOwner(surface: AsideSurfaceState): string {
+  if (!isAsideV2(surface)) return "legacy";
+  return surface.sessions[surface.sessionIndex]?.id ?? `session-${surface.sessionIndex}`;
+}
+
+/** Stable row and selection identity for a saved answer in one Aside session. */
+export function asideAnswerRowId(
+  surface: AsideSurfaceState,
+  noteIndex: number
+): string {
+  if (!isAsideV2(surface)) {
+    return `aside-answer:${asideAnswerOwner(surface)}:${noteIndex}`;
+  }
+  const turn = currentAsideTurns(surface)[noteIndex];
+  if (turn === undefined) return `aside-answer:${asideAnswerOwner(surface)}:unknown`;
+  return `aside-answer:${asideAnswerOwner(surface)}:${asideTurnRowIdentity(turn)}`;
+}
+
+/** Resolve a saved-answer identity against the current Aside session. */
+export function asideAnswerIndexFromRowId(
+  rowId: string,
+  surface: AsideSurfaceState
+): number {
+  const prefix = `aside-answer:${asideAnswerOwner(surface)}:`;
+  if (!rowId.startsWith(prefix)) return -1;
+  const identity = rowId.slice(prefix.length);
+  if (!isAsideV2(surface)) {
+    const value = Number(identity);
+    return Number.isInteger(value) && value >= 0 ? value : -1;
+  }
+  if (!identity.startsWith("id:") && !identity.startsWith("ref:")) return -1;
+  return currentAsideTurns(surface).findIndex(
+    (turn) => asideTurnRowIdentity(turn) === identity
+  );
 }
 
 export function setAsideSessionTurns(

--- a/tui/src/aside-use.ts
+++ b/tui/src/aside-use.ts
@@ -12,14 +12,12 @@ import { openFactFromSelection } from "./editor-action.js";
 import {
   asideCursor,
   asideNotes,
-  currentAsideTurns,
   disarmAsideClear,
-  isAsideV2,
   setAsideCursor,
   type AsideSurfaceState
 } from "./aside-surface.js";
-import type { AsideTurnView } from "./aside-surface.js";
 import type { RuntimeState } from "./state.js";
+import type { StorySelectionSpan } from "./selection-projection.js";
 
 export type AsideUseActionId =
   | "copy"
@@ -58,21 +56,6 @@ const ASIDE_SELECTION_USE_ACTION: AsideUseAction = {
   description: "copy the highlighted text"
 };
 
-/** Protocol turns normally have no id. Keep their row identity in memory so
- * deleting an earlier turn can rebase a click without retargeting a clone. */
-const asideTurnIdentity = new WeakMap<object, string>();
-let nextAsideTurnIdentity = 0;
-
-function asideTurnRowIdentity(turn: AsideTurnView): string {
-  if (turn.id !== undefined && turn.id.length > 0) return `id:${turn.id}`;
-  const object = turn as object;
-  const existing = asideTurnIdentity.get(object);
-  if (existing !== undefined) return `ref:${existing}`;
-  const identity = `turn-${++nextAsideTurnIdentity}`;
-  asideTurnIdentity.set(object, identity);
-  return `ref:${identity}`;
-}
-
 /** The selected-text menu adds Copy before the complete-answer actions. Keep
  * the complete-answer list stable so existing keyboard and Placement paths
  * retain their row order. */
@@ -87,42 +70,6 @@ export function asideUseActions(
       ASIDE_USE_ACTIONS.find(({ id }) => id === "insert-as-new-fact")!,
       ASIDE_USE_ACTIONS.find(({ id }) => id === "insert-into-story")!
     ];
-}
-
-function asideAnswerOwner(surface: AsideSurfaceState): string {
-  if (!isAsideV2(surface)) return "legacy";
-  return surface.sessions[surface.sessionIndex]?.id ?? `session-${surface.sessionIndex}`;
-}
-
-/** Stable row identity for a saved answer in one Aside session. */
-export function asideAnswerRowId(
-  surface: AsideSurfaceState,
-  noteIndex: number
-): string {
-  if (!isAsideV2(surface)) {
-    return `aside-answer:${asideAnswerOwner(surface)}:${noteIndex}`;
-  }
-  const turn = currentAsideTurns(surface)[noteIndex];
-  if (turn === undefined) return `aside-answer:${asideAnswerOwner(surface)}:unknown`;
-  return `aside-answer:${asideAnswerOwner(surface)}:${asideTurnRowIdentity(turn)}`;
-}
-
-/** Resolve a saved-answer row identity against the current Aside session. */
-export function asideAnswerIndexFromRowId(
-  rowId: string,
-  surface: AsideSurfaceState
-): number {
-  const prefix = `aside-answer:${asideAnswerOwner(surface)}:`;
-  if (!rowId.startsWith(prefix)) return -1;
-  const identity = rowId.slice(prefix.length);
-  if (!isAsideV2(surface)) {
-    const value = Number(identity);
-    return Number.isInteger(value) && value >= 0 ? value : -1;
-  }
-  if (!identity.startsWith("id:") && !identity.startsWith("ref:")) return -1;
-  return currentAsideTurns(surface).findIndex(
-    (turn) => asideTurnRowIdentity(turn) === identity
-  );
 }
 
 /** Hit-map / selection identity for one use-menu action in one menu session. */
@@ -155,7 +102,8 @@ export function openAsideUseMenu(
   surface: AsideSurfaceState,
   noteIndex: number,
   cursor = 0,
-  selectionText?: string
+  selectionText?: string,
+  selectionSpans: readonly StorySelectionSpan[] = []
 ): boolean {
   if (surface.busy) return false;
   const notes = asideNotes(surface);
@@ -167,6 +115,7 @@ export function openAsideUseMenu(
   surface.useMenu = {
     noteIndex,
     ...(selectionText === undefined ? {} : { selectionText }),
+    ...(selectionSpans.length === 0 ? {} : { selectionSpans: selectionSpans.slice() }),
     cursor: Math.max(0, Math.min(actions.length - 1, cursor)),
     // New id every open so A→B menu clicks cannot reconcile on action alone.
     sessionId: crypto.randomUUID()

--- a/tui/src/aside-v2-layout.ts
+++ b/tui/src/aside-v2-layout.ts
@@ -3,6 +3,7 @@ import { wrapText } from "./wrap.js";
 import { truncate, truncateTail, visibleWidth } from "./screens/story/frame.js";
 import { asideHopStripText, UNANCHORED_ASIDE_ID } from "./aside-hop.js";
 import {
+  asideAnswerRowId,
   currentAsideSession,
   currentAsideTurns,
   normalizeAsideSession,
@@ -314,7 +315,7 @@ export function asideChatLayout(
         row < questionCount + thoughtCount
           ? null
           : {
-            key: `aside-answer:${turn.id ?? `${surface.sessionIndex}-${index}`}:${index}`,
+            key: asideAnswerRowId(surface, index),
             text: turn.a,
             start: answers[row - questionCount - thoughtCount]!.start
           }

--- a/tui/src/aside-v2-settlement.ts
+++ b/tui/src/aside-v2-settlement.ts
@@ -8,6 +8,7 @@ import type { StoryAsidePresenceAnchor, StoryPayload } from "../../shared/types.
 import { asideHopAnchorIndex, UNANCHORED_ASIDE_ID } from "./aside-hop.js";
 import {
   currentAsideSession,
+  inheritAsideTurnRowIdentities,
   normalizeAsideSession,
   type AsideAnchorView,
   type AsideSessionAnchor,
@@ -145,12 +146,15 @@ function applySingleSession(
 ): void {
   const normalized = normalizeAsideSession(response, surface.sessions.length);
   if (normalized === null) return;
+  const matching = surface.sessions.findIndex((entry) => entry.id === normalized.id);
+  if (matching >= 0) {
+    inheritAsideTurnRowIdentities(surface.sessions[matching]!.turns, normalized.turns);
+  }
   const session: AsideSessionView = {
     ...normalized,
     anchor: hydrateAsideAnchor(normalized.anchor, surface.anchors, surface.anchor)
   };
   const currentIndex = surface.sessionIndex;
-  const matching = surface.sessions.findIndex((entry) => entry.id === session.id);
   const sessionIndex = matching >= 0 ? matching : surface.sessions.length;
   if (matching >= 0) surface.sessions[matching] = session;
   else surface.sessions = [...surface.sessions, session];

--- a/tui/src/overlay-actions.ts
+++ b/tui/src/overlay-actions.ts
@@ -149,7 +149,8 @@ export async function handleOverlayAction(
         state.aside,
         resolved.index ?? asideCursor(state.aside),
         0,
-        resolved.selectionText
+        resolved.selectionText,
+        resolved.selectionSpans
       );
     }
     return true;

--- a/tui/src/presented-mouse-action.ts
+++ b/tui/src/presented-mouse-action.ts
@@ -25,11 +25,11 @@ import {
 } from "./mouse-actions.js";
 import type { RuntimeState } from "./state.js";
 import {
-  asideAnswerIndexFromRowId,
   asideUseActions,
   asideUseActionIndexFromRowId,
   asideUseRowId
 } from "./aside-use.js";
+import { asideAnswerIndexFromRowId } from "./aside-surface.js";
 import { availableTextActions } from "./text-actions.js";
 
 export interface PresentedInteraction {

--- a/tui/src/screens/story/aside-screen.ts
+++ b/tui/src/screens/story/aside-screen.ts
@@ -13,6 +13,7 @@ import {
 import type { AsideChatRowKind } from "../../aside-v2-layout.js";
 import {
   ASIDE_INPUT_PLACEHOLDER,
+  asideAnswerRowId,
   asideNotes,
   currentAsideTurns,
   isAsideV2,
@@ -22,7 +23,6 @@ import {
 } from "../../aside-surface.js";
 import { resetAsideStatus } from "../../aside-v2-actions.js";
 import {
-  asideAnswerRowId,
   asideUseActions,
   asideUseMenuTitle,
   asideUseRowId
@@ -53,6 +53,7 @@ import {
 import { renderComposerLayout } from "./composer.js";
 import type { StoryScreenFrame } from "../story.js";
 import { lightWorkKeyword, streamLivenessMark } from "../work-light.js";
+import { paintStorySelection } from "./selection-highlight.js";
 
 function renderAsideV2Status(
   state: StoryScreenState,
@@ -229,6 +230,10 @@ function renderAsideV2Screen(
   });
   const storySelectionProjection = buildStorySelectionProjection(lines, width);
   let renderedLines = lines.slice(0, height);
+  if (surface.useMenu?.selectionSpans !== undefined
+    && surface.useMenu.selectionSpans.length > 0) {
+    renderedLines = paintStorySelection(renderedLines, surface.useMenu.selectionSpans);
+  }
   if (surface.useMenu !== null) {
     renderedLines = renderAsideUseMenu(renderedLines, surface, width, height, hitRows);
   }
@@ -681,6 +686,10 @@ export function renderAsideScreen(
   });
   // Menu first (owns scrim), connection banner last so its retry hit stays live.
   let renderedLines = visibleLines;
+  if (surface.useMenu?.selectionSpans !== undefined
+    && surface.useMenu.selectionSpans.length > 0) {
+    renderedLines = paintStorySelection(renderedLines, surface.useMenu.selectionSpans);
+  }
   if (surface.useMenu !== null) {
     renderedLines = renderAsideUseMenu(renderedLines, surface, width, height, hitRows);
   }

--- a/tui/test/aside-readability.test.ts
+++ b/tui/test/aside-readability.test.ts
@@ -4,6 +4,7 @@ import { dispatch, initialState } from "../src/app.js";
 import {
   asideBodyHeight,
   asideComposerRows,
+  asideHistoryLayout,
   sendAsideQuestion
 } from "../src/aside-actions.js";
 import {
@@ -201,6 +202,48 @@ describe("Aside readability and navigation", () => {
     await handleOverlayAction({ action: "scroll-line-down" }, state, source, context);
     expect(surface.scrollTop).toBe(middle + page + 1);
     expect(surface.turnCursor).toBe(selectedTurn);
+  });
+
+  test("Up then Down reveals the selected question from its start", async () => {
+    const targetIndex = 6;
+    const turns = [
+      ...Array.from({ length: targetIndex }, (_, index) => ({
+        q: `short question ${index}`,
+        a: `short answer ${index}`
+      })),
+      {
+        q: "long-question-start " + "question-word ".repeat(160) + "long-question-end",
+        a: "long-answer-start " + "answer-word ".repeat(600) + "long-answer-end"
+      }
+    ];
+
+    for (const [width, height] of [[24, 8], [120, 36]] as const) {
+      const source = demoAppSource();
+      const state = initialState(source, false);
+      const surface = v2Surface(state, turns[targetIndex]!.q, turns[targetIndex]!.a);
+      const session = surface.sessions[surface.sessionIndex]!;
+      surface.sessions[surface.sessionIndex] = { ...session, turns };
+      surface.focus = "turns";
+      surface.turnCursor = targetIndex;
+      surface.scrollTop = null;
+      const context = overlayContext(state, width, height);
+
+      for (let index = targetIndex; index > 0; index -= 1) {
+        await handleOverlayAction({ action: "focus-previous" }, state, source, context);
+      }
+      for (let index = 0; index < targetIndex; index += 1) {
+        await handleOverlayAction({ action: "focus-next" }, state, source, context);
+      }
+
+      const layout = asideHistoryLayout(surface, width);
+      const bodyRows = asideBodyHeight(surface, width, height, asideComposerRows(height));
+      const max = Math.max(0, layout.body.length - bodyRows);
+      expect(surface.turnCursor).toBe(targetIndex);
+      expect(surface.scrollTop ?? max).toBe(layout.turnStarts[targetIndex]);
+      const text = frameText(renderAsideScreen(state, surface, width, height).lines);
+      expect(text).toContain("long-question-start");
+      if (height > 8) expect(text).toContain("long-answer-start");
+    }
   });
 
   test("busy v2 scrolling remains visible and survives settlement", async () => {

--- a/tui/test/aside-use-menu-mouse.test.ts
+++ b/tui/test/aside-use-menu-mouse.test.ts
@@ -2,8 +2,11 @@
  * Aside use-menu mouse hits and presented-frame reconciliation.
  */
 import { describe, expect, test } from "bun:test";
-import { createAsideSurface } from "../src/aside-surface.js";
-import { isAsideV2 } from "../src/aside-surface.js";
+import {
+  asideAnswerRowId,
+  createAsideSurface,
+  isAsideV2
+} from "../src/aside-surface.js";
 import { demoAppSource } from "../src/demo.js";
 import { initialState } from "../src/app.js";
 import { handleOverlayAction } from "../src/overlay-actions.js";
@@ -12,7 +15,6 @@ import { createWrapCache, type ProseStyle } from "../src/wrap.js";
 import { renderStoryScreen } from "../src/screens/story.js";
 import { frameText, plainLine, visibleWidth } from "../src/screens/story/frame.js";
 import {
-  asideAnswerRowId,
   asideUseActions,
   focusAsideUseMenuIndex,
   openAsideUseMenu
@@ -135,6 +137,67 @@ function activateStoryStream(state: ReturnType<typeof initialState>): void {
 }
 
 describe("Aside use-menu mouse", () => {
+  test("keeps a selected answer visibly highlighted while its use menu is open", async () => {
+    const answer = "alpha bravo charlie delta echo foxtrot golf hotel";
+    const width = 80;
+    const height = 36;
+    for (const variant of ["legacy", "v2"] as const) {
+      const source = demoAppSource();
+      const state = initialState(source, false);
+      const surface = variant === "legacy"
+        ? installLegacyAside(state, answer)
+        : installV2Aside(state, answer);
+      const initialFrame = renderStoryScreen(state, { width, height });
+      state.hitRows = initialFrame.derived.hitRows;
+      const projection = initialFrame.derived.storySelectionProjection;
+      expect(projection).not.toBeNull();
+      const answerCells = projection!.flatMap((cell, index) => cell === null
+        ? [] : [{ cell, index }]).filter(({ cell }) => cell.key.startsWith("aside-answer:"));
+      const first = answerCells[0]!;
+      const last = answerCells[15]!;
+      const expected = answer.slice(first.cell.start, last.cell.end);
+      const answerRow = state.hitRows.findIndex((row) => row?.target.kind === "aside-answer");
+      expect(answerRow).toBeGreaterThan(-1);
+      const raw = mouseToAction({
+        type: "down",
+        button: 2,
+        x: 4,
+        y: answerRow,
+        modifiers: { shift: false, alt: false, ctrl: false }
+      }, state);
+      expect(raw?.action).toBe("open-aside-use");
+
+      const native = selectionReader(`  ${expected}`, {
+        start: first.index,
+        end: last.index + 1
+      });
+      const decorated = selectionAwarePartMenuAction(
+        native.event as never,
+        raw,
+        native.renderer as never,
+        projection
+      );
+      expect(decorated?.selectionText).toBe(expected);
+      expect(decorated?.selectionSpans).toEqual([{
+        key: first.cell.key,
+        text: answer,
+        start: first.cell.start,
+        end: last.cell.end
+      }]);
+
+      await handleOverlayAction(decorated!, state, source, overlayContext(state, width, height));
+      const menuFrame = renderStoryScreen(state, { width, height });
+      const highlightedText = menuFrame.lines.flatMap((line) => line)
+        .filter((part) => part.role === "background" && part.background === "focus / accent")
+        .map((part) => part.text)
+        .join("");
+      expect(highlightedText).toContain(expected);
+      expect(surface.useMenu?.selectionText).toBe(expected);
+      expect(surface.useMenu?.selectionSpans).toEqual(decorated?.selectionSpans);
+      expect(surface.useMenu?.selectionSpans?.[0]?.text).toBe(answer);
+    }
+  });
+
   test("right-clicking a wrapped answer uses exact source text in legacy and v2", async () => {
     const answer = "alpha bravo charlie delta echo foxtrot golf hotel india juliet kilo lima";
     const width = 36;
@@ -267,6 +330,21 @@ describe("Aside use-menu mouse", () => {
     const action = mouseToAction(capturedEvent, state);
     expect(action).toMatchObject({ action: "open-aside-use", index: 1 });
     expect(action?.rowId).toContain(":ref:");
+    const laterCells = initialFrame.derived.storySelectionProjection!
+      .flatMap((cell, index) => cell?.text === "later answer" ? [{ cell, index }] : []);
+    const first = laterCells[0]!;
+    const last = laterCells[4]!;
+    const native = selectionReader("later", {
+      start: first.index,
+      end: last.index + 1
+    });
+    const selectedAction = selectionAwarePartMenuAction(
+      native.event as never,
+      action,
+      native.renderer as never,
+      initialFrame.derived.storySelectionProjection
+    );
+    expect(selectedAction?.selectionText).toBe("later");
 
     const captured: PresentedInteraction = {
       version: 1,
@@ -276,6 +354,11 @@ describe("Aside use-menu mouse", () => {
       state: captureMouseActionState(state)
     };
     const session = surface.sessions[surface.sessionIndex]!;
+    surface.deleteUndo = {
+      sessionId: session.id,
+      turnIndex: 0,
+      turn: session.turns[0]!
+    };
     const laterTurn = session.turns[1]!;
     surface.sessions[surface.sessionIndex] = { ...session, turns: [laterTurn] };
     state.hitRows = renderStoryScreen(state, { width, height }).derived.hitRows;
@@ -287,7 +370,7 @@ describe("Aside use-menu mouse", () => {
       state: captureMouseActionState(state)
     };
     const rebased = reconcilePresentedMouseAction({
-      action: action!,
+      action: selectedAction!,
       event: capturedEvent,
       captured,
       presented,
@@ -298,10 +381,40 @@ describe("Aside use-menu mouse", () => {
       index: 0,
       rowId: action?.rowId
     });
-    await handleOverlayAction(rebased!, state, source, overlayContext(state, width, height));
+    const sourceWithDelete = {
+      ...source,
+      api: {
+        ...source.api,
+        deleteAsideTurn: async () => ({
+          schemaVersion: 2 as const,
+          id: "session-1",
+          title: "session",
+          anchor: null,
+          turns: [{ q: "later", a: "later answer" }]
+        })
+      }
+    };
+    const context = overlayContext(state, width, height);
+    await handleOverlayAction(rebased!, state, sourceWithDelete, context);
     expect(surface.useMenu?.noteIndex).toBe(0);
-    expect(surface.useMenu?.selectionText).toBe(undefined);
+    expect(surface.useMenu?.selectionText).toBe("later");
     expect(surface.sessions[surface.sessionIndex]?.turns[0]?.a).toBe("later answer");
+    const menuFrame = renderStoryScreen(state, { width, height });
+    const highlightedText = menuFrame.lines.flatMap((line) => line)
+      .filter((part) => part.role === "background" && part.background === "focus / accent")
+      .map((part) => part.text)
+      .join("");
+    expect(highlightedText).toContain("later");
+
+    await handleOverlayAction({ action: "focus-index", index: 0 }, state, sourceWithDelete, context);
+    await context.backend.settle();
+    expect(surface.sessions[surface.sessionIndex]?.turns[0]).not.toBe(laterTurn);
+    const settledFrame = renderStoryScreen(state, { width, height });
+    const settledHighlight = settledFrame.lines.flatMap((line) => line)
+      .filter((part) => part.role === "background" && part.background === "focus / accent")
+      .map((part) => part.text)
+      .join("");
+    expect(settledHighlight).toContain("later");
   });
 
   test("v2 id-less answer click drops when its turn object is replaced", () => {


### PR DESCRIPTION
## Outcome

Aside now keeps highlighted answer text visible after the Use selection menu opens. Turn navigation now reveals the selected question from its first row when the complete turn is not visible.

## Changes

- Preserve semantic selection spans for legacy and v2 Aside screens.
- Keep v2 answer identity stable through queued deletion and mutation settlement.
- Reveal the selected turn from its question start after Up and Down navigation.
- Preserve direct line, page, and wheel scrolling.
- Preserve existing Aside data and legacy behavior.

## Verification

- `npm run typecheck`
- `cd tui && bun run typecheck`
- `cd tui && bun test --timeout 30000` (2,259 passed, 2 skipped)
- AutoReview: pass
- Thermonuclear maintainability review: pass
- Claude Fable design review: pass

## Risk and follow-up

The change affects only Aside rendering, identity reconciliation, and focus reveal. The tests cover legacy and v2 screens, narrow and wide terminals, long content, queued deletion, and fresh mutation-response objects.

Tracks #331. The issue remains open until a stable release contains the change.
