### PR TITLE
fix(installer): emphasize Windows start command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This file records notable changes to 1667. Product terms use the definitions in
 
 ## Unreleased
 
+- **Windows installation shows the exact start command.** The PowerShell
+  Installer tells the user to open a new PowerShell window and run `1667.exe`.
+  It warns that `1667` without `.exe` does not start the app.
+
 ## 0.10.4-rc.2 - 2026-08-28
 
 - **Windows upgrades show the correct next command.** Stable update checks do

--- a/README.md
+++ b/README.md
@@ -71,6 +71,15 @@ On Windows x64, use the PowerShell Installer:
 powershell -ExecutionPolicy Bypass -c "irm https://1667.ai/install.ps1 | iex"
 ```
 
+After installation, open a new PowerShell window. Start 1667 with this command:
+
+```powershell
+1667.exe
+```
+
+Include `.exe` when you start 1667. The command `1667` does not start the app
+because PowerShell treats it as a number.
+
 Each Installer verifies the downloaded Release Archive checksum. The Shell
 Installer supports macOS and Linux. The PowerShell Installer supports Windows
 x64.

--- a/scripts/release-install-powershell-body.ts
+++ b/scripts/release-install-powershell-body.ts
@@ -454,9 +454,12 @@ function Main {
     if ($null -ne $lock) { $lock.Dispose() }
   }
   Write-Output "Installed 1667 $ProductVersion ($InstallChannel) for $ArtifactTarget to $active"
-  Write-Output 'PowerShell treats 1667 as a number.'
+  Write-Output ''
   Write-Output 'Open a new PowerShell window.'
-  Write-Output 'Then run: 1667.exe'
+  Write-Output 'Start 1667 with this command:'
+  Write-Output '  1667.exe'
+  Write-Output 'IMPORTANT: Include .exe when you start 1667.'
+  Write-Output '1667 without .exe does not start the app because PowerShell treats it as a number.'
 }
 
 Main

--- a/test/release-install-powershell.test.ts
+++ b/test/release-install-powershell.test.ts
@@ -78,7 +78,7 @@ test("PowerShell Installer handles install, repeat, and upgrade cases", async (t
   assert.match(fresh.stdout, /Installed 1667 1\.2\.3 \(stable\)/u);
   assert.match(
     fresh.stdout,
-    /PowerShell treats 1667 as a number\.\r?\nOpen a new PowerShell window\.\r?\nThen run: 1667\.exe/u
+    /\r?\n\r?\nOpen a new PowerShell window\.\r?\nStart 1667 with this command:\r?\n  1667\.exe\r?\nIMPORTANT: Include \.exe when you start 1667\.\r?\n1667 without \.exe does not start the app because PowerShell treats it as a number\./u
   );
   assert.equal(await installedVersion(installRoot), "1.2.3");
   assert.equal(await accessRulesAreProtected(installRoot), false);


### PR DESCRIPTION
Summary
- show 1667.exe as the exact Windows start command after installation
- explain that 1667 without .exe is a PowerShell number
- add the same instruction to the README

Tests
- npm run typecheck
- generated installer test
- Windows integration assertion updated; local fixture blocked by the WSL bash alias

Tracks #351