### PR TITLE
chore(release): prepare 0.10.3-rc.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ This file records notable changes to 1667. Product terms use the definitions in
 
 ## Unreleased
 
+## 0.10.3-rc.4 - 2026-08-26
+
+- **Aside keeps selected text and turn context visible.** Highlighted answer
+  text stays highlighted while the Use selection menu is open, including
+  during a saved turn update. Up and Down navigation shows the selected
+  question from its first line and keeps as much answer visible as the screen
+  permits.
+
 ## 0.10.3-rc.3 - 2026-08-26
 
 - **Aside shows selected turns and status clearly.** Wrapped lines in the

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "1667-workspace",
-  "version": "0.10.3-rc.3",
+  "version": "0.10.3-rc.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "1667-workspace",
-      "version": "0.10.3-rc.3",
+      "version": "0.10.3-rc.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@earendil-works/pi-ai": "0.84.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667-workspace",
-  "version": "0.10.3-rc.3",
+  "version": "0.10.3-rc.4",
   "private": true,
   "description": "Source workspace for the 1667 terminal writing environment",
   "license": "Apache-2.0",

--- a/shared/release-notes.ts
+++ b/shared/release-notes.ts
@@ -11,6 +11,11 @@ export interface ReleaseNote {
  *  a release, and is not included. */
 export const RELEASE_NOTES: readonly ReleaseNote[] = [
   {
+    version: "0.10.3-rc.4",
+    date: "2026-08-26",
+    body: "- **Aside keeps selected text and turn context visible.** Highlighted answer\n  text stays highlighted while the Use selection menu is open, including\n  during a saved turn update. Up and Down navigation shows the selected\n  question from its first line and keeps as much answer visible as the screen\n  permits."
+  },
+  {
     version: "0.10.3-rc.3",
     date: "2026-08-26",
     body: "- **Aside shows selected turns and status clearly.** Wrapped lines in the\n  selected question keep their highlight. The writing and thinking labels\n  animate. Anchored sessions show the correct part and take after reads and\n  updates."

--- a/tui/package.json
+++ b/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667",
-  "version": "0.10.3-rc.3",
+  "version": "0.10.3-rc.4",
   "private": true,
   "description": "A terminal environment for writing fiction with language models",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Outcome

Prepare beta `0.10.3-rc.4` with the latest Aside selection and turn-navigation fixes.

## Changes

- Set the root, TUI, and lockfile versions to `0.10.3-rc.4`.
- Add the `0.10.3-rc.4` changelog section.
- Regenerate the embedded release notes.

## Verification

- `npm run notes:check-version -- 0.10.3-rc.4`
- `npm run typecheck`
- `cd tui && bun run typecheck`
- Focused Aside integration tests: 19 passed
- `git diff --check`

## Risk and follow-up

This is a prerelease. Issue #331 stays open until a stable release contains the change.

Tracks #331
