### PR TITLE
feat(tui): refine new-user onboarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ This file records notable changes to 1667. Product terms use the definitions in
 
 ## Unreleased
 
+- **New users start with the Graphite theme.** Existing users keep their saved
+  theme. An older config without a theme keeps the Lantern theme. The Theme row
+  now appears in Simple Settings.
+- **The starter tour ends with setup instructions.** It tells the user how to
+  delete the onboarding stories and select a model provider.
+
 ## 0.10.4-rc.1 - 2026-08-28
 
 - **Graphite and bone themes use the 1667 website colors.** Select either

--- a/docs/model-providers.md
+++ b/docs/model-providers.md
@@ -312,11 +312,11 @@ release refuses a schema 5 Settings document. Back up Settings before you try
 ## Settings views
 
 Settings has two views: **Simple view** and **Advanced view**. Simple view
-is the default. Simple view shows the Default Author Brief row, the Default
-Continue direction row, the provider row, the model row, the context size
-row, the base URL row, and the API key row. Advanced view shows every row.
-Every row this document names that is not in that list appears only in
-Advanced view.
+is the default. Simple view shows the Theme row, the Default Author Brief row,
+the Default Continue direction row, the provider row, the model row, the
+context size row, the base URL row, and the API key row. Advanced view shows
+every row. Every row this document names that is not in that list appears only
+in Advanced view.
 
 Press `,` to open Settings. Press `m` to switch between Simple view and
 Advanced view. 1667 remembers your choice for your next session.

--- a/shared/starter-keys.ts
+++ b/shared/starter-keys.ts
@@ -16,7 +16,7 @@ export interface StarterKey {
   readonly name: string;
   /** How the prose spells the key, wrapped in square brackets. */
   readonly token: string;
-  readonly mode: "NAV" | "MAP";
+  readonly mode: "NAV" | "MAP" | "LIBRARY";
   readonly shift?: true;
   readonly ctrl?: true;
   /** Map bindings that only exist in a particular view. */
@@ -44,6 +44,7 @@ export const STARTER_KEYS = {
   prune: { name: "d", token: "D", mode: "NAV", shift: true },
   openMap: { name: "m", token: "m", mode: "NAV" },
   openLibrary: { name: "o", token: "o", mode: "NAV" },
+  deleteStory: { name: "d", token: "D", mode: "LIBRARY", shift: true },
   openFacts: { name: "f", token: "f", mode: "NAV" },
   openChapters: { name: "c", token: "c", mode: "NAV" },
   createChapter: { name: "c", token: "C", mode: "NAV", shift: true },

--- a/shared/starter-vault.ts
+++ b/shared/starter-vault.ts
@@ -242,16 +242,11 @@ const TOUR: StarterStory = {
           slug: "ending",
           instruction: "Close the tour. Give explicit permission to delete it.",
           tag: { name: "End of the tour", status: "Canon" },
-          keys: ["openLibrary", "newStory", "quit"],
-          text: "That is the whole instrument.\n\n"
-            + "Next door is \"A Door in the Hedge\" — one paragraph, no takes, nothing "
-            + "explained. Press [o] and open it if you want somewhere already warm to start. "
-            + "Press [n] for a story of your own if you would rather begin cold.\n\n"
-            + "When this tour has taught you what it can, delete it. Open the library with "
-            + "[o] and remove it there. A starter story that outstays its welcome is just "
-            + "clutter with sentimental value.\n\n"
-            + "[q] quits, and everything is already saved.\n\n"
-            + "Go and write something."
+          keys: ["openLibrary", "deleteStory", "settings"],
+          text: "This is the end of the tour. You can now delete the onboarding stories by "
+            + "pressing [o] and [D].\n\n"
+            + "Then set up your own model connection in the settings [,] under the "
+            + "\"connection\" -> \"provider\"."
         },
         {
           slug: "ending-alt",

--- a/tui/src/config.ts
+++ b/tui/src/config.ts
@@ -79,6 +79,8 @@ export interface UserConfig {
 
 const DEFAULTS: UserConfig = {
   schemaVersion: 1,
+  // Keep this legacy fallback for an existing config without a theme. A new
+  // install gets Graphite only when `loadConfigWithStatus` finds no file.
   theme: "lantern",
   factsRail: "auto",
   composeFocus: "off",
@@ -201,7 +203,11 @@ export function loadConfigWithStatus(
     raw = readFileSync(file, "utf8");
   } catch (error) {
     const status = isEnoent(error) ? "absent" : "unreadable";
-    return { status, config: normalizeUserConfig(null) };
+    const config = normalizeUserConfig(null);
+    return {
+      status,
+      config: status === "absent" ? { ...config, theme: "graphite" } : config
+    };
   }
   try {
     return { status: "loaded", config: normalizeUserConfig(JSON.parse(raw)) };

--- a/tui/src/settings-view-mode.ts
+++ b/tui/src/settings-view-mode.ts
@@ -10,6 +10,7 @@ import type { RuntimeState, SettingsOverlayState, SettingsRowId } from "./state.
  *  rule instead of two that could drift apart. Writing rows come from the
  *  field-definition table so simple/advanced visibility cannot drift. */
 const SETTINGS_SIMPLE_ROW_IDS: ReadonlySet<SettingsRowId> = new Set([
+  "theme",
   "update-checks",
   ...WRITING_PROMPT_FIELD_DEFINITIONS
     .filter((entry) => entry.view === "simple")

--- a/tui/test/config.test.ts
+++ b/tui/test/config.test.ts
@@ -1,9 +1,10 @@
 import { afterEach, expect, test } from "bun:test";
-import { chmod, mkdtemp, readdir, rm } from "node:fs/promises";
+import { chmod, mkdtemp, readdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import {
   loadConfig,
+  loadConfigWithStatus,
   normalizeUserConfig,
   saveConfig
 } from "../src/config.js";
@@ -56,6 +57,29 @@ test("config replacement publishes one complete new document", async () => {
 
   expect(loadConfig({ file })).toEqual(config);
   expect((await readdir(root)).sort()).toEqual(["config.json"]);
+});
+
+test("a new install uses graphite while existing configs keep the old fallback", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "1667-config-"));
+  roots.push(root);
+  const file = path.join(root, "config.json");
+
+  expect(loadConfigWithStatus({ file })).toMatchObject({
+    status: "absent",
+    config: { theme: "graphite" }
+  });
+
+  await writeFile(file, "{}\n", "utf8");
+  expect(loadConfigWithStatus({ file })).toMatchObject({
+    status: "loaded",
+    config: { theme: "lantern" }
+  });
+
+  await writeFile(file, '{"theme":"bone"}\n', "utf8");
+  expect(loadConfigWithStatus({ file })).toMatchObject({
+    status: "loaded",
+    config: { theme: "bone" }
+  });
 });
 
 test("aside Thoughts defaults to hide and accepts the snake-case setting", () => {

--- a/tui/test/golden-panels.test.ts
+++ b/tui/test/golden-panels.test.ts
@@ -339,21 +339,8 @@ describe("run C overlay frames", () => {
     expect(keyedShedLine).not.toContain("✓ keyed");
   });
 
-  test("settings overlay shows theme switcher and editable fields", async () => {
-    // "m" switches to advanced mode, which is what shows the theme switcher,
-    // and keeps the cursor on update checks. Seven downs skip the writing
-    // rows and reach provider, a cycler, for the choice-footer keyline.
-    const frame = await renderWithKeys(demoAppSource(), 120, 36, [
-      key(","),
-      key("m"),
-      key("down"),
-      key("down"),
-      key("down"),
-      key("down"),
-      key("down"),
-      key("down"),
-      key("down")
-    ]);
+  test("simple settings shows the theme switcher and editable fields", async () => {
+    const frame = await renderWithKeys(demoAppSource(), 120, 36, [key(",")]);
     expect(frame).toContain("┏━ settings ━");
     expect(frame).toContain("‹ lantern ›");
     expect(frame).toContain("provider");
@@ -365,15 +352,9 @@ describe("run C overlay frames", () => {
     const clean = await renderOnce(demoAppSource(), 120, 36, ",");
     expect(clean).not.toContain("revision");
 
-    // "m" switches to advanced mode and keeps the cursor on update checks.
-    // Seven downs reach provider, which can cycle and dirty the draft with
-    // Right.
+    // Four downs reach provider in Simple view. Right changes its value.
     const dirty = await renderWithKeys(demoAppSource(), 120, 36, [
       key(","),
-      key("m"),
-      key("down"),
-      key("down"),
-      key("down"),
       key("down"),
       key("down"),
       key("down"),
@@ -392,8 +373,7 @@ describe("run C overlay frames", () => {
       const view = { ...source.settingsView, pendingRevision, activeRevision: 3 };
       source.settingsView = view as typeof source.settingsView;
       source.api.getSettings = async () => view as typeof source.settingsView;
-      // "m" switches to advanced mode, which is what shows the theme row.
-      const lines = (await renderOnce(source, 120, 48, ",m")).split("\n");
+      const lines = (await renderOnce(source, 120, 48, ",")).split("\n");
       const rowOf = (text: string): number => lines.findIndex((line) => line.includes(text));
       return { theme: rowOf("theme"), provider: rowOf("provider"), prompt: rowOf("author brief") };
     };

--- a/tui/test/hit-map-chrome.test.ts
+++ b/tui/test/hit-map-chrome.test.ts
@@ -115,9 +115,8 @@ const footerCases: FooterCase[] = [
     ],
     setup: (state, source) => {
       state.mode = "SETTINGS";
-      // Row 0 is "theme" (a cycler, matching this case's CHOICE footer) only
-      // in advanced mode; simple mode's row 0 is "update-checks", a plain
-      // toggle with a different footer.
+      // Advanced mode selects the `m simple` footer. Row 0 is "theme", a
+      // cycler that selects the choice footer.
       state.config = { ...state.config, settingsViewMode: "advanced" };
       state.settings = initialSettingsOverlay(source.settingsView, state.config);
     } }
@@ -1247,7 +1246,7 @@ describe("hit map clickable chrome", () => {
         expected: "↑↓ move · ←→ choose · ↵ next · s save · c check · m simple · esc",
         setup: (state, source) => {
           state.mode = "SETTINGS";
-          // Row 0 is "theme" (a cycler) only in advanced mode.
+          // Advanced mode selects the `m simple` footer. Row 0 is "theme".
           state.config = { ...state.config, settingsViewMode: "advanced" };
           state.settings = initialSettingsOverlay(source.settingsView, state.config);
         } },

--- a/tui/test/settings-view-mode.test.ts
+++ b/tui/test/settings-view-mode.test.ts
@@ -86,12 +86,27 @@ test("simple mode shows only the intended rows, and advanced mode shows every ro
   // Default demo settings use dry-run, so base-url/api-key stay visible in
   // simple mode too — they are hidden only by the fixed-subscription rule.
   expect(settingsRowIds(overlay)).toEqual([
-    "update-checks", "default-author-brief", "default-continue-direction", "provider", "base-url", "api-key", "model", "context-window"
+    "theme", "update-checks", "default-author-brief", "default-continue-direction",
+    "provider", "base-url", "api-key", "model", "context-window"
   ]);
 
   await press(key("m"));
 
   expect(settingsRowIds(overlay)).toEqual([...SETTINGS_ROW_IDS]);
+});
+
+test("simple mode can change the theme", async () => {
+  const { source, state, press } = settingsHarness(
+    undefined,
+    { settingsViewMode: "simple" }
+  );
+  await openSettings(press);
+
+  expect(settingsRowIds(state.settings!)[state.settings!.cursor]).toBe("theme");
+  await press(key("right"));
+
+  expect(state.config.theme).toBe("iron gall");
+  expect(source.config.theme).toBe("iron gall");
 });
 
 test("base-url and api-key stay visible in simple mode until a fixed subscription connection hides them", async () => {
@@ -125,12 +140,12 @@ test("toggling the view mode preserves the cursor by row identity and never park
   expect(settingsCursorRowIdentity(overlay)).toBe("model");
   expect(settingsRowIds(overlay)[overlay.cursor]).toBe("model");
 
-  // "theme" only exists in advanced mode. Flipping back to simple must not
+  // "compose-focus" only exists in advanced mode. Flipping back to simple must not
   // leave the cursor pointing at a row that just vanished.
-  await selectRow(press, state, "theme");
+  await selectRow(press, state, "compose-focus");
   await press(key("m"));
   const rows = settingsRowIds(overlay);
-  expect(rows.includes("theme")).toBeFalse();
+  expect(rows.includes("compose-focus")).toBeFalse();
   expect(overlay.cursor).toBeGreaterThan(-1);
   expect(overlay.cursor).toBeLessThan(rows.length);
 });

--- a/tui/test/settings-writing-prompts.test.ts
+++ b/tui/test/settings-writing-prompts.test.ts
@@ -109,6 +109,7 @@ describe("table-driven Settings writing prompts", () => {
     const { state, press } = settingsHarness(undefined, { settingsViewMode: "simple" });
     await openSettings(press);
     const simple = settingsRowIds(state.settings!);
+    expect(simple).toContain("theme");
     expect(simple).toContain("default-author-brief");
     expect(simple).toContain("default-continue-direction");
     for (const definition of WRITING_PROMPT_FIELD_DEFINITIONS) {


### PR DESCRIPTION
## Outcome\n\nFresh installs now start with Graphite. Existing configs preserve a valid saved theme and fall back to Lantern when no theme was stored. Theme is available in Simple Settings.\n\nThe starter tour now ends with direct instructions for deleting onboarding stories and selecting a provider.\n\n## Changes\n\n- distinguish a missing config file from an existing config without a theme\n- expose Theme in Simple Settings\n- bind the tour D token to the Library delete action\n- update onboarding copy, documentation, changelog, and behavior tests\n\n## Verification\n\n- npm run build\n- npm test: 2,781 passed; 227 platform skips\n- bun run typecheck\n- changed-path TUI tests: 93 passed\n- starter storage tests: 10 passed\n- full TUI run: 2,287 passed; 2 platform skips; one deadline timing test failed under concurrent load\n- isolated deadline timing rerun: 2 passed\n\n## Risk\n\nThe default changes only when the user config file is absent. Loaded and unreadable existing files retain the Lantern fallback unless they contain a valid selected theme.\n\nTracks #347. Keep the issue open until a stable release contains this change.