### PR TITLE
docs: simplify reader-facing copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <img src="docs/assets/1667-rainbow.svg" alt="1667" width="420">
 
-**A full-screen terminal environment for fiction writing with language models.**
+**Write and revise branching fiction from your terminal.**
 
 [![npm](https://img.shields.io/npm/v/%401667-ai%2Fcli/latest?label=npm)](https://www.npmjs.com/package/@1667-ai/cli)
 [![CI and standalone builds](https://github.com/1667-ai/1667/actions/workflows/ci.yml/badge.svg?branch=main&event=push)](https://github.com/1667-ai/1667/actions/workflows/ci.yml?query=branch%3Amain)
@@ -10,52 +10,38 @@
 
 </div>
 
-1667 provides a keyboard interface and a story model with alternative takes.
-1667 also provides a direct connection to a selected model provider. This
-repository contains the terminal user interface (TUI) and its backend runtime.
+1667 is a full-screen terminal app for fiction writing. Write story parts, keep
+alternative takes, and select the story line that you want to read. Connect a
+model when you want generated prose, or write every take yourself.
+
+This repository contains the terminal user interface (TUI) and the backend.
 
 [![1667 in a terminal: a direction is composed, the model streams the next part, two sibling takes are compared, and the path map opens](https://1667.ai/demo-3.gif)](https://1667.ai)
 
-## Features
+## What you can do
 
-- Write in a full-screen terminal interface with eight themes.
-- Add sibling takes to any story part.
-- Select a take for each story part.
-- Read a story as a story line, a tree, or a mass map.
-- View Facts and estimated request context in the side rail.
-- Keep one Author's Note for the next continuation or prompted retake.
-- Override the Default Author Brief for one story.
-- Set the Default Author Brief and the Default Continue direction in Settings.
-- Set Rewrite, Title, Summary, and Aside guidance in Advanced view.
-- Open each Settings row and Sampling control from the command palette.
-- Use keys to include a Fact only when the request context matches it.
-- Order, rank, and budget Facts so a full context window drops low-value ones first.
-- Inspect the next provider request in the request viewer.
-- Inspect the alternative tokens the model weighed in the token probability viewer.
-- Manage chapter boundaries and chapter summaries in the Chapters view.
-- Edit story parts, facts, and chapter summaries in the full-screen editor.
-- Use the embedded backend worker without a network port.
-- Seal project files at rest with a Vault Password.
-- Stop a generation and save model text that already arrived.
-- Use a ChatGPT Plus or Pro plan, or a Claude Pro or Max plan, without an API key.
-- Connect to OpenAI-compatible endpoints or Anthropic Messages endpoints.
+- Write and edit story parts in a full-screen terminal.
+- Keep several takes for one story part without replacing earlier text.
+- Select one take at each point to form a story line.
+- View the selected line, the full tree, or a compact map.
+- Organize long stories with chapters, summaries, Facts, and notes.
+- Import an existing manuscript and export the selected story line as Markdown.
+- Seal project files with a Vault Password.
+- Choose from eight themes.
 
-## Writing prompts
+## Write with or without a model
 
-The system prompt in Settings is the Default Author Brief. 1667 uses this
-value. Set the Default Continue direction in Simple view. Set Rewrite, Title,
-Summary, and Aside guidance in Advanced view.
+You do not need a model provider to edit prose, create takes, select a story
+line, manage chapters and Facts, or import and export Markdown. See
+[Write without a model](docs/write-without-a-model.md).
 
-These fields add guidance. They do not replace fixed operation contracts.
-Title, summary, and Aside still use the Utility Generation Profile. Each of
-those operations has its own guidance row.
+When you want generated prose, connect a provider in Settings. 1667 supports
+ChatGPT and Claude plan connections. It also supports OpenAI-compatible and
+Anthropic Messages endpoints.
 
-Writing prompts are machine-wide Settings values. A Profile Export does not
-include them.
-
-The first successful Settings save publishes Settings schema 5. An older
-release refuses a schema 5 Settings document. Back up Settings before you try
-`0.10.2-rc.1`. An older release cannot open schema 5.
+You can inspect the next provider request before you send it. You can also set
+an Author Brief, directions, Facts, and sampling controls. See
+[Facts, context, and model providers](docs/model-providers.md).
 
 ## Install
 
@@ -84,24 +70,20 @@ Each Installer verifies the downloaded Release Archive checksum. The Shell
 Installer supports macOS and Linux. The PowerShell Installer supports Windows
 x64.
 
-Run `1667 upgrade` to update a Managed Installation that the Shell Installer
-created. The command shows download progress in a terminal. On Windows, exit
-1667 and run the PowerShell Installer again. The Installer shows download
-progress. `1667 upgrade` shows the required command.
+Create a project, then start 1667:
 
-Run the Shell Installer again to update a valid Shell Managed Installation. It
-preserves the `installationId`, keeps the previous executable for rollback,
-and sets the selected Installer channel. It refuses an unmanaged executable or
-invalid installation state.
+```sh
+mkdir my-story
+cd my-story
+1667 init
+1667
+```
 
-`1667 upgrade --version <version>` selects an exact published release. The
-version can be older than the current version. Before a downgrade, 1667 warns
-that the downgrade can make the Vault unreadable or damage Vault data. Back up
-the Vault before you continue.
+`1667 init` creates a `.1667/` directory in the project. Run `1667` from the
+project or one of its subdirectories.
 
-Run `1667 upgrade --list` to show the published launcher releases. 1667 checks
-platform support when `--version` selects a release. An exact version reuses
-the previous executable when that executable has the selected version.
+Run `1667 upgrade` to update an installation from the Shell Installer. On
+Windows, exit 1667 and run the PowerShell Installer again.
 
 Install with npm:
 
@@ -109,19 +91,17 @@ Install with npm:
 npm install --global @1667-ai/cli@latest
 ```
 
-npm manages this installation. Use npm to install a later release.
+npm manages this installation. Use npm to update it.
 
-1667 checks for a new release by default. The check reads public package
-metadata from the npm registry. It does not send story, prompt, account, or
-configuration data. Turn **update checks** off in Settings to disable the
-check. A Managed Installation notice shows `1667 upgrade`. Other notices show
-only the new version.
+1667 checks the public npm registry for updates. The check does not send your
+story, prompts, account data, or settings. You can turn off **update checks**
+in Settings.
 
 Install from source with the
 [source installation procedure](docs/run-from-source.md).
 Git manages this installation.
 
-## Subscription plans
+## Connect a subscription plan
 
 1667 can use a ChatGPT Plus or Pro plan, or a Claude Pro or Max plan. These
 connections do not need a separate API key.
@@ -140,7 +120,7 @@ Sign in to Claude:
 
 Then select **ChatGPT plan** or **Claude plan** in Settings.
 
-These plan connections are experimental community integrations. The provider
+These connections are experimental community integrations. Your provider
 applies its subscription limits, terms, and data controls.
 
 ## Keyboard orientation
@@ -153,15 +133,6 @@ applies its subscription limits, terms, and data controls.
 | Go to the previous or next chapter | `[` and `]` |
 | Continue the story | `Space` |
 | Open the composer | `Enter` or `i` |
-| Copy selected editor text | `Ctrl+C` or `Command+C` |
-| Cut selected editor text | `Ctrl+X` or `Command+X` |
-| Paste text into an editor | `Ctrl+V` or `Command+V` |
-| Select all text in an editor | `Ctrl+A` or `Command+A` |
-| Undo or redo an editor change | `Ctrl+Z` and `Ctrl+Shift+Z`, or `Command+Z` and `Command+Shift+Z` |
-| Go to the start or end of an editor line or buffer | `Command+Arrow` |
-| Delete to the start of an editor line | `Command+Backspace` |
-| Move by one editor page | `Page Up` or `Page Down` |
-| Open the editor action menu | Right-click an editor |
 | Add a manual take | `w` |
 | Edit the selected story part | `e` |
 | Open Aside | `a` |
@@ -180,38 +151,31 @@ The keys `h`, `j`, `k`, and `l` do not move between story parts. `l` opens
 the token probability viewer instead. In the map, `l` follows or opens the
 selected story line. Press `?` for the complete key reference.
 
-Aside keeps separate sessions for story takes. Press `Left` or `Right` to
-select a session. Press `[` or `]` to select an Aside anchor. Existing Side
-Notes remain available in the unanchored bucket. Press `t` to show or hide
-stored Thoughts. Stored Thoughts do not enter later model requests.
-
 ## Privacy
 
-1667 stores stories and project settings in the project tier. Demo mode and
-dry-run mode send no data to a model provider.
+1667 stores stories and project settings in the project's `.1667/` directory.
+Provider credentials stay on your machine. Demo mode and dry-run mode do not
+contact a model provider.
 
 During generation, 1667 sends request context to the selected provider. This
 context can contain:
 
-- Story prose
-- Facts
-- Chapter summaries
-- Author's Note
-- Author Brief
-- Default Continue direction
-- Rewrite, Title, Summary, or Aside guidance
-- User instructions
+- story prose,
+- Facts,
+- chapter summaries,
+- the Author's Note and Author Brief,
+- directions and other guidance, and
+- your current instruction.
 
-1667 sends the selected credential in the authentication header when a
-connection requires a credential. Select a provider with an acceptable data
-policy.
+Choose a provider whose data policy meets your needs.
 
 Press `Ctrl+R` to open the request viewer. The request viewer shows the next
-request plan. It does not show the authentication header or its credential.
+provider request without showing the credential.
 
 ## Documentation
 
 - [Run 1667 from source](docs/run-from-source.md)
+- [Write without a model](docs/write-without-a-model.md)
 - [Story storage](docs/story-storage.md)
 - [Facts, context, and model providers](docs/model-providers.md)
 - [Move from SillyTavern](https://1667.ai/docs/move-from-sillytavern)

--- a/docs/write-without-a-model.md
+++ b/docs/write-without-a-model.md
@@ -1,0 +1,114 @@
+---
+summary: Write, revise, branch, import, and export prose without a model provider
+read_when:
+  - changing manual writing actions
+  - changing Markdown import or export
+  - changing which actions use a model provider
+---
+
+# Write without a model
+
+You can use 1667 to organize prose that you write yourself. You do not need to
+set up a model provider.
+
+The manual workflow includes these tasks:
+
+- Import a Markdown draft.
+- Edit story parts.
+- Keep alternative takes.
+- Select one story line.
+- Add chapters and Facts.
+- Use the tree and map views.
+- Export the selected story line.
+
+## Start with a Markdown draft
+
+Write your draft in a Markdown file. Use a `#` heading for the story title. Use
+`##` headings for chapters. Separate story parts with blank lines.
+
+Import the file:
+
+```sh
+1667 init
+1667 import draft.md
+1667
+```
+
+1667 creates a new story. The source file stays unchanged.
+
+## Write and edit takes
+
+Press `w` on a story part to write a sibling take. A sibling take is another
+version of the same story part.
+
+Press `e` to edit the focused story part. A normal save keeps the earlier text
+as another take. The editor also has an action to update the current take.
+
+Use these keys to move and choose text:
+
+| Task | Keys |
+| --- | --- |
+| Move between story parts | `↑` and `↓` |
+| Select a sibling take | `←` and `→` |
+| Go to the first or last story part | `g` and `G` |
+| Copy a story part or story line | `y` or `Y` |
+
+The selected take at each point forms the story line. Other takes remain in the
+tree. You can select them again at any time.
+
+## Organize the story
+
+| Task | Key |
+| --- | --- |
+| Open the map | `m` |
+| Open the Chapters view | `c` |
+| Start a chapter | `C` |
+| Open Facts | `f` |
+| Tag a story line | `t` |
+| Open the Library | `o` |
+
+Chapters, Facts, tags, and maps do not require a provider. You can write chapter
+titles, chapter summaries, and Facts yourself.
+
+## Export the selected story line
+
+Run this command in the project:
+
+```sh
+1667 export
+```
+
+1667 writes a Markdown file to the project root. The file contains the selected
+story line. It does not contain unselected takes.
+
+Run the command again after you select different takes. 1667 writes the story
+line that is selected at that time.
+
+## Know which actions use a provider
+
+The following actions request model output:
+
+- Continue a story with `Space`.
+- Send a direction from the composer with `Enter` or `i`.
+- Request a Retake with `r` or `R`.
+- Rewrite selected prose from the command palette.
+- Create a story name with **autoname story**.
+- Generate a chapter summary.
+- Send a question in Aside.
+
+Do not use these actions during a manual session. Editing, take selection,
+chapters, Facts, maps, import, and export remain available.
+
+## Find your files
+
+1667 stores each project in the `.1667/` directory at the project root. An
+exported Markdown file is next to that directory.
+
+Use a Vault Password if you want to seal the project files at rest. See
+[Story storage](story-storage.md).
+
+## Related documents
+
+- [Story storage](story-storage.md)
+- [Technical terms](technical-terms.md)
+- [Facts, context, and model providers](model-providers.md)

--- a/shared/starter-vault.ts
+++ b/shared/starter-vault.ts
@@ -76,40 +76,34 @@ const TOUR: StarterStory = {
       takes: [
         {
           slug: "open-1",
-          instruction: "Open the tour. Teach take flipping by making the reader do it.",
+          instruction: "Show how to move between takes.",
           keys: ["takeNext", "takePrevious"],
           text: STARTER_LOGO_TEXT + "\n\n"
-            + "Welcome to 1667. This story is also the manual, which means you can "
-            + "ruin it freely, and you can delete both starter "
-            + "stories the moment they stop being useful.\n\n"
-            + "Start with the thing that makes this editor different. This paragraph exists in "
-            + "three versions. They are called takes. Press [→] to read the next one, and [←] "
-            + "to come back.\n\n"
-            + "Flipping costs nothing. Every take stays exactly where it is, and the one left "
-            + "on screen is simply the one the story reads as its own."
+            + "Welcome to 1667. This story is a short tour. You can edit or delete both "
+            + "starter stories at any time.\n\n"
+            + "This story part has three takes. A take is an alternative version of one "
+            + "story part. Press [→] to read the next take. Press [←] to return.\n\n"
+            + "1667 keeps every take. The take on screen is part of the selected story line."
         },
         {
           slug: "open-2",
-          instruction: "Second take. Same beat, plainer voice, so the difference is felt.",
+          instruction: "Show that a take changes only one story part.",
           keys: ["takeNext", "takePrevious"],
-          text: "Take two of three.\n\n"
-            + "Same moment in the story, different words for it. That is all a take is: an "
-            + "alternative for one beat, not a fork of the whole book. You will accumulate "
-            + "them without meaning to. Every retake lands here, beside its siblings, "
-            + "rather than on top of them.\n\n"
-            + "Nothing you have read so far was overwritten to show you this. Press [→] for "
-            + "the last one, or [←] to go back."
+          text: "Take two of three covers the same point in different words.\n\n"
+            + "A take changes one story part, "
+            + "not the rest of the story. New retakes appear beside the current take. They "
+            + "do not replace it.\n\n"
+            + "Press [→] for the last take. Press [←] to return."
         },
         {
           slug: "open-3",
-          instruction: "Third take. Close the row and hand the reader downward.",
+          instruction: "Show the end of a take row and introduce tags.",
           tag: { name: "The long way round", status: "Alt" },
           keys: ["takeNext", "takePrevious", "focusNext"],
-          text: "Take three, and the end of the row — [→] stops here, and [←] walks back.\n\n"
-            + "This one has a tag on it, named \"The long way round\". You will see it "
-            + "again in the map later: a tag is how you make one take "
-            + "findable months later, when you have forgotten it existed.\n\n"
-            + "Now go back to the first take with [←]. And then press [↓]."
+          text: "Take three is the last take in this row. [→] stops here, and [←] moves back.\n\n"
+            + "The story line that ends here has the tag \"The long way round\". Tags help "
+            + "you find a story line in the map.\n\n"
+            + "Press [←] until you return to the first take. Then press [↓]."
         }
       ]
     },
@@ -117,15 +111,15 @@ const TOUR: StarterStory = {
       takes: [
         {
           slug: "moving",
-          instruction: "Movement: focus versus viewport.",
+          instruction: "Show how focus and scrolling work.",
           keys: ["focusNext", "focusPrevious", "scrollLineDown", "scrollLineUp", "top", "leaf"],
-          text: "[↓] and [↑] move between parts.\n\n"
-            + "The focused part is highlighted. Tagging, retaking, editing, and deleting "
-            + "all act on it.\n\n"
-            + "Reading is a separate motion. Hold shift and the view slides without dragging "
-            + "focus along: [⇧↓] and [⇧↑] nudge it one line. To travel further, [g] jumps to "
-            + "the top of the story and [G] runs to the end of the story line you are on.\n\n"
-            + "Keep going down."
+          text: "Press [↓] or [↑] to move between story parts.\n\n"
+            + "The focused part is highlighted. Edit, retake, tag, and delete actions apply "
+            + "to that part.\n\n"
+            + "Use [⇧↓] or [⇧↑] to scroll one line without moving the focus. [g] goes to "
+            + "the first story part. [G] goes to the last part of the selected "
+            + "story line.\n\n"
+            + "Press [↓] to continue."
         }
       ]
     },
@@ -133,19 +127,15 @@ const TOUR: StarterStory = {
       takes: [
         {
           slug: "writing",
-          instruction: "Introduce the two ways prose arrives.",
+          instruction: "Show manual writing and model generation.",
           keys: ["continue", "compose", "write", "regenerate", "reprompt"],
-          text: "Prose arrives two ways, and both are one keystroke.\n\n"
-            + "Press [space] to continue from here. No instruction, no ceremony, just carry "
-            + "on. Press [enter] instead when you want to say something first: describe the "
-            + "next beat, then send it.\n\n"
-            + "This install is wired to a dry-run model, so anything you generate comes back "
-            + "as obvious placeholder text rather than a bill. Connect a "
-            + "real model whenever you like. The tour tells you where, further down.\n\n"
-            + "When a result disappoints, [r] retakes it as a new take beside the old "
-            + "one, and [R] retakes it with a fresh instruction. The disappointing version "
-            + "does not vanish; it just stops being the one on screen.\n\n"
-            + "To write in your own hand rather than the model's, press [w]."
+          text: "You can write a take yourself or ask a model to write one.\n\n"
+            + "[w] opens an editor for your own take. [space] asks the selected provider to "
+            + "continue the story. [enter] lets you give a direction before the request.\n\n"
+            + "The tour starts with a dry-run provider. It returns placeholder text and does "
+            + "not contact an external service. You can select a provider later in Settings.\n\n"
+            + "Press [r] to request another take with the same direction. Press [R] to change "
+            + "the direction first. 1667 keeps the earlier take."
         }
       ]
     },
@@ -153,18 +143,15 @@ const TOUR: StarterStory = {
       takes: [
         {
           slug: "revising",
-          instruction: "Editing, undo, and pruning — the destructive end of the keyboard.",
+          instruction: "Show editing, chapter undo, pruning, and saved directions.",
           keys: ["edit", "takePrevious", "undo", "prune", "instructions"],
-          text: "Press [e] to edit the focused part in place. Your changes become a take, so "
-            + "the model's original stays reachable behind [←].\n\n"
-            + "[u] takes back a chapter break you made or removed, and only that. There is no "
-            + "undo for prose, so read the next sentence twice. [D] prunes — it deletes takes "
-            + "and their children, which is how a story that sprawled during a long session "
-            + "gets its shape back. Pruning asks first if you are sure, and [u] will not bring "
-            + "back what it takes.\n\n"
-            + "One more: [p] toggles the instructions that produced each part. Try it here. "
-            + "Every part in this tour carries the note it was written against, which is "
-            + "usually the fastest way to remember what you were trying to do."
+          text: "Press [e] to edit the focused part. By default, 1667 saves the edit as a new "
+            + "take. Press [←] to return to the earlier take.\n\n"
+            + "Press [u] to restore the last chapter break that you added or removed. It does "
+            + "not undo prose changes. Press [D] to delete the focused take and its children. "
+            + "1667 asks for confirmation because the deletion is permanent.\n\n"
+            + "Press [p] to show or hide the saved direction for each story part. The tour "
+            + "includes a direction for every part."
         }
       ]
     },
@@ -173,21 +160,15 @@ const TOUR: StarterStory = {
       takes: [
         {
           slug: "map",
-          instruction: "The map, and why it exists.",
+          instruction: "Show the map views and story-line tags.",
           keys: ["openMap", "mapCycleView", "mapClose", "mapDetail", "mapJump", "mapTag"],
           text: "Press [m] to open the map.\n\n"
-            + "A story with takes is a tree, not a page, and past a few thousand words the "
-            + "tree is the real picture of it. The map draws that tree: the line you "
-            + "are reading, the takes hanging off it, the tags you left behind.\n\n"
-            + "Inside the map, [m] cycles between its views, [esc] closes it, [a] turns "
-            + "detail up or down, and [t] tags whatever row you are on. Press [enter] "
-            + "to jump the story to that row and land back in the text exactly there.\n\n"
-            + "Tags go on the end of a story line, never in the middle: you are naming "
-            + "where a storyline arrived, not annotating a paragraph. Two of them are already out "
-            + "there — one on the take you skipped at the start, one at the end of this tour. "
-            + "Each tag carries a status: Canon, Alt, Draft, Discarded, Summary. Use them "
-            + "loosely — they sort the map, they do not police anything. Name a second line "
-            + "Canon and the first one steps down to Alt, keeping its name."
+            + "The map shows the selected story line, the other takes, and the tags. [m] "
+            + "changes the map view. [a] changes the detail level. [enter] opens the selected "
+            + "story part. [esc] closes the map.\n\n"
+            + "Press [t] to tag the selected story line. A tag has a name and one status: "
+            + "Canon, Alt, Draft, Discarded, or Summary. A story can have only one Canon line. "
+            + "If you set a second line to Canon, the first line becomes Alt."
         }
       ]
     },
@@ -195,16 +176,13 @@ const TOUR: StarterStory = {
       takes: [
         {
           slug: "chapters",
-          instruction: "Chapters as context boundaries, not decoration.",
+          instruction: "Show chapter navigation and chapter context.",
           keys: ["openChapters", "createChapter"],
-          text: "You crossed a chapter break a moment ago: the part about the map opens a "
-            + "chapter called \"The Map\", and you are inside it now.\n\n"
-            + "Press [c] to see the chapters in this story, and [C] to start a new one at the "
-            + "focused part. Chapters are not decoration. They bound what gets sent to the "
-            + "model, so a long book stays affordable: earlier chapters can be summarised "
-            + "once and then travel as a summary rather than as forty thousand words.\n\n"
-            + "For a story this short you will never need them. For the one you are about to "
-            + "write, you will."
+          text: "The previous story part starts a chapter named \"The Map\".\n\n"
+            + "Press [c] to open the Chapters view. Press [C] to start a chapter at the "
+            + "focused part.\n\n"
+            + "Chapters also organize provider context. 1667 can use a summary for an earlier "
+            + "chapter instead of sending all of its prose. Add chapters as your story grows."
         }
       ]
     },
@@ -212,26 +190,17 @@ const TOUR: StarterStory = {
       takes: [
         {
           slug: "elsewhere",
-          instruction: "The remaining overlays, briefly, without drowning the reader.",
+          instruction: "Show the main panels and references.",
           keys: ["openLibrary", "openFacts", "actions", "commands", "settings", "keys"],
-          text: "The rest of the surface, quickly.\n\n"
-            + "[o] opens the library — every story you have, including the second starter "
-            + "story sitting next to this one. That is how you switch.\n\n"
-            + "[f] holds facts: the names, places, and rules you want kept straight, sent "
-            + "with every request that writes prose so the model stops renaming your "
-            + "characters. A fact can "
-            + "carry a tag of its own: a short word for sorting your facts, which is a "
-            + "different thing from tagging a story line back in the map. There are a few "
-            + "in here already, and the hedge story next door keeps the kind you will "
-            + "actually write.\n\n"
-            + "[x] opens a menu of whatever applies to the focused part, for the days you "
-            + "would rather point than recall. [:] is the command palette, which can reach "
-            + "things no key is bound to.\n\n"
-            + "[,] opens settings — that is where you connect a real model in place of the "
-            + "dry-run one.\n\n"
-            + "And [?] is the key reference: the keys grouped by what they are for, each "
-            + "beside a line saying what it does. If you remember one key from this tour, "
-            + "remember that one."
+          text: "Press [o] to open the Library and select another story. The Library includes "
+            + "the second starter story.\n\n"
+            + "Press [f] to open Facts. Use Facts for names, places, items, and rules that a "
+            + "provider can use when it writes prose. A Fact tag sorts Facts. It is separate "
+            + "from a story-line tag. Both starter stories include examples.\n\n"
+            + "Press [x] to show actions for the focused story part. Press [:] to open the "
+            + "command palette.\n\n"
+            + "Press [,] to open Settings and select a provider.\n\n"
+            + "Press [?] to open the complete key reference."
         }
       ]
     },
@@ -239,67 +208,63 @@ const TOUR: StarterStory = {
       takes: [
         {
           slug: "ending",
-          instruction: "Close the tour. Give explicit permission to delete it.",
+          instruction: "Explain how to remove the tour and select a provider.",
           tag: { name: "End of the tour", status: "Canon" },
           keys: ["openLibrary", "deleteStory", "settings"],
-          text: "This is the end of the tour. You can now delete the onboarding stories by "
-            + "pressing [o] and [D].\n\n"
-            + "Then set up your own model connection in the settings [,] under the "
-            + "\"connection\" -> \"provider\"."
+          text: "The tour is complete.\n\n"
+            + "To delete a starter story, press [o]. Select the story, then press [D].\n\n"
+            + "To connect a model, press [,]. Open Connection, then select a Provider. You do "
+            + "not need a provider to write or edit your own takes."
         },
         {
           slug: "ending-alt",
-          instruction: "A shorter goodbye, kept as a second take so the last beat also has a row.",
+          instruction: "End with a short key reminder.",
           tag: { name: "Short goodbye", status: "Draft" },
           keys: ["keys"],
-          text: "Arrows move. Space continues. Everything else is on [?].\n\n"
-            + "Delete this story whenever you like."
+          text: "Use the arrow keys to move. Press Space to request a continuation. Press [?] "
+            + "to see every key.\n\nDelete this story when you no longer need it."
         }
       ]
     }
   ],
-  // The tour's facts describe the instrument, because the tour is the manual and
-  // a fact must be true of the story that carries it. The hedge story next door
-  // carries the other kind, which is the kind the reader will write.
+  // The tour's facts explain Facts. The second starter story shows Facts for
+  // fictional people, places, and rules.
   facts: [
     {
       slug: "fixed-context",
       tag: "how facts work",
-      text: "Facts are fixed context\n"
-        + "Every fact in this list travels with every request that writes prose, whole and "
-        + "unsummarised. That is what keeps a name spelled the same way in chapter nine as in "
-        + "chapter one. Chapter summaries are the exception: they are written from the prose "
-        + "alone, so nothing you record here can bend a recap of what already happened."
+      text: "Facts can enter provider context\n"
+        + "An always-active Fact enters each continuation and rewrite request. A keyed Fact "
+        + "enters a request only when the context matches one of its keys. 1667 sends each "
+        + "included Fact as one complete block."
     },
     {
       slug: "fact-shape",
       tag: "how facts work",
       text: "The first line is the name\n"
-        + "A fact is one block of text. Its first line names it in this list, and the lines "
-        + "under it are the body. Short name, specific body."
+        + "A Fact is one block of text. The first line names the Fact in this list. The other "
+        + "lines contain its details."
     },
     {
       slug: "fact-tag",
       tag: "how facts work",
-      text: "A tag sorts this list, and the model reads it\n"
-        + "The tag on a fact fills the chips at the top of this overlay, and it travels beside "
-        + "the fact in every request. A tag like \"rules\" tells the model what kind of thing it "
-        + "is holding, so write tags you would be content to have read back to you. It is a "
-        + "different thing from the tag you leave on a story line in the map."
+      text: "A Fact tag sorts the list\n"
+        + "A Fact tag creates a filter at the top of the Facts panel. It can also enter a "
+        + "provider request with the Fact. A Fact tag is separate from a story-line tag."
     },
     {
       slug: "fact-cost",
       tag: "upkeep",
-      text: "A fact you never need is one you pay for every time\n"
-        + "Facts are the one part of the prompt that never gets shorter as the book grows. "
-        + "Prune this list the way you prune takes."
+      text: "Remove Facts that you no longer need\n"
+        + "Each included Fact uses part of the provider context. Use activation keys, "
+        + "priorities, and budgets to control which Facts 1667 includes."
     },
     {
       slug: "fact-examples",
       tag: "upkeep",
-      text: "These are examples\n"
-        + "Delete them once the shape is obvious. Facts belong to one story, so removing these "
-        + "leaves the hedge story's own facts where they are."
+      text: "Delete these example Facts when you are ready\n"
+        + "Facts belong to one story. Deleting these Facts does not change the Facts in the "
+        + "second starter story."
     }
   ]
 };
@@ -313,48 +278,46 @@ const SEED: StarterStory = {
         {
           slug: "hedge",
           instruction: "Continue the story.",
-          text: "The hedge had been there longer than the house, and the door had been in the "
-            + "hedge longer than either — a low green door, latched, with hinges that nobody "
-            + "living remembered oiling.\n\n"
-            + "Every gardener since the war had trimmed around it. None of them had opened "
-            + "it. This was not superstition exactly. It was more that opening it had never "
-            + "once been the most pressing thing to do that afternoon, and afternoons, as "
-            + "everyone knows, are how a life gets spent.\n\n"
-            + "This morning the latch was on the wrong side."
+          text: "The hedge was older than the house. A low green door sat inside it, latched "
+            + "and half-covered by leaves. No one alive remembered oiling its hinges.\n\n"
+            + "Every gardener since the war had trimmed around the door. None had opened it. "
+            + "There was always work to finish before sunset, and the door could wait until "
+            + "tomorrow.\n\n"
+            + "This morning, the latch was on the wrong side."
         }
       ]
     }
   ],
-  // Written the way a reader's own facts should read: what the model must not
-  // get wrong about a story that is one paragraph old.
+  // These Facts show the form that writers can use for fictional reference
+  // material.
   facts: [
     {
       slug: "hedge",
       tag: "places",
       text: "The hedge\n"
-        + "Older than the house. Every gardener since the war has trimmed around it, and none "
-        + "has cut it back far enough to find where it ends."
+        + "The hedge is older than the house. Every gardener since the war has trimmed around "
+        + "it. No one has cut it back far enough to find where it ends."
     },
     {
       slug: "door",
       tag: "places",
       text: "The green door\n"
-        + "Low, latched, set into the hedge. The hinges have not been oiled in living memory. "
-        + "The latch was on the garden side until this morning."
+        + "The door is low, latched, and half-covered by leaves. Its hinges have not been "
+        + "oiled in living memory. The latch was on the garden side until this morning."
     },
     {
       slug: "gardener",
       tag: "people",
       text: "The gardener\n"
-        + "The latest of a line of them. Trims around the door twice a year. Has never opened it, "
-        + "and does not think of this as a decision."
+        + "The current gardener trims around the door twice each year. The gardener has never "
+        + "opened it and does not think of this as a decision."
     },
     {
       slug: "house-habit",
       tag: "rules",
-      text: "Nobody in the house discusses the door\n"
-        + "This is habit, not fear. Opening it has never once been the most pressing thing to do "
-        + "that afternoon. Write it that way: no one warns anybody."
+      text: "No one in the house discusses the door\n"
+        + "The people in the house are busy, not afraid. No one warns the gardener about the "
+        + "door."
     }
   ]
 };

--- a/tui/test/starter-vault-keys.test.ts
+++ b/tui/test/starter-vault-keys.test.ts
@@ -73,7 +73,7 @@ describe("starter vault key contract", () => {
     // that confidently describes a removed screen is the same failure as
     // teaching a rebound key.
     const prose = starterProse().map((entry) => entry.text).join("\n");
-    expect(prose).toContain("[?] is the key reference");
+    expect(prose).toContain("Press [?] to open the complete key reference.");
     expect(prose).not.toContain("keyboard");
   });
 


### PR DESCRIPTION
## Outcome

Makes the README and starter tour easier to read. Adds a direct guide for writers who do not want to use a model provider.

## Changes

- Rewrites the README around reader tasks.
- Replaces internal, vague, and decorative starter-tour copy with short instructions.
- Corrects the starter Facts explanation for activation keys and budgets.
- Adds the write-without-a-model guide.

## Verification

- `npm run typecheck`
- `npm test` — 3,008 tests; 2,781 passed; 227 skipped
- `bun run typecheck` in `tui/`
- `bun run test` in `tui/` — all 16 shards passed
- Slopless 0.2.36 — zero findings for README, guide, and extracted starter prose
- `git diff --check`

## Risk

Copy-only product changes. Key bindings and starter data structure are unchanged.

Closes #257