### PR TITLE
chore(release): prepare 0.10.3-rc.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ This file records notable changes to 1667. Product terms use the definitions in
 
 ## Unreleased
 
+## 0.10.3-rc.6 - 2026-08-26
+
+- **Aside mouse actions keep their exact target.** Right-clicking selected
+  text preserves the selection, active turn, focus, and scroll position. Each
+  Use Selection, Use Answer, and visible session hop item works with one
+  click, including in narrow or clipped layouts. A failed delete preserves
+  its target and error for retry. Existing legacy Side Notes remain available.
+
 ## 0.10.3-rc.5 - 2026-08-26
 
 - **Aside text selection works across the full chat width.** Questions and

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "1667-workspace",
-  "version": "0.10.3-rc.5",
+  "version": "0.10.3-rc.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "1667-workspace",
-      "version": "0.10.3-rc.5",
+      "version": "0.10.3-rc.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@earendil-works/pi-ai": "0.84.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667-workspace",
-  "version": "0.10.3-rc.5",
+  "version": "0.10.3-rc.6",
   "private": true,
   "description": "Source workspace for the 1667 terminal writing environment",
   "license": "Apache-2.0",

--- a/shared/release-notes.ts
+++ b/shared/release-notes.ts
@@ -11,6 +11,11 @@ export interface ReleaseNote {
  *  a release, and is not included. */
 export const RELEASE_NOTES: readonly ReleaseNote[] = [
   {
+    version: "0.10.3-rc.6",
+    date: "2026-08-26",
+    body: "- **Aside mouse actions keep their exact target.** Right-clicking selected\n  text preserves the selection, active turn, focus, and scroll position. Each\n  Use Selection, Use Answer, and visible session hop item works with one\n  click, including in narrow or clipped layouts. A failed delete preserves\n  its target and error for retry. Existing legacy Side Notes remain available."
+  },
+  {
     version: "0.10.3-rc.5",
     date: "2026-08-26",
     body: "- **Aside text selection works across the full chat width.** Questions and\n  answers use distinct `You` and `Assistant` labels, and question rows keep a\n  stronger visual treatment without adding a selection-breaking side pane.\n  Copying across both roles keeps the complete exchange.\n- **Destructive shortcuts use capital `D` consistently.** Aside turns, Facts,\n  chapter breaks, tags, Sampling entries, and Generation Profiles require a\n  confirmation before deletion. A different action cancels the confirmation.\n  Lowercase `d` is non-destructive."

--- a/tui/package.json
+++ b/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667",
-  "version": "0.10.3-rc.5",
+  "version": "0.10.3-rc.6",
   "private": true,
   "description": "A terminal environment for writing fiction with language models",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Outcome

Prepare the beta release that contains the merged Aside mouse-interaction fix from PR #342.

## Changes

- Set the root workspace, TUI package, and lockfile version to `0.10.3-rc.6`.
- Add the `0.10.3-rc.6` changelog section.
- Generate the embedded release notes.

## Verification

- `npm run notes:write`: passed.
- `npm run build`: passed.
- `npm run notes:check-version -- 0.10.3-rc.6`: passed.
- Release diff contains only the five expected metadata files.

## Risk

This PR changes release metadata only. The hosted release workflow will build, verify, and publish all six packages after the tag is created.

Tracks #331. Keep the issue open until a stable release contains the change.
