### PR TITLE
fix(upgrade): clarify Windows installer guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ This file records notable changes to 1667. Product terms use the definitions in
 
 ## Unreleased
 
+- **Windows upgrades show the correct next command.** Stable update checks do
+  not show beta releases. A PowerShell Installation now gives the PowerShell
+  Installer command for a stable release. For beta, 1667 gives commands to
+  download and verify the release Installer before it runs. An exact
+  prerelease no longer names an Installer file that does not exist.
+
 ## 0.10.4-rc.1 - 2026-08-28
 
 - **Graphite and bone themes use the 1667 website colors.** Select either

--- a/tui/src/upgrade-cli.ts
+++ b/tui/src/upgrade-cli.ts
@@ -1,4 +1,4 @@
-import { compareSemVer, isSemVer } from "../../shared/semver.js";
+import { compareSemVer, isSemVer, parseSemVer } from "../../shared/semver.js";
 import { AI_1667_PRODUCT_VERSION } from "../../shared/build-identity.js";
 import {
   heldTargetRefusal,
@@ -76,7 +76,7 @@ ${DOWNGRADE_WARNING.trimEnd()}
 
 If you installed 1667 with npm, or you built it from source, update it the same
 way you installed it.
-On Windows, exit 1667 and run the PowerShell Installer again.`;
+On Windows, a PowerShell installation updates through the PowerShell Installer.`;
 
 export function windowsInstallCommand(
   installRoot: string,
@@ -87,11 +87,17 @@ export function windowsInstallCommand(
     throw new TypeError("Windows Installer target version must be SemVer");
   }
   const root = installRoot.replaceAll("'", "''");
+  const installerChannel = targetVersion === undefined
+    ? channel
+    : windowsInstallerChannel(targetVersion, channel);
+  if (installerChannel !== "stable") {
+    throw new TypeError("Automatic Windows Installer commands require the stable channel");
+  }
   const installerUrl = targetVersion === undefined
     ? "https://1667.ai/install.ps1"
     : `https://github.com/1667-ai/1667/releases/download/v${
       encodeURIComponent(targetVersion)
-    }/install-${channel}.ps1`;
+    }/install-${installerChannel}.ps1`;
   const script = `& ([scriptblock]::Create((irm ${installerUrl}))) `
     + "-InstallRoot '" + root + "'";
   return "powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -EncodedCommand "
@@ -100,6 +106,8 @@ export function windowsInstallCommand(
 
 const INSTRUCTIONS_ORIGIN =
   `https://www.npmjs.com/package/${RELEASE_LAUNCHER_PACKAGE}/v`;
+const NPM_RELEASE_SIGNER = "1667-ai/1667/.github/workflows/release-npm.yml";
+const LEGACY_RELEASE_SIGNER = "1667-ai/1667/.github/workflows/release-github.yml";
 
 export interface UpgradeCliDependencies {
   readonly observation?: UpgradeObservation;
@@ -251,10 +259,18 @@ async function dispatchUpgradeCommand(
       throw new UpgradeFailure("internal_error", "The release list was not handled.");
     case "rollback": {
       if (authority.kind === "powershell") {
-        requireServableWindowsChannel(authority.channel);
+        if (authority.channel === "beta") {
+          throw new UpgradeFailure(
+            "unsupported_target",
+            "Windows rollback is unavailable.\n"
+              + betaInstallerGuidance(observation.currentVersion, authority.installRoot)
+          );
+        }
         throw new UpgradeFailure(
           "unsupported_target",
-          "Windows rollback is unavailable. Exit 1667, then run: "
+          "Windows rollback is unavailable. "
+          + "A Windows PowerShell installation updates through the PowerShell Installer. "
+          + "To install it, run:\n"
           + windowsInstallCommand(authority.installRoot)
         );
       }
@@ -278,10 +294,7 @@ async function dispatchUpgradeCommand(
         registry,
         dependencies.signal
       );
-      if (method === "powershell" && plan.status !== "up-to-date") {
-        requireServableWindowsChannel(plan.channel);
-      }
-      return publicEnvelopeFromPlan(plan, authority);
+      return publicEnvelopeFromPlan(plan, authority, false, plan.channel === "stable");
     }
     case "apply": {
       if (authority.kind === "shell") {
@@ -309,10 +322,31 @@ async function dispatchUpgradeCommand(
       warnIfDowngrade(plan, onDowngradeWarning);
       if (method === "powershell"
         && command.version === null
-        && (plan.status !== "up-to-date" || channelSwitch)) {
-        requireServableWindowsChannel(plan.channel);
+        && (plan.status !== "up-to-date" || channelSwitch)
+      ) {
+        requireServableWindowsChannel(
+          plan.channel,
+          plan.status === "up-to-date" ? plan.latest : plan.target,
+          authority.installRoot
+        );
       }
-      return publicEnvelopeFromPlan(plan, authority, channelSwitch);
+      if (method === "powershell"
+        && command.version !== null
+        && plan.status !== "up-to-date"
+        && authority.kind === "powershell"
+        && windowsInstallerChannel(plan.target, authority.channel) === "beta"
+      ) {
+        throwBetaWindowsGuidance(plan.target, authority.installRoot);
+      }
+      return publicEnvelopeFromPlan(
+        plan,
+        authority,
+        channelSwitch,
+        true,
+        command.version !== null && authority.kind === "powershell"
+          ? authority.channel
+          : plan.channel
+      );
     }
   }
 }
@@ -334,7 +368,9 @@ function warnIfDowngrade(
 export function publicEnvelopeFromPlan(
   plan: UpgradeCorePlan,
   authority: InstallationAuthority,
-  forcePowerShellInstall = false
+  forcePowerShellInstall = false,
+  includePowerShellCommand = true,
+  powerShellInstallerChannel: UpgradeChannel = plan.channel
 ): UpgradeSuccessEnvelope {
   const method = authorityMethod(authority);
   if (forcePowerShellInstall
@@ -360,13 +396,14 @@ export function publicEnvelopeFromPlan(
       method
     });
   }
-  if (method === "shell") {
+  if (method === "shell" || (method === "powershell" && !includePowerShellCommand)) {
     return upgradeEnvelope({
       status: "available",
       current: plan.current,
       latest: plan.latest,
       target: plan.target,
-      channel: plan.channel
+      channel: plan.channel,
+      ...(method === "powershell" ? { method: "powershell" as const } : {})
     });
   }
   if (authority.kind === "powershell") {
@@ -377,7 +414,11 @@ export function publicEnvelopeFromPlan(
       target: plan.target,
       channel: plan.channel,
       method: "powershell",
-      command: windowsInstallCommand(authority.installRoot, plan.target, plan.channel)
+      command: windowsInstallCommand(
+        authority.installRoot,
+        plan.target,
+        powerShellInstallerChannel
+      )
     });
   }
   return upgradeEnvelope({
@@ -391,20 +432,57 @@ export function publicEnvelopeFromPlan(
 }
 
 /**
- * `https://1667.ai/install.ps1` serves the one promoted release, which is the
- * stable channel. A beta PowerShell Installation therefore cannot be pointed at
- * it: the plan would verify a beta version and the command would install the
- * stable one, then rewrite the Ownership Record to `stable`. Refuse instead, and
- * name the attested asset that does carry the requested channel.
+ * `https://1667.ai/install.ps1` serves the promoted stable release. A beta
+ * Installer must come from its immutable release and pass attestation before a
+ * user runs it.
  */
-function requireServableWindowsChannel(channel: UpgradeChannel): void {
+function requireServableWindowsChannel(
+  channel: UpgradeChannel,
+  targetVersion?: string | null,
+  installRoot?: string
+): void {
   if (channel === "stable") return;
+  const guidance = targetVersion === undefined || targetVersion === null
+    ? "Select a beta version, then download and attest its release Installer before you run it."
+    : betaInstallerGuidance(targetVersion, installRoot);
   throw new UpgradeFailure(
     "unsupported_target",
-    `The Windows Installer route serves the stable channel only. `
-    + `Download and attest install-${channel}.ps1 from the GitHub release, `
-    + "then run it."
+    "The standard Windows Installer URL supports stable releases only.\n" + guidance
   );
+}
+
+function throwBetaWindowsGuidance(
+  targetVersion: string,
+  installRoot: string
+): never {
+  throw new UpgradeFailure(
+    "unsupported_target",
+    `1667 ${targetVersion} requires the beta PowerShell Installer.\n`
+      + betaInstallerGuidance(targetVersion, installRoot)
+  );
+}
+
+function betaInstallerGuidance(targetVersion: string, installRoot?: string): string {
+  const installCommand = installRoot === undefined
+    ? "powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\\install-beta.ps1"
+    : "powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\\install-beta.ps1"
+      + ` -InstallRoot '${installRoot.replaceAll("'", "''")}'`;
+  return `To install 1667 ${targetVersion}, download this release Installer:\n`
+    + `${windowsInstallerUrl(targetVersion, "beta")}\n`
+    + `gh release download v${targetVersion} --repo 1667-ai/1667 `
+    + "--pattern install-beta.ps1 --output .\\install-beta.ps1\n"
+    + "Verify it with the current release workflow:\n"
+    + betaAttestationCommand(NPM_RELEASE_SIGNER) + "\n"
+    + "For an older beta release, use this command if the first command cannot find an attestation:\n"
+    + betaAttestationCommand(LEGACY_RELEASE_SIGNER) + "\n"
+    + "The beta Installer sets the saved channel to beta.\n"
+    + "Run the verified Installer:\n"
+    + installCommand;
+}
+
+function betaAttestationCommand(signerWorkflow: string): string {
+  return "gh attestation verify .\\install-beta.ps1 --repo 1667-ai/1667 "
+    + `--signer-workflow ${signerWorkflow} --deny-self-hosted-runners`;
 }
 
 export async function runProcessUpgrade(
@@ -478,24 +556,23 @@ function renderUpgrade(
       );
       break;
   }
-  // A Managed Installation says nothing about itself: the update it can do is
-  // the command the reader just ran. Only an installation 1667 cannot update
-  // has to say so, because that fact is why the instructions below differ.
-  if (envelope.method !== "shell") {
-    lines.push("1667 did not install this copy, so it cannot update it.");
-  }
   if (envelope.restartRequired) {
     lines.push("Restart 1667 to run the new version.");
   }
   if (command.kind === "check") {
     if (envelope.status === "manual") {
       if (envelope.method === "powershell") {
-        lines.push("Exit 1667, then run:", envelope.command);
+        appendPowerShellGuidance(lines, envelope, command);
       } else {
         lines.push("Run '1667 upgrade' to see how to update.");
       }
     } else if (envelope.status === "available") {
-      lines.push("Run '1667 upgrade' to install it.");
+      lines.push(
+        envelope.method === "powershell"
+          ? "A Windows PowerShell installation updates through the PowerShell Installer."
+            + ` Run '1667 upgrade --channel ${envelope.channel}' for installation instructions.`
+          : "Run '1667 upgrade' to install it."
+      );
     }
     return `${lines.join("\n")}\n`;
   }
@@ -504,14 +581,45 @@ function renderUpgrade(
   }
   if (envelope.status === "manual") {
     if (envelope.method === "powershell") {
-      lines.push("Exit 1667, then run:");
-      lines.push(envelope.command);
+      appendPowerShellGuidance(lines, envelope, command);
       return `${lines.join("\n")}\n`;
     }
     lines.push(`Instructions: ${instructionsUrl(envelope.target)}`);
     lines.push("Start 1667 again after you update it.");
   }
   return `${lines.join("\n")}\n`;
+}
+
+function appendPowerShellGuidance(
+  lines: string[],
+  envelope: Extract<UpgradeSuccessEnvelope, { method: "powershell" }>,
+  command: UpgradeCommand
+): void {
+  lines.push("A Windows PowerShell installation updates through the PowerShell Installer.");
+  if (command.kind === "apply" && command.version !== null) {
+    lines.push("Selecting an exact version does not change your saved channel.");
+  }
+  if (envelope.command === null) {
+    lines.push("Run '1667 upgrade --channel beta' for installation instructions.");
+    return;
+  }
+  lines.push("To install it, run:");
+  lines.push(envelope.command);
+}
+
+function windowsInstallerChannel(
+  targetVersion: string,
+  channel: UpgradeChannel
+): UpgradeChannel {
+  const parsed = parseSemVer(targetVersion);
+  if (parsed === null) throw new TypeError("Windows Installer target version must be SemVer");
+  return parsed.prerelease.length > 0 ? "beta" : channel;
+}
+
+function windowsInstallerUrl(targetVersion: string, channel: UpgradeChannel): string {
+  return `https://github.com/1667-ai/1667/releases/download/v${
+    encodeURIComponent(targetVersion)
+  }/install-${windowsInstallerChannel(targetVersion, channel)}.ps1`;
 }
 
 function authorityMethod(authority: InstallationAuthority): UpgradeMethod {

--- a/tui/src/upgrade-cli.ts
+++ b/tui/src/upgrade-cli.ts
@@ -320,7 +320,7 @@ async function dispatchUpgradeCommand(
         && authority.kind === "powershell"
         && command.channel !== authority.channel;
       warnIfDowngrade(plan, onDowngradeWarning);
-      if (method === "powershell"
+      if (authority.kind === "powershell"
         && command.version === null
         && (plan.status !== "up-to-date" || channelSwitch)
       ) {

--- a/tui/src/upgrade-contract.ts
+++ b/tui/src/upgrade-contract.ts
@@ -21,7 +21,7 @@ export interface UpgradeError {
 interface UpgradeEnvelopeBase {
   method: UpgradeMethod;
   restartRequired: boolean;
-  /** Only a PowerShell Installation reports a command. See UpgradeManualEnvelope. */
+  /** Only a PowerShell Installation can report a command. See UpgradeManualEnvelope. */
   command: string | null;
 }
 
@@ -39,9 +39,9 @@ export interface UpgradeUpToDateEnvelope extends UpgradeSuccessEnvelopeBase {
 }
 
 /**
- * A read-only plan. A PowerShell Installation always carries the command that
- * applies it; every other manual Installation never does. The two cases are
- * separate members so the pairing cannot be built wrong.
+ * A read-only plan. A PowerShell Installation carries the command that applies
+ * it. Every other manual Installation has no command. Beta checks use an
+ * UpgradeAvailableEnvelope until the user requests installation instructions.
  */
 export type UpgradeManualEnvelope =
   | (UpgradeSuccessEnvelopeBase & {
@@ -61,7 +61,7 @@ export type UpgradeManualEnvelope =
 
 export interface UpgradeAvailableEnvelope extends UpgradeSuccessEnvelopeBase {
   status: "available";
-  method: "shell";
+  method: "shell" | "powershell";
   target: string;
   restartRequired: false;
 }
@@ -134,6 +134,7 @@ export function upgradeEnvelope(
         latest: string;
         target: string;
         channel: UpgradeChannel;
+        method?: "shell" | "powershell";
       }
     | {
         status: "applied";
@@ -163,7 +164,7 @@ export function upgradeEnvelope(
       latest: values.latest,
       target: values.target,
       channel: values.channel,
-      method: "shell",
+      method: values.method ?? "shell",
       restartRequired: false,
       command: null,
       error: null

--- a/tui/test/upgrade-cli.test.ts
+++ b/tui/test/upgrade-cli.test.ts
@@ -531,7 +531,7 @@ test("selecting beta without an exact version stays safe and gives release guida
   expect(requested.stderr).not.toContain("https://1667.ai/install.ps1");
   expect(requested.stderr).toContain("powershell -NoLogo -NoProfile -ExecutionPolicy Bypass");
   expect(requested.stderr).not.toContain("EncodedCommand");
-  expect(requested.stderr).not.toMatch(/\birm\b.*install-beta\.ps1/i);
+  expect(/\birm\b.*install-beta\.ps1/i.test(requested.stderr)).toBe(false);
 });
 
 test("an exact PowerShell prerelease gives attested beta release guidance", async () => {
@@ -559,7 +559,7 @@ test("an exact PowerShell prerelease gives attested beta release guidance", asyn
   expect(output).toMatch(/powershell\b.*-File\b.*install-beta\.ps1/i);
   expect(output).toContain("powershell -NoLogo -NoProfile -ExecutionPolicy Bypass");
   expect(output).not.toContain("EncodedCommand");
-  expect(output).not.toMatch(/\birm\b.*install-beta\.ps1/i);
+  expect(/\birm\b.*install-beta\.ps1/i.test(output)).toBe(false);
   expect(output).not.toContain("install-stable.ps1");
   expect(() => windowsInstallCommand(POWERSHELL_ROOT, version)).toThrow(
     /stable channel/

--- a/tui/test/upgrade-cli.test.ts
+++ b/tui/test/upgrade-cli.test.ts
@@ -293,6 +293,12 @@ test("manual current releases do not recommend a redundant reinstall", async () 
 });
 
 const POWERSHELL_ROOT = "C:\\Users\\writer\\AppData\\Local\\Programs\\1667\\bin";
+const NPM_BETA_ATTESTATION = "gh attestation verify .\\install-beta.ps1 --repo 1667-ai/1667 "
+  + "--signer-workflow 1667-ai/1667/.github/workflows/release-npm.yml "
+  + "--deny-self-hosted-runners";
+const LEGACY_BETA_ATTESTATION = "gh attestation verify .\\install-beta.ps1 --repo 1667-ai/1667 "
+  + "--signer-workflow 1667-ai/1667/.github/workflows/release-github.yml "
+  + "--deny-self-hosted-runners";
 
 function powershellAuthority(channel: "stable" | "beta") {
   return {
@@ -302,6 +308,18 @@ function powershellAuthority(channel: "stable" | "beta") {
     executable: `${POWERSHELL_ROOT}\\1667.exe`
   };
 }
+
+test("an up-to-date stable PowerShell install prints only its stable state", async () => {
+  const result = await executeUpgradeCli([], {
+    observation,
+    authority: powershellAuthority("stable"),
+    registry: fakeRegistry(observation.currentVersion)
+  });
+  expect(result).toMatchObject({ exitCode: 0, stderr: "" });
+  expect(result.stdout).toBe(
+    `1667 ${observation.currentVersion} is up to date on stable.\n`
+  );
+});
 
 test("PowerShell installs return the rerunnable Windows Installer command", async () => {
   const authority = powershellAuthority("stable");
@@ -323,8 +341,12 @@ test("PowerShell installs return the rerunnable Windows Installer command", asyn
     authority,
     registry: fakeRegistry("2.0.0")
   });
-  expect(applied.stdout).toContain("Exit 1667, then run:");
+  expect(applied.stdout).toContain("1667 2.0.0 is available on stable.");
+  expect(applied.stdout).toContain("A Windows PowerShell installation updates through the PowerShell Installer.");
+  expect(applied.stdout).toContain("To install it, run:");
   expect(applied.stdout).toContain(managedCommand);
+  expect(applied.stdout).not.toContain("1667 did not install this copy");
+  expect(applied.stdout).not.toContain("Exit 1667");
   expect(applied.stdout).not.toContain("npmjs.com");
 
   const rollback = await executeUpgradeCli(["--rollback"], {
@@ -334,6 +356,21 @@ test("PowerShell installs return the rerunnable Windows Installer command", asyn
   });
   expect(rollback.exitCode).toBe(1);
   expect(rollback.stderr).toContain(windowsInstallCommand(POWERSHELL_ROOT));
+});
+
+test("an exact stable PowerShell version explains that the saved channel stays stable", async () => {
+  const applied = await executeUpgradeCli(["--version", "2.0.0"], {
+    observation,
+    authority: powershellAuthority("stable"),
+    registry: fakeRegistry("2.0.0")
+  });
+  expect(applied.exitCode).toBe(0);
+  expect(applied.stdout).toContain("1667 2.0.0 is available.");
+  expect(applied.stdout).toContain("Selecting an exact version does not change your saved channel.");
+  expect(applied.stdout).toContain("To install it, run:");
+  expect(applied.stdout).toContain(windowsInstallCommand(POWERSHELL_ROOT, "2.0.0"));
+  expect(applied.stdout).not.toContain("1667 did not install this copy");
+  expect(applied.stdout).not.toContain("Exit 1667");
 });
 
 test("PowerShell plans bind the command to the exact immutable stable Installer", async () => {
@@ -358,28 +395,37 @@ test("PowerShell plans bind the command to the exact immutable stable Installer"
   expect(script).not.toContain("https://1667.ai/install.ps1");
 });
 
-test("an exact PowerShell downgrade keeps the selected channel", async () => {
-  const applied = await executeUpgradeCli(["--version", "1.0.0", "--json"], {
+test("an exact version on beta requires an attested beta Installer", async () => {
+  const applied = await executeUpgradeCli([
+    "--version",
+    "1.0.0",
+    "--channel",
+    "stable",
+    "--json"
+  ], {
     observation,
     authority: powershellAuthority("beta"),
-    registry: fakeRegistry("2.0.0-beta.1")
+    registry: fakeRegistry("2.0.0")
   });
-  expect(applied.exitCode).toBe(0);
+  expect(applied.exitCode).toBe(1);
   expect(applied.stderr).toContain("make the Vault unreadable or damage Vault data");
   const envelope = JSON.parse(applied.stdout);
   expect(envelope).toMatchObject({
-    status: "manual",
+    status: "error",
     current: "1.2.3",
-    latest: "2.0.0-beta.1",
-    target: "1.0.0",
-    channel: "beta",
-    method: "powershell"
+    latest: null,
+    target: null,
+    channel: "stable",
+    method: "powershell",
+    command: null,
+    error: { code: "unsupported_target" }
   });
-  const encoded = (envelope.command as string).split(" ").at(-1)!;
-  const script = Buffer.from(encoded, "base64").toString("utf16le");
-  expect(script).toContain(
-    "irm https://github.com/1667-ai/1667/releases/download/v1.0.0/install-beta.ps1"
+  expect(envelope.error.message).toContain(
+    "https://github.com/1667-ai/1667/releases/download/v1.0.0/install-beta.ps1"
   );
+  expect(envelope.error.message).toContain(NPM_BETA_ATTESTATION);
+  expect(envelope.error.message).toContain(LEGACY_BETA_ATTESTATION);
+  expect(envelope.error.message).not.toContain("EncodedCommand");
 });
 
 test("an exact current PowerShell version does not install the channel head", async () => {
@@ -428,35 +474,113 @@ test("PowerShell reruns preserve custom roots and explicit channel switches", as
   });
 });
 
-// https://1667.ai/install.ps1 serves the one promoted release. Handing it to a
-// beta Installation would verify a beta version and then install the stable
-// one, rewriting the Ownership Record to the wrong channel.
-test("a channel the Windows Installer route cannot serve is refused", async () => {
-  const authority = powershellAuthority("beta");
-  const checked = await executeUpgradeCli(["--check", "--json"], {
+test("checking beta on PowerShell reports the newer beta without an executable command", async () => {
+  const checked = await executeUpgradeCli(["--check", "--channel", "beta", "--json"], {
     observation,
-    authority,
-    registry: fakeRegistry("2.0.0")
+    authority: powershellAuthority("stable"),
+    registry: fakeRegistry("2.0.0-beta.1")
   });
-  expect(checked.exitCode).toBe(1);
+  expect(checked.exitCode).toBe(0);
+  expect(checked.stderr).toBe("");
   const envelope = JSON.parse(checked.stdout);
-  expect(envelope.status).toBe("error");
-  expect(envelope.error.code).toBe("unsupported_target");
-  expect(envelope.error.message).toContain("install-beta.ps1");
-  expect(checked.stdout).not.toContain("https://1667.ai/install.ps1");
+  expect(envelope).toMatchObject({
+    status: "available",
+    current: observation.currentVersion,
+    latest: "2.0.0-beta.1",
+    target: "2.0.0-beta.1",
+    channel: "beta",
+    method: "powershell",
+    command: null
+  });
+  expect(checked.stdout).not.toContain("powershell -NoLogo");
 
+  const human = await executeUpgradeCli(["--check", "--channel", "beta"], {
+    observation,
+    authority: powershellAuthority("stable"),
+    registry: fakeRegistry("2.0.0-beta.1")
+  });
+  expect(human.exitCode).toBe(0);
+  expect(human.stderr).toBe("");
+  expect(human.stdout).toContain("1667 2.0.0-beta.1 is available on beta.");
+  expect(human.stdout).toContain("Run '1667 upgrade --channel beta'");
+});
+
+test("selecting beta without an exact version stays safe and gives release guidance", async () => {
   const requested = await executeUpgradeCli(["--channel", "beta"], {
+    observation,
+    authority: powershellAuthority("stable"),
+    registry: fakeRegistry("2.0.0-beta.1")
+  });
+  expect(requested.exitCode).toBe(1);
+  expect(requested.stdout).toBe("");
+  expect(requested.stderr).toMatch(/Windows .*Installer.*stable.*only/i);
+  expect(requested.stderr).toContain("2.0.0-beta.1");
+  expect(requested.stderr).toMatch(/download .*Installer/i);
+  expect(requested.stderr).toContain(
+    "https://github.com/1667-ai/1667/releases/download/v2.0.0-beta.1/install-beta.ps1"
+  );
+  expect(requested.stderr).toContain(NPM_BETA_ATTESTATION);
+  expect(requested.stderr).toContain(LEGACY_BETA_ATTESTATION);
+  expect(requested.stderr).toContain(
+    "gh release download v2.0.0-beta.1 --repo 1667-ai/1667 "
+      + "--pattern install-beta.ps1 --output .\\install-beta.ps1"
+  );
+  expect(requested.stderr).toMatch(/saved channel.*beta/i);
+  expect(requested.stderr).toMatch(/powershell\b.*-File\b.*install-beta\.ps1/i);
+  expect(requested.stderr).not.toContain("install-stable.ps1");
+  expect(requested.stderr).not.toContain("https://1667.ai/install.ps1");
+  expect(requested.stderr).toContain("powershell -NoLogo -NoProfile -ExecutionPolicy Bypass");
+  expect(requested.stderr).not.toContain("EncodedCommand");
+  expect(requested.stderr).not.toMatch(/\birm\b.*install-beta\.ps1/i);
+});
+
+test("an exact PowerShell prerelease gives attested beta release guidance", async () => {
+  const version = "2.0.0-rc.1";
+  const applied = await executeUpgradeCli(["--version", version], {
     observation,
     authority: powershellAuthority("stable"),
     registry: fakeRegistry("2.0.0")
   });
-  expect(requested.exitCode).toBe(1);
-  expect(requested.stderr).toContain("install-beta.ps1");
-  expect(requested.stderr).not.toContain("https://1667.ai/install.ps1");
+  const output = applied.stdout + applied.stderr;
+  expect(applied.exitCode).toBe(1);
+  expect(applied.stdout).toBe("");
+  expect(output).toContain(version);
+  expect(output).toMatch(/download .*Installer/i);
+  expect(output).toContain(
+    "https://github.com/1667-ai/1667/releases/download/v2.0.0-rc.1/install-beta.ps1"
+  );
+  expect(output).toContain(NPM_BETA_ATTESTATION);
+  expect(output).toContain(LEGACY_BETA_ATTESTATION);
+  expect(output).toContain(
+    "gh release download v2.0.0-rc.1 --repo 1667-ai/1667 "
+      + "--pattern install-beta.ps1 --output .\\install-beta.ps1"
+  );
+  expect(output).toMatch(/saved channel.*beta/i);
+  expect(output).toMatch(/powershell\b.*-File\b.*install-beta\.ps1/i);
+  expect(output).toContain("powershell -NoLogo -NoProfile -ExecutionPolicy Bypass");
+  expect(output).not.toContain("EncodedCommand");
+  expect(output).not.toMatch(/\birm\b.*install-beta\.ps1/i);
+  expect(output).not.toContain("install-stable.ps1");
+  expect(() => windowsInstallCommand(POWERSHELL_ROOT, version)).toThrow(
+    /stable channel/
+  );
 });
 
-// The refusal is about the command the route cannot serve. A beta Installation
-// that is already current is offered no command, so there is nothing to refuse.
+test("beta PowerShell rollback states the refusal before reinstall guidance", async () => {
+  const rollback = await executeUpgradeCli(["--rollback"], {
+    observation,
+    authority: powershellAuthority("beta"),
+    registry: fakeRegistry("2.0.0-beta.1")
+  });
+  expect(rollback.exitCode).toBe(1);
+  expect(rollback.stdout).toBe("");
+  expect(rollback.stderr).toContain("Windows rollback is unavailable.");
+  expect(rollback.stderr).toContain(NPM_BETA_ATTESTATION);
+  expect(rollback.stderr).toContain("install-beta.ps1");
+});
+
+// A beta Installation that is already current is offered no command, so there
+// is no installer route to reject.
 test("an up-to-date beta PowerShell install still reports its state", async () => {
   const current = await executeUpgradeCli(["--check", "--json"], {
     observation,


### PR DESCRIPTION
Tracks #351

Summary:
- explain the PowerShell Installer handoff with the exact next action
- report beta availability without emitting an unverified execution command
- route beta installation through pinned artifact attestation guidance
- prevent prerelease requests from naming a missing stable Installer

Tests:
- npm run typecheck
- 72 platform-neutral upgrade tests