### PR TITLE
fix(tui): stabilize Aside mouse interactions

### DIFF
--- a/tui/src/app.ts
+++ b/tui/src/app.ts
@@ -693,7 +693,7 @@ export async function dispatch(
     if (composer !== null) composer.cutConfirmation = null;
   }
   if (generationBusy(state) && resolved.action === "cancel" && isPlainNavigation(state)) return await cancelStream();
-  if (state.toast !== null) state.toast = null;
+  if (state.toast !== null && resolved.action !== "open-aside-use") state.toast = null;
   state.quitArmed = false;
   // The part menu carries its own per-action guard (Copy stays legal during a
   // stream), so the blanket one would wrongly refuse it here.

--- a/tui/src/aside-hop.ts
+++ b/tui/src/aside-hop.ts
@@ -2,6 +2,7 @@ import type {
   AsideAnchorView,
   AsideSessionAnchor
 } from "./aside-surface.js";
+import { graphemeCells } from "./cell-width.js";
 import { truncate, visibleWidth } from "./screens/story/frame.js";
 
 /** Internal address used for the unanchored hop entry. Never send it to the
@@ -23,6 +24,60 @@ export interface AsideHopWindow {
   readonly end: number;
   readonly hiddenBefore: number;
   readonly hiddenAfter: number;
+}
+
+/** A rendered hop-strip segment. Entries carry the stable mouse identity for
+ * the label they paint; chrome and separators leave it unset. */
+export interface AsideHopStripSegment {
+  readonly text: string;
+  readonly entry?: AsideHopEntry;
+}
+
+/** Text and hit-bearing segments for one hop strip at one terminal width. */
+export interface AsideHopStripLayout {
+  readonly text: string;
+  readonly segments: readonly AsideHopStripSegment[];
+}
+
+function clipHopSegments(
+  segments: readonly AsideHopStripSegment[],
+  width: number
+): AsideHopStripSegment[] {
+  const clipped: AsideHopStripSegment[] = [];
+  let used = 0;
+  for (const part of segments) {
+    if (used >= width) break;
+    let text = "";
+    let partWidth = 0;
+    for (const cell of graphemeCells(part.text)) {
+      if (used + partWidth + cell.width > width) break;
+      text += cell.text;
+      partWidth += cell.width;
+    }
+    if (text.length > 0) {
+      clipped.push({
+        text,
+        ...(part.entry === undefined ? {} : { entry: part.entry })
+      });
+    }
+    used += partWidth;
+  }
+  return clipped;
+}
+
+/** Project hit-bearing segments onto an exact clipped header line. */
+export function clipAsideHopStripLayout(
+  layout: AsideHopStripLayout,
+  text: string
+): AsideHopStripLayout {
+  if (layout.text === text) return layout;
+  const ellipsis = text.endsWith("…");
+  const contentWidth = Math.max(0, visibleWidth(text) - (ellipsis ? 1 : 0));
+  const segments = clipHopSegments(layout.segments, contentWidth);
+  if (ellipsis) segments.push({ text: "…" });
+  return segments.map((part) => part.text).join("") === text
+    ? { text, segments }
+    : { text, segments: [] };
 }
 
 function numberOrInfinity(value: number | undefined): number {
@@ -129,6 +184,13 @@ export function asideHopEntries(
   });
 }
 
+/** Stable identity for one ordered hop target. Anchor addresses survive
+ * presence refreshes and are not tied to the target's current index. */
+export function asideHopRowId(entry: AsideHopEntry): string {
+  if (entry.anchor.unanchored === true) return `aside-hop:${UNANCHORED_ASIDE_ID}`;
+  return `aside-hop:${entry.anchor.partId}\u0000${entry.anchor.takeId}`;
+}
+
 /** Window a crowded hop strip around the current anchor. */
 export function asideHopWindow(
   entries: readonly AsideHopEntry[],
@@ -187,23 +249,47 @@ export function asideHopStripText(
   width = Number.POSITIVE_INFINITY,
   maxVisible = 5
 ): string {
+  return asideHopStripLayout(anchors, current, width, maxVisible).text;
+}
+
+/** Build the hop strip once so rendering and hit testing use the same window. */
+export function asideHopStripLayout(
+  anchors: readonly AsideAnchorView[],
+  current: AsideSessionAnchor | null,
+  width = Number.POSITIVE_INFINITY,
+  maxVisible = 5
+): AsideHopStripLayout {
   const entries = asideHopEntries(anchors, current);
-  if (entries.length === 0) return "";
+  if (entries.length === 0) return { text: "", segments: [] };
   const currentIndex = entries.findIndex((entry) => entry.current);
-  const render = (window: AsideHopWindow): string => {
+  const render = (window: AsideHopWindow): AsideHopStripLayout => {
     const before = window.hiddenBefore > 0 ? `‹${window.start + 1} … ` : "";
     const after = window.hiddenAfter > 0 ? ` … ${window.end}›` : "";
-    const labels = window.entries.map((entry) => entry.current ? `[ ${entry.label} ]` : entry.label);
-    return `elsewhere   ${before}${labels.join("    ")}${after}`;
+    const segments: AsideHopStripSegment[] = [{ text: "elsewhere   " }];
+    if (before.length > 0) segments.push({ text: before });
+    for (const [index, entry] of window.entries.entries()) {
+      segments.push({
+        text: entry.current ? `[ ${entry.label} ]` : entry.label,
+        entry
+      });
+      if (index < window.entries.length - 1) segments.push({ text: "    " });
+    }
+    if (after.length > 0) segments.push({ text: after });
+    return {
+      text: segments.map((segment) => segment.text).join(""),
+      segments
+    };
   };
   const limit = Math.min(Math.max(1, Math.floor(maxVisible)), entries.length);
   for (let visible = limit; visible > 0; visible -= 1) {
-    const text = render(asideHopWindow(entries, currentIndex, visible));
-    if (!Number.isFinite(width) || visibleWidth(text) <= width) return text;
+    const layout = render(asideHopWindow(entries, currentIndex, visible));
+    if (!Number.isFinite(width) || visibleWidth(layout.text) <= width) return layout;
   }
   // The current entry is always retained. This final truncation only applies
   // when the caller gives less room than the one-entry label itself.
-  return truncate(render(asideHopWindow(entries, currentIndex, 1)), Math.max(0, width));
+  const layout = render(asideHopWindow(entries, currentIndex, 1));
+  const clippedWidth = Math.max(0, Math.floor(width));
+  return clipAsideHopStripLayout(layout, truncate(layout.text, clippedWidth));
 }
 
 /** Useful for geometry callers that need the rendered strip width. */

--- a/tui/src/aside-use.ts
+++ b/tui/src/aside-use.ts
@@ -123,6 +123,23 @@ export function openAsideUseMenu(
   return true;
 }
 
+/** Open a mouse-targeted menu without changing the active Aside viewport. */
+export function openAsideUseMenuFromMouse(
+  surface: AsideSurfaceState,
+  noteIndex: number,
+  selectionText?: string,
+  selectionSpans: readonly StorySelectionSpan[] = []
+): boolean {
+  const focus = surface.focus;
+  const cursor = asideCursor(surface);
+  const opened = openAsideUseMenu(
+    surface, noteIndex, 0, selectionText, selectionSpans
+  );
+  surface.focus = focus;
+  setAsideCursor(surface, cursor);
+  return opened;
+}
+
 export function closeAsideUseMenu(surface: AsideSurfaceState): void {
   surface.useMenu = null;
 }

--- a/tui/src/aside-v2-actions.ts
+++ b/tui/src/aside-v2-actions.ts
@@ -198,6 +198,9 @@ function restoreDelete(
   turns.splice(Math.min(undo.turnIndex, turns.length), 0, undo.turn);
   setAsideSessionTurns(surface, sessionIndex, turns);
   if (owningSessionSelected) {
+    if (surface.useMenu !== null && surface.useMenu.noteIndex >= undo.turnIndex) {
+      surface.useMenu.noteIndex += 1;
+    }
     surface.sessionIndex = sessionIndex;
     surface.turnCursor = undo.turnIndex;
     surface.scrollTop = null;

--- a/tui/src/aside-v2-actions.ts
+++ b/tui/src/aside-v2-actions.ts
@@ -14,6 +14,7 @@ import {
   isAsideV2,
   setAsideSessionTurns,
   type AsideDeleteUndo,
+  type AsideAnchorView,
   type AsideSessionSurfaceState,
   type AsideSessionView,
   type AsideSurfaceState,
@@ -21,6 +22,7 @@ import {
 } from "./aside-surface.js";
 import type { ResolvedKey } from "./keys.js";
 import type { RuntimeState } from "./state.js";
+import { asideUseActions } from "./aside-use.js";
 import { adoptSameStoryPayload } from "./story-adoption.js";
 import { recordNotice } from "./notice-log.js";
 import { saveConfig } from "./config.js";
@@ -93,6 +95,76 @@ function applySessionResponse(
 function currentAnchor(surface: AsideSessionSurfaceState): AsideAnchor | null {
   const anchor = surface.anchor;
   return anchor === null ? null : { partId: anchor.partId, takeId: anchor.takeId };
+}
+
+function asideAnchorIsCurrent(
+  surface: AsideSessionSurfaceState,
+  anchor: AsideAnchorView
+): boolean {
+  return anchor.unanchored === true
+    ? surface.anchor === null
+    : surface.anchor !== null
+      && surface.anchor.partId === anchor.partId
+      && surface.anchor.takeId === anchor.takeId;
+}
+
+/** Delete is optimistic. Start its durable commit for every next action, but
+ * wait for it only when that action must claim the exclusive backend slot. */
+function resolvedActionNeedsBackend(
+  resolved: ResolvedKey,
+  surface: AsideSessionSurfaceState
+): boolean {
+  if (resolved.action === "aside-hop-to") {
+    const anchor = asideHopTarget(
+      surface.anchors,
+      resolved.index ?? surface.anchorIndex
+    );
+    return anchor !== null && !asideAnchorIsCurrent(surface, anchor);
+  }
+  if (surface.useMenu === null
+    || (resolved.action !== "apply" && resolved.action !== "open-selected")) {
+    return false;
+  }
+  const index = resolved.index ?? surface.useMenu.cursor;
+  return asideUseActions(surface.useMenu.selectionText)[index]?.id === "insert-into-story";
+}
+
+function hopToAsideAnchor(
+  state: RuntimeState,
+  surface: AsideSessionSurfaceState,
+  anchor: AsideAnchorView,
+  context: AsideContext
+): boolean {
+  const requestedAnchor = anchor.unanchored === true
+    ? null : { partId: anchor.partId, takeId: anchor.takeId };
+  // Clicking the selected hop is a safe no-op. It must not clear or reload the
+  // current session.
+  if (asideAnchorIsCurrent(surface, anchor)) return true;
+  const getAsideV2 = context.source.api.getAsideV2;
+  if (getAsideV2 === undefined) {
+    throw new Error("This transport cannot hop Aside sessions.");
+  }
+  context.backend.observe(context.backend.run("hopping Aside sessions", async (task) => {
+    const response = await getAsideV2({
+      storyId: surface.storyId,
+      anchor: requestedAnchor
+    });
+    if (response === null || !taskInteractionCurrent(state, surface, task)) return;
+    const model = asideSessionsFromResponse(response, requestedAnchor);
+    surface.sessions = model.sessions;
+    surface.anchor = requestedAnchor;
+    surface.sessionIndex = Math.max(0, model.sessions.length - 1);
+    surface.turnCursor = Math.max(0, currentAsideTurns(surface).length - 1);
+    surface.anchors = model.anchors.length > 0
+      ? model.anchors : surface.anchors;
+    surface.anchorIndex = asideHopAnchorIndex(
+      surface.anchors,
+      surface.anchor
+    );
+    surface.focus = currentAsideTurns(surface).length > 0 ? "turns" : "composer";
+    surface.scrollTop = null;
+  }));
+  return true;
 }
 
 function taskCurrent(
@@ -418,14 +490,22 @@ export async function asideV2KeyAction(
     if (undoAsideDelete(surface)) state.toast = "turn restored";
     return true;
   }
+  const deleteCommitNeedsAwait = resolvedActionNeedsBackend(resolved, surface);
+  let deleteCommit: Promise<boolean> | null = null;
   if (surface.deleteUndo !== null && state.backendTask === null) {
     const undo = surface.deleteUndo;
     // The undo is a pre-commit affordance. Remove it before `run` repaints
     // and keep the captured turn private until the request settles.
     surface.deleteUndo = null;
-    context.backend.observe(context.backend.run("deleting Aside turn", (task) =>
+    deleteCommit = context.backend.run("deleting Aside turn", (task) =>
       commitAsideDelete(state, surface, context.source.api, context.cache, task, undo)
-    ));
+    );
+    context.backend.observe(deleteCommit);
+  }
+  if (deleteCommit !== null && deleteCommitNeedsAwait) {
+    // `observe` keeps the existing toast/error behavior. Swallow the same
+    // rejection here so a failed commit does not abort the follow-up action.
+    await deleteCommit.catch(() => false);
   }
   if (surface.useMenu !== null) return false;
   if (resolved.action === "cancel" && surface.confirmReset !== null) {
@@ -537,6 +617,13 @@ export async function asideV2KeyAction(
         && orderedAnchors[0]!.partId === surface.anchor.partId
         && orderedAnchors[0]!.takeId === surface.anchor.takeId
   );
+  if (resolved.action === "aside-hop-to") {
+    const anchor = asideHopTarget(
+      surface.anchors,
+      resolved.index ?? surface.anchorIndex
+    );
+    return anchor === null ? true : hopToAsideAnchor(state, surface, anchor, context);
+  }
   const bracketHopAction = resolved.action === "input"
     && surface.composer.text.length === 0
     && emptyCurrentBucket
@@ -567,33 +654,7 @@ export async function asideV2KeyAction(
     const nextAnchorIndex = (baseIndex + delta + orderedAnchors.length)
       % orderedAnchors.length;
     const anchor = orderedAnchors[nextAnchorIndex]!;
-    const getAsideV2 = context.source.api.getAsideV2;
-    if (getAsideV2 === undefined) {
-      throw new Error("This transport cannot hop Aside sessions.");
-    }
-    const requestedAnchor = anchor.unanchored === true
-      ? null : { partId: anchor.partId, takeId: anchor.takeId };
-    context.backend.observe(context.backend.run("hopping Aside sessions", async (task) => {
-      const response = await getAsideV2({
-        storyId: surface.storyId,
-        anchor: requestedAnchor
-      });
-      if (response === null || !taskInteractionCurrent(state, surface, task)) return;
-      const model = asideSessionsFromResponse(response, requestedAnchor);
-      surface.sessions = model.sessions;
-      surface.anchor = requestedAnchor;
-      surface.sessionIndex = Math.max(0, model.sessions.length - 1);
-      surface.turnCursor = Math.max(0, currentAsideTurns(surface).length - 1);
-      surface.anchors = model.anchors.length > 0
-        ? model.anchors : surface.anchors;
-      surface.anchorIndex = asideHopAnchorIndex(
-        surface.anchors,
-        surface.anchor
-      );
-      surface.focus = currentAsideTurns(surface).length > 0 ? "turns" : "composer";
-      surface.scrollTop = null;
-    }));
-    return true;
+    return hopToAsideAnchor(state, surface, anchor, context);
   }
   if (resolved.action === "aside-go-anchor") {
     const anchor = asideHopTarget(

--- a/tui/src/aside-v2-actions.ts
+++ b/tui/src/aside-v2-actions.ts
@@ -510,11 +510,12 @@ export async function asideV2KeyAction(
   if (deleteCommit !== null && deleteCommitNeedsAwait) {
     // `observe` keeps the existing toast/error behavior. Swallow the same
     // rejection here so a failed commit does not abort the follow-up action.
-    await deleteCommit.catch(() => false);
+    const deleteCommitted = await deleteCommit.catch(() => false);
     if (state.interactionVersion !== delayedInteractionVersion
       || state.aside !== surface
       || delayedMenuSessionId !== undefined
         && surface.useMenu?.sessionId !== delayedMenuSessionId) return true;
+    if (!deleteCommitted) return true;
   }
   if (surface.useMenu !== null) return false;
   if (resolved.action === "cancel" && surface.confirmReset !== null) {

--- a/tui/src/aside-v2-actions.ts
+++ b/tui/src/aside-v2-actions.ts
@@ -494,6 +494,8 @@ export async function asideV2KeyAction(
     return true;
   }
   const deleteCommitNeedsAwait = resolvedActionNeedsBackend(resolved, surface);
+  const delayedInteractionVersion = state.interactionVersion;
+  const delayedMenuSessionId = surface.useMenu?.sessionId;
   let deleteCommit: Promise<boolean> | null = null;
   if (surface.deleteUndo !== null && state.backendTask === null) {
     const undo = surface.deleteUndo;
@@ -509,6 +511,10 @@ export async function asideV2KeyAction(
     // `observe` keeps the existing toast/error behavior. Swallow the same
     // rejection here so a failed commit does not abort the follow-up action.
     await deleteCommit.catch(() => false);
+    if (state.interactionVersion !== delayedInteractionVersion
+      || state.aside !== surface
+      || delayedMenuSessionId !== undefined
+        && surface.useMenu?.sessionId !== delayedMenuSessionId) return true;
   }
   if (surface.useMenu !== null) return false;
   if (resolved.action === "cancel" && surface.confirmReset !== null) {

--- a/tui/src/hit.ts
+++ b/tui/src/hit.ts
@@ -49,6 +49,8 @@ export type HitTarget =
    * one exists, while the row identity supplies the answer's Placement
    * anchor. */
   | { kind: "aside-answer"; noteIndex: number; rowId: string }
+  /** One exact hop-strip anchor in Aside v2. */
+  | { kind: "aside-hop"; index: number; rowId: string }
   | { kind: "scrim" }
   /** Panel chrome — titles, headers, rules: visible but not actionable. */
   | { kind: "panel" };

--- a/tui/src/keys.ts
+++ b/tui/src/keys.ts
@@ -63,7 +63,7 @@ export type KeyAction =
   | "open-aside" | "open-authors-note" | "note-depth-decrease" | "note-depth-increase"
   | "aside-retake" | "aside-delete" | "aside-reset" | "aside-new-session"
   | "aside-session-next" | "aside-session-previous" | "aside-anchor-next" | "aside-anchor-previous"
-  | "aside-go-anchor" | "aside-undo-delete"
+  | "aside-go-anchor" | "aside-hop-to" | "aside-undo-delete"
   | "filter" | "cycle" | "check" | "detect-context" | "discard-pending" | "retry" | "continue"
   | "scroll-down" | "scroll-up" | "scroll-line-down" | "scroll-line-up" | "toggle-rail" | "copy-part" | "copy-line" | "open-actions" | "focus-index" | "open-aside-use"
   | "open-chapters" | "create-chapter" | "summarize-chapter" | "chapter-previous" | "chapter-next"

--- a/tui/src/mouse-actions.ts
+++ b/tui/src/mouse-actions.ts
@@ -343,6 +343,13 @@ export function mouseToAction(
   if (state.mode === "COMPOSE" && event.button === 2) return null;
 
   if (target.kind === "scrim") return { action: "cancel" };
+  if (target.kind === "aside-hop" && state.mode === "ASIDE" && event.button === 0) {
+    return {
+      action: "aside-hop-to",
+      index: target.index,
+      rowId: target.rowId
+    };
+  }
   if (target.kind === "aside-answer" && state.mode === "ASIDE" && event.button === 2
     && state.aside?.useMenu === null) {
     return {
@@ -429,6 +436,10 @@ export function mouseToAction(
   }
   if (target.kind === "list" && event.button === 0) {
     const identity = target.rowId === undefined ? {} : { rowId: target.rowId };
+    if (state.mode === "ASIDE" && state.aside?.useMenu !== null
+      && state.aside?.useMenu !== undefined) {
+      return { action: "apply", index: target.index, ...identity };
+    }
     return (target.selected ?? listCursor(state) === target.index)
       ? { action: "open-selected", ...identity }
       : { action: "focus-index", index: target.index, ...identity };

--- a/tui/src/overlay-actions.ts
+++ b/tui/src/overlay-actions.ts
@@ -61,7 +61,12 @@ import { composerMotion } from "./composer-motion.js";
 import { directComposerWrapWidth } from "./composer-geometry.js";
 import { composerPageRows } from "./composer-viewport.js";
 import { composerSurfaceAction } from "./composer-surface-action.js";
-import { asideCursor, disarmAsideClear, isAsideV2 } from "./aside-surface.js";
+import {
+  asideCursor,
+  disarmAsideClear,
+  isAsideV2,
+  setAsideCursor
+} from "./aside-surface.js";
 import { asideV2KeyAction } from "./aside-v2-actions.js";
 import { openRewriteComposer, partIdFromTextSelection, resolveRewriteTarget } from "./rewrite-action.js";
 import type { AppSource } from "./app.js";
@@ -145,6 +150,8 @@ export async function handleOverlayAction(
   }
   if (resolved.action === "open-aside-use") {
     if (state.mode === "ASIDE" && state.aside !== null) {
+      const focus = state.aside.focus;
+      const cursor = asideCursor(state.aside);
       openAsideUseMenu(
         state.aside,
         resolved.index ?? asideCursor(state.aside),
@@ -152,6 +159,10 @@ export async function handleOverlayAction(
         resolved.selectionText,
         resolved.selectionSpans
       );
+      // Opening from a mouse selection must not reflow the V2 history or move
+      // the active turn. Keyboard Enter still uses openAsideUseMenu directly.
+      state.aside.focus = focus;
+      setAsideCursor(state.aside, cursor);
     }
     return true;
   }
@@ -881,6 +892,9 @@ async function asideKeyAction(
       return;
     }
     if (resolved.action === "apply" || resolved.action === "open-selected") {
+      if (resolved.index !== undefined) {
+        focusAsideUseMenuIndex(surface, resolved.index);
+      }
       await applyAsideUseMenu(state);
       return;
     }

--- a/tui/src/overlay-actions.ts
+++ b/tui/src/overlay-actions.ts
@@ -854,7 +854,6 @@ async function asideKeyAction(
     }
     if (surface.useMenu !== null) {
       closeAsideUseMenu(surface);
-      surface.focus = "notes";
       return;
     }
     if (surface.focus === "notes" || surface.focus === "turns") {

--- a/tui/src/overlay-actions.ts
+++ b/tui/src/overlay-actions.ts
@@ -48,6 +48,7 @@ import {
   moveAsideNoteFocus,
   moveAsideUseMenuCursor,
   openAsideUseMenu,
+  openAsideUseMenuFromMouse,
   closeAsideUseMenu
 } from "./aside-use.js";
 import {
@@ -61,12 +62,7 @@ import { composerMotion } from "./composer-motion.js";
 import { directComposerWrapWidth } from "./composer-geometry.js";
 import { composerPageRows } from "./composer-viewport.js";
 import { composerSurfaceAction } from "./composer-surface-action.js";
-import {
-  asideCursor,
-  disarmAsideClear,
-  isAsideV2,
-  setAsideCursor
-} from "./aside-surface.js";
+import { asideCursor, disarmAsideClear, isAsideV2 } from "./aside-surface.js";
 import { asideV2KeyAction } from "./aside-v2-actions.js";
 import { openRewriteComposer, partIdFromTextSelection, resolveRewriteTarget } from "./rewrite-action.js";
 import type { AppSource } from "./app.js";
@@ -150,19 +146,12 @@ export async function handleOverlayAction(
   }
   if (resolved.action === "open-aside-use") {
     if (state.mode === "ASIDE" && state.aside !== null) {
-      const focus = state.aside.focus;
-      const cursor = asideCursor(state.aside);
-      openAsideUseMenu(
+      openAsideUseMenuFromMouse(
         state.aside,
         resolved.index ?? asideCursor(state.aside),
-        0,
         resolved.selectionText,
         resolved.selectionSpans
       );
-      // Opening from a mouse selection must not reflow the V2 history or move
-      // the active turn. Keyboard Enter still uses openAsideUseMenu directly.
-      state.aside.focus = focus;
-      setAsideCursor(state.aside, cursor);
     }
     return true;
   }

--- a/tui/src/presented-mouse-action.ts
+++ b/tui/src/presented-mouse-action.ts
@@ -30,6 +30,7 @@ import {
   asideUseRowId
 } from "./aside-use.js";
 import { asideAnswerIndexFromRowId } from "./aside-surface.js";
+import { asideHopEntries, asideHopRowId } from "./aside-hop.js";
 import { availableTextActions } from "./text-actions.js";
 
 export interface PresentedInteraction {
@@ -154,9 +155,26 @@ function rebaseByStableIdentity(
       .findIndex((row) => row.id === action.rowId);
     return index < 0 ? null : { ...action, index };
   }
+  if (action.action === "apply" && action.rowId !== undefined
+    && state.mode === "ASIDE" && state.aside?.useMenu !== null
+    && state.aside?.useMenu !== undefined) {
+    const index = asideUseActionIndexFromRowId(
+      action.rowId,
+      state.aside.useMenu.sessionId,
+      state.aside.useMenu.selectionText
+    );
+    return index < 0 ? null : { ...action, index };
+  }
   if (action.action === "open-aside-use" && action.rowId !== undefined
     && state.mode === "ASIDE" && state.aside !== null) {
     const index = asideAnswerIndexFromRowId(action.rowId, state.aside);
+    return index < 0 ? null : { ...action, index };
+  }
+  if (action.action === "aside-hop-to" && action.rowId !== undefined
+    && state.mode === "ASIDE" && state.aside !== null
+    && state.aside.modelVersion === 2) {
+    const index = asideHopEntries(state.aside.anchors, state.aside.anchor)
+      .findIndex((entry) => asideHopRowId(entry) === action.rowId);
     return index < 0 ? null : { ...action, index };
   }
   return relativeMouseAction(action) ? action : null;

--- a/tui/src/screens/story/aside-screen.ts
+++ b/tui/src/screens/story/aside-screen.ts
@@ -27,6 +27,11 @@ import {
   asideUseMenuTitle,
   asideUseRowId
 } from "../../aside-use.js";
+import {
+  asideHopRowId,
+  asideHopStripLayout,
+  clipAsideHopStripLayout
+} from "../../aside-hop.js";
 import type { HitRows, HitTarget } from "../../hit.js";
 import {
   buildComposerSelectionProjection,
@@ -54,6 +59,7 @@ import { renderComposerLayout } from "./composer.js";
 import type { StoryScreenFrame } from "../story.js";
 import { lightWorkKeyword, streamLivenessMark } from "../work-light.js";
 import { paintStorySelection } from "./selection-highlight.js";
+import { addInlineHits } from "./hits.js";
 
 function renderAsideV2Status(
   state: StoryScreenState,
@@ -206,8 +212,11 @@ function renderAsideV2Screen(
   const history = asideHistoryWindowWithKinds(
     surface, width, historyRows, state.now, historyLayout
   );
+  const headerLines = header.map((text) =>
+    renderAsideV2HeaderLine(text, surface, width)
+  );
   const lines: FrameLine[] = [
-    ...header.map(renderAsideV2HeaderLine),
+    ...headerLines,
     ...history.lines.map((text, index) =>
       renderAsideV2HistoryLine(
         text,
@@ -235,6 +244,7 @@ function renderAsideV2Screen(
     if (row < composerStart || row >= composerStart + composerLines.length) return null;
     return { target: { kind: "composer" }, left: 0, right: width };
   });
+  addInlineHits(headerLines, hitRows);
   const storySelectionProjection = buildStorySelectionProjection(lines, width);
   let renderedLines = lines.slice(0, height);
   if (surface.useMenu?.selectionSpans !== undefined
@@ -379,8 +389,35 @@ function asideAnswerSegment(
   };
 }
 
-function renderAsideV2HeaderLine(text: string): FrameLine {
+function renderAsideV2HeaderLine(
+  text: string,
+  surface: AsideSessionSurfaceState,
+  width: number
+): FrameLine {
   if (text.startsWith("elsewhere   ")) {
+    const hopLayout = clipAsideHopStripLayout(
+      asideHopStripLayout(surface.anchors, surface.anchor, width),
+      text
+    );
+    if (hopLayout.segments.some((part) => part.entry !== undefined)) {
+      return hopLayout.segments.map((part) => {
+        if (part.entry === undefined) return segment(part.text, "chrome");
+        const hit: HitTarget = {
+          kind: "aside-hop",
+          index: part.entry.index,
+          rowId: asideHopRowId(part.entry)
+        };
+        return part.entry.current
+          ? {
+              text: part.text,
+              role: "background",
+              background: "focus / accent",
+              bold: true,
+              hit
+            }
+          : segment(part.text, "chrome", hit);
+      });
+    }
     const currentStart = text.indexOf("[ ", 12);
     const currentEnd = currentStart < 0 ? -1 : text.indexOf(" ]", currentStart + 2);
     if (currentStart >= 0 && currentEnd >= 0) {

--- a/tui/test/aside-hop-mouse.test.ts
+++ b/tui/test/aside-hop-mouse.test.ts
@@ -9,8 +9,8 @@ import {
 } from "../src/aside-surface.js";
 import { asideHopEntries, asideHopRowId } from "../src/aside-hop.js";
 import { demoAppSource } from "../src/demo.js";
-import { initialState } from "../src/app.js";
-import { ActionRuntime } from "../src/action-runtime.js";
+import { dispatch, initialState } from "../src/app.js";
+import { ActionRuntime, withActionAdmission } from "../src/action-runtime.js";
 import { handleOverlayAction } from "../src/overlay-actions.js";
 import { renderStoryScreen } from "../src/screens/story.js";
 import { mouseToAction, captureMouseActionState } from "../src/mouse-actions.js";
@@ -265,5 +265,56 @@ describe("Aside hop mouse", () => {
     expect(reads).toEqual([{ partId: "part-1", takeId: "take-1" }]);
     expect(state.mode).toBe("ASIDE");
     expect(surface.anchor).toEqual({ partId: "part-1", takeId: "take-1" });
+  });
+
+  test("a newer Escape cancels a hop waiting on delete persistence", async () => {
+    const { app, state, surface, reads, context } = setup();
+    let releaseDelete!: () => void;
+    const deleteGate = new Promise<void>((resolve) => { releaseDelete = resolve; });
+    const source = {
+      ...app,
+      api: {
+        ...app.api,
+        deleteAsideTurn: async () => {
+          await deleteGate;
+          return {
+            schemaVersion: 2 as const,
+            id: "session-current",
+            title: "current",
+            anchor: CURRENT,
+            turns: []
+          };
+        }
+      }
+    };
+    await handleOverlayAction({ action: "aside-delete" }, state, source, context);
+    await handleOverlayAction({ action: "aside-delete" }, state, source, context);
+    const target = asideHopEntries(ANCHORS, CURRENT).find((entry) =>
+      entry.anchor.partId === "part-1");
+    if (target === undefined) throw new Error("missing target hop");
+    const action = mouseToAction(clickForHop(state, asideHopRowId(target)), state);
+    let admit!: () => void;
+    const admitted = new Promise<void>((resolve) => { admit = resolve; });
+    const pending = dispatch(
+      action!, state, source, context.cache, () => undefined,
+      async () => undefined, () => undefined, null,
+      () => undefined, () => undefined,
+      withActionAdmission(context.backend, admit)
+    );
+    await admitted;
+
+    await dispatch(
+      { action: "cancel" }, state, source, context.cache, () => undefined,
+      async () => undefined, () => undefined, null,
+      () => undefined, () => undefined, context.backend
+    );
+    expect(state.mode).toBe("NAV");
+    releaseDelete();
+    await pending;
+    await context.backend.settle();
+
+    expect(state.aside).toBeNull();
+    expect(reads).toEqual([]);
+    expect(surface.anchor).toEqual(CURRENT);
   });
 });

--- a/tui/test/aside-hop-mouse.test.ts
+++ b/tui/test/aside-hop-mouse.test.ts
@@ -247,6 +247,7 @@ describe("Aside hop mouse", () => {
       }
     };
     await handleOverlayAction({ action: "aside-delete" }, state, source, context);
+    await handleOverlayAction({ action: "aside-delete" }, state, source, context);
     expect(surface.deleteUndo).not.toBeNull();
 
     const target = asideHopEntries(ANCHORS, CURRENT).find((entry) =>

--- a/tui/test/aside-hop-mouse.test.ts
+++ b/tui/test/aside-hop-mouse.test.ts
@@ -1,0 +1,268 @@
+/** Mouse activation for the Aside v2 hop strip. */
+import { describe, expect, test } from "bun:test";
+import type { AsideReadRequest, AsideReadResponse } from "../../shared/aside-transport.js";
+import {
+  createAsideSurface,
+  isAsideV2,
+  type AsideAnchorView,
+  type AsideSessionAnchor
+} from "../src/aside-surface.js";
+import { asideHopEntries, asideHopRowId } from "../src/aside-hop.js";
+import { demoAppSource } from "../src/demo.js";
+import { initialState } from "../src/app.js";
+import { ActionRuntime } from "../src/action-runtime.js";
+import { handleOverlayAction } from "../src/overlay-actions.js";
+import { renderStoryScreen } from "../src/screens/story.js";
+import { mouseToAction, captureMouseActionState } from "../src/mouse-actions.js";
+import { createWrapCache, type ProseStyle } from "../src/wrap.js";
+import {
+  reconcilePresentedMouseAction,
+  type FrozenMouseEvent,
+  type PresentedInteraction
+} from "../src/presented-mouse-action.js";
+
+const ANCHORS: readonly AsideAnchorView[] = [
+  { partId: "part-1", takeId: "take-1", partNumber: 1, sessionCount: 1 },
+  { partId: "part-2", takeId: "take-2", partNumber: 2, sessionCount: 2 },
+  { partId: "part-3", takeId: "take-3", partNumber: 3, sessionCount: 1 },
+  { partId: "part-4", takeId: "take-4", partNumber: 4, sessionCount: 1 },
+  {
+    partId: "__aside_unanchored__",
+    takeId: "__aside_unanchored__",
+    sessionCount: 2,
+    unanchored: true
+  }
+];
+
+const CURRENT: AsideSessionAnchor = { partId: "part-2", takeId: "take-2" };
+
+function setup() {
+  const source = demoAppSource();
+  const state = initialState(source, false);
+  const surface = createAsideSurface(
+    state.payload.id,
+    state.payload.title,
+    [{
+      id: "session-current",
+      title: "current",
+      anchor: CURRENT,
+      turns: [{ q: "Current?", a: "Current answer." }]
+    }],
+    null,
+    null,
+    { v2: true, anchor: CURRENT, anchors: ANCHORS }
+  );
+  if (!isAsideV2(surface)) throw new Error("expected v2 Aside surface");
+  state.aside = surface;
+  state.mode = "ASIDE";
+  const reads: (AsideSessionAnchor | null)[] = [];
+  const api = {
+    ...source.api,
+    getAsideV2: async (request: AsideReadRequest): Promise<AsideReadResponse> => {
+      const anchor = request.anchor ?? null;
+      reads.push(anchor);
+      return {
+        schemaVersion: 2,
+        anchor,
+        sessions: [{
+          schemaVersion: 2,
+          id: "session-target",
+          title: "target",
+          anchor,
+          turns: [{ q: "Target?", a: "Target answer." }]
+        }],
+        anchors: ANCHORS.filter((entry) => entry.unanchored !== true).map((entry) => ({
+          partId: entry.partId,
+          takeId: entry.takeId,
+          partNumber: entry.partNumber,
+          sessionCount: entry.sessionCount
+        })),
+        unanchoredCount: 2
+      };
+    }
+  } as typeof source.api;
+  const app = { ...source, api };
+  const context = {
+    backend: new ActionRuntime(state, () => undefined),
+    cache: createWrapCache<ProseStyle>(),
+    repaint: () => undefined,
+    renderer: { width: 120, height: 24 } as never,
+    applyTheme: () => undefined,
+    previewTheme: () => undefined
+  };
+  return { app, state, surface, reads, context };
+}
+
+function clickForHop(
+  state: ReturnType<typeof initialState>,
+  rowId: string,
+  width = 120,
+  height = 24
+): FrozenMouseEvent {
+  const frame = renderStoryScreen(state, { width, height });
+  state.hitRows = frame.derived.hitRows;
+  for (let y = 0; y < height; y += 1) {
+    for (let x = 0; x < width; x += 1) {
+      const action = mouseToAction({
+        type: "down",
+        button: 0,
+        x,
+        y,
+        modifiers: { shift: false, alt: false, ctrl: false }
+      }, state);
+      if (action?.action === "aside-hop-to" && action.rowId === rowId) {
+        return {
+          type: "down",
+          button: 0,
+          x,
+          y,
+          modifiers: { shift: false, alt: false, ctrl: false }
+        };
+      }
+    }
+  }
+  throw new Error(`hop target not rendered: ${rowId}`);
+}
+
+describe("Aside hop mouse", () => {
+  test("a partially visible current hop label remains clickable", () => {
+    const { state } = setup();
+    const current = asideHopEntries(ANCHORS, CURRENT).find((entry) => entry.current);
+    if (current === undefined) throw new Error("missing current hop");
+    const click = clickForHop(state, asideHopRowId(current), 20, 24);
+    expect(mouseToAction(click, state)).toEqual({
+      action: "aside-hop-to",
+      index: current.index,
+      rowId: asideHopRowId(current)
+    });
+  });
+
+  test("a height-clipped hop row keeps its visible labels clickable", () => {
+    const { state } = setup();
+    const current = asideHopEntries(ANCHORS, CURRENT).find((entry) => entry.current);
+    if (current === undefined) throw new Error("missing current hop");
+    const click = clickForHop(state, asideHopRowId(current), 80, 6);
+    expect(mouseToAction(click, state)).toMatchObject({
+      action: "aside-hop-to",
+      rowId: asideHopRowId(current)
+    });
+  });
+
+  test("clicking every visible hop target loads its exact session", async () => {
+    const entries = asideHopEntries(ANCHORS, CURRENT);
+    for (const entry of entries) {
+      const { app, state, surface, reads, context } = setup();
+      const click = clickForHop(state, asideHopRowId(entry));
+      const action = mouseToAction(click, state);
+      expect(action).toEqual({
+        action: "aside-hop-to",
+        index: entry.index,
+        rowId: asideHopRowId(entry)
+      });
+      await handleOverlayAction(action!, state, app, context);
+      await context.backend.settle();
+      expect(state.mode).toBe("ASIDE");
+      expect(state.aside).toBe(surface);
+      if (entry.current) {
+        expect(reads).toEqual([]);
+        expect(surface.anchor).toEqual(CURRENT);
+      } else {
+        expect(reads).toEqual([entry.anchor.unanchored === true ? null : {
+          partId: entry.anchor.partId,
+          takeId: entry.anchor.takeId
+        }]);
+        expect(surface.anchor).toEqual(
+          entry.anchor.unanchored === true ? null : {
+            partId: entry.anchor.partId,
+            takeId: entry.anchor.takeId
+          }
+        );
+      }
+    }
+  });
+
+  test("queued hop click rebases by stable anchor identity", async () => {
+    const { app, state, surface, reads, context } = setup();
+    const target = asideHopEntries(ANCHORS, CURRENT).find((entry) =>
+      entry.anchor.partId === "part-4");
+    if (target === undefined) throw new Error("missing target hop");
+    const click = clickForHop(state, asideHopRowId(target));
+    const action = mouseToAction(click, state);
+    expect(action?.index).toBe(target.index);
+    const captured: PresentedInteraction = {
+      version: 1,
+      frameToken: 1,
+      interactive: true,
+      storyId: state.payload.id,
+      state: captureMouseActionState(state)
+    };
+
+    // Presence refresh removes an earlier target, changing the index while
+    // keeping the clicked anchor address alive.
+    surface.anchors = surface.anchors.filter((entry) => entry.partId !== "part-1");
+    state.hitRows = renderStoryScreen(state, { width: 120, height: 24 }).derived.hitRows;
+    const presented: PresentedInteraction = {
+      version: 2,
+      frameToken: 2,
+      interactive: true,
+      storyId: state.payload.id,
+      state: captureMouseActionState(state)
+    };
+    const rebased = reconcilePresentedMouseAction({
+      action: action!,
+      event: click,
+      captured,
+      presented,
+      state
+    });
+    expect(rebased).toEqual({
+      action: "aside-hop-to",
+      index: 2,
+      rowId: asideHopRowId(target)
+    });
+    await handleOverlayAction(rebased!, state, app, context);
+    await context.backend.settle();
+    expect(reads).toEqual([{ partId: "part-4", takeId: "take-4" }]);
+    expect(state.mode).toBe("ASIDE");
+    expect(surface.anchor).toEqual({ partId: "part-4", takeId: "take-4" });
+  });
+
+  test("hop click waits for an undoable delete commit", async () => {
+    const { app, state, surface, reads, context } = setup();
+    let deletes = 0;
+    const source = {
+      ...app,
+      api: {
+        ...app.api,
+        deleteAsideTurn: async () => {
+          deletes += 1;
+          return {
+            schemaVersion: 2 as const,
+            id: "session-current",
+            title: "current",
+            anchor: CURRENT,
+            turns: []
+          };
+        }
+      }
+    };
+    await handleOverlayAction({ action: "aside-delete" }, state, source, context);
+    expect(surface.deleteUndo).not.toBeNull();
+
+    const target = asideHopEntries(ANCHORS, CURRENT).find((entry) =>
+      entry.anchor.partId === "part-1");
+    if (target === undefined) throw new Error("missing target hop");
+    const action = mouseToAction(
+      clickForHop(state, asideHopRowId(target)),
+      state
+    );
+    expect(action).toMatchObject({ action: "aside-hop-to", index: target.index });
+    await handleOverlayAction(action!, state, source, context);
+    await context.backend.settle();
+
+    expect(deletes).toBe(1);
+    expect(reads).toEqual([{ partId: "part-1", takeId: "take-1" }]);
+    expect(state.mode).toBe("ASIDE");
+    expect(surface.anchor).toEqual({ partId: "part-1", takeId: "take-1" });
+  });
+});

--- a/tui/test/aside-use-menu-mouse.test.ts
+++ b/tui/test/aside-use-menu-mouse.test.ts
@@ -230,6 +230,63 @@ describe("Aside use-menu mouse", () => {
     expect(closedRows).toEqual(beforeRows);
   });
 
+  test("production right-click retains narrow toast footer geometry", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const turns = Array.from({ length: 5 }, (_, index) => ({
+      id: `turn-${index}`,
+      q: `Question ${index}`,
+      a: `Answer ${index} ${"answer-word ".repeat(5)}`
+    }));
+    const surface = createAsideSurface(
+      state.payload.id,
+      state.payload.title,
+      [{ id: "session-1", title: "session", anchor: null, turns }],
+      null,
+      null,
+      { v2: true }
+    );
+    if (!isAsideV2(surface)) throw new Error("expected v2 Aside surface");
+    state.aside = surface;
+    state.mode = "ASIDE";
+    surface.focus = "turns";
+    surface.turnCursor = 4;
+    state.toast = "▸ deleted 1 turn · u undoes";
+    const width = 80;
+    const height = 24;
+    const selectedKey = asideAnswerRowId(surface, 4);
+    const before = renderStoryScreen(state, { width, height });
+    state.hitRows = before.derived.hitRows;
+    const beforeRows = [...new Set(before.derived.storySelectionProjection!
+      .flatMap((cell, index) => cell?.key === selectedKey
+        ? [Math.floor(index / (width + 1))] : []))];
+    const answerRow = state.hitRows.findIndex((row) =>
+      row?.target.kind === "aside-answer" && row.target.noteIndex === 4);
+    expect(answerRow).toBeGreaterThan(-1);
+    const action = mouseToAction({
+      type: "down",
+      button: 2,
+      x: 4,
+      y: answerRow,
+      modifiers: { shift: false, alt: false, ctrl: false }
+    }, state);
+    const context = overlayContext(state, width, height);
+
+    await dispatch(
+      action!, state, source, context.cache, () => undefined,
+      async () => undefined, () => undefined, context.renderer,
+      () => undefined, () => undefined, context.backend
+    );
+
+    expect(state.toast).toBe("▸ deleted 1 turn · u undoes");
+    expect(surface.useMenu).not.toBeNull();
+    const after = renderStoryScreen(state, { width, height });
+    const afterRows = [...new Set(after.derived.storySelectionProjection!
+      .flatMap((cell, index) => cell?.key === selectedKey
+        ? [Math.floor(index / (width + 1))] : []))];
+    expect(afterRows).toEqual(beforeRows);
+  });
+
   test("every selected-text menu row applies from one mouse click", async () => {
     const answer = "complete saved answer";
     const selected = "selected answer";

--- a/tui/test/aside-use-menu-mouse.test.ts
+++ b/tui/test/aside-use-menu-mouse.test.ts
@@ -16,6 +16,7 @@ import { renderStoryScreen } from "../src/screens/story.js";
 import { frameText, plainLine, visibleWidth } from "../src/screens/story/frame.js";
 import {
   asideUseActions,
+  asideUseRowId,
   focusAsideUseMenuIndex,
   openAsideUseMenu
 } from "../src/aside-use.js";
@@ -927,6 +928,55 @@ describe("Aside use-menu mouse", () => {
     expect(state.mode).toBe("PLACE");
     expect(state.aside).toBeNull();
     expect(state.placement?.answer).toBe("later answer");
+  });
+
+  test("delete rollback keeps a one-click Placement target on the same answer", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const surface = createAsideSurface(
+      state.payload.id,
+      state.payload.title,
+      [{
+        id: "session-1",
+        title: "session",
+        anchor: null,
+        turns: [
+          { q: "first", a: "restored first answer" },
+          { q: "later", a: "target later answer" }
+        ]
+      }],
+      null,
+      null,
+      { v2: true }
+    );
+    if (!isAsideV2(surface)) throw new Error("expected v2 Aside surface");
+    state.aside = surface;
+    state.mode = "ASIDE";
+    surface.focus = "turns";
+    surface.turnCursor = 0;
+    const sourceWithFailure = {
+      ...source,
+      api: {
+        ...source.api,
+        deleteAsideTurn: async () => { throw new Error("delete failed"); }
+      }
+    };
+    const context = overlayContext(state, 80, 24);
+    await handleOverlayAction({ action: "aside-delete" }, state, sourceWithFailure, context);
+    await handleOverlayAction({ action: "aside-delete" }, state, sourceWithFailure, context);
+    expect(openAsideUseMenu(surface, 0)).toBeTrue();
+    const sessionId = surface.useMenu!.sessionId;
+
+    await handleOverlayAction({
+      action: "apply",
+      index: 1,
+      rowId: asideUseRowId(sessionId, "insert-into-story")
+    }, state, sourceWithFailure, context);
+    await context.backend.settle();
+
+    expect(state.mode).toBe("PLACE");
+    expect(state.placement?.answer).toBe("target later answer");
+    expect(state.placement?.returnAside.useMenu?.noteIndex).toBe(1);
   });
 
   test("stale use-menu click for note A is dropped after menu reopens on note B", async () => {

--- a/tui/test/aside-use-menu-mouse.test.ts
+++ b/tui/test/aside-use-menu-mouse.test.ts
@@ -8,9 +8,9 @@ import {
   isAsideV2
 } from "../src/aside-surface.js";
 import { demoAppSource } from "../src/demo.js";
-import { initialState } from "../src/app.js";
+import { dispatch, initialState } from "../src/app.js";
 import { handleOverlayAction } from "../src/overlay-actions.js";
-import { ActionRuntime } from "../src/action-runtime.js";
+import { ActionRuntime, withActionAdmission } from "../src/action-runtime.js";
 import { createWrapCache, type ProseStyle } from "../src/wrap.js";
 import { renderStoryScreen } from "../src/screens/story.js";
 import { frameText, plainLine, visibleWidth } from "../src/screens/story/frame.js";
@@ -991,6 +991,87 @@ describe("Aside use-menu mouse", () => {
     expect(state.mode).toBe("PLACE");
     expect(state.placement?.answer).toBe("target later answer");
     expect(state.placement?.returnAside.useMenu?.noteIndex).toBe(1);
+  });
+
+  test("a newer Escape cancels Placement while its click waits on delete persistence", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const later = { q: "later", a: "later answer" };
+    const surface = createAsideSurface(
+      state.payload.id,
+      state.payload.title,
+      [{
+        id: "session-1",
+        title: "session",
+        anchor: null,
+        turns: [{ q: "first", a: "first answer" }, later]
+      }],
+      null,
+      null,
+      { v2: true }
+    );
+    if (!isAsideV2(surface)) throw new Error("expected v2 Aside surface");
+    state.aside = surface;
+    state.mode = "ASIDE";
+    surface.focus = "turns";
+    surface.turnCursor = 0;
+    let releaseDelete!: () => void;
+    const deleteGate = new Promise<void>((resolve) => { releaseDelete = resolve; });
+    const sourceWithDelete = {
+      ...source,
+      api: {
+        ...source.api,
+        deleteAsideTurn: async () => {
+          await deleteGate;
+          return {
+            schemaVersion: 2 as const,
+            id: "session-1",
+            title: "session",
+            anchor: null,
+            turns: [later]
+          };
+        }
+      }
+    };
+    const context = overlayContext(state, 80, 24);
+    await handleOverlayAction({ action: "aside-delete" }, state, sourceWithDelete, context);
+    await handleOverlayAction({ action: "aside-delete" }, state, sourceWithDelete, context);
+    expect(openAsideUseMenu(surface, 0)).toBeTrue();
+    const sessionId = surface.useMenu!.sessionId;
+    let admit!: () => void;
+    const admitted = new Promise<void>((resolve) => { admit = resolve; });
+    const pending = dispatch(
+      {
+        action: "apply",
+        index: 1,
+        rowId: asideUseRowId(sessionId, "insert-into-story")
+      },
+      state,
+      sourceWithDelete,
+      context.cache,
+      () => undefined,
+      async () => undefined,
+      () => undefined,
+      null,
+      () => undefined,
+      () => undefined,
+      withActionAdmission(context.backend, admit)
+    );
+    await admitted;
+
+    await dispatch(
+      { action: "cancel" }, state, sourceWithDelete, context.cache,
+      () => undefined, async () => undefined, () => undefined, null,
+      () => undefined, () => undefined, context.backend
+    );
+    expect(surface.useMenu).toBeNull();
+    releaseDelete();
+    await pending;
+    await context.backend.settle();
+
+    expect(state.mode).toBe("ASIDE");
+    expect(surface.useMenu).toBeNull();
+    expect(state.placement).toBeNull();
   });
 
   test("stale use-menu click for note A is dropped after menu reopens on note B", async () => {

--- a/tui/test/aside-use-menu-mouse.test.ts
+++ b/tui/test/aside-use-menu-mouse.test.ts
@@ -137,6 +137,191 @@ function activateStoryStream(state: ReturnType<typeof initialState>): void {
 }
 
 describe("Aside use-menu mouse", () => {
+  test("right-click preserves a clipped V2 viewport and exact native answer range", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const turns = Array.from({ length: 8 }, (_, index) => ({
+      id: `turn-${index}`,
+      q: `Question ${index} ${"q ".repeat(3)}`,
+      a: `Answer ${index} ${"answer-word ".repeat(8)}`
+    }));
+    const surface = createAsideSurface(
+      state.payload.id,
+      state.payload.title,
+      [{ id: "session-1", title: "session", anchor: null, turns }],
+      null,
+      null,
+      { v2: true }
+    );
+    if (!isAsideV2(surface)) throw new Error("expected v2 Aside surface");
+    state.aside = surface;
+    state.mode = "ASIDE";
+    surface.focus = "composer";
+
+    const width = 80;
+    const height = 36;
+    const before = renderStoryScreen(state, { width, height });
+    state.hitRows = before.derived.hitRows;
+    const projection = before.derived.storySelectionProjection;
+    expect(projection).not.toBeNull();
+    const selectedKey = asideAnswerRowId(surface, 4);
+    const selectedCells = projection!.flatMap((cell, index) =>
+      cell?.key === selectedKey ? [{ cell, index }] : []);
+    expect(selectedCells.length).toBeGreaterThan(0);
+    // The first turn is clipped above this nonzero bottom-follow viewport.
+    expect(projection!.some((cell) => cell?.key === asideAnswerRowId(surface, 0))).toBeFalse();
+    const first = selectedCells[0]!;
+    const last = selectedCells.at(-1)!;
+    const beforeRows = [...new Set(selectedCells.map(({ index }) =>
+      Math.floor(index / (width + 1))))];
+    const answerRow = state.hitRows.findIndex((row) =>
+      row?.target.kind === "aside-answer" && row.target.noteIndex === 4);
+    expect(answerRow).toBeGreaterThan(-1);
+    const rawEvent = {
+      type: "down" as const,
+      button: 2 as const,
+      x: 4,
+      y: answerRow,
+      modifiers: { shift: false, alt: false, ctrl: false }
+    };
+    const raw = mouseToAction(rawEvent, state);
+    expect(raw).toMatchObject({ action: "open-aside-use", index: 4 });
+    const native = selectionReader("native terminal range", {
+      start: first.index,
+      end: last.index + 1
+    });
+    const decorated = selectionAwarePartMenuAction(
+      { ...native.event, x: rawEvent.x, y: rawEvent.y } as never,
+      raw,
+      native.renderer as never,
+      projection
+    );
+    expect(decorated?.selectionText).toBe(turns[4]!.a);
+    await handleOverlayAction(
+      decorated!,
+      state,
+      source,
+      overlayContext(state, width, height)
+    );
+    expect(surface.focus).toBe("composer");
+    expect(surface.useMenu?.selectionText).toBe(turns[4]!.a);
+
+    const after = renderStoryScreen(state, { width, height });
+    const afterCells = after.derived.storySelectionProjection!.flatMap((cell, index) =>
+      cell?.key === selectedKey ? [{ cell, index }] : []);
+    const afterRows = [...new Set(afterCells.map(({ index }) =>
+      Math.floor(index / (width + 1))))];
+    expect(afterRows).toEqual(beforeRows);
+    expect(surface.useMenu?.selectionSpans).toEqual(decorated?.selectionSpans);
+  });
+
+  test("every selected-text menu row applies from one mouse click", async () => {
+    const answer = "complete saved answer";
+    const selected = "selected answer";
+    const actions = asideUseActions(selected);
+    const expectedModes = ["ASIDE", "COMPOSE", "EDITOR", "PLACE"] as const;
+    for (const [index, action] of actions.entries()) {
+      const source = demoAppSource();
+      const state = initialState(source, false);
+      const surface = installLegacyAside(state, answer);
+      expect(openAsideUseMenu(surface, 0, 0, selected)).toBeTrue();
+      const frame = renderStoryScreen(state, { width: 80, height: 24 });
+      state.hitRows = frame.derived.hitRows;
+      let click: FrozenMouseEvent | null = null;
+      for (let y = 0; y < frame.derived.hitRows.length && click === null; y += 1) {
+        for (let x = 0; x < 80; x += 1) {
+          const candidate = mouseToAction({
+            type: "down",
+            button: 0,
+            x,
+            y,
+            modifiers: { shift: false, alt: false, ctrl: false }
+          }, state);
+          if (candidate?.action === "apply"
+            && candidate.index === index
+            && candidate.rowId !== undefined) {
+            click = { type: "down", button: 0, x, y,
+              modifiers: { shift: false, alt: false, ctrl: false } };
+            expect(candidate.rowId).toContain(`:${action.id}`);
+            break;
+          }
+        }
+      }
+      expect(click).not.toBeNull();
+      const resolved = mouseToAction(click!, state);
+      expect(resolved).toMatchObject({ action: "apply", index });
+      // A native selection can still be present on the release event. The
+      // direct apply action does not enter the prose focus guard.
+      const native = selectionReader(selected, { start: 0, end: selected.length });
+      const released = selectionAwarePartMenuAction(
+        { ...click!, type: "up" } as never,
+        resolved,
+        native.renderer as never
+      );
+      expect(released).toEqual(resolved);
+      await handleOverlayAction(
+        resolved!,
+        state,
+        source,
+        overlayContext(state, 80, 24)
+      );
+      expect(state.mode).toBe(expectedModes[index]);
+    }
+  });
+
+  test("right-click keeps V2 turn focus and cursor after navigation", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const turns = Array.from({ length: 8 }, (_, index) => ({
+      id: `turn-${index}`,
+      q: `Question ${index}`,
+      a: `Answer ${index} ${"answer-word ".repeat(4)}`
+    }));
+    const surface = createAsideSurface(
+      state.payload.id,
+      state.payload.title,
+      [{ id: "session-1", title: "session", anchor: null, turns }],
+      null,
+      null,
+      { v2: true }
+    );
+    if (!isAsideV2(surface)) throw new Error("expected v2 Aside surface");
+    state.aside = surface;
+    state.mode = "ASIDE";
+    surface.focus = "turns";
+    surface.turnCursor = 6;
+    const context = overlayContext(state, 80, 36);
+    await handleOverlayAction({ action: "focus-previous" }, state, source, context);
+    await handleOverlayAction({ action: "focus-next" }, state, source, context);
+    expect(surface.turnCursor).toBe(6);
+
+    const before = renderStoryScreen(state, { width: 80, height: 36 });
+    state.hitRows = before.derived.hitRows;
+    const selectedKey = asideAnswerRowId(surface, 5);
+    const beforeRows = [...new Set(before.derived.storySelectionProjection!.flatMap((cell, index) =>
+      cell?.key === selectedKey ? [Math.floor(index / 81)] : []))];
+    expect(beforeRows.length).toBeGreaterThan(0);
+    const answerRow = state.hitRows.findIndex((row) =>
+      row?.target.kind === "aside-answer" && row.target.noteIndex === 5);
+    expect(answerRow).toBeGreaterThan(-1);
+    const click = {
+      type: "down" as const,
+      button: 2 as const,
+      x: 4,
+      y: answerRow,
+      modifiers: { shift: false, alt: false, ctrl: false }
+    };
+    const action = mouseToAction(click, state);
+    expect(action).toMatchObject({ action: "open-aside-use", index: 5 });
+    await handleOverlayAction(action!, state, source, context);
+    expect(surface.focus).toBe("turns");
+    expect(surface.turnCursor).toBe(6);
+    const after = renderStoryScreen(state, { width: 80, height: 36 });
+    const afterRows = [...new Set(after.derived.storySelectionProjection!.flatMap((cell, index) =>
+      cell?.key === selectedKey ? [Math.floor(index / 81)] : []))];
+    expect(afterRows).toEqual(beforeRows);
+  });
+
   test("keeps a selected answer visibly highlighted while its use menu is open", async () => {
     const answer = "alpha bravo charlie delta echo foxtrot golf hotel";
     const width = 80;
@@ -571,7 +756,7 @@ describe("Aside use-menu mouse", () => {
     expect(listTargets.every((target) => target.kind === "list" && target.index === 0)).toBeTrue();
   });
 
-  test("use-menu mouse click selects insert into story then opens Placement", async () => {
+  test("use-menu mouse click applies insert into story in one click", async () => {
     const source = demoAppSource();
     const state = initialState(source, false);
     const surface = createAsideSurface(
@@ -598,7 +783,7 @@ describe("Aside use-menu mouse", () => {
         y,
         modifiers: { shift: false, alt: false, ctrl: false }
       }, state);
-      if (action?.action === "focus-index"
+      if (action?.action === "apply"
         && action.rowId !== undefined
         && action.rowId.endsWith(":insert-into-story")) {
         storyY = y;
@@ -628,7 +813,7 @@ describe("Aside use-menu mouse", () => {
     expect(capturedFocus.state.aside?.useMenu?.cursor).toBe(0);
     const first = mouseToAction(click, state);
     expect(first).toEqual({
-      action: "focus-index",
+      action: "apply",
       index: 1,
       rowId: storyRowId
     });
@@ -651,50 +836,96 @@ describe("Aside use-menu mouse", () => {
       state
     });
     expect(reconciledFocus).toEqual({
-      action: "focus-index",
+      action: "apply",
       index: 1,
       rowId: storyRowId
     });
     await handleOverlayAction(reconciledFocus!, state, source, context);
-    expect(surface.useMenu?.cursor).toBe(1);
-
-    // Second click: captured before selection; presented after selection so
-    // open-selected survives via selected session+action identity.
-    const afterFocusFrame = renderStoryScreen(state, { width: 80, height: 24 });
-    state.hitRows = afterFocusFrame.derived.hitRows;
-    const capturedOpen: PresentedInteraction = {
-      version: 3,
-      frameToken: 3,
-      interactive: true,
-      storyId: state.payload.id,
-      state: captureMouseActionState(state)
-    };
-    expect(capturedOpen.state.aside?.useMenu?.cursor).toBe(1);
-    const second = mouseToAction(click, state);
-    expect(second?.action).toBe("open-selected");
-    expect(second?.rowId).toBe(storyRowId);
-    state.hitRows = renderStoryScreen(state, { width: 80, height: 24 }).derived.hitRows;
-    const presentedOpen: PresentedInteraction = {
-      version: 4,
-      frameToken: 4,
-      interactive: true,
-      storyId: state.payload.id,
-      state: captureMouseActionState(state)
-    };
-    expect(presentedOpen).not.toBe(capturedOpen);
-    const reconciledOpen = reconcilePresentedMouseAction({
-      action: second!,
-      event: click,
-      captured: capturedOpen,
-      presented: presentedOpen,
-      state
-    });
-    expect(reconciledOpen?.action).toBe("open-selected");
-    await handleOverlayAction(reconciledOpen!, state, source, context);
     expect(state.mode).toBe("PLACE");
     expect(state.aside).toBeNull();
     expect(state.placement?.answer).toBe("from mouse menu");
     expect(state.placement?.interactionId).toBe(sessionId);
+  });
+
+  test("insert-into-story mouse click waits for an undoable delete commit", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const later = { q: "later", a: "later answer" };
+    const surface = createAsideSurface(
+      state.payload.id,
+      state.payload.title,
+      [{
+        id: "session-1",
+        title: "session",
+        anchor: null,
+        turns: [{ q: "first", a: "first answer" }, later]
+      }],
+      null,
+      null,
+      { v2: true }
+    );
+    if (!isAsideV2(surface)) throw new Error("expected v2 Aside surface");
+    state.aside = surface;
+    state.mode = "ASIDE";
+    surface.focus = "turns";
+    surface.turnCursor = 0;
+    let deletes = 0;
+    const sourceWithDelete = {
+      ...source,
+      api: {
+        ...source.api,
+        deleteAsideTurn: async () => {
+          deletes += 1;
+          return {
+            schemaVersion: 2 as const,
+            id: "session-1",
+            title: "session",
+            anchor: null,
+            turns: [later]
+          };
+        }
+      }
+    };
+    const context = overlayContext(state, 80, 24);
+    await handleOverlayAction({ action: "aside-delete" }, state, sourceWithDelete, context);
+    expect(surface.deleteUndo).not.toBeNull();
+    expect(openAsideUseMenu(surface, 0)).toBeTrue();
+
+    const frame = renderStoryScreen(state, { width: 80, height: 24 });
+    state.hitRows = frame.derived.hitRows;
+    let click: FrozenMouseEvent | null = null;
+    for (let y = 0; y < frame.derived.hitRows.length && click === null; y += 1) {
+      for (let x = 0; x < 80; x += 1) {
+        const candidate = mouseToAction({
+          type: "down",
+          button: 0,
+          x,
+          y,
+          modifiers: { shift: false, alt: false, ctrl: false }
+        }, state);
+        if (candidate?.action === "apply"
+          && candidate.rowId?.endsWith(":insert-into-story")) {
+          click = {
+            type: "down",
+            button: 0,
+            x,
+            y,
+            modifiers: { shift: false, alt: false, ctrl: false }
+          };
+          break;
+        }
+      }
+    }
+    expect(click).not.toBeNull();
+    const action = mouseToAction(click!, state);
+    expect(action).toMatchObject({ action: "apply", index: 1 });
+    await handleOverlayAction(action!, state, sourceWithDelete, context);
+    await context.backend.settle();
+
+    expect(deletes).toBe(1);
+    expect(state.mode).toBe("PLACE");
+    expect(state.aside).toBeNull();
+    expect(state.placement?.answer).toBe("later answer");
   });
 
   test("stale use-menu click for note A is dropped after menu reopens on note B", async () => {
@@ -730,7 +961,7 @@ describe("Aside use-menu mouse", () => {
         y,
         modifiers: { shift: false, alt: false, ctrl: false }
       }, state);
-      if (action?.action === "focus-index"
+      if (action?.action === "apply"
         && action.rowId === `aside-use:${sessionA}:insert-into-story`) {
         storyY = y;
         break;
@@ -753,7 +984,7 @@ describe("Aside use-menu mouse", () => {
     };
     const actionA = mouseToAction(click, state);
     expect(actionA).toEqual({
-      action: "focus-index",
+      action: "apply",
       index: 1,
       rowId: `aside-use:${sessionA}:insert-into-story`
     });

--- a/tui/test/aside-use-menu-mouse.test.ts
+++ b/tui/test/aside-use-menu-mouse.test.ts
@@ -888,6 +888,7 @@ describe("Aside use-menu mouse", () => {
     };
     const context = overlayContext(state, 80, 24);
     await handleOverlayAction({ action: "aside-delete" }, state, sourceWithDelete, context);
+    await handleOverlayAction({ action: "aside-delete" }, state, sourceWithDelete, context);
     expect(surface.deleteUndo).not.toBeNull();
     expect(openAsideUseMenu(surface, 0)).toBeTrue();
 

--- a/tui/test/aside-use-menu-mouse.test.ts
+++ b/tui/test/aside-use-menu-mouse.test.ts
@@ -214,6 +214,20 @@ describe("Aside use-menu mouse", () => {
       Math.floor(index / (width + 1))))];
     expect(afterRows).toEqual(beforeRows);
     expect(surface.useMenu?.selectionSpans).toEqual(decorated?.selectionSpans);
+
+    await handleOverlayAction(
+      { action: "cancel" },
+      state,
+      source,
+      overlayContext(state, width, height)
+    );
+    expect(surface.useMenu).toBeNull();
+    expect(surface.focus).toBe("composer");
+    const closed = renderStoryScreen(state, { width, height });
+    const closedRows = [...new Set(closed.derived.storySelectionProjection!
+      .flatMap((cell, index) => cell?.key === selectedKey
+        ? [Math.floor(index / (width + 1))] : []))];
+    expect(closedRows).toEqual(beforeRows);
   });
 
   test("every selected-text menu row applies from one mouse click", async () => {

--- a/tui/test/aside-use-menu-mouse.test.ts
+++ b/tui/test/aside-use-menu-mouse.test.ts
@@ -1001,7 +1001,7 @@ describe("Aside use-menu mouse", () => {
     expect(state.placement?.answer).toBe("later answer");
   });
 
-  test("delete rollback keeps a one-click Placement target on the same answer", async () => {
+  test("delete rollback keeps its error and the next Placement target", async () => {
     const source = demoAppSource();
     const state = initialState(source, false);
     const surface = createAsideSurface(
@@ -1038,13 +1038,28 @@ describe("Aside use-menu mouse", () => {
     expect(openAsideUseMenu(surface, 0)).toBeTrue();
     const sessionId = surface.useMenu!.sessionId;
 
-    await handleOverlayAction({
-      action: "apply",
+    const action = {
+      action: "apply" as const,
       index: 1,
       rowId: asideUseRowId(sessionId, "insert-into-story")
-    }, state, sourceWithFailure, context);
+    };
+    await dispatch(
+      action, state, sourceWithFailure, context.cache, () => undefined,
+      async () => undefined, () => undefined, null,
+      () => undefined, () => undefined, context.backend
+    );
     await context.backend.settle();
 
+    expect(state.mode).toBe("ASIDE");
+    expect(state.placement).toBeNull();
+    expect(state.toast).toBe("delete failed");
+    expect(surface.useMenu?.noteIndex).toBe(1);
+
+    await dispatch(
+      action, state, sourceWithFailure, context.cache, () => undefined,
+      async () => undefined, () => undefined, null,
+      () => undefined, () => undefined, context.backend
+    );
     expect(state.mode).toBe("PLACE");
     expect(state.placement?.answer).toBe("target later answer");
     expect(state.placement?.returnAside.useMenu?.noteIndex).toBe(1);


### PR DESCRIPTION
## Outcome

Keep the writer-selected Aside text and viewport stable when the writer opens the context menu. Make every Aside menu and hop action operable with one mouse click.

## Changes

- Preserve the selected text, active Aside, focus, and scroll position when the context menu opens.
- Make all Use Selection and Use Answer rows respond to direct mouse clicks.
- Make each visible Aside hop label a stable mouse target, including clipped layouts.
- Revalidate delayed mouse actions by surface and stable Aside identity.
- Preserve rollback targets and failure notices for delete-driven actions.
- Keep the legacy Aside document path unchanged.
- Add integration coverage for narrow and clipped layouts, large Aside collections, selection retention, rollback, failure, and stale input.

## Verification

- `npm test -- --test-concurrency=1`: 2,781 passed, 227 skipped, 0 failed.
- `cd tui && bun test --timeout 30000`: 2,279 passed, 2 platform skips, 0 failed.
- `npm run build`: passed.
- Focused Aside suites: 79 passed, 0 failed.
- AutoReview: no actionable defects.
- Thermonuclear maintainability review: no actionable defects or unnecessary abstraction.
- Claude Fable design review: SHIP.

## Risk

The change affects TUI mouse routing and delayed Aside actions. Stable identity checks prevent a delayed click from acting on a different Aside or overlay.

Tracks #331. Keep the issue open until a stable release contains the change.
