### PR TITLE
chore(release): prepare 0.10.4-rc.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This file records notable changes to 1667. Product terms use the definitions in
 
 ## Unreleased
 
+## 0.10.4-rc.2 - 2026-08-28
+
 - **Windows upgrades show the correct next command.** Stable update checks do
   not show beta releases. A PowerShell Installation now gives the PowerShell
   Installer command for a stable release. For beta, 1667 gives commands to

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "1667-workspace",
-  "version": "0.10.4-rc.1",
+  "version": "0.10.4-rc.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "1667-workspace",
-      "version": "0.10.4-rc.1",
+      "version": "0.10.4-rc.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@earendil-works/pi-ai": "0.84.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667-workspace",
-  "version": "0.10.4-rc.1",
+  "version": "0.10.4-rc.2",
   "private": true,
   "description": "Source workspace for the 1667 terminal writing environment",
   "license": "Apache-2.0",

--- a/shared/release-notes.ts
+++ b/shared/release-notes.ts
@@ -11,6 +11,11 @@ export interface ReleaseNote {
  *  a release, and is not included. */
 export const RELEASE_NOTES: readonly ReleaseNote[] = [
   {
+    version: "0.10.4-rc.2",
+    date: "2026-08-28",
+    body: "- **Windows upgrades show the correct next command.** Stable update checks do\n  not show beta releases. A PowerShell Installation now gives the PowerShell\n  Installer command for a stable release. For beta, 1667 gives commands to\n  download and verify the release Installer before it runs. An exact\n  prerelease no longer names an Installer file that does not exist.\n- **New users start with the Graphite theme.** Existing users keep their saved\n  theme. An older config without a theme keeps the Lantern theme. The Theme row\n  now appears in Simple Settings.\n- **The starter tour ends with setup instructions.** It tells the user how to\n  delete the onboarding stories and select a model provider."
+  },
+  {
     version: "0.10.4-rc.1",
     date: "2026-08-28",
     body: "- **Graphite and bone themes use the 1667 website colors.** Select either\n  theme in Settings or from the command palette. Both themes include truecolor\n  and 256-color palettes."

--- a/tui/package.json
+++ b/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667",
-  "version": "0.10.4-rc.1",
+  "version": "0.10.4-rc.2",
   "private": true,
   "description": "A terminal environment for writing fiction with language models",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Outcome\n\nPrepare 0.10.4-rc.2 for beta publication. This candidate contains the Graphite default, Simple Settings theme row, and revised onboarding ending merged in PR #349.\n\n## Changes\n\n- set root, lockfile, and TUI versions to 0.10.4-rc.2\n- publish the Unreleased notes as the dated 0.10.4-rc.2 section\n- regenerate embedded release notes\n\n## Verification\n\n- npm run notes:check-version -- 0.10.4-rc.2\n- npm run build\n- npm test: 2,781 passed; 227 platform skips\n- bun run typecheck\n- bun test: 2,288 passed; 2 platform skips\n- bun run build:standalone\n\n## Risk\n\nThe local performance gate still misses three existing repaint budgets: full wide surface repaint, wide wheel-scroll repaint, and append final frame plus surface. This release preparation changes only version and release-note metadata.\n\nTracks #347. Keep the issue open until a stable release contains the change.