### PR TITLE
chore(release): prepare 0.10.4-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This file records notable changes to 1667. Product terms use the definitions in
 
 ## Unreleased
 
+- **Graphite and bone themes use the 1667 website colors.** Select either
+  theme in Settings or from the command palette. Both themes include truecolor
+  and 256-color palettes.
+
 ## 0.10.3 - 2026-08-26
 
 - **This release has no additional product changes.** It contains the same

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This file records notable changes to 1667. Product terms use the definitions in
 
 ## Unreleased
 
+## 0.10.4-rc.1 - 2026-08-28
+
 - **Graphite and bone themes use the 1667 website colors.** Select either
   theme in Settings or from the command palette. Both themes include truecolor
   and 256-color palettes.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ repository contains the terminal user interface (TUI) and its backend runtime.
 
 ## Features
 
-- Write in a full-screen terminal interface with six themes.
+- Write in a full-screen terminal interface with eight themes.
 - Add sibling takes to any story part.
 - Select a take for each story part.
 - Read a story as a story line, a tree, or a mass map.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "1667-workspace",
-  "version": "0.10.3",
+  "version": "0.10.4-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "1667-workspace",
-      "version": "0.10.3",
+      "version": "0.10.4-rc.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@earendil-works/pi-ai": "0.84.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667-workspace",
-  "version": "0.10.3",
+  "version": "0.10.4-rc.1",
   "private": true,
   "description": "Source workspace for the 1667 terminal writing environment",
   "license": "Apache-2.0",

--- a/shared/release-notes.ts
+++ b/shared/release-notes.ts
@@ -11,6 +11,11 @@ export interface ReleaseNote {
  *  a release, and is not included. */
 export const RELEASE_NOTES: readonly ReleaseNote[] = [
   {
+    version: "0.10.4-rc.1",
+    date: "2026-08-28",
+    body: "- **Graphite and bone themes use the 1667 website colors.** Select either\n  theme in Settings or from the command palette. Both themes include truecolor\n  and 256-color palettes."
+  },
+  {
     version: "0.10.3",
     date: "2026-08-26",
     body: "- **This release has no additional product changes.** It contains the same\n  behavior as 0.10.3-rc.6."

--- a/tui/package.json
+++ b/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667",
-  "version": "0.10.3",
+  "version": "0.10.4-rc.1",
   "private": true,
   "description": "A terminal environment for writing fiction with language models",
   "license": "Apache-2.0",

--- a/tui/src/app.ts
+++ b/tui/src/app.ts
@@ -2,6 +2,7 @@ import {
   CliRenderEvents,
   TextRenderable,
   createCliRenderer,
+  type CapturedFrame,
   type KeyEvent
 } from "@opentui/core";
 import { createTestRenderer } from "@opentui/core/testing";
@@ -140,8 +141,13 @@ type InteractivePresentedInteraction = PresentedInteraction & {
   storySelectionProjection: RuntimeState["storySelectionProjection"];
 };
 
-export async function renderOnce(source: AppSource, width: number, height: number, keys = ""): Promise<string> {
-  const palette = createPalette(source.config.theme);
+async function captureRenderOnce(
+  source: AppSource,
+  width: number,
+  height: number,
+  keys = ""
+): Promise<{ readonly text: string; readonly frame: CapturedFrame }> {
+  let palette = createPalette(source.config.theme);
   const setup = await createTestRenderer({ width, height, backgroundColor: palette.color("background") });
   const state = initialState(source, true);
   const cache = createWrapCache<ProseStyle>();
@@ -154,6 +160,7 @@ export async function renderOnce(source: AppSource, width: number, height: numbe
   const applyThemeInFrame = (theme: ThemeName) => {
     source.config = { ...source.config, theme };
     state.config = source.config;
+    palette = createPalette(theme);
   };
   for (const character of [...keys]) {
     // The render-once demo paints a synthetic empty stream without a runtime
@@ -186,6 +193,7 @@ export async function renderOnce(source: AppSource, width: number, height: numbe
   setup.renderer.root.add(text);
   await setup.renderOnce();
   const captured = setup.captureCharFrame();
+  const capturedFrame = setup.captureSpans();
   state.abort?.controller.abort();
   // A frame is captured the moment the keys land, so a scan still waiting out
   // a pause has nothing left to draw to. This path is not demo-only — an
@@ -193,7 +201,25 @@ export async function renderOnce(source: AppSource, width: number, height: numbe
   if (state.search !== null) abortPendingSearch(state.search);
   backend.dispose();
   setup.renderer.destroy();
-  return captured;
+  return { text: captured, frame: capturedFrame };
+}
+
+export async function renderOnce(
+  source: AppSource,
+  width: number,
+  height: number,
+  keys = ""
+): Promise<string> {
+  return (await captureRenderOnce(source, width, height, keys)).text;
+}
+
+export async function renderOnceSpans(
+  source: AppSource,
+  width: number,
+  height: number,
+  keys = ""
+): Promise<CapturedFrame> {
+  return (await captureRenderOnce(source, width, height, keys)).frame;
 }
 
 export async function runInteractive(source: AppSource): Promise<void> {

--- a/tui/src/config.ts
+++ b/tui/src/config.ts
@@ -19,6 +19,8 @@ export type ThemeName =
   | "iron gall"
   | "parchment"
   | "bond"
+  | "graphite"
+  | "bone"
   | "hi-contrast dark"
   | "hi-contrast light";
 
@@ -27,6 +29,8 @@ export const THEME_NAMES: readonly ThemeName[] = [
   "iron gall",
   "parchment",
   "bond",
+  "graphite",
+  "bone",
   "hi-contrast dark",
   "hi-contrast light"
 ];

--- a/tui/src/palette.ts
+++ b/tui/src/palette.ts
@@ -101,6 +101,34 @@ const THEMES: Record<ThemeName, ThemeTable> = {
     logoOrange: "#A84D18", logoGreen: "#257A48", logoCyan: "#156B74", logoBlue: "#235A8C",
     freshIntermediate: ["#1A1C1E", "#212426"], freshBold: true
   },
+  "graphite": {
+    background: "#121215", raised: "#1B1B1F", chrome: "#85858D",
+    prose: "#E6E4DE", "prose · dim": "#A9A9B0",
+    "focus / accent": "#D8F55A", "accent · deep": "#A5BC45",
+    "compose accent": "#8FB8D9",
+    streaming: "#F4F3ED", "human edit": "#8FB8D9", summary: "#8F8F96",
+    "tag · canon": "#E4C65A", "tag · alt": "#C59BEF",
+    "tag · draft": "#82CED2", "tag · discarded": "#6A6A72",
+    danger: "#F06755", "dimmed page": "#55555C",
+    brassDim: "#A5BC45", humanEditDim: "#6D91B8", dangerText: "#FF8A78", contextWarning: "#F2B84B",
+    matchWash: "#26262B", matchInk: "#D8F55A",
+    logoOrange: "#FF9E4A", logoGreen: "#79D88F", logoCyan: "#57D2D5", logoBlue: "#75A9FF",
+    freshIntermediate: ["#F0EFE9", "#EBEAE4"], freshBold: false
+  },
+  "bone": {
+    background: "#EDEBE3", raised: "#E9E6DD", chrome: "#6B675C",
+    prose: "#1C1B18", "prose · dim": "#4A473F",
+    "focus / accent": "#B52D14", "accent · deep": "#7A2416",
+    "compose accent": "#245F8E",
+    streaming: "#141310", "human edit": "#245F8E", summary: "#5B554B",
+    "tag · canon": "#8C6500", "tag · alt": "#714A79",
+    "tag · draft": "#2F6D79", "tag · discarded": "#85806F",
+    danger: "#760000", "dimmed page": "#8A867A",
+    brassDim: "#7A641F", humanEditDim: "#3C6994", dangerText: "#760000", contextWarning: "#8A5200",
+    matchWash: "#E7D8D1", matchInk: "#7F2E1C",
+    logoOrange: "#B95D1E", logoGreen: "#2F7A4A", logoCyan: "#1F7880", logoBlue: "#245F8E",
+    freshIntermediate: ["#171613", "#1A1916"], freshBold: true
+  },
   "hi-contrast dark": {
     background: "#000000", raised: "#0D0D0D", chrome: "#9A9A9A",
     prose: "#FFFFFF", "prose · dim": "#C4C4C4",
@@ -193,6 +221,34 @@ const THEMES_256: Record<ThemeName, ThemeTable256> = {
     matchWash: 188, matchInk: 88,
     logoOrange: 130, logoGreen: 29, logoCyan: 30, logoBlue: 24,
     freshIntermediate: [234, 235]
+  },
+  graphite: {
+    background: 233, raised: 234, chrome: 245,
+    prose: 253, "prose · dim": 248,
+    "focus / accent": 191, "accent · deep": 149,
+    "compose accent": 110,
+    streaming: 231, "human edit": 110, summary: 246,
+    "tag · canon": 185, "tag · alt": 183,
+    "tag · draft": 116, "tag · discarded": 243,
+    danger: 203, "dimmed page": 240,
+    brassDim: 149, humanEditDim: 67, dangerText: 216, contextWarning: 221,
+    matchWash: 235, matchInk: 191,
+    logoOrange: 215, logoGreen: 114, logoCyan: 80, logoBlue: 111,
+    freshIntermediate: [255, 254]
+  },
+  bone: {
+    background: 255, raised: 254, chrome: 241,
+    prose: 234, "prose · dim": 238,
+    "focus / accent": 124, "accent · deep": 88,
+    "compose accent": 24,
+    streaming: 16, "human edit": 24, summary: 95,
+    "tag · canon": 94, "tag · alt": 96,
+    "tag · draft": 23, "tag · discarded": 244,
+    danger: 52, "dimmed page": 245,
+    brassDim: 100, humanEditDim: 61, dangerText: 52, contextWarning: 94,
+    matchWash: 253, matchInk: 88,
+    logoOrange: 130, logoGreen: 29, logoCyan: 30, logoBlue: 24,
+    freshIntermediate: [232, 233]
   },
   "hi-contrast dark": {
     background: 16, raised: 233, chrome: 247,

--- a/tui/test/golden-panels.test.ts
+++ b/tui/test/golden-panels.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import type { KeyEvent } from "@opentui/core";
-import { handleKey, initialState, renderOnce } from "../src/app.js";
+import { RGBA, type KeyEvent } from "@opentui/core";
+import { handleKey, initialState, renderOnce, renderOnceSpans } from "../src/app.js";
 import { createDemoController, demoAppSource, demoStoryApi, DEMO_SETTINGS_DOCUMENT } from "../src/demo.js";
 import { createStoryViewModel, rowIndexForNode } from "../src/model.js";
+import { createPalette } from "../src/palette.js";
 import { renderStoryScreen } from "../src/screens/story.js";
 import { frameText } from "../src/screens/story/frame.js";
 import { cellWidth } from "../src/cell-width.js";
@@ -529,9 +530,15 @@ describe("run C overlay frames", () => {
   });
 
   test("theme command switches the palette for the frame", async () => {
-    const source = demoAppSource();
-    await renderOnce(source, 120, 36, ":parchment\r");
-    expect(source.config.theme).toBe("parchment");
+    for (const theme of ["graphite", "bone"] as const) {
+      const source = demoAppSource();
+      const frame = await renderOnceSpans(source, 120, 36, `:${theme}\r`);
+      expect(source.config.theme).toBe(theme);
+      const accent = createPalette(theme).color("focus / accent");
+      const expected = typeof accent === "string" ? RGBA.fromHex(accent) : accent;
+      expect(frame.lines.some((line) => line.spans.some((span) =>
+        span.fg.equals(expected)))).toBeTrue();
+    }
   });
 
   test("summary command opens the modal with stretch and lock copy", async () => {

--- a/tui/test/palette-config.test.ts
+++ b/tui/test/palette-config.test.ts
@@ -46,6 +46,16 @@ const CORE: Record<ThemeName, Record<CoreRole, string>> = {
     chrome: "#6C685E", "focus / accent": "#A8321E", streaming: "#0A0C0E",
     "human edit": "#235A8C", "tag · canon": "#7A6010", danger: "#8E1F10"
   },
+  graphite: {
+    background: "#121215", prose: "#E6E4DE", "prose · dim": "#A9A9B0",
+    chrome: "#85858D", "focus / accent": "#D8F55A", streaming: "#F4F3ED",
+    "human edit": "#8FB8D9", "tag · canon": "#E4C65A", danger: "#F06755"
+  },
+  bone: {
+    background: "#EDEBE3", prose: "#1C1B18", "prose · dim": "#4A473F",
+    chrome: "#6B675C", "focus / accent": "#B52D14", streaming: "#141310",
+    "human edit": "#245F8E", "tag · canon": "#8C6500", danger: "#760000"
+  },
   "hi-contrast dark": {
     background: "#000000", prose: "#FFFFFF", "prose · dim": "#C4C4C4",
     chrome: "#9A9A9A", "focus / accent": "#FFC400", streaming: "#FFFFFF",
@@ -144,9 +154,10 @@ function displayHex(theme: ThemeName, depth: ColorDepth, role: DisplayRole): str
 }
 
 describe("theme palette", () => {
-  test("ships all six themes in settings order", () => {
+  test("ships all eight themes in settings order", () => {
     expect(THEME_NAMES).toEqual([
-      "lantern", "iron gall", "parchment", "bond", "hi-contrast dark", "hi-contrast light"
+      "lantern", "iron gall", "parchment", "bond", "graphite", "bone",
+      "hi-contrast dark", "hi-contrast light"
     ]);
   });
 
@@ -167,11 +178,11 @@ describe("theme palette", () => {
 
   test("bolds fresh ink only on light-theme polarity", () => {
     expect(THEME_NAMES.map((theme) => createPalette(theme, "truecolor").freshBold))
-      .toEqual([false, false, true, true, false, true]);
+      .toEqual([false, false, true, true, false, true, false, true]);
   });
 
   test("corrected light text clears 4.5:1 and high-contrast chrome clears 7:1", () => {
-    for (const theme of ["parchment", "bond"] as const) {
+    for (const theme of ["parchment", "bond", "bone"] as const) {
       const background = hex(theme, "background");
       for (const role of ["prose", "prose · dim", "chrome"] as const) {
         expect(contrast(background, hex(theme, role))).toBeGreaterThan(4.499);
@@ -185,6 +196,12 @@ describe("theme palette", () => {
   test("pins a distinct 256-color table for every theme", () => {
     expect(ALL_ROLES.map((role) => theme256Index("lantern", role))).toEqual([
       233, 234, 241, 187, 101, 215, 179, 110, 230, 110, 180, 178, 139, 109, 243, 166, 240
+    ]);
+    expect(ALL_ROLES.map((role) => theme256Index("graphite", role))).toEqual([
+      233, 234, 245, 253, 248, 191, 149, 110, 231, 110, 246, 185, 183, 116, 243, 203, 240
+    ]);
+    expect(ALL_ROLES.map((role) => theme256Index("bone", role))).toEqual([
+      255, 254, 241, 234, 238, 124, 88, 24, 16, 24, 95, 94, 96, 23, 244, 52, 245
     ]);
     for (const theme of THEME_NAMES) {
       for (const role of ALL_ROLES) {
@@ -225,6 +242,63 @@ describe("theme palette", () => {
     expect(canon).not.toBe(theme256Index("parchment", "focus / accent"));
   });
 
+  test("keeps specimen palette text visible on raised surfaces", () => {
+    for (const theme of ["graphite", "bone"] as const) {
+      const raised = hex(theme, "raised");
+      expect(contrast(raised, hex(theme, "chrome"))).toBeGreaterThan(4.499);
+      expect(contrast(raised, hex(theme, "tag · discarded"))).toBeGreaterThan(2.999);
+
+      const raised256 = xtermHex(theme256Index(theme, "raised"));
+      expect(contrast(raised256, xtermHex(theme256Index(theme, "chrome"))))
+        .toBeGreaterThan(4.499);
+      expect(contrast(raised256, xtermHex(theme256Index(theme, "tag · discarded"))))
+        .toBeGreaterThan(2.999);
+    }
+    expect(contrast(hex("bone", "raised"), hex("bone", "dimmed page")))
+      .toBeGreaterThan(2.499);
+    expect(contrast(
+      xtermHex(theme256Index("bone", "raised")),
+      xtermHex(theme256Index("bone", "dimmed page"))
+    )).toBeGreaterThan(2.499);
+  });
+
+  test("keeps the bone accent readable on its paper surfaces", () => {
+    for (const surface of ["background", "raised"] as const) {
+      expect(contrast(hex("bone", surface), hex("bone", "focus / accent")))
+        .toBeGreaterThan(4.499);
+      expect(contrast(
+        xtermHex(theme256Index("bone", surface)),
+        xtermHex(theme256Index("bone", "focus / accent"))
+      )).toBeGreaterThan(4.499);
+    }
+  });
+
+  test("keeps secondary bone text readable", () => {
+    for (const depth of ["truecolor", "256"] as const) {
+      const background = depth === "truecolor"
+        ? hex("bone", "background") : xtermHex(theme256Index("bone", "background"));
+      expect(contrast(background, displayHex("bone", depth, "human edit dim")))
+        .toBeGreaterThan(4.499);
+      for (const surface of ["background", "raised"] as const) {
+        const surfaceColor = depth === "truecolor"
+          ? hex("bone", surface) : xtermHex(theme256Index("bone", surface));
+        expect(contrast(surfaceColor, displayHex("bone", depth, "tag · draft")))
+          .toBeGreaterThan(4.499);
+      }
+    }
+  });
+
+  test("keeps specimen fresh ink moving toward resting prose", () => {
+    for (const [theme, direction] of [["graphite", -1], ["bone", 1]] as const) {
+      for (const depth of ["truecolor", "256"] as const) {
+        const steps = ["streaming", "fresh 1", "fresh 2", "prose"] as const;
+        const luminances = steps.map((role) => relativeLuminance(displayHex(theme, depth, role)));
+        expect(luminances.every((value, index) => index === 0
+          || direction * luminances[index - 1]! < direction * value)).toBeTrue();
+      }
+    }
+  });
+
   test("keeps the warning band distinct from normal high-contrast accent", () => {
     const palette = createPalette("hi-contrast dark", "truecolor");
     expect(palette.contextWarning).not.toBe(palette.color("focus / accent"));
@@ -242,8 +316,22 @@ describe("theme palette", () => {
           ? hex(theme, "background") : xtermHex(theme256Index(theme, "background"));
         const colors = BREAKDOWN_ROLES.map((role) => displayHex(theme, depth, role));
 
-        expect(new Set(colors).size).toBe(4);
+        expect(new Set(colors).size).toBe(BREAKDOWN_ROLES.length);
         for (const color of colors) expect(contrast(background, color)).toBeGreaterThan(2.999);
+      }
+    }
+  });
+
+  test("keeps visual context visible in every theme", () => {
+    for (const theme of THEME_NAMES) {
+      for (const depth of ["truecolor", "256"] as const) {
+        const background = depth === "truecolor"
+          ? hex(theme, "background") : xtermHex(theme256Index(theme, "background"));
+        const visual = displayHex(theme, depth, "context visual");
+        expect(contrast(background, visual)).toBeGreaterThan(2.749);
+        if (theme === "graphite" || theme === "bone") {
+          expect(contrast(background, visual)).toBeGreaterThan(2.999);
+        }
       }
     }
   });
@@ -280,6 +368,31 @@ describe("theme palette", () => {
           expect(pulse).not.toBe(request);
         }
       }
+    }
+  });
+
+  test("keeps request severity and destructive ink distinct", () => {
+    const requestFills: readonly DisplayRole[] =
+      ["focus / accent", "context warning", "danger"];
+    for (const theme of THEME_NAMES) {
+      for (const depth of ["truecolor", "256"] as const) {
+        const fills = requestFills.map((role) => displayHex(theme, depth, role));
+        expect(new Set(fills).size).toBe(requestFills.length);
+        if (theme === "graphite" || theme === "bone") {
+          expect(displayHex(theme, depth, "danger"))
+            .not.toBe(displayHex(theme, depth, "accent · deep"));
+        }
+      }
+    }
+    for (const depth of ["truecolor", "256"] as const) {
+      expect(contrast(
+        displayHex("bone", depth, "focus / accent"),
+        displayHex("bone", depth, "danger")
+      )).toBeGreaterThan(1.499);
+      expect(contrast(
+        displayHex("bone", depth, "focus / accent"),
+        displayHex("bone", depth, "accent · deep")
+      )).toBeGreaterThan(1.299);
     }
   });
 
@@ -407,5 +520,10 @@ describe("user config normalization", () => {
     expect(normalizeUserConfig({ wordWrap: "off" }).wordWrap).toBe("off");
     expect(normalizeUserConfig({ word_wrap: "off" }).wordWrap).toBe("off");
     expect(normalizeUserConfig({ wordWrap: "sometimes" }).wordWrap).toBe("on");
+  });
+
+  test("accepts the specimen themes from user config", () => {
+    expect(normalizeUserConfig({ theme: "graphite" }).theme).toBe("graphite");
+    expect(normalizeUserConfig({ theme: "bone" }).theme).toBe("bone");
   });
 });


### PR DESCRIPTION
## Outcome

Add the graphite and bone themes, and prepare beta 0.10.4-rc.1.

## Changes

- Add truecolor and 256-color graphite and bone palettes.
- Add both themes to Settings and command selection.
- Verify theme switching through rendered palette spans.
- Set the workspace and TUI versions to 0.10.4-rc.1.
- Add and generate the release notes.

## Verification

- npm run build: passed.
- npm test: 2,781 passed, 227 platform or environment skips, 0 failed.
- bun run typecheck: passed.
- bun run test: 2,286 passed, 2 platform skips, 0 failed.
- bun run build:standalone: passed.
- npm run notes:check-version -- 0.10.4-rc.1: passed.
- Claude/Fable max review: no accepted or actionable findings.

## Risk

The new render-once capture helper affects test and demo rendering only. The interactive renderer is unchanged. The local performance gate missed five existing 500-part repaint budgets; the changed render-once path is not used by those benchmarks. Hosted checks must pass before merge and publication.

Tracks #347. Keep the issue open until a stable release contains the change.