### PR TITLE
chore(release): prepare 0.10.3-rc.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This file records notable changes to 1667. Product terms use the definitions in
 
 ## Unreleased
 
+## 0.10.3-rc.5 - 2026-08-26
+
 - **Aside text selection works across the full chat width.** Questions and
   answers use distinct `You` and `Assistant` labels, and question rows keep a
   stronger visual treatment without adding a selection-breaking side pane.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "1667-workspace",
-  "version": "0.10.3-rc.4",
+  "version": "0.10.3-rc.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "1667-workspace",
-      "version": "0.10.3-rc.4",
+      "version": "0.10.3-rc.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@earendil-works/pi-ai": "0.84.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667-workspace",
-  "version": "0.10.3-rc.4",
+  "version": "0.10.3-rc.5",
   "private": true,
   "description": "Source workspace for the 1667 terminal writing environment",
   "license": "Apache-2.0",

--- a/shared/release-notes.ts
+++ b/shared/release-notes.ts
@@ -11,6 +11,11 @@ export interface ReleaseNote {
  *  a release, and is not included. */
 export const RELEASE_NOTES: readonly ReleaseNote[] = [
   {
+    version: "0.10.3-rc.5",
+    date: "2026-08-26",
+    body: "- **Aside text selection works across the full chat width.** Questions and\n  answers use distinct `You` and `Assistant` labels, and question rows keep a\n  stronger visual treatment without adding a selection-breaking side pane.\n  Copying across both roles keeps the complete exchange.\n- **Destructive shortcuts use capital `D` consistently.** Aside turns, Facts,\n  chapter breaks, tags, Sampling entries, and Generation Profiles require a\n  confirmation before deletion. A different action cancels the confirmation.\n  Lowercase `d` is non-destructive."
+  },
+  {
     version: "0.10.3-rc.4",
     date: "2026-08-26",
     body: "- **Aside keeps selected text and turn context visible.** Highlighted answer\n  text stays highlighted while the Use selection menu is open, including\n  during a saved turn update. Up and Down navigation shows the selected\n  question from its first line and keeps as much answer visible as the screen\n  permits."

--- a/tui/package.json
+++ b/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667",
-  "version": "0.10.3-rc.4",
+  "version": "0.10.3-rc.5",
   "private": true,
   "description": "A terminal environment for writing fiction with language models",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Outcome

Prepare the `0.10.3-rc.5` beta release for the merged Aside selection, role readability, and consistent capital-`D` deletion UX.

Tracks #331

## Changes

- Bump workspace, TUI, and lockfile versions to `0.10.3-rc.5`.
- Publish the Unreleased Aside changes as the dated `0.10.3-rc.5` changelog section.
- Regenerate embedded release notes.

## Verification

- `npm run notes:check`
- `npm run notes:check-version -- 0.10.3-rc.5`
- `npm run typecheck`
- Hosted implementation CI: all required and packaged jobs passed on #340.
- Local macOS lane: root suite, TUI suite (2,266 passed, 2 platform skips), typecheck, and standalone build passed.
- Local Docker Linux x64 lane passed.
- Local Docker Linux ARM exposed unrelated container-only flakes; native hosted Linux ARM is required to pass before merge.

## Risk

Version and release-note metadata only. Publication remains gated by protected CI, immutable tag checks, release preflight, npm provenance, and post-publication verification.