### PR TITLE
chore(release): prepare 0.10.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ This file records notable changes to 1667. Product terms use the definitions in
 
 ## Unreleased
 
+## 0.10.3 - 2026-08-26
+
+- **This release has no additional product changes.** It contains the same
+  behavior as 0.10.3-rc.6.
+
 ## 0.10.3-rc.6 - 2026-08-26
 
 - **Aside mouse actions keep their exact target.** Right-clicking selected

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "1667-workspace",
-  "version": "0.10.3-rc.6",
+  "version": "0.10.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "1667-workspace",
-      "version": "0.10.3-rc.6",
+      "version": "0.10.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@earendil-works/pi-ai": "0.84.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667-workspace",
-  "version": "0.10.3-rc.6",
+  "version": "0.10.3",
   "private": true,
   "description": "Source workspace for the 1667 terminal writing environment",
   "license": "Apache-2.0",

--- a/shared/release-notes.ts
+++ b/shared/release-notes.ts
@@ -11,6 +11,11 @@ export interface ReleaseNote {
  *  a release, and is not included. */
 export const RELEASE_NOTES: readonly ReleaseNote[] = [
   {
+    version: "0.10.3",
+    date: "2026-08-26",
+    body: "- **This release has no additional product changes.** It contains the same\n  behavior as 0.10.3-rc.6."
+  },
+  {
     version: "0.10.3-rc.6",
     date: "2026-08-26",
     body: "- **Aside mouse actions keep their exact target.** Right-clicking selected\n  text preserves the selection, active turn, focus, and scroll position. Each\n  Use Selection, Use Answer, and visible session hop item works with one\n  click, including in narrow or clipped layouts. A failed delete preserves\n  its target and error for retry. Existing legacy Side Notes remain available."

--- a/tui/package.json
+++ b/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667",
-  "version": "0.10.3-rc.6",
+  "version": "0.10.3",
   "private": true,
   "description": "A terminal environment for writing fiction with language models",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Outcome

Promote the verified `0.10.3-rc.6` behavior to stable `0.10.3` without additional product changes.

## Changes

- Set the root workspace, TUI package, and lockfile version to `0.10.3`.
- Add the stable `0.10.3` changelog section.
- Generate the embedded stable release notes.

## Verification

- Beta `0.10.3-rc.6` completed its hosted release workflow successfully.
- `npm run notes:write`: passed.
- `npm run build`: passed.
- `npm run notes:check-version -- 0.10.3`: passed.
- Release diff contains only the five expected metadata files.

## Risk

This PR changes release metadata only. Stable behavior is identical to `0.10.3-rc.6`. The hosted release workflow will rebuild and verify all six packages before publication.

Tracks #331. Do not close the issue until stable publication completes.
