### PR TITLE
fix: automate Windows beta upgrades

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -255,6 +255,8 @@ jobs:
         run: >-
           bun test --timeout 30000
           test/upgrade-cli.test.ts
+          test/windows-powershell-upgrade.test.ts
+          test/windows-powershell-upgrade-recovery.test.ts
           test/install-ownership-authority.test.ts
           test/clipboard-command-runner.test.ts
           test/clipboard-windows.test.ts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,6 +257,7 @@ jobs:
           test/upgrade-cli.test.ts
           test/windows-powershell-upgrade.test.ts
           test/windows-powershell-upgrade-recovery.test.ts
+          test/windows-powershell-upgrade-compat.test.ts
           test/install-ownership-authority.test.ts
           test/clipboard-command-runner.test.ts
           test/clipboard-windows.test.ts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This file records notable changes to 1667. Product terms use the definitions in
 
 ## Unreleased
 
+- **Windows beta upgrades now use one command.** Run
+  `1667.exe upgrade --channel beta`. 1667 verifies the release and starts a
+  local update process. Windows installs the release after the command exits.
+  The user does not download or attest an Installer.
 - **Windows installation shows the exact start command.** The PowerShell
   Installer tells the user to open a new PowerShell window and run `1667.exe`.
   It warns that `1667` without `.exe` does not start the app.

--- a/README.md
+++ b/README.md
@@ -85,9 +85,25 @@ Installer supports macOS and Linux. The PowerShell Installer supports Windows
 x64.
 
 Run `1667 upgrade` to update a Managed Installation that the Shell Installer
-created. The command shows download progress in a terminal. On Windows, exit
-1667 and run the PowerShell Installer again. The Installer shows download
-progress. `1667 upgrade` shows the required command.
+created. The command shows download progress in a terminal.
+
+On Windows, run this command to switch to the beta channel and install its
+current release:
+
+```powershell
+1667.exe upgrade --channel beta
+```
+
+1667 downloads and verifies the beta release. It starts a local update
+process. Windows replaces the locked `1667.exe` file after the command exits.
+Wait for the update to finish. Then start `1667.exe` again. You do not need a
+separate Installer download or attestation command.
+
+If the saved channel is stable, run `1667.exe upgrade` for a stable Windows
+update. To switch from beta to stable, run
+`1667.exe upgrade --channel stable`. 1667 shows the applicable PowerShell
+Installer command. Exit 1667 before you run that command. The Installer shows
+download progress.
 
 Run the Shell Installer again to update a valid Shell Managed Installation. It
 preserves the `installationId`, keeps the previous executable for rollback,

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -573,14 +573,20 @@ Package.
 
 `1667 upgrade --rollback` works offline.
 
-Windows does not replace the running `1667.exe` file. On Windows, `1667 upgrade`
-verifies the available release and shows the applicable PowerShell Installer
-command. The command downloads `install-<channel>.ps1` from the exact, immutable
-`v<version>` GitHub release that the plan selected; it does not re-resolve the
-moving homepage route. Exit 1667 before you run that command. Run the same
-command again for an upgrade. The PowerShell Installer keeps the Installation
-ID. The PowerShell Installer shows archive download progress. Windows does not
-support `1667 upgrade --rollback`.
+Windows does not replace the running `1667.exe` file. A beta upgrade downloads
+the Platform Package from the canonical npm registry. 1667 verifies the
+SHA-512 integrity value and the Candidate build identity. It starts a local
+PowerShell update process. The process waits for the running executable to
+exit. It verifies the Candidate again and replaces `1667.exe`. A channel switch
+updates the Ownership Record. The user does not download or attest an
+Installer.
+
+A stable Windows upgrade shows the applicable PowerShell Installer command.
+The command downloads `install-stable.ps1` from the exact, immutable
+`v<version>` GitHub release that the plan selected. It does not re-resolve the
+moving homepage route. Exit 1667 before you run that command. The PowerShell
+Installer keeps the Installation ID. The PowerShell Installer shows archive
+download progress. Windows does not support `1667 upgrade --rollback`.
 
 Background update checks are on by default. A user can turn them off in
 Settings. The check reads public package metadata from the npm registry. It

--- a/scripts/release-install-upgrade-e2e-verify.ts
+++ b/scripts/release-install-upgrade-e2e-verify.ts
@@ -88,7 +88,7 @@ export function assertEnvelope(
       `${label} envelope command is ${JSON.stringify(env.command)}, expected null.`
     );
   }
-  const restartRequired = env.status === "applied";
+  const restartRequired = env.status === "applied" || env.status === "staged";
   if (env.restartRequired !== restartRequired) {
     throw new StepError(
       stepNum,

--- a/shared/release-tar-extract.ts
+++ b/shared/release-tar-extract.ts
@@ -27,7 +27,10 @@ import {
   validatePlatformPackageInspection,
   type ValidatedPlatformPackage
 } from "./platform-package-policy.js";
-import type { PublishedPlatformPackage } from "./release-targets.js";
+import {
+  releaseTargetForPackage,
+  type PublishedPlatformPackage
+} from "./release-targets.js";
 import type { TarballEntry } from "./release-package-layout.js";
 import {
   UstarStreamParser,
@@ -81,7 +84,18 @@ export async function extractPlatformPackageExecutable(
   const gzipSha256 = createHash("sha256");
   const gzipSha512 = createHash("sha512");
   let gzipBytes = 0;
-  const sinkState = createExtractSink(stagingPath, maximumExecutableBytes);
+  const target = releaseTargetForPackage(options.packageName);
+  if (target === null || target.heldFromPublication !== null) {
+    throw tarError("Release package target is not published");
+  }
+  const packageExecutablePath = `package/${target.executable}`;
+  const packageExecutableMode = target.executable.endsWith(".exe") ? 0o644 : 0o755;
+  const sinkState = createExtractSink(
+    stagingPath,
+    maximumExecutableBytes,
+    packageExecutablePath,
+    packageExecutableMode
+  );
   const parser = new UstarStreamParser({
     maximumExpandedBytes: MAX_RELEASE_ARTIFACT_TAR_BYTES,
     maximumEntries: MAX_RELEASE_ARTIFACT_ENTRIES,
@@ -180,7 +194,9 @@ export function integrityMatches(integrity: string, sha512Hex: string): boolean 
 
 function createExtractSink(
   destinationPath: string,
-  maximumExecutableBytes: number
+  maximumExecutableBytes: number,
+  expectedExecutablePath: string,
+  expectedExecutableMode: 0o644 | 0o755
 ): {
   onEntryStart(entry: UstarEntry): void;
   onBody(entry: UstarEntry, chunk: Uint8Array): void;
@@ -215,8 +231,8 @@ function createExtractSink(
         throw tarError(`Tarball ${entry.path} is outside the size bound`);
       }
       if (entry.type === "file"
-        && entry.path.startsWith("package/bin/")
-        && entry.mode === 0o755) {
+        && entry.path === expectedExecutablePath
+        && entry.mode === expectedExecutableMode) {
         if (packageExecutablePath !== null) {
           throw tarError("Package contains more than one executable");
         }

--- a/shared/safe-file-write.ts
+++ b/shared/safe-file-write.ts
@@ -109,7 +109,9 @@ export function closeAndFsync(fd: number, path: string): void {
 }
 
 export function fsyncPath(path: string): void {
-  const fd = openSync(path, "r");
+  // Bun on Windows rejects fsync for a read-only handle. These paths are
+  // owned writable staging or destination files.
+  const fd = openSync(path, process.platform === "win32" ? "r+" : "r");
   try {
     fsyncSync(fd);
   } finally {

--- a/tui/src/upgrade-cli.ts
+++ b/tui/src/upgrade-cli.ts
@@ -45,6 +45,15 @@ import {
   type UpgradeObservation,
   type UpgradeRegistry
 } from "./upgrade-plan.js";
+import { applyPowerShellBetaUpgrade } from "./windows-upgrade-apply.js";
+import type {
+  WindowsUpgradeChannelSaver,
+  WindowsUpgradeHandoffStarter
+} from "./windows-upgrade-handoff.js";
+import {
+  recoverWindowsUpgradeFailure,
+  type WindowsUpgradeFailureRecoverer
+} from "./windows-upgrade-recovery.js";
 
 export {
   formatUpgradeApplyCommand,
@@ -66,7 +75,7 @@ export const UPGRADE_HELP = `Usage:
   1667 upgrade --rollback [--json] [--force]
 
 --force accepts an Install Root that another account on this machine can write.
-It waives no checksum, attestation, or version check.
+It waives no package verification or version check.
 
 --version selects one exact published release. It can downgrade 1667.
 ${DOWNGRADE_WARNING.trimEnd()}
@@ -76,7 +85,8 @@ ${DOWNGRADE_WARNING.trimEnd()}
 
 If you installed 1667 with npm, or you built it from source, update it the same
 way you installed it.
-On Windows, a PowerShell installation updates through the PowerShell Installer.`;
+On Windows, run 1667.exe. Beta upgrades are automatic. Stable upgrades use the
+PowerShell Installer.`;
 
 export function windowsInstallCommand(
   installRoot: string,
@@ -106,9 +116,6 @@ export function windowsInstallCommand(
 
 const INSTRUCTIONS_ORIGIN =
   `https://www.npmjs.com/package/${RELEASE_LAUNCHER_PACKAGE}/v`;
-const NPM_RELEASE_SIGNER = "1667-ai/1667/.github/workflows/release-npm.yml";
-const LEGACY_RELEASE_SIGNER = "1667-ai/1667/.github/workflows/release-github.yml";
-
 export interface UpgradeCliDependencies {
   readonly observation?: UpgradeObservation;
   readonly registry?: UpgradeRegistry;
@@ -119,6 +126,9 @@ export interface UpgradeCliDependencies {
   readonly defaultChannel?: UpgradeChannel;
   readonly onDownloadProgress?: PackageDownloadProgressHandler;
   readonly onDowngradeWarning?: (warning: string) => void;
+  readonly startWindowsUpgradeHandoff?: WindowsUpgradeHandoffStarter;
+  readonly saveWindowsUpgradeChannel?: WindowsUpgradeChannelSaver;
+  readonly recoverWindowsUpgradeFailure?: WindowsUpgradeFailureRecoverer;
 }
 
 export interface UpgradeCliOutput {
@@ -204,14 +214,42 @@ export async function executeUpgradeCli(
   }
   const method = authorityMethod(authority);
   const downgradeWarnings: string[] = [];
+  const recoveryWarnings: string[] = [];
   const onDowngradeWarning = dependencies.onDowngradeWarning
     ?? ((warning: string) => downgradeWarnings.push(warning));
   try {
+    if (parsed.command.kind === "apply" && authority.kind === "powershell") {
+      const recoverer = dependencies.recoverWindowsUpgradeFailure
+        ?? (process.platform === "win32" ? recoverWindowsUpgradeFailure : undefined);
+      if (recoverer !== undefined) {
+        let previousFailure: string | null;
+        try {
+          previousFailure = await recoverer(authority);
+        } catch (error) {
+          const detail = error instanceof Error && error.message.length > 0
+            ? ` ${error.message}`
+            : "";
+          throw new UpgradeFailure(
+            "internal_error",
+            `Could not recover the previous Windows upgrade.${detail}`,
+            true
+          );
+        }
+        if (previousFailure !== null) {
+          const message = previousFailure.endsWith(".")
+            ? previousFailure
+            : `${previousFailure}.`;
+          recoveryWarnings.push(
+            `Warning: Previous Windows upgrade did not finish: ${message} `
+              + "Continuing with this upgrade command.\n"
+          );
+        }
+      }
+    }
     const envelope = await dispatchUpgradeCommand(
       parsed.command,
       authority,
       observation,
-      method,
       registry,
       dependencies,
       parsed.force,
@@ -223,7 +261,7 @@ export async function executeUpgradeCli(
       stdout: parsed.json
         ? `${JSON.stringify(envelope)}\n`
         : renderUpgrade(envelope, parsed.command),
-      stderr: downgradeWarnings.join(""),
+      stderr: recoveryWarnings.join("") + downgradeWarnings.join(""),
       envelope
     };
   } catch (error) {
@@ -237,9 +275,10 @@ export async function executeUpgradeCli(
       method,
       exitCode
     );
-    return downgradeWarnings.length === 0
+    const warnings = recoveryWarnings.join("") + downgradeWarnings.join("");
+    return warnings.length === 0
       ? output
-      : { ...output, stderr: downgradeWarnings.join("") + output.stderr };
+      : { ...output, stderr: warnings + output.stderr };
   }
 }
 
@@ -247,7 +286,6 @@ async function dispatchUpgradeCommand(
   command: UpgradeCommand,
   authority: InstallationAuthority,
   observation: UpgradeObservation,
-  method: UpgradeMethod,
   registry: UpgradeRegistry,
   dependencies: UpgradeCliDependencies,
   force: boolean,
@@ -259,19 +297,10 @@ async function dispatchUpgradeCommand(
       throw new UpgradeFailure("internal_error", "The release list was not handled.");
     case "rollback": {
       if (authority.kind === "powershell") {
-        if (authority.channel === "beta") {
-          throw new UpgradeFailure(
-            "unsupported_target",
-            "Windows rollback is unavailable.\n"
-              + betaInstallerGuidance(observation.currentVersion, authority.installRoot)
-          );
-        }
         throw new UpgradeFailure(
           "unsupported_target",
           "Windows rollback is unavailable. "
-          + "A Windows PowerShell installation updates through the PowerShell Installer. "
-          + "To install it, run:\n"
-          + windowsInstallCommand(authority.installRoot)
+          + "Run '1667.exe upgrade --list' to select an exact release."
         );
       }
       if (authority.kind !== "shell") {
@@ -309,6 +338,21 @@ async function dispatchUpgradeCommand(
           force
         });
       }
+      if (authority.kind === "powershell"
+        && powerShellTargetRequiresBeta(command, authority.channel)) {
+        return await applyPowerShellBetaUpgrade(command, {
+          authority,
+          observation,
+          registry,
+          fetcher: dependencies.fetcher,
+          signal: dependencies.signal,
+          onDownloadProgress,
+          onDowngradeWarning,
+          downgradeWarning: DOWNGRADE_WARNING,
+          startHandoff: dependencies.startWindowsUpgradeHandoff,
+          saveChannel: dependencies.saveWindowsUpgradeChannel
+        });
+      }
       // External installs stay read-only: verify metadata, emit manual envelope.
       const plan = await planUpgrade(
         command,
@@ -320,24 +364,6 @@ async function dispatchUpgradeCommand(
         && authority.kind === "powershell"
         && command.channel !== authority.channel;
       warnIfDowngrade(plan, onDowngradeWarning);
-      if (authority.kind === "powershell"
-        && command.version === null
-        && (plan.status !== "up-to-date" || channelSwitch)
-      ) {
-        requireServableWindowsChannel(
-          plan.channel,
-          plan.status === "up-to-date" ? plan.latest : plan.target,
-          authority.installRoot
-        );
-      }
-      if (method === "powershell"
-        && command.version !== null
-        && plan.status !== "up-to-date"
-        && authority.kind === "powershell"
-        && windowsInstallerChannel(plan.target, authority.channel) === "beta"
-      ) {
-        throwBetaWindowsGuidance(plan.target, authority.installRoot);
-      }
       return publicEnvelopeFromPlan(
         plan,
         authority,
@@ -431,60 +457,6 @@ export function publicEnvelopeFromPlan(
   });
 }
 
-/**
- * `https://1667.ai/install.ps1` serves the promoted stable release. A beta
- * Installer must come from its immutable release and pass attestation before a
- * user runs it.
- */
-function requireServableWindowsChannel(
-  channel: UpgradeChannel,
-  targetVersion?: string | null,
-  installRoot?: string
-): void {
-  if (channel === "stable") return;
-  const guidance = targetVersion === undefined || targetVersion === null
-    ? "Select a beta version, then download and attest its release Installer before you run it."
-    : betaInstallerGuidance(targetVersion, installRoot);
-  throw new UpgradeFailure(
-    "unsupported_target",
-    "The standard Windows Installer URL supports stable releases only.\n" + guidance
-  );
-}
-
-function throwBetaWindowsGuidance(
-  targetVersion: string,
-  installRoot: string
-): never {
-  throw new UpgradeFailure(
-    "unsupported_target",
-    `1667 ${targetVersion} requires the beta PowerShell Installer.\n`
-      + betaInstallerGuidance(targetVersion, installRoot)
-  );
-}
-
-function betaInstallerGuidance(targetVersion: string, installRoot?: string): string {
-  const installCommand = installRoot === undefined
-    ? "powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\\install-beta.ps1"
-    : "powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\\install-beta.ps1"
-      + ` -InstallRoot '${installRoot.replaceAll("'", "''")}'`;
-  return `To install 1667 ${targetVersion}, download this release Installer:\n`
-    + `${windowsInstallerUrl(targetVersion, "beta")}\n`
-    + `gh release download v${targetVersion} --repo 1667-ai/1667 `
-    + "--pattern install-beta.ps1 --output .\\install-beta.ps1\n"
-    + "Verify it with the current release workflow:\n"
-    + betaAttestationCommand(NPM_RELEASE_SIGNER) + "\n"
-    + "For an older beta release, use this command if the first command cannot find an attestation:\n"
-    + betaAttestationCommand(LEGACY_RELEASE_SIGNER) + "\n"
-    + "The beta Installer sets the saved channel to beta.\n"
-    + "Run the verified Installer:\n"
-    + installCommand;
-}
-
-function betaAttestationCommand(signerWorkflow: string): string {
-  return "gh attestation verify .\\install-beta.ps1 --repo 1667-ai/1667 "
-    + `--signer-workflow ${signerWorkflow} --deny-self-hosted-runners`;
-}
-
 export async function runProcessUpgrade(
   argv: readonly string[],
   fetcher?: RegistryFetch
@@ -547,6 +519,9 @@ function renderUpgrade(
             : `Upgraded 1667 from ${envelope.current} to ${envelope.target}.`
       );
       break;
+    case "staged":
+      lines.push(`1667 ${envelope.target} is verified and staged.`);
+      break;
     case "available":
     case "manual":
       lines.push(
@@ -557,7 +532,12 @@ function renderUpgrade(
       break;
   }
   if (envelope.restartRequired) {
-    lines.push("Restart 1667 to run the new version.");
+    lines.push(
+      envelope.method === "powershell"
+        ? "Windows will finish the upgrade after this command exits. "
+          + "Start 1667.exe again after it finishes."
+        : "Restart 1667 to run the new version."
+    );
   }
   if (command.kind === "check") {
     if (envelope.status === "manual") {
@@ -569,14 +549,17 @@ function renderUpgrade(
     } else if (envelope.status === "available") {
       lines.push(
         envelope.method === "powershell"
-          ? "A Windows PowerShell installation updates through the PowerShell Installer."
-            + ` Run '1667 upgrade --channel ${envelope.channel}' for installation instructions.`
+          ? envelope.channel === "beta"
+            ? "Run '1667.exe upgrade --channel beta'. "
+              + "1667 verifies the release and starts the Windows update automatically."
+            : "A Windows PowerShell installation updates through the PowerShell Installer."
+              + ` Run '1667.exe upgrade --channel ${envelope.channel}' to install it.`
           : "Run '1667 upgrade' to install it."
       );
     }
     return `${lines.join("\n")}\n`;
   }
-  if (envelope.status === "applied") {
+  if (envelope.status === "applied" || envelope.status === "staged") {
     return `${lines.join("\n")}\n`;
   }
   if (envelope.status === "manual") {
@@ -600,7 +583,7 @@ function appendPowerShellGuidance(
     lines.push("Selecting an exact version does not change your saved channel.");
   }
   if (envelope.command === null) {
-    lines.push("Run '1667 upgrade --channel beta' for installation instructions.");
+    lines.push("Run '1667.exe upgrade --channel beta' to install it.");
     return;
   }
   lines.push("To install it, run:");
@@ -616,10 +599,13 @@ function windowsInstallerChannel(
   return parsed.prerelease.length > 0 ? "beta" : channel;
 }
 
-function windowsInstallerUrl(targetVersion: string, channel: UpgradeChannel): string {
-  return `https://github.com/1667-ai/1667/releases/download/v${
-    encodeURIComponent(targetVersion)
-  }/install-${windowsInstallerChannel(targetVersion, channel)}.ps1`;
+function powerShellTargetRequiresBeta(
+  command: Extract<UpgradeCommand, { kind: "apply" }>,
+  savedChannel: UpgradeChannel
+): boolean {
+  return command.version === null
+    ? command.channel === "beta"
+    : windowsInstallerChannel(command.version, savedChannel) === "beta";
 }
 
 function authorityMethod(authority: InstallationAuthority): UpgradeMethod {

--- a/tui/src/upgrade-contract.ts
+++ b/tui/src/upgrade-contract.ts
@@ -73,11 +73,20 @@ export interface UpgradeAppliedEnvelope extends UpgradeSuccessEnvelopeBase {
   restartRequired: true;
 }
 
+/** A verified Windows candidate that the local helper applies after process exit. */
+export interface UpgradeStagedEnvelope extends UpgradeSuccessEnvelopeBase {
+  status: "staged";
+  method: "powershell";
+  target: string;
+  restartRequired: true;
+}
+
 export type UpgradeSuccessEnvelope =
   | UpgradeUpToDateEnvelope
   | UpgradeManualEnvelope
   | UpgradeAvailableEnvelope
-  | UpgradeAppliedEnvelope;
+  | UpgradeAppliedEnvelope
+  | UpgradeStagedEnvelope;
 
 export interface UpgradeErrorEnvelope extends UpgradeEnvelopeBase {
   status: "error";
@@ -143,7 +152,27 @@ export function upgradeEnvelope(
         target: string;
         channel: UpgradeChannel;
       }
+    | {
+        status: "staged";
+        current: string;
+        latest: string;
+        target: string;
+        channel: UpgradeChannel;
+      }
 ): UpgradeSuccessEnvelope {
+  if (values.status === "staged") {
+    return {
+      status: "staged",
+      current: values.current,
+      latest: values.latest,
+      target: values.target,
+      channel: values.channel,
+      method: "powershell",
+      restartRequired: true,
+      command: null,
+      error: null
+    };
+  }
   if (values.status === "applied") {
     return {
       status: "applied",

--- a/tui/src/windows-upgrade-apply.ts
+++ b/tui/src/windows-upgrade-apply.ts
@@ -1,0 +1,163 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import path from "node:path";
+import { compareSemVer } from "../../shared/semver.js";
+import type { InstallationAuthority } from "./install-ownership.js";
+import type { RegistryFetch } from "./npm-upgrade-registry.js";
+import type { UpgradeApplyCommand } from "./upgrade-command.js";
+import {
+  UpgradeFailure,
+  upgradeEnvelope,
+  type UpgradeSuccessEnvelope
+} from "./upgrade-contract.js";
+import { materializeCandidate } from "./upgrade-candidate.js";
+import {
+  downloadPlatformPackage,
+  type PackageDownloadProgressHandler
+} from "./upgrade-download.js";
+import {
+  planUpgrade,
+  type UpgradeObservation,
+  type UpgradeRegistry
+} from "./upgrade-plan.js";
+import {
+  saveWindowsUpgradeChannel,
+  sha256File,
+  startWindowsUpgradeHandoff,
+  type WindowsUpgradeChannelSaver,
+  type WindowsUpgradeHandoffStarter
+} from "./windows-upgrade-handoff.js";
+
+export interface PowerShellUpgradeDependencies {
+  readonly authority: Extract<InstallationAuthority, { kind: "powershell" }>;
+  readonly observation: UpgradeObservation;
+  readonly registry: UpgradeRegistry;
+  readonly fetcher?: RegistryFetch;
+  readonly signal?: AbortSignal;
+  readonly onDownloadProgress?: PackageDownloadProgressHandler;
+  readonly onDowngradeWarning: (warning: string) => void;
+  readonly downgradeWarning: string;
+  readonly startHandoff?: WindowsUpgradeHandoffStarter;
+  readonly saveChannel?: WindowsUpgradeChannelSaver;
+}
+
+/**
+ * Verify and stage a beta candidate before a local helper replaces the locked
+ * Windows executable after this process exits.
+ */
+export async function applyPowerShellBetaUpgrade(
+  command: UpgradeApplyCommand,
+  dependencies: PowerShellUpgradeDependencies
+): Promise<UpgradeSuccessEnvelope> {
+  const signal = dependencies.signal ?? new AbortController().signal;
+  const plan = await planUpgrade(
+    command,
+    dependencies.observation,
+    dependencies.registry,
+    signal
+  );
+  const channelSwitch = command.version === null
+    && command.channel !== dependencies.authority.channel;
+  if (plan.status === "up-to-date") {
+    if (channelSwitch) {
+      try {
+        await (dependencies.saveChannel ?? saveWindowsUpgradeChannel)(
+          dependencies.authority,
+          command.channel
+        );
+      } catch (error) {
+        if (error instanceof UpgradeFailure) throw error;
+        const detail = error instanceof Error && error.message.length > 0
+          ? ` ${error.message}`
+          : "";
+        throw new UpgradeFailure(
+          "internal_error",
+          `Could not save the ${command.channel} update channel.${detail}`
+        );
+      }
+    }
+    return upgradeEnvelope({
+      status: "up-to-date",
+      current: plan.current,
+      latest: plan.latest,
+      target: null,
+      channel: plan.channel,
+      method: "powershell"
+    });
+  }
+
+  const targetVersion = plan.target;
+  const platformMetadata = plan.platformMetadata;
+  if (compareSemVer(targetVersion, plan.current) < 0) {
+    dependencies.onDowngradeWarning(dependencies.downgradeWarning);
+  }
+
+  let workRoot: string;
+  try {
+    workRoot = mkdtempSync(path.join(
+      dependencies.authority.installRoot,
+      ".1667-upgrade."
+    ));
+  } catch {
+    throw new UpgradeFailure("internal_error", "Could not prepare the Windows upgrade.");
+  }
+  const packagePath = path.join(workRoot, "release-package.tgz");
+  const candidatePath = path.join(workRoot, "1667-candidate.exe");
+  let handedOff = false;
+  try {
+    await downloadPlatformPackage({
+      tarballUrl: platformMetadata.tarball,
+      packageName: dependencies.observation.platformPackage,
+      version: targetVersion,
+      integrity: platformMetadata.integrity,
+      destinationPath: packagePath,
+      signal,
+      fetcher: dependencies.fetcher,
+      onProgress: dependencies.onDownloadProgress
+    });
+    await materializeCandidate({
+      packagePath,
+      destinationPath: candidatePath,
+      packageName: dependencies.observation.platformPackage,
+      version: targetVersion,
+      signal
+    });
+    const candidateSha256 = await sha256File(candidatePath);
+    if (signal.aborted) {
+      throw new UpgradeFailure("interrupted", "The update was interrupted.");
+    }
+    try {
+      await (dependencies.startHandoff ?? startWindowsUpgradeHandoff)({
+        authority: dependencies.authority,
+        currentVersion: plan.current,
+        targetVersion,
+        channel: command.channel,
+        updateChannel: command.version === null,
+        candidatePath,
+        candidateSha256,
+        workRoot
+      });
+    } catch {
+      throw new UpgradeFailure(
+        "internal_error",
+        "Could not start the Windows upgrade helper."
+      );
+    }
+    handedOff = true;
+  } finally {
+    if (!handedOff) {
+      try {
+        rmSync(workRoot, { recursive: true, force: true });
+      } catch {
+        // The original upgrade failure is more useful than cleanup failure.
+      }
+    }
+  }
+
+  return upgradeEnvelope({
+    status: "staged",
+    current: plan.current,
+    latest: plan.latest,
+    target: targetVersion,
+    channel: command.channel
+  });
+}

--- a/tui/src/windows-upgrade-handoff-script.ts
+++ b/tui/src/windows-upgrade-handoff-script.ts
@@ -305,8 +305,8 @@ function Main {
         installationId = [string]$record.installationId
         method = 'powershell'
         channel = $savedChannel
-        installRoot = $root
-        executable = $active
+        installRoot = [string]$record.installRoot
+        executable = [string]$record.executable
         artifactTarget = $ArtifactTarget
       }
       Write-TextAtomic $recordPath (($next | ConvertTo-Json -Compress) + [Environment]::NewLine) ([IO.Path]::Combine($work, $OwnershipName))

--- a/tui/src/windows-upgrade-handoff-script.ts
+++ b/tui/src/windows-upgrade-handoff-script.ts
@@ -141,7 +141,18 @@ function Clear-MatchingFailureRecord([string]$Installation) {
 
 function Assert-Candidate([string]$PathValue) {
   Assert-NoReparsePoint $PathValue
-  $actual = (Get-FileHash -LiteralPath $PathValue -Algorithm SHA256).Hash.ToLowerInvariant()
+  $stream = $null
+  $sha256 = $null
+  try {
+    $stream = [IO.File]::Open($PathValue, [IO.FileMode]::Open,
+      [IO.FileAccess]::Read, [IO.FileShare]::Read)
+    $sha256 = [Security.Cryptography.SHA256]::Create()
+    $digest = $sha256.ComputeHash($stream)
+    $actual = [BitConverter]::ToString($digest).Replace('-', '').ToLowerInvariant()
+  } finally {
+    if ($null -ne $sha256) { $sha256.Dispose() }
+    if ($null -ne $stream) { $stream.Dispose() }
+  }
   if ($actual -cne $CandidateSha256) { Fail 'Candidate SHA-256 digest changed before handoff.' }
   Assert-ReleaseIdentity $PathValue $TargetVersion 'Candidate'
 }

--- a/tui/src/windows-upgrade-handoff-script.ts
+++ b/tui/src/windows-upgrade-handoff-script.ts
@@ -1,0 +1,394 @@
+import { INSTALL_OWNERSHIP_FILE } from "../../shared/install-ownership-record.js";
+import { INSTALL_LOCK_FILE } from "../../shared/install-layout.js";
+import { WINDOWS_UPGRADE_FAILURE_FILE } from "./windows-upgrade-state.js";
+
+export const HANDOFF_SCRIPT = "handoff.ps1" as const;
+export const HANDOFF_REQUEST = "request.json" as const;
+export const WINDOWS_HANDOFF_BODY = String.raw`[CmdletBinding()]
+param()
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+$OwnershipName = '${INSTALL_OWNERSHIP_FILE}'
+$LockName = '${INSTALL_LOCK_FILE}'
+$RequestName = '${HANDOFF_REQUEST}'
+$TransactionName = 'transaction.json'
+$ErrorName = 'error.txt'
+$FailureName = '${WINDOWS_UPGRADE_FAILURE_FILE}'
+$ArtifactTarget = 'windows-x64'
+$WorkRoot = [IO.Path]::GetFullPath((Get-Location).ProviderPath).TrimEnd('\')
+
+function Fail([string]$Message) { throw "1667 upgrade: $Message" }
+
+function Read-Request {
+  $requestPath = [IO.Path]::Combine($WorkRoot, $RequestName)
+  $item = Get-Item -LiteralPath $requestPath -Force
+  if ($item.PSIsContainer -or $item.Length -le 0 -or $item.Length -gt 16384) {
+    Fail 'Upgrade handoff request is invalid.'
+  }
+  try { $request = [IO.File]::ReadAllText($requestPath) | ConvertFrom-Json }
+  catch { Fail 'Upgrade handoff request is invalid.' }
+  $names = @($request.PSObject.Properties.Name | Sort-Object)
+  $expected = @('candidate','candidateSha256','currentVersion','executable','expectedChannel','installationId','installRoot','targetChannel','targetVersion','updateChannel')
+  if (($names -join ',') -cne ($expected -join ',') -or
+      $request.installRoot -isnot [string] -or $request.executable -isnot [string] -or
+      $request.installationId -isnot [string] -or
+      $request.installationId -cnotmatch '^[0-9a-f]{32}$' -or
+      $request.expectedChannel -notin @('stable','beta') -or
+      $request.targetChannel -notin @('stable','beta') -or
+      $request.updateChannel -isnot [bool] -or $request.candidate -isnot [string] -or
+      $request.candidateSha256 -isnot [string] -or
+      $request.candidateSha256 -cnotmatch '^[0-9a-f]{64}$' -or
+      $request.currentVersion -isnot [string] -or $request.targetVersion -isnot [string]) {
+    Fail 'Upgrade handoff request is invalid.'
+  }
+  return $request
+}
+
+function Assert-NoReparsePoint([string]$PathValue) {
+  $current = [IO.Path]::GetPathRoot($PathValue)
+  $relative = $PathValue.Substring($current.Length)
+  foreach ($part in $relative.Split(@('\'), [StringSplitOptions]::RemoveEmptyEntries)) {
+    $current = [IO.Path]::Combine($current, $part)
+    if (-not [IO.File]::Exists($current) -and -not [IO.Directory]::Exists($current)) {
+      Fail "Path is missing: $current"
+    }
+    $item = Get-Item -LiteralPath $current -Force
+    if (($item.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0) {
+      Fail "Path contains a reparse point: $current"
+    }
+  }
+}
+
+function Read-Ownership([string]$RecordPath) {
+  Assert-NoReparsePoint $RecordPath
+  $item = Get-Item -LiteralPath $RecordPath -Force
+  if ($item.PSIsContainer -or $item.Length -le 0 -or $item.Length -gt 16384) {
+    Fail 'Ownership Record is invalid.'
+  }
+  try { $record = [IO.File]::ReadAllText($RecordPath) | ConvertFrom-Json }
+  catch { Fail 'Ownership Record is invalid.' }
+  $names = @($record.PSObject.Properties.Name | Sort-Object)
+  $expected = @('artifactTarget','channel','executable','installationId','installRoot','method','product','schemaVersion')
+  if (($names -join ',') -cne ($expected -join ',')) { Fail 'Ownership Record is invalid.' }
+  if ($record.schemaVersion -ne 1 -or $record.product -cne '1667' -or
+      $record.method -cne 'powershell' -or $record.artifactTarget -cne $ArtifactTarget -or
+      ($record.channel -cne 'stable' -and $record.channel -cne 'beta') -or
+      $record.installRoot -ine $InstallRoot -or
+      $record.executable -ine $Executable -or
+      $record.installationId -cne $InstallationId -or
+      $record.installationId -cnotmatch '^[0-9a-f]{32}$') {
+    Fail 'Ownership Record changed before the upgrade handoff.'
+  }
+  return $record
+}
+
+function Write-TextAtomic([string]$PathValue, [string]$Text, [string]$Temporary) {
+  [IO.File]::WriteAllText($Temporary, $Text, (New-Object Text.UTF8Encoding($false)))
+  if ([IO.File]::Exists($PathValue)) {
+    $backup = "$Temporary.previous"
+    [IO.File]::Replace($Temporary, $PathValue, $backup, $true)
+    try {
+      if ([IO.File]::Exists($backup)) { [IO.File]::Delete($backup) }
+    } catch { }
+  } else {
+    [IO.File]::Move($Temporary, $PathValue)
+  }
+}
+
+function Sanitize-FailureMessage([string]$Message) {
+  $clean = ($Message -replace '[\x00-\x1F\x7F]+', ' ').Trim()
+  $clean = ($clean -replace '^1667 upgrade:\s*', '').Trim()
+  if ([String]::IsNullOrWhiteSpace($clean)) { $clean = 'The Windows upgrade helper failed.' }
+  if ($clean.Length -gt 512) { $clean = $clean.Substring(0, 512).TrimEnd() }
+  return $clean
+}
+
+function Write-FailureRecord([string]$ActiveState, [string]$Message) {
+  $failure = [ordered]@{
+    schemaVersion = 1
+    product = '1667'
+    installationId = $InstallationId
+    workRoot = [IO.Path]::GetFileName($WorkRoot)
+    fromVersion = $CurrentVersion
+    targetVersion = $TargetVersion
+    targetChannel = $TargetChannel
+    activeState = $ActiveState
+    message = (Sanitize-FailureMessage $Message)
+  }
+  $failurePath = [IO.Path]::Combine($InstallRoot, $FailureName)
+  $temporary = [IO.Path]::Combine($WorkRoot, 'failure-record.tmp')
+  Write-TextAtomic $failurePath (($failure | ConvertTo-Json -Compress) + [Environment]::NewLine) $temporary
+}
+
+function Clear-MatchingFailureRecord([string]$Installation) {
+  $failurePath = [IO.Path]::Combine($InstallRoot, $FailureName)
+  if (-not [IO.File]::Exists($failurePath)) { return }
+  try {
+    $item = Get-Item -LiteralPath $failurePath -Force
+    if ($item.PSIsContainer -or $item.Length -le 0 -or $item.Length -gt 4096 -or
+        ($item.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0) { return }
+    $failure = [IO.File]::ReadAllText($failurePath) | ConvertFrom-Json
+    $names = @($failure.PSObject.Properties.Name | Sort-Object)
+    $expected = @('activeState','fromVersion','installationId','message','product','schemaVersion','targetChannel','targetVersion','workRoot')
+    if (($names -join ',') -ceq ($expected -join ',') -and
+        $failure.schemaVersion -eq 1 -and $failure.product -ceq '1667' -and
+        $failure.installationId -ceq $Installation) {
+      [IO.File]::Delete($failurePath)
+    }
+  } catch { }
+}
+
+function Assert-Candidate([string]$PathValue) {
+  Assert-NoReparsePoint $PathValue
+  $actual = (Get-FileHash -LiteralPath $PathValue -Algorithm SHA256).Hash.ToLowerInvariant()
+  if ($actual -cne $CandidateSha256) { Fail 'Candidate SHA-256 digest changed before handoff.' }
+  Assert-ReleaseIdentity $PathValue $TargetVersion 'Candidate'
+}
+
+function Read-ReleaseVersion([string]$PathValue, [string]$Label) {
+  Assert-NoReparsePoint $PathValue
+  $start = New-Object Diagnostics.ProcessStartInfo
+  $start.FileName = $PathValue
+  $start.Arguments = '--version --json'
+  $start.UseShellExecute = $false
+  $start.CreateNoWindow = $true
+  $start.RedirectStandardOutput = $true
+  $start.RedirectStandardError = $true
+  $process = New-Object Diagnostics.Process
+  $process.StartInfo = $start
+  if (-not $process.Start()) { Fail "$Label version probe did not start." }
+  if (-not $process.WaitForExit(5000)) {
+    try { $process.Kill() } catch { }
+    Fail "$Label version probe timed out."
+  }
+  $output = $process.StandardOutput.ReadToEnd()
+  $errorOutput = $process.StandardError.ReadToEnd()
+  if ($process.ExitCode -ne 0 -or $output.Length -gt 65536 -or $errorOutput.Length -gt 65536) {
+    Fail "$Label version probe failed."
+  }
+  try { $identity = $output | ConvertFrom-Json }
+  catch { Fail "$Label version probe returned invalid JSON." }
+  if ($identity.schemaVersion -ne 1 -or $identity.product -cne '1667' -or
+      $identity.productVersion -isnot [string] -or
+      $identity.artifactTarget -cne $ArtifactTarget -or
+      $identity.buildKind -cne 'release' -or $identity.sourceDirty -ne $false) {
+    Fail "$Label release identity is invalid."
+  }
+  return [string]$identity.productVersion
+}
+
+function Assert-ReleaseIdentity([string]$PathValue, [string]$Version, [string]$Label) {
+  if ((Read-ReleaseVersion $PathValue $Label) -cne $Version) {
+    Fail "$Label release identity is invalid."
+  }
+}
+
+function Open-InstallLock([string]$PathValue) {
+  $deadline = [Diagnostics.Stopwatch]::StartNew()
+  while ($true) {
+    try {
+      return [IO.File]::Open($PathValue, [IO.FileMode]::OpenOrCreate,
+        [IO.FileAccess]::ReadWrite, [IO.FileShare]::None)
+    } catch [IO.IOException] {
+      $nativeCode = $_.Exception.HResult -band 0xFFFF
+      if ($nativeCode -ne 32 -and $nativeCode -ne 33) {
+        Fail 'Could not acquire the Install Root lock.'
+      }
+      if ($deadline.ElapsedMilliseconds -ge 65000) {
+        Fail 'Another installer holds the Install Root lock.'
+      }
+      Start-Sleep -Milliseconds 100
+    } catch [UnauthorizedAccessException] {
+      Fail 'Could not acquire the Install Root lock.'
+    }
+  }
+}
+
+function Replace-AfterUnlock([string]$CandidatePath, [string]$ActivePath, [string]$BackupPath) {
+  $deadline = [Diagnostics.Stopwatch]::StartNew()
+  while ($true) {
+    try {
+      [IO.File]::Replace($CandidatePath, $ActivePath, $BackupPath, $true)
+      return
+    } catch [IO.IOException] {
+      $nativeCode = $_.Exception.HResult -band 0xFFFF
+      if ($nativeCode -ne 32 -and $nativeCode -ne 33) {
+        Fail "Could not replace 1667.exe: $($_.Exception.Message)"
+      }
+      if ($deadline.ElapsedMilliseconds -ge 60000) {
+        Fail 'Could not replace 1667.exe. Close all running 1667 processes, then run the upgrade command again.'
+      }
+      Start-Sleep -Milliseconds 100
+    } catch [UnauthorizedAccessException] {
+      Fail 'Could not replace 1667.exe. Check the file permissions, then run the upgrade command again.'
+    }
+  }
+}
+
+function Main {
+  $request = Read-Request
+  $InstallRoot = [string]$request.installRoot
+  $Executable = [string]$request.executable
+  $InstallationId = [string]$request.installationId
+  $ExpectedChannel = [string]$request.expectedChannel
+  $TargetChannel = [string]$request.targetChannel
+  $UpdateChannel = [bool]$request.updateChannel
+  $Candidate = [string]$request.candidate
+  $CandidateSha256 = [string]$request.candidateSha256
+  $CurrentVersion = [string]$request.currentVersion
+  $TargetVersion = [string]$request.targetVersion
+  $root = [IO.Path]::GetFullPath($InstallRoot).TrimEnd('\')
+  $active = [IO.Path]::GetFullPath($Executable)
+  $work = [IO.Path]::GetFullPath($WorkRoot).TrimEnd('\')
+  $candidatePath = [IO.Path]::GetFullPath($Candidate)
+  if ($root -notmatch '^[A-Za-z]:\\' -or
+      $active -ine [IO.Path]::Combine($root, '1667.exe') -or
+      [IO.Path]::GetDirectoryName($work) -ine $root -or
+      -not [IO.Path]::GetFileName($work).StartsWith('.1667-upgrade.', [StringComparison]::Ordinal) -or
+      $candidatePath -ine [IO.Path]::Combine($work, '1667-candidate.exe')) {
+    Fail 'Upgrade handoff paths are invalid.'
+  }
+  Assert-NoReparsePoint $root
+  Assert-NoReparsePoint $work
+
+  $lockPath = [IO.Path]::Combine($root, $LockName)
+  $lock = $null
+  $replaced = $false
+  $failureRecordAuthorized = $false
+  $backup = [IO.Path]::Combine($work, '1667-previous.exe')
+  $recordPath = [IO.Path]::Combine($root, $OwnershipName)
+  $transactionPath = [IO.Path]::Combine($work, $TransactionName)
+  try {
+    $lock = Open-InstallLock $lockPath
+    $record = Read-Ownership $recordPath
+    $savedChannel = if ($UpdateChannel) { $TargetChannel } else { $ExpectedChannel }
+    $activeVersion = Read-ReleaseVersion $active 'Active executable'
+    if ($record.channel -ceq $savedChannel -and $activeVersion -ceq $TargetVersion) {
+      try { Clear-MatchingFailureRecord ([string]$record.installationId) } catch { }
+    } elseif ($record.channel -ceq $ExpectedChannel -and
+        $activeVersion -ceq $CurrentVersion) {
+      $failureRecordAuthorized = $true
+      Assert-Candidate $candidatePath
+
+      $transaction = [ordered]@{
+        schemaVersion = 1
+        product = '1667'
+        installationId = [string]$record.installationId
+        fromVersion = $CurrentVersion
+        toVersion = $TargetVersion
+        channel = $TargetChannel
+        updateChannel = $UpdateChannel
+        executable = $active
+        candidate = $candidatePath
+        phase = 'candidate-ready'
+      }
+      Write-TextAtomic $transactionPath (($transaction | ConvertTo-Json -Compress) + [Environment]::NewLine) "$transactionPath.tmp"
+
+      Replace-AfterUnlock $candidatePath $active $backup
+      $replaced = $true
+
+      $next = [ordered]@{
+        schemaVersion = 1
+        product = '1667'
+        installationId = [string]$record.installationId
+        method = 'powershell'
+        channel = $savedChannel
+        installRoot = $root
+        executable = $active
+        artifactTarget = $ArtifactTarget
+      }
+      Write-TextAtomic $recordPath (($next | ConvertTo-Json -Compress) + [Environment]::NewLine) ([IO.Path]::Combine($work, $OwnershipName))
+      $replaced = $false
+      $failureRecordAuthorized = $false
+      try { Clear-MatchingFailureRecord ([string]$record.installationId) } catch { }
+      try {
+        if ([IO.File]::Exists($backup)) { [IO.File]::Delete($backup) }
+      } catch { }
+      try {
+        if ([IO.File]::Exists($transactionPath)) { [IO.File]::Delete($transactionPath) }
+      } catch { }
+    } else {
+      Fail 'The Windows installation changed before the upgrade handoff.'
+    }
+  } catch {
+    $failureMessage = [string]$_.Exception.Message
+    $activeState = 'unchanged'
+    if ($replaced) {
+      $activeState = 'target-preserved'
+      if ([IO.File]::Exists($backup)) {
+        try {
+          $failed = [IO.Path]::Combine($work, '1667-failed.exe')
+          [IO.File]::Replace($backup, $active, $failed, $true)
+          $activeState = 'restored'
+          if ([IO.File]::Exists($failed)) { [IO.File]::Delete($failed) }
+        } catch {
+          $failureMessage += " Rollback also failed: $($_.Exception.Message)"
+        }
+      }
+    }
+    if ($failureRecordAuthorized) {
+      try { Write-FailureRecord $activeState $failureMessage } catch { }
+    }
+    try {
+      [IO.File]::WriteAllText([IO.Path]::Combine($work, $ErrorName),
+        ((Sanitize-FailureMessage $failureMessage) + [Environment]::NewLine),
+        (New-Object Text.UTF8Encoding($false)))
+    } catch { }
+    throw $failureMessage
+  } finally {
+    if ($null -ne $lock) { $lock.Dispose() }
+  }
+
+  try {
+    Set-Location -LiteralPath $root
+    [Environment]::CurrentDirectory = $root
+    Remove-Item -LiteralPath $work -Recurse -Force
+  } catch { }
+}
+
+try {
+  Main
+} catch {
+  try {
+    [IO.File]::WriteAllText([IO.Path]::Combine($WorkRoot, $ErrorName),
+      ($_.Exception.Message + [Environment]::NewLine),
+      (New-Object Text.UTF8Encoding($false)))
+  } catch { }
+  exit 1
+}
+`;
+export const WINDOWS_HANDOFF_BOOTSTRAP = String.raw`[CmdletBinding()]
+param()
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+$workRoot = [IO.Path]::GetFullPath((Get-Location).ProviderPath).TrimEnd('\')
+$powerShell = [IO.Path]::Combine(
+  $env:SystemRoot,
+  'System32',
+  'WindowsPowerShell',
+  'v1.0',
+  'powershell.exe'
+)
+if (-not [IO.File]::Exists($powerShell)) {
+  throw 'Windows PowerShell is unavailable.'
+}
+$bodyPath = [IO.Path]::Combine($workRoot, '${HANDOFF_SCRIPT}')
+$escapedBodyPath = $bodyPath.Replace("'", "''")
+$launcher = "& ([ScriptBlock]::Create([IO.File]::ReadAllText('$escapedBodyPath')))"
+$encoded = [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes($launcher))
+$arguments = @(
+  '-NoLogo',
+  '-NoProfile',
+  '-NonInteractive',
+  '-ExecutionPolicy',
+  'Bypass',
+  '-EncodedCommand',
+  $encoded
+)
+$helper = Start-Process -FilePath $powerShell -ArgumentList $arguments -WorkingDirectory $workRoot -WindowStyle Hidden -PassThru
+if ($null -eq $helper -or $helper.Id -le 0) {
+  throw 'Could not start the Windows upgrade helper.'
+}
+`;

--- a/tui/src/windows-upgrade-handoff.ts
+++ b/tui/src/windows-upgrade-handoff.ts
@@ -1,0 +1,166 @@
+import { spawn } from "node:child_process";
+import { createHash, randomUUID } from "node:crypto";
+import {
+  createReadStream,
+  lstatSync,
+  renameSync,
+  writeFileSync
+} from "node:fs";
+import path from "node:path";
+import { INSTALL_OWNERSHIP_FILE } from "../../shared/install-ownership-record.js";
+import { fsyncPath, removeQuietly } from "../../shared/safe-file-write.js";
+import { acquireInstallationLock } from "./install-lock.js";
+import type { InstallationAuthority } from "./install-ownership.js";
+import type { UpgradeChannel } from "./upgrade-contract.js";
+import {
+  HANDOFF_REQUEST,
+  HANDOFF_SCRIPT,
+  WINDOWS_HANDOFF_BODY,
+  WINDOWS_HANDOFF_BOOTSTRAP
+} from "./windows-upgrade-handoff-script.js";
+import {
+  readPowerShellOwnershipRecord
+} from "./windows-upgrade-state.js";
+
+export interface WindowsUpgradeHandoffRequest {
+  readonly authority: Extract<InstallationAuthority, { kind: "powershell" }>;
+  readonly currentVersion: string;
+  readonly targetVersion: string;
+  readonly channel: UpgradeChannel;
+  readonly updateChannel: boolean;
+  readonly candidatePath: string;
+  readonly candidateSha256: string;
+  /** The handoff owns this directory after it starts. */
+  readonly workRoot: string;
+}
+
+export type WindowsUpgradeHandoffStarter = (
+  request: WindowsUpgradeHandoffRequest
+) => void | Promise<void>;
+
+export type WindowsUpgradeChannelSaver = (
+  authority: Extract<InstallationAuthority, { kind: "powershell" }>,
+  channel: UpgradeChannel
+) => void | Promise<void>;
+
+/**
+ * Start a detached local helper. The helper retries the replacement until the
+ * running Windows executable releases its file lock.
+ */
+export function startWindowsUpgradeHandoff(
+  request: WindowsUpgradeHandoffRequest
+): Promise<void> {
+  const ownership = readPowerShellOwnershipRecord(request.authority);
+  const scriptPath = path.win32.join(request.workRoot, HANDOFF_SCRIPT);
+  const requestPath = path.win32.join(request.workRoot, HANDOFF_REQUEST);
+  writeFileSync(scriptPath, WINDOWS_HANDOFF_BODY, { encoding: "utf8", flag: "wx", mode: 0o600 });
+  writeFileSync(requestPath, `${JSON.stringify({
+    installRoot: request.authority.installRoot,
+    executable: request.authority.executable,
+    installationId: ownership.installationId,
+    expectedChannel: request.authority.channel,
+    targetChannel: request.channel,
+    updateChannel: request.updateChannel,
+    candidate: request.candidatePath,
+    candidateSha256: request.candidateSha256,
+    currentVersion: request.currentVersion,
+    targetVersion: request.targetVersion
+  })}\n`, { encoding: "utf8", flag: "wx", mode: 0o600 });
+  const bootstrapCommand = Buffer.from(
+    WINDOWS_HANDOFF_BOOTSTRAP,
+    "utf16le"
+  ).toString("base64");
+  const powerShell = windowsPowerShellPath();
+  const child = spawn(
+    powerShell,
+    [
+      "-NoLogo",
+      "-NoProfile",
+      "-NonInteractive",
+      "-ExecutionPolicy",
+      "Bypass",
+      "-EncodedCommand",
+      bootstrapCommand
+    ],
+    {
+      cwd: request.workRoot,
+      stdio: "ignore",
+      windowsHide: true
+    }
+  );
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    child.once("error", (error) => {
+      if (settled) return;
+      settled = true;
+      reject(error);
+    });
+    child.once("exit", (code) => {
+      if (settled) return;
+      settled = true;
+      if (code === 0) resolve();
+      else reject(new Error("Windows upgrade bootstrap failed"));
+    });
+  });
+}
+
+function windowsPowerShellPath(): string {
+  const systemRoot = process.env.SystemRoot;
+  if (systemRoot === undefined
+    || !path.win32.isAbsolute(systemRoot)
+    || systemRoot.startsWith("\\\\")) {
+    throw new Error("Windows SystemRoot is invalid");
+  }
+  const executable = path.win32.join(
+    systemRoot,
+    "System32",
+    "WindowsPowerShell",
+    "v1.0",
+    "powershell.exe"
+  );
+  const stats = lstatSync(executable);
+  if (!stats.isFile() || stats.isSymbolicLink()) {
+    throw new Error("Windows PowerShell is unavailable");
+  }
+  return executable;
+}
+
+/** Read a file without loading the release executable into memory. */
+export async function sha256File(file: string): Promise<string> {
+  const hash = createHash("sha256");
+  const stream = createReadStream(file);
+  for await (const chunk of stream) hash.update(chunk);
+  return hash.digest("hex");
+}
+
+/** Save a channel-only switch under the same lock used by the Installer. */
+export async function saveWindowsUpgradeChannel(
+  authority: Extract<InstallationAuthority, { kind: "powershell" }>,
+  channel: UpgradeChannel
+): Promise<void> {
+  const lock = await acquireInstallationLock(authority.installRoot);
+  try {
+    const recordPath = path.win32.join(authority.installRoot, INSTALL_OWNERSHIP_FILE);
+    const record = readPowerShellOwnershipRecord(authority);
+    const temporary = path.win32.join(
+      authority.installRoot,
+      `${INSTALL_OWNERSHIP_FILE}.${randomUUID()}.tmp`
+    );
+    const next = `${JSON.stringify({ ...record, channel })}\n`;
+    try {
+      writeFileSync(temporary, next, { encoding: "utf8", flag: "wx", mode: 0o600 });
+      fsyncPath(temporary);
+      renameSync(temporary, recordPath);
+      fsyncPath(recordPath);
+    } catch (error) {
+      try {
+        removeQuietly(temporary);
+      } catch {
+        // Keep the channel-write failure.
+      }
+      throw error;
+    }
+  } finally {
+    await lock.release();
+  }
+}

--- a/tui/src/windows-upgrade-recovery.ts
+++ b/tui/src/windows-upgrade-recovery.ts
@@ -1,0 +1,305 @@
+import {
+  lstatSync,
+  readFileSync,
+  readdirSync,
+  realpathSync,
+  rmdirSync,
+  unlinkSync
+} from "node:fs";
+import path from "node:path";
+import { probeReleaseExecutable } from "../../shared/executable-probe.js";
+import { parseJsonRejectingDuplicateKeys } from "../../shared/strict-json.js";
+import { isSemVer } from "../../shared/semver.js";
+import { acquireInstallationLock } from "./install-lock.js";
+import type { InstallationAuthority } from "./install-ownership.js";
+import {
+  readPowerShellOwnershipRecord,
+  windowsPathEquals,
+  WINDOWS_UPGRADE_FAILURE_FILE,
+  WINDOWS_UPGRADE_WORK_PREFIX
+} from "./windows-upgrade-state.js";
+
+type PowerShellAuthority = Extract<InstallationAuthority, { kind: "powershell" }>;
+type ActiveState = "unchanged" | "restored" | "target-preserved";
+
+interface WindowsUpgradeFailureRecord {
+  readonly schemaVersion: 1;
+  readonly product: "1667";
+  readonly installationId: string;
+  readonly workRoot: string;
+  readonly fromVersion: string;
+  readonly targetVersion: string;
+  readonly targetChannel: "stable" | "beta";
+  readonly activeState: ActiveState;
+  readonly message: string;
+}
+
+interface WindowsUpgradeHandoffRecord {
+  readonly installationId: string;
+  readonly installRoot: string;
+  readonly executable: string;
+  readonly expectedChannel: "stable" | "beta";
+  readonly targetChannel: "stable" | "beta";
+  readonly updateChannel: boolean;
+  readonly candidate: string;
+  readonly candidateSha256: string;
+  readonly currentVersion: string;
+  readonly targetVersion: string;
+}
+
+export type WindowsUpgradeFailureRecoverer = (
+  authority: PowerShellAuthority
+) => string | null | Promise<string | null>;
+
+const FAILURE_KEYS = [
+  "activeState",
+  "fromVersion",
+  "installationId",
+  "message",
+  "product",
+  "schemaVersion",
+  "targetChannel",
+  "targetVersion",
+  "workRoot"
+] as const;
+const REQUEST_KEYS = [
+  "candidate",
+  "candidateSha256",
+  "currentVersion",
+  "executable",
+  "expectedChannel",
+  "installRoot",
+  "installationId",
+  "targetChannel",
+  "targetVersion",
+  "updateChannel"
+] as const;
+const WORK_FILES = new Set([
+  ".1667-install.json",
+  ".1667-install.json.previous",
+  "1667-candidate.exe",
+  "1667-failed.exe",
+  "1667-previous.exe",
+  "error.txt",
+  "failure-record.tmp",
+  "failure-record.tmp.previous",
+  "handoff.ps1",
+  "release-package.tgz",
+  "request.json",
+  "transaction.json",
+  "transaction.json.tmp",
+  "transaction.json.tmp.previous"
+]);
+
+/** Surface one authenticated helper failure and make a new attempt safe. */
+export async function recoverWindowsUpgradeFailure(
+  authority: PowerShellAuthority
+): Promise<string | null> {
+  const failurePath = path.win32.join(
+    authority.installRoot,
+    WINDOWS_UPGRADE_FAILURE_FILE
+  );
+  // Most runs have no result to recover. Do not create an Install Root lock
+  // only to prove that the fixed marker is absent.
+  try {
+    lstatSync(failurePath);
+  } catch (error) {
+    if (isNotFound(error)) return null;
+    throw error;
+  }
+  const lock = await acquireInstallationLock(authority.installRoot);
+  try {
+    const failureText = readBoundedRegularFile(failurePath, 4096, true);
+    if (failureText === null) return null;
+
+    const ownership = readPowerShellOwnershipRecord(authority);
+    const failure = parseFailureRecord(failureText);
+    if (failure.installationId !== ownership.installationId) {
+      throw new Error("Windows upgrade failure belongs to another installation");
+    }
+    const workRoot = resolveOwnedWorkRoot(authority.installRoot, failure.workRoot);
+    const requestText = readBoundedRegularFile(
+      path.win32.join(workRoot, "request.json"),
+      16_384,
+      false
+    );
+    const request = parseHandoffRecord(requestText!);
+    assertBoundRequest(request, failure, authority, workRoot);
+    assertRemovableWorkRoot(workRoot);
+
+    const activeVersion = failure.activeState === "target-preserved"
+      ? failure.targetVersion
+      : failure.fromVersion;
+    await probeReleaseExecutable(authority.executable, {
+      version: activeVersion,
+      artifactTarget: "windows-x64"
+    }, { timeoutMs: 5000 });
+
+    // Remove the marker first. A validated but still-open work directory does
+    // not block a new unique attempt, and cleanup can finish best-effort.
+    unlinkSync(failurePath);
+    removeValidatedWorkRoot(workRoot);
+    return failure.message;
+  } finally {
+    await lock.release();
+  }
+}
+
+function parseFailureRecord(text: string): WindowsUpgradeFailureRecord {
+  const record = parseObject(text, FAILURE_KEYS, "Windows upgrade failure");
+  if (record.schemaVersion !== 1
+    || record.product !== "1667"
+    || typeof record.installationId !== "string"
+    || !/^[0-9a-f]{32}$/u.test(record.installationId)
+    || typeof record.workRoot !== "string"
+    || typeof record.fromVersion !== "string"
+    || !isSemVer(record.fromVersion)
+    || typeof record.targetVersion !== "string"
+    || !isSemVer(record.targetVersion)
+    || (record.targetChannel !== "stable" && record.targetChannel !== "beta")
+    || !isActiveState(record.activeState)
+    || typeof record.message !== "string"
+    || record.message.length === 0
+    || record.message.length > 512
+    || /[\u0000-\u001f\u007f]/u.test(record.message)) {
+    throw new Error("Windows upgrade failure is invalid");
+  }
+  return record as unknown as WindowsUpgradeFailureRecord;
+}
+
+function parseHandoffRecord(text: string): WindowsUpgradeHandoffRecord {
+  const record = parseObject(text, REQUEST_KEYS, "Windows upgrade handoff request");
+  if (typeof record.installationId !== "string"
+    || !/^[0-9a-f]{32}$/u.test(record.installationId)
+    || typeof record.installRoot !== "string"
+    || typeof record.executable !== "string"
+    || (record.expectedChannel !== "stable" && record.expectedChannel !== "beta")
+    || (record.targetChannel !== "stable" && record.targetChannel !== "beta")
+    || typeof record.updateChannel !== "boolean"
+    || typeof record.candidate !== "string"
+    || typeof record.candidateSha256 !== "string"
+    || !/^[0-9a-f]{64}$/u.test(record.candidateSha256)
+    || typeof record.currentVersion !== "string"
+    || !isSemVer(record.currentVersion)
+    || typeof record.targetVersion !== "string"
+    || !isSemVer(record.targetVersion)) {
+    throw new Error("Windows upgrade handoff request is invalid");
+  }
+  return record as unknown as WindowsUpgradeHandoffRecord;
+}
+
+function parseObject(
+  text: string,
+  expectedKeys: readonly string[],
+  label: string
+): Record<string, unknown> {
+  const value = parseJsonRejectingDuplicateKeys(text);
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${label} is invalid`);
+  }
+  const record = value as Record<string, unknown>;
+  const keys = Object.keys(record).sort();
+  if (keys.length !== expectedKeys.length
+    || keys.some((key, index) => key !== expectedKeys[index])) {
+    throw new Error(`${label} is invalid`);
+  }
+  return record;
+}
+
+function resolveOwnedWorkRoot(installRoot: string, basename: string): string {
+  if (path.win32.basename(basename) !== basename
+    || !basename.startsWith(WINDOWS_UPGRADE_WORK_PREFIX)
+    || basename.length <= WINDOWS_UPGRADE_WORK_PREFIX.length
+    || basename.length > WINDOWS_UPGRADE_WORK_PREFIX.length + 64) {
+    throw new Error("Windows upgrade work directory is invalid");
+  }
+  const workRoot = path.win32.join(installRoot, basename);
+  const stats = lstatSync(workRoot);
+  if (!stats.isDirectory() || stats.isSymbolicLink()) {
+    throw new Error("Windows upgrade work directory is invalid");
+  }
+  const realInstallRoot = realpathSync(installRoot);
+  const realWorkRoot = realpathSync(workRoot);
+  if (!windowsPathEquals(path.win32.dirname(realWorkRoot), realInstallRoot)
+    || path.win32.basename(realWorkRoot) !== basename) {
+    throw new Error("Windows upgrade work directory left the Install Root");
+  }
+  return workRoot;
+}
+
+function assertBoundRequest(
+  request: WindowsUpgradeHandoffRecord,
+  failure: WindowsUpgradeFailureRecord,
+  authority: PowerShellAuthority,
+  workRoot: string
+): void {
+  if (request.installationId !== failure.installationId
+    || !windowsPathEquals(request.installRoot, authority.installRoot)
+    || !windowsPathEquals(request.executable, authority.executable)
+    || request.expectedChannel !== authority.channel
+    || request.currentVersion !== failure.fromVersion
+    || request.targetVersion !== failure.targetVersion
+    || request.targetChannel !== failure.targetChannel
+    || !windowsPathEquals(
+      request.candidate,
+      path.win32.join(workRoot, "1667-candidate.exe")
+    )) {
+    throw new Error("Windows upgrade failure does not match its handoff request");
+  }
+}
+
+function assertRemovableWorkRoot(workRoot: string): void {
+  const entries = readdirSync(workRoot, { withFileTypes: true });
+  if (entries.length > WORK_FILES.size) {
+    throw new Error("Windows upgrade work directory has unexpected files");
+  }
+  for (const entry of entries) {
+    if (!WORK_FILES.has(entry.name) || !entry.isFile() || entry.isSymbolicLink()) {
+      throw new Error("Windows upgrade work directory has unexpected files");
+    }
+    const stats = lstatSync(path.win32.join(workRoot, entry.name));
+    if (!stats.isFile() || stats.isSymbolicLink()) {
+      throw new Error("Windows upgrade work directory has an unsafe file");
+    }
+  }
+}
+
+function removeValidatedWorkRoot(workRoot: string): void {
+  try {
+    for (const entry of readdirSync(workRoot, { withFileTypes: true })) {
+      if (WORK_FILES.has(entry.name) && entry.isFile() && !entry.isSymbolicLink()) {
+        unlinkSync(path.win32.join(workRoot, entry.name));
+      }
+    }
+    rmdirSync(workRoot);
+  } catch {
+    // A helper can still have this directory as its working directory. The
+    // unique stale directory does not block the next attempt.
+  }
+}
+
+function readBoundedRegularFile(
+  file: string,
+  maxBytes: number,
+  allowMissing: boolean
+): string | null {
+  let stats;
+  try {
+    stats = lstatSync(file);
+  } catch (error) {
+    if (allowMissing && isNotFound(error)) return null;
+    throw error;
+  }
+  if (!stats.isFile() || stats.isSymbolicLink() || stats.size <= 0 || stats.size > maxBytes) {
+    throw new Error("Windows upgrade state file is invalid");
+  }
+  return readFileSync(file, "utf8");
+}
+
+function isActiveState(value: unknown): value is ActiveState {
+  return value === "unchanged" || value === "restored" || value === "target-preserved";
+}
+
+function isNotFound(error: unknown): boolean {
+  return error instanceof Error && "code" in error && error.code === "ENOENT";
+}

--- a/tui/src/windows-upgrade-state.ts
+++ b/tui/src/windows-upgrade-state.ts
@@ -1,0 +1,61 @@
+import { lstatSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { AI_1667_PRODUCT } from "../../shared/build-identity.js";
+import {
+  INSTALL_OWNERSHIP_FILE,
+  RECORD_KEYS
+} from "../../shared/install-ownership-record.js";
+import { parseJsonRejectingDuplicateKeys } from "../../shared/strict-json.js";
+import type { InstallationAuthority } from "./install-ownership.js";
+import type { UpgradeChannel } from "./upgrade-contract.js";
+
+export const WINDOWS_UPGRADE_FAILURE_FILE = ".1667-upgrade-failure.json" as const;
+export const WINDOWS_UPGRADE_WORK_PREFIX = ".1667-upgrade." as const;
+
+export interface PowerShellOwnershipRecord {
+  readonly schemaVersion: 1;
+  readonly product: typeof AI_1667_PRODUCT;
+  readonly installationId: string;
+  readonly method: "powershell";
+  readonly channel: UpgradeChannel;
+  readonly installRoot: string;
+  readonly executable: string;
+  readonly artifactTarget: "windows-x64";
+}
+
+export function readPowerShellOwnershipRecord(
+  authority: Extract<InstallationAuthority, { kind: "powershell" }>
+): PowerShellOwnershipRecord {
+  const recordPath = path.win32.join(authority.installRoot, INSTALL_OWNERSHIP_FILE);
+  const stats = lstatSync(recordPath);
+  if (!stats.isFile() || stats.isSymbolicLink() || stats.size <= 0 || stats.size > 16_384) {
+    throw new Error("Ownership Record is invalid");
+  }
+  const value = parseJsonRejectingDuplicateKeys(readFileSync(recordPath, "utf8"));
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("Ownership Record is invalid");
+  }
+  const record = value as Record<string, unknown>;
+  const expectedKeys = [...RECORD_KEYS].sort();
+  const keys = Object.keys(record).sort();
+  if (keys.length !== expectedKeys.length
+    || keys.some((key, index) => key !== expectedKeys[index])
+    || record.schemaVersion !== 1
+    || record.product !== AI_1667_PRODUCT
+    || record.method !== "powershell"
+    || record.artifactTarget !== "windows-x64"
+    || (record.channel !== "stable" && record.channel !== "beta")
+    || record.channel !== authority.channel
+    || !windowsPathEquals(record.installRoot, authority.installRoot)
+    || !windowsPathEquals(record.executable, authority.executable)
+    || typeof record.installationId !== "string"
+    || !/^[0-9a-f]{32}$/u.test(record.installationId)) {
+    throw new Error("Ownership Record changed before the Windows upgrade");
+  }
+  return record as unknown as PowerShellOwnershipRecord;
+}
+
+export function windowsPathEquals(left: unknown, right: string): boolean {
+  return typeof left === "string"
+    && path.win32.normalize(left).toLowerCase() === path.win32.normalize(right).toLowerCase();
+}

--- a/tui/test/managed-package-fixture.ts
+++ b/tui/test/managed-package-fixture.ts
@@ -90,6 +90,7 @@ export function buildCanonicalPlatformPackage(input: {
   readonly packageName: PublishedPlatformPackage;
   readonly version: string;
   readonly target: BuiltArtifactTarget;
+  readonly executableBody?: Buffer | string;
   readonly omit?: string;
   readonly badMode?: string;
   readonly noticeBody?: Buffer | string;
@@ -132,7 +133,8 @@ export function buildCanonicalPlatformPackage(input: {
       input.target
     )
   );
-  const executable = stubExecutableSource(input.version, input.target);
+  const executable = input.executableBody
+    ?? stubExecutableSource(input.version, input.target);
   const packageJson = JSON.stringify({
     name: input.packageName,
     version: input.version,
@@ -166,7 +168,11 @@ export function buildCanonicalPlatformPackage(input: {
     { path: "package/bin", body: "", mode: 0o755 },
     { path: "package/package.json", body: packageJson, mode: 0o644 },
     { path: "package/build-manifest.json", body: packageBuildManifest, mode: 0o644 },
-    { path: `package/${descriptor.executable}`, body: executable, mode: 0o755 },
+    {
+      path: `package/${descriptor.executable}`,
+      body: executable,
+      mode: descriptor.executable.endsWith(".exe") ? 0o644 : 0o755
+    },
     { path: "package/sbom.spdx.json", body: sbom, mode: 0o644 },
     { path: "package/LICENSE", body: license, mode: 0o644 },
     { path: "package/NOTICE", body: notice, mode: 0o644 }

--- a/tui/test/upgrade-cli.test.ts
+++ b/tui/test/upgrade-cli.test.ts
@@ -293,12 +293,6 @@ test("manual current releases do not recommend a redundant reinstall", async () 
 });
 
 const POWERSHELL_ROOT = "C:\\Users\\writer\\AppData\\Local\\Programs\\1667\\bin";
-const NPM_BETA_ATTESTATION = "gh attestation verify .\\install-beta.ps1 --repo 1667-ai/1667 "
-  + "--signer-workflow 1667-ai/1667/.github/workflows/release-npm.yml "
-  + "--deny-self-hosted-runners";
-const LEGACY_BETA_ATTESTATION = "gh attestation verify .\\install-beta.ps1 --repo 1667-ai/1667 "
-  + "--signer-workflow 1667-ai/1667/.github/workflows/release-github.yml "
-  + "--deny-self-hosted-runners";
 
 function powershellAuthority(channel: "stable" | "beta") {
   return {
@@ -355,7 +349,8 @@ test("PowerShell installs return the rerunnable Windows Installer command", asyn
     registry: fakeRegistry("2.0.0")
   });
   expect(rollback.exitCode).toBe(1);
-  expect(rollback.stderr).toContain(windowsInstallCommand(POWERSHELL_ROOT));
+  expect(rollback.stderr).toContain("Windows rollback is unavailable.");
+  expect(rollback.stderr).toContain("1667.exe upgrade --list");
 });
 
 test("an exact stable PowerShell version explains that the saved channel stays stable", async () => {
@@ -393,39 +388,6 @@ test("PowerShell plans bind the command to the exact immutable stable Installer"
   );
   expect(script).toContain("-InstallRoot 'C:\\Writer''s $tools'");
   expect(script).not.toContain("https://1667.ai/install.ps1");
-});
-
-test("an exact version on beta requires an attested beta Installer", async () => {
-  const applied = await executeUpgradeCli([
-    "--version",
-    "1.0.0",
-    "--channel",
-    "stable",
-    "--json"
-  ], {
-    observation,
-    authority: powershellAuthority("beta"),
-    registry: fakeRegistry("2.0.0")
-  });
-  expect(applied.exitCode).toBe(1);
-  expect(applied.stderr).toContain("make the Vault unreadable or damage Vault data");
-  const envelope = JSON.parse(applied.stdout);
-  expect(envelope).toMatchObject({
-    status: "error",
-    current: "1.2.3",
-    latest: null,
-    target: null,
-    channel: "stable",
-    method: "powershell",
-    command: null,
-    error: { code: "unsupported_target" }
-  });
-  expect(envelope.error.message).toContain(
-    "https://github.com/1667-ai/1667/releases/download/v1.0.0/install-beta.ps1"
-  );
-  expect(envelope.error.message).toContain(NPM_BETA_ATTESTATION);
-  expect(envelope.error.message).toContain(LEGACY_BETA_ATTESTATION);
-  expect(envelope.error.message).not.toContain("EncodedCommand");
 });
 
 test("an exact current PowerShell version does not install the channel head", async () => {
@@ -502,71 +464,14 @@ test("checking beta on PowerShell reports the newer beta without an executable c
   expect(human.exitCode).toBe(0);
   expect(human.stderr).toBe("");
   expect(human.stdout).toContain("1667 2.0.0-beta.1 is available on beta.");
-  expect(human.stdout).toContain("Run '1667 upgrade --channel beta'");
+  expect(human.stdout).toContain(
+    "Run '1667.exe upgrade --channel beta'. "
+    + "1667 verifies the release and starts the Windows update automatically."
+  );
+  expect(human.stdout).not.toContain("PowerShell Installer");
 });
 
-test("selecting beta without an exact version stays safe and gives release guidance", async () => {
-  const requested = await executeUpgradeCli(["--channel", "beta"], {
-    observation,
-    authority: powershellAuthority("stable"),
-    registry: fakeRegistry("2.0.0-beta.1")
-  });
-  expect(requested.exitCode).toBe(1);
-  expect(requested.stdout).toBe("");
-  expect(requested.stderr).toMatch(/Windows .*Installer.*stable.*only/i);
-  expect(requested.stderr).toContain("2.0.0-beta.1");
-  expect(requested.stderr).toMatch(/download .*Installer/i);
-  expect(requested.stderr).toContain(
-    "https://github.com/1667-ai/1667/releases/download/v2.0.0-beta.1/install-beta.ps1"
-  );
-  expect(requested.stderr).toContain(NPM_BETA_ATTESTATION);
-  expect(requested.stderr).toContain(LEGACY_BETA_ATTESTATION);
-  expect(requested.stderr).toContain(
-    "gh release download v2.0.0-beta.1 --repo 1667-ai/1667 "
-      + "--pattern install-beta.ps1 --output .\\install-beta.ps1"
-  );
-  expect(requested.stderr).toMatch(/saved channel.*beta/i);
-  expect(requested.stderr).toMatch(/powershell\b.*-File\b.*install-beta\.ps1/i);
-  expect(requested.stderr).not.toContain("install-stable.ps1");
-  expect(requested.stderr).not.toContain("https://1667.ai/install.ps1");
-  expect(requested.stderr).toContain("powershell -NoLogo -NoProfile -ExecutionPolicy Bypass");
-  expect(requested.stderr).not.toContain("EncodedCommand");
-  expect(/\birm\b.*install-beta\.ps1/i.test(requested.stderr)).toBe(false);
-});
-
-test("an exact PowerShell prerelease gives attested beta release guidance", async () => {
-  const version = "2.0.0-rc.1";
-  const applied = await executeUpgradeCli(["--version", version], {
-    observation,
-    authority: powershellAuthority("stable"),
-    registry: fakeRegistry("2.0.0")
-  });
-  const output = applied.stdout + applied.stderr;
-  expect(applied.exitCode).toBe(1);
-  expect(applied.stdout).toBe("");
-  expect(output).toContain(version);
-  expect(output).toMatch(/download .*Installer/i);
-  expect(output).toContain(
-    "https://github.com/1667-ai/1667/releases/download/v2.0.0-rc.1/install-beta.ps1"
-  );
-  expect(output).toContain(NPM_BETA_ATTESTATION);
-  expect(output).toContain(LEGACY_BETA_ATTESTATION);
-  expect(output).toContain(
-    "gh release download v2.0.0-rc.1 --repo 1667-ai/1667 "
-      + "--pattern install-beta.ps1 --output .\\install-beta.ps1"
-  );
-  expect(output).toMatch(/saved channel.*beta/i);
-  expect(output).toMatch(/powershell\b.*-File\b.*install-beta\.ps1/i);
-  expect(output).toContain("powershell -NoLogo -NoProfile -ExecutionPolicy Bypass");
-  expect(output).not.toContain("EncodedCommand");
-  expect(/\birm\b.*install-beta\.ps1/i.test(output)).toBe(false);
-  expect(output).not.toContain("install-stable.ps1");
-  expect(() => windowsInstallCommand(POWERSHELL_ROOT, version)).toThrow(
-    /stable channel/
-  );
-});
-
-test("beta PowerShell rollback states the refusal before reinstall guidance", async () => {
+test("beta PowerShell rollback points to exact release selection", async () => {
   const rollback = await executeUpgradeCli(["--rollback"], {
     observation,
     authority: powershellAuthority("beta"),
@@ -575,8 +480,9 @@ test("beta PowerShell rollback states the refusal before reinstall guidance", as
   expect(rollback.exitCode).toBe(1);
   expect(rollback.stdout).toBe("");
   expect(rollback.stderr).toContain("Windows rollback is unavailable.");
-  expect(rollback.stderr).toContain(NPM_BETA_ATTESTATION);
-  expect(rollback.stderr).toContain("install-beta.ps1");
+  expect(rollback.stderr).toContain("1667.exe upgrade --list");
+  expect(rollback.stderr).not.toContain("attestation");
+  expect(rollback.stderr).not.toContain("install-beta.ps1");
 });
 
 // A beta Installation that is already current is offered no command, so there
@@ -608,6 +514,13 @@ test("help is local and performs no registry I/O", async () => {
   // substring still passes if the guidance loses a case or is reversed.
   expect(result.stdout).toContain(
     "If you installed 1667 with npm, or you built it from source, update it the same\nway you installed it."
+  );
+  expect(result.stdout).toContain(
+    "On Windows, run 1667.exe. Beta upgrades are automatic. Stable upgrades use the\n"
+    + "PowerShell Installer."
+  );
+  expect(result.stdout).not.toContain(
+    "a PowerShell installation updates through the PowerShell Installer"
   );
   for (const internal of ["Managed Installation", "Candidate", "External installation"]) {
     expect(result.stdout).not.toContain(internal);

--- a/tui/test/windows-powershell-upgrade-compat.test.ts
+++ b/tui/test/windows-powershell-upgrade-compat.test.ts
@@ -1,0 +1,92 @@
+import { expect, test } from "bun:test";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  writeFileSync
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { readReleaseExecutableIdentity } from "../../shared/executable-probe.js";
+import { INSTALL_OWNERSHIP_FILE } from "../../shared/install-ownership-record.js";
+import { startWindowsUpgradeHandoff } from "../src/windows-upgrade-handoff.js";
+import { HANDOFF_SCRIPT } from "../src/windows-upgrade-handoff-script.js";
+import { WINDOWS_UPGRADE_FAILURE_FILE } from "../src/windows-upgrade-state.js";
+import {
+  removeWindowsHandoffScratch,
+  windowsTestExecutable
+} from "./windows-powershell-upgrade-fixture.js";
+
+const CURRENT = "1.2.3";
+const NEXT = "2.0.0-beta.1";
+
+test("the Windows helper validates SHA-256 without Get-FileHash", async () => {
+  if (process.platform !== "win32") return;
+
+  const scratch = mkdtempSync(path.join(tmpdir(), "1667-windows-digest-test-"));
+  try {
+    const installRoot = path.join(scratch, "installed");
+    const activePath = path.join(installRoot, "1667.exe");
+    const workRoot = path.join(installRoot, ".1667-upgrade.digest-integration");
+    const candidatePath = path.join(workRoot, "1667-candidate.exe");
+    const ownershipPath = path.join(installRoot, INSTALL_OWNERSHIP_FILE);
+    const failurePath = path.join(installRoot, WINDOWS_UPGRADE_FAILURE_FILE);
+    mkdirSync(workRoot, { recursive: true });
+    writeFileSync(activePath, windowsTestExecutable(scratch, CURRENT, "digest-current"));
+    writeFileSync(candidatePath, windowsTestExecutable(scratch, NEXT, "digest-candidate"));
+    writeFileSync(ownershipPath, `${JSON.stringify({
+      schemaVersion: 1,
+      product: "1667",
+      installationId: "abcdef0123456789abcdef0123456789",
+      method: "powershell",
+      channel: "stable",
+      installRoot,
+      executable: activePath,
+      artifactTarget: "windows-x64"
+    })}\n`);
+    const authority = {
+      kind: "powershell" as const,
+      channel: "stable" as const,
+      installRoot,
+      executable: activePath
+    };
+
+    await startWindowsUpgradeHandoff({
+      authority,
+      currentVersion: CURRENT,
+      targetVersion: NEXT,
+      channel: "beta",
+      updateChannel: true,
+      candidatePath,
+      candidateSha256: "0".repeat(64),
+      workRoot
+    });
+    await waitForFailureMarker(failurePath, workRoot);
+
+    expect(readFileSync(path.join(workRoot, HANDOFF_SCRIPT), "utf8"))
+      .not.toContain("Get-FileHash");
+    expect(JSON.parse(readFileSync(failurePath, "utf8"))).toMatchObject({
+      activeState: "unchanged",
+      message: "Candidate SHA-256 digest changed before handoff."
+    });
+    expect((await readReleaseExecutableIdentity(activePath)).productVersion).toBe(CURRENT);
+    expect(JSON.parse(readFileSync(ownershipPath, "utf8"))).toMatchObject({
+      channel: "stable"
+    });
+  } finally {
+    await removeWindowsHandoffScratch(scratch);
+  }
+}, 45_000);
+
+async function waitForFailureMarker(failurePath: string, workRoot: string): Promise<void> {
+  const deadline = Date.now() + 15_000;
+  while (Date.now() < deadline) {
+    if (existsSync(failurePath)) return;
+    await new Promise<void>((resolve) => setTimeout(resolve, 25));
+  }
+  const helperError = path.join(workRoot, "error.txt");
+  throw new Error(existsSync(helperError)
+    ? readFileSync(helperError, "utf8").trim()
+    : "Windows handoff did not report its digest failure");
+}

--- a/tui/test/windows-powershell-upgrade-fixture.ts
+++ b/tui/test/windows-powershell-upgrade-fixture.ts
@@ -1,0 +1,104 @@
+import { execFileSync } from "node:child_process";
+import { chmodSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import {
+  releaseIdentityJson,
+  stubExecutableSource
+} from "./managed-package-fixture.js";
+
+const TARGET = "windows-x64" as const;
+
+export function windowsTestExecutable(
+  scratch: string,
+  version: string,
+  name = "candidate"
+): Buffer | string {
+  if (process.platform !== "win32") return stubExecutableSource(version, TARGET);
+
+  const sourcePath = path.join(scratch, `${name}.cs`);
+  const outputPath = path.join(scratch, `${name}.exe`);
+  const compilerPath = path.join(scratch, `${name}-compile.ps1`);
+  const identity = releaseIdentityJson(version, TARGET);
+  writeFileSync(sourcePath, `using System;
+using System.IO;
+using System.Reflection;
+using System.Threading;
+public static class Program {
+  public static void Main(string[] args) {
+    if (args.Length == 2 && args[0] == "--version" && args[1] == "--json") {
+      Console.WriteLine(${JSON.stringify(identity)});
+      return;
+    }
+    if (args.Length == 1 && args[0] == "--hold") {
+      using (File.Open(Assembly.GetExecutingAssembly().Location, FileMode.Open,
+          FileAccess.Read, FileShare.Read)) {
+        Console.WriteLine("holding");
+        Thread.Sleep(60000);
+      }
+      return;
+    }
+    if (args.Length == 2 && args[0] == "--hold-file") {
+      using (File.Open(args[1], FileMode.Open, FileAccess.Read, FileShare.Read)) {
+        Console.WriteLine("holding");
+        Thread.Sleep(60000);
+      }
+      return;
+    }
+    if (args.Length == 2 && args[0] == "--wait-hold-file") {
+      DateTime deadline = DateTime.UtcNow.AddSeconds(15);
+      while (true) {
+        if (DateTime.UtcNow >= deadline) Environment.Exit(2);
+        if (!File.Exists(args[1])) {
+          Thread.Sleep(10);
+          continue;
+        }
+        try {
+          using (File.Open(args[1], FileMode.Open, FileAccess.ReadWrite, FileShare.Read)) {
+            Console.WriteLine("holding");
+            Thread.Sleep(60000);
+          }
+          return;
+        } catch (IOException) {
+          Thread.Sleep(10);
+        }
+      }
+    }
+    Environment.Exit(1);
+  }
+}
+`);
+  writeFileSync(compilerPath, `param([string]$Source, [string]$Output)
+$ErrorActionPreference = 'Stop'
+Add-Type -Path $Source -OutputAssembly $Output -OutputType ConsoleApplication
+`);
+  execFileSync("powershell.exe", [
+    "-NoLogo",
+    "-NoProfile",
+    "-ExecutionPolicy",
+    "Bypass",
+    "-File",
+    compilerPath,
+    sourcePath,
+    outputPath
+  ]);
+  chmodSync(outputPath, 0o755);
+  return readFileSync(outputPath);
+}
+
+export async function removeWindowsHandoffScratch(scratch: string): Promise<void> {
+  const deadline = Date.now() + 5_000;
+  while (true) {
+    try {
+      rmSync(scratch, { recursive: true, force: true });
+      return;
+    } catch (error) {
+      const code = error && typeof error === "object" && "code" in error
+        ? String(error.code)
+        : "";
+      if (!new Set(["EBUSY", "ENOTEMPTY", "EPERM"]).has(code) || Date.now() >= deadline) {
+        throw error;
+      }
+      await new Promise<void>((resolve) => setTimeout(resolve, 50));
+    }
+  }
+}

--- a/tui/test/windows-powershell-upgrade-recovery.test.ts
+++ b/tui/test/windows-powershell-upgrade-recovery.test.ts
@@ -259,6 +259,7 @@ test("post-commit cleanup failure preserves the successful Windows upgrade", asy
     expect((await readReleaseExecutableIdentity(activePath)).productVersion).toBe(NEXT);
     expect(JSON.parse(readFileSync(ownershipPath, "utf8"))).toMatchObject({
       channel: "beta",
+      installRoot,
       executable: activePath
     });
 
@@ -369,6 +370,7 @@ for (const scenario of [
       expect((await readReleaseExecutableIdentity(activePath)).productVersion).toBe(NEXT);
       expect(JSON.parse(readFileSync(ownershipPath, "utf8"))).toMatchObject({
         channel: scenario.savedChannel,
+        installRoot,
         executable: activePath
       });
       expect(workRoots.some((workRoot) => existsSync(workRoot))).toBe(false);

--- a/tui/test/windows-powershell-upgrade-recovery.test.ts
+++ b/tui/test/windows-powershell-upgrade-recovery.test.ts
@@ -1,0 +1,444 @@
+import { expect, test } from "bun:test";
+import { spawn, type ChildProcess } from "node:child_process";
+import { createHash } from "node:crypto";
+import { once } from "node:events";
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  writeFileSync
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { readReleaseExecutableIdentity } from "../../shared/executable-probe.js";
+import { INSTALL_OWNERSHIP_FILE } from "../../shared/install-ownership-record.js";
+import { INSTALL_LOCK_FILE } from "../../shared/install-layout.js";
+import {
+  releaseTargetForArtifact,
+  type PublishedPlatformPackage
+} from "../../shared/release-targets.js";
+import { executeUpgradeCli } from "../src/upgrade-cli.js";
+import { startWindowsUpgradeHandoff } from "../src/windows-upgrade-handoff.js";
+import { recoverWindowsUpgradeFailure } from "../src/windows-upgrade-recovery.js";
+import { WINDOWS_UPGRADE_FAILURE_FILE } from "../src/windows-upgrade-state.js";
+import {
+  buildCanonicalPlatformPackage,
+  fakeManagedRegistry
+} from "./managed-package-fixture.js";
+import {
+  removeWindowsHandoffScratch,
+  windowsTestExecutable
+} from "./windows-powershell-upgrade-fixture.js";
+
+const TARGET = "windows-x64" as const;
+const PACKAGE = releaseTargetForArtifact(TARGET).packageName as PublishedPlatformPackage;
+const CURRENT = "1.2.3";
+const NEXT = "2.0.0-beta.1";
+
+test("a rolled-back Windows handoff is visible and the next upgrade retries", async () => {
+  if (process.platform !== "win32") return;
+
+  const scratch = mkdtempSync(path.join(tmpdir(), "1667-windows-recovery-test-"));
+  let ownershipLocker: ChildProcess | undefined;
+  try {
+    const installRoot = path.join(scratch, "installed");
+    const activePath = path.join(installRoot, "1667.exe");
+    const failedWorkRoot = path.join(installRoot, ".1667-upgrade.failure-integration");
+    const failedCandidate = path.join(failedWorkRoot, "1667-candidate.exe");
+    const failurePath = path.join(installRoot, WINDOWS_UPGRADE_FAILURE_FILE);
+    const ownershipPath = path.join(installRoot, INSTALL_OWNERSHIP_FILE);
+    mkdirSync(failedWorkRoot, { recursive: true });
+    writeFileSync(activePath, windowsTestExecutable(scratch, CURRENT, "recovery-current"));
+    writeFileSync(failedCandidate, windowsTestExecutable(scratch, NEXT, "recovery-failed"));
+    writeFileSync(ownershipPath, `${JSON.stringify({
+      schemaVersion: 1,
+      product: "1667",
+      installationId: "0123456789abcdef0123456789abcdef",
+      method: "powershell",
+      channel: "stable",
+      installRoot,
+      executable: activePath,
+      artifactTarget: TARGET
+    })}\n`);
+    const lockerPath = path.join(scratch, "locker.exe");
+    copyFileSync(activePath, lockerPath);
+    ownershipLocker = spawn(lockerPath, ["--hold-file", ownershipPath], {
+      stdio: ["ignore", "pipe", "pipe"],
+      windowsHide: true
+    });
+    await once(ownershipLocker.stdout!, "data");
+    const authority = {
+      kind: "powershell" as const,
+      channel: "stable" as const,
+      installRoot,
+      executable: activePath
+    };
+
+    await startWindowsUpgradeHandoff({
+      authority,
+      currentVersion: CURRENT,
+      targetVersion: NEXT,
+      channel: "beta",
+      updateChannel: true,
+      candidatePath: failedCandidate,
+      candidateSha256: createHash("sha256")
+        .update(readFileSync(failedCandidate))
+        .digest("hex"),
+      workRoot: failedWorkRoot
+    });
+    await waitForFailureMarker(failurePath, failedWorkRoot);
+    const failure = JSON.parse(readFileSync(failurePath, "utf8")) as {
+      activeState: string;
+      message: string;
+    };
+    expect(failure).toMatchObject({
+      fromVersion: CURRENT,
+      targetVersion: NEXT,
+      targetChannel: "beta",
+      activeState: "restored"
+    });
+    expect(failure.message.length > 0).toBe(true);
+    expect((await readReleaseExecutableIdentity(activePath)).productVersion).toBe(CURRENT);
+    expect(JSON.parse(readFileSync(ownershipPath, "utf8"))).toMatchObject({
+      channel: "stable"
+    });
+
+    const lockerClose = once(ownershipLocker, "close");
+    expect(ownershipLocker.kill()).toBe(true);
+    await lockerClose;
+    ownershipLocker = undefined;
+
+    const executableBody = windowsTestExecutable(scratch, NEXT, "recovery-retry");
+    const pkg = buildCanonicalPlatformPackage({
+      packageName: PACKAGE,
+      version: NEXT,
+      target: TARGET,
+      executableBody
+    });
+    let retryHandoffs = 0;
+    const retry = await executeUpgradeCli(["--channel=beta", "--json"], {
+      observation: { currentVersion: CURRENT, platformPackage: PACKAGE },
+      authority,
+      registry: fakeManagedRegistry(NEXT, PACKAGE, pkg.integrity, pkg.tarballUrl),
+      fetcher: async (input: string | URL | Request) => {
+        if (String(input) === pkg.tarballUrl) {
+          return new Response(new Uint8Array(pkg.bytes), { status: 200 });
+        }
+        throw new Error(`unexpected fetch: ${String(input)}`);
+      },
+      startWindowsUpgradeHandoff: async (request) => {
+        retryHandoffs += 1;
+        expect(request.workRoot).not.toBe(failedWorkRoot);
+        expect(existsSync(failurePath)).toBe(false);
+        expect(existsSync(path.join(failedWorkRoot, "request.json"))).toBe(false);
+        expect((await readReleaseExecutableIdentity(request.candidatePath)).productVersion)
+          .toBe(NEXT);
+      }
+    });
+
+    expect(retry).toMatchObject({ exitCode: 0 });
+    expect(retry.stderr).toBe(
+      "Warning: Previous Windows upgrade did not finish: "
+      + `${failure.message}${failure.message.endsWith(".") ? "" : "."} `
+      + "Continuing with this upgrade command.\n"
+    );
+    expect(retry.stderr).not.toContain("Retrying");
+    expect(JSON.parse(retry.stdout)).toEqual({
+      status: "staged",
+      current: CURRENT,
+      latest: NEXT,
+      target: NEXT,
+      channel: "beta",
+      method: "powershell",
+      restartRequired: true,
+      command: null,
+      error: null
+    });
+    expect(retry.envelope).toEqual(JSON.parse(retry.stdout));
+    expect(retryHandoffs).toBe(1);
+    expect((await readReleaseExecutableIdentity(activePath)).productVersion).toBe(CURRENT);
+    expect(JSON.parse(readFileSync(ownershipPath, "utf8")))
+      .toMatchObject({ channel: "stable" });
+  } finally {
+    if (ownershipLocker?.exitCode === null) {
+      const lockerClose = once(ownershipLocker, "close");
+      ownershipLocker.kill();
+      await lockerClose;
+    }
+    await removeWindowsHandoffScratch(scratch);
+  }
+}, 45_000);
+
+test("post-commit cleanup failure preserves the successful Windows upgrade", async () => {
+  if (process.platform !== "win32") return;
+
+  const scratch = mkdtempSync(path.join(tmpdir(), "1667-windows-cleanup-test-"));
+  let activeProcess: ChildProcess | undefined;
+  let transactionLocker: ChildProcess | undefined;
+  let completionWaiter: ChildProcess | undefined;
+  try {
+    const installRoot = path.join(scratch, "installed");
+    const activePath = path.join(installRoot, "1667.exe");
+    const workRoot = path.join(installRoot, ".1667-upgrade.cleanup-integration");
+    const candidatePath = path.join(workRoot, "1667-candidate.exe");
+    const transactionPath = path.join(workRoot, "transaction.json");
+    const ownershipPath = path.join(installRoot, INSTALL_OWNERSHIP_FILE);
+    const failurePath = path.join(installRoot, WINDOWS_UPGRADE_FAILURE_FILE);
+    mkdirSync(workRoot, { recursive: true });
+    writeFileSync(activePath, windowsTestExecutable(scratch, CURRENT, "cleanup-current"));
+    writeFileSync(candidatePath, windowsTestExecutable(scratch, NEXT, "cleanup-candidate"));
+    writeFileSync(ownershipPath, `${JSON.stringify({
+      schemaVersion: 1,
+      product: "1667",
+      installationId: "fedcba9876543210fedcba9876543210",
+      method: "powershell",
+      channel: "stable",
+      installRoot,
+      executable: activePath,
+      artifactTarget: TARGET
+    })}\n`);
+    const authority = {
+      kind: "powershell" as const,
+      channel: "stable" as const,
+      installRoot,
+      executable: activePath
+    };
+
+    activeProcess = spawn(activePath, ["--hold"], {
+      stdio: ["ignore", "pipe", "pipe"],
+      windowsHide: true
+    });
+    await once(activeProcess.stdout!, "data");
+    const lockerPath = path.join(scratch, "cleanup-locker.exe");
+    copyFileSync(activePath, lockerPath);
+    transactionLocker = spawn(lockerPath, ["--wait-hold-file", transactionPath], {
+      stdio: ["ignore", "pipe", "pipe"],
+      windowsHide: true
+    });
+    const transactionLocked = once(transactionLocker.stdout!, "data");
+
+    await startWindowsUpgradeHandoff({
+      authority,
+      currentVersion: CURRENT,
+      targetVersion: NEXT,
+      channel: "beta",
+      updateChannel: true,
+      candidatePath,
+      candidateSha256: createHash("sha256")
+        .update(readFileSync(candidatePath))
+        .digest("hex"),
+      workRoot
+    });
+    await transactionLocked;
+    expect(activeProcess.exitCode).toBe(null);
+    expect((await readReleaseExecutableIdentity(activePath)).productVersion).toBe(CURRENT);
+
+    const activeClose = once(activeProcess, "close");
+    expect(activeProcess.kill()).toBe(true);
+    await activeClose;
+    activeProcess = undefined;
+
+    completionWaiter = spawn(lockerPath, [
+      "--wait-hold-file",
+      path.join(installRoot, INSTALL_LOCK_FILE)
+    ], {
+      stdio: ["ignore", "pipe", "pipe"],
+      windowsHide: true
+    });
+    await once(completionWaiter.stdout!, "data");
+    const completionClose = once(completionWaiter, "close");
+    expect(completionWaiter.kill()).toBe(true);
+    await completionClose;
+    completionWaiter = undefined;
+
+    expect(await recoverWindowsUpgradeFailure({ ...authority, channel: "beta" })).toBe(null);
+    expect(existsSync(transactionPath)).toBe(true);
+    expect(existsSync(failurePath)).toBe(false);
+    expect((await readReleaseExecutableIdentity(activePath)).productVersion).toBe(NEXT);
+    expect(JSON.parse(readFileSync(ownershipPath, "utf8"))).toMatchObject({
+      channel: "beta",
+      executable: activePath
+    });
+
+    const lockerClose = once(transactionLocker, "close");
+    expect(transactionLocker.kill()).toBe(true);
+    await lockerClose;
+    transactionLocker = undefined;
+  } finally {
+    if (activeProcess?.exitCode === null) {
+      const activeClose = once(activeProcess, "close");
+      activeProcess.kill();
+      await activeClose;
+    }
+    if (transactionLocker?.exitCode === null) {
+      const lockerClose = once(transactionLocker, "close");
+      transactionLocker.kill();
+      await lockerClose;
+    }
+    if (completionWaiter?.exitCode === null) {
+      const completionClose = once(completionWaiter, "close");
+      completionWaiter.kill();
+      await completionClose;
+    }
+    await removeWindowsHandoffScratch(scratch);
+  }
+}, 45_000);
+
+for (const scenario of [
+  { name: "channel switch", updateChannel: true, savedChannel: "beta" },
+  { name: "exact version", updateChannel: false, savedChannel: "stable" }
+] as const) {
+  test(`concurrent Windows ${scenario.name} handoffs converge safely`, async () => {
+    if (process.platform !== "win32") return;
+
+    const scratch = mkdtempSync(path.join(tmpdir(), "1667-windows-concurrent-test-"));
+    let activeProcess: ChildProcess | undefined;
+    try {
+      const installRoot = path.join(scratch, "installed");
+      const activePath = path.join(installRoot, "1667.exe");
+      const ownershipPath = path.join(installRoot, INSTALL_OWNERSHIP_FILE);
+      const failurePath = path.join(installRoot, WINDOWS_UPGRADE_FAILURE_FILE);
+      const workRoots = [
+        path.join(installRoot, ".1667-upgrade.concurrent-a"),
+        path.join(installRoot, ".1667-upgrade.concurrent-b")
+      ];
+      for (const workRoot of workRoots) mkdirSync(workRoot, { recursive: true });
+      writeFileSync(activePath, windowsTestExecutable(scratch, CURRENT, "concurrent-current"));
+      const candidate = windowsTestExecutable(scratch, NEXT, "concurrent-candidate");
+      for (const workRoot of workRoots) {
+        writeFileSync(path.join(workRoot, "1667-candidate.exe"), candidate);
+      }
+      writeFileSync(ownershipPath, `${JSON.stringify({
+        schemaVersion: 1,
+        product: "1667",
+        installationId: "00112233445566778899aabbccddeeff",
+        method: "powershell",
+        channel: "stable",
+        installRoot,
+        executable: activePath,
+        artifactTarget: TARGET
+      })}\n`);
+      const authority = {
+        kind: "powershell" as const,
+        channel: "stable" as const,
+        installRoot,
+        executable: activePath
+      };
+      activeProcess = spawn(activePath, ["--hold"], {
+        stdio: ["ignore", "pipe", "pipe"],
+        windowsHide: true
+      });
+      await once(activeProcess.stdout!, "data");
+
+      await Promise.all(workRoots.map(async (workRoot) => {
+        const candidatePath = path.join(workRoot, "1667-candidate.exe");
+        await startWindowsUpgradeHandoff({
+          authority,
+          currentVersion: CURRENT,
+          targetVersion: NEXT,
+          channel: "beta",
+          updateChannel: scenario.updateChannel,
+          candidatePath,
+          candidateSha256: createHash("sha256")
+            .update(readFileSync(candidatePath))
+            .digest("hex"),
+          workRoot
+        });
+      }));
+      await waitForAnyTransaction(workRoots, failurePath);
+
+      const activeClose = once(activeProcess, "close");
+      expect(activeProcess.kill()).toBe(true);
+      await activeClose;
+      activeProcess = undefined;
+
+      await waitForConcurrentSuccess(
+        activePath,
+        ownershipPath,
+        workRoots,
+        failurePath,
+        scenario.savedChannel
+      );
+      expect(await recoverWindowsUpgradeFailure({
+        ...authority,
+        channel: scenario.savedChannel
+      })).toBe(null);
+      expect(existsSync(failurePath)).toBe(false);
+      expect((await readReleaseExecutableIdentity(activePath)).productVersion).toBe(NEXT);
+      expect(JSON.parse(readFileSync(ownershipPath, "utf8"))).toMatchObject({
+        channel: scenario.savedChannel,
+        executable: activePath
+      });
+      expect(workRoots.some((workRoot) => existsSync(workRoot))).toBe(false);
+    } finally {
+      if (activeProcess?.exitCode === null) {
+        const activeClose = once(activeProcess, "close");
+        activeProcess.kill();
+        await activeClose;
+      }
+      await removeWindowsHandoffScratch(scratch);
+    }
+  }, 60_000);
+}
+
+async function waitForFailureMarker(failurePath: string, workRoot: string): Promise<void> {
+  const deadline = Date.now() + 15_000;
+  while (Date.now() < deadline) {
+    if (existsSync(failurePath)) return;
+    await new Promise<void>((resolve) => setTimeout(resolve, 25));
+  }
+  const helperError = path.join(workRoot, "error.txt");
+  throw new Error(existsSync(helperError)
+    ? readFileSync(helperError, "utf8").trim()
+    : "Windows handoff did not report its failure");
+}
+
+async function waitForAnyTransaction(
+  workRoots: readonly string[],
+  failurePath: string
+): Promise<void> {
+  const deadline = Date.now() + 15_000;
+  while (Date.now() < deadline) {
+    if (existsSync(failurePath)) {
+      throw new Error(readFileSync(failurePath, "utf8"));
+    }
+    if (workRoots.some((root) => existsSync(path.join(root, "transaction.json")))) return;
+    await new Promise<void>((resolve) => setTimeout(resolve, 25));
+  }
+  throw new Error("Concurrent Windows handoffs did not reach the replacement attempt");
+}
+
+async function waitForConcurrentSuccess(
+  activePath: string,
+  ownershipPath: string,
+  workRoots: readonly string[],
+  failurePath: string,
+  expectedChannel: "stable" | "beta"
+): Promise<void> {
+  const deadline = Date.now() + 30_000;
+  while (Date.now() < deadline) {
+    if (existsSync(failurePath)) {
+      throw new Error(readFileSync(failurePath, "utf8"));
+    }
+    try {
+      const ownership = JSON.parse(readFileSync(ownershipPath, "utf8")) as {
+        channel?: unknown;
+      };
+      if (ownership.channel === expectedChannel
+        && workRoots.every((workRoot) => !existsSync(workRoot))) {
+        const identity = await readReleaseExecutableIdentity(activePath);
+        if (identity.productVersion === NEXT) return;
+      }
+    } catch {
+      // The other helper can be replacing an observed file.
+    }
+    await new Promise<void>((resolve) => setTimeout(resolve, 50));
+  }
+  const errors = workRoots
+    .map((root) => path.join(root, "error.txt"))
+    .filter(existsSync)
+    .map((file) => readFileSync(file, "utf8").trim());
+  throw new Error(errors.join("; ") || "Concurrent Windows handoffs did not finish");
+}

--- a/tui/test/windows-powershell-upgrade.test.ts
+++ b/tui/test/windows-powershell-upgrade.test.ts
@@ -348,6 +348,7 @@ process.stdout.write(String(process.pid));
     expect((await readReleaseExecutableIdentity(activePath)).productVersion).toBe(NEXT);
     expect(JSON.parse(readFileSync(ownershipPath, "utf8"))).toMatchObject({
       channel: "beta",
+      installRoot,
       executable: activePath
     });
   } finally {

--- a/tui/test/windows-powershell-upgrade.test.ts
+++ b/tui/test/windows-powershell-upgrade.test.ts
@@ -1,0 +1,409 @@
+import { expect, test } from "bun:test";
+import { execFileSync, spawn, type ChildProcess } from "node:child_process";
+import { createHash } from "node:crypto";
+import { once } from "node:events";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { readReleaseExecutableIdentity } from "../../shared/executable-probe.js";
+import { INSTALL_OWNERSHIP_FILE } from "../../shared/install-ownership-record.js";
+import {
+  releaseTargetForArtifact,
+  type PublishedPlatformPackage
+} from "../../shared/release-targets.js";
+import { executeUpgradeCli } from "../src/upgrade-cli.js";
+import {
+  buildCanonicalPlatformPackage,
+  fakeManagedRegistry
+} from "./managed-package-fixture.js";
+import {
+  removeWindowsHandoffScratch,
+  windowsTestExecutable
+} from "./windows-powershell-upgrade-fixture.js";
+
+const TARGET = "windows-x64" as const;
+const PACKAGE = releaseTargetForArtifact(TARGET).packageName as PublishedPlatformPackage;
+const CURRENT = "1.2.3";
+const NEXT = "2.0.0-beta.1";
+
+test("a PowerShell beta switch verifies the npm Candidate and starts the handoff", async () => {
+  const scratch = mkdtempSync(path.join(tmpdir(), "1667-windows-upgrade-test-"));
+  const workRoots = new Set<string>();
+  try {
+    const executableBody = windowsTestExecutable(scratch, NEXT);
+    const pkg = buildCanonicalPlatformPackage({
+      packageName: PACKAGE,
+      version: NEXT,
+      target: TARGET,
+      executableBody
+    });
+    const registry = fakeManagedRegistry(NEXT, PACKAGE, pkg.integrity, pkg.tarballUrl);
+    const installRoot = path.join(scratch, "installed");
+    mkdirSync(installRoot);
+    const starts: Array<{
+      readonly channel: string;
+      readonly updateChannel: boolean;
+      readonly currentVersion: string;
+      readonly targetVersion: string;
+      readonly candidateVersion: string;
+    }> = [];
+    const dependencies = {
+      observation: { currentVersion: CURRENT, platformPackage: PACKAGE },
+      authority: {
+        kind: "powershell" as const,
+        channel: "stable" as const,
+        installRoot,
+        executable: path.join(installRoot, "1667.exe")
+      },
+      registry,
+      fetcher: async (input: string | URL | Request) => {
+        if (String(input) === pkg.tarballUrl) {
+          return new Response(new Uint8Array(pkg.bytes), { status: 200 });
+        }
+        throw new Error(`unexpected fetch: ${String(input)}`);
+      },
+      startWindowsUpgradeHandoff: async (request: {
+        readonly channel: string;
+        readonly updateChannel: boolean;
+        readonly currentVersion: string;
+        readonly targetVersion: string;
+        readonly candidatePath: string;
+        readonly workRoot: string;
+      }) => {
+        workRoots.add(request.workRoot);
+        const identity = await readReleaseExecutableIdentity(request.candidatePath);
+        starts.push({
+          channel: request.channel,
+          updateChannel: request.updateChannel,
+          currentVersion: request.currentVersion,
+          targetVersion: request.targetVersion,
+          candidateVersion: identity.productVersion
+        });
+      }
+    };
+
+    const human = await executeUpgradeCli(["--channel=beta"], dependencies);
+    expect(human).toMatchObject({ exitCode: 0, stderr: "" });
+    expect(human.stdout).toBe(
+      `1667 ${NEXT} is verified and staged.\n`
+        + "Windows will finish the upgrade after this command exits. "
+        + "Start 1667.exe again after it finishes.\n"
+    );
+
+    const json = await executeUpgradeCli(["--channel=beta", "--json"], dependencies);
+    expect(json).toMatchObject({ exitCode: 0, stderr: "" });
+    expect(JSON.parse(json.stdout)).toEqual({
+      status: "staged",
+      current: CURRENT,
+      latest: NEXT,
+      target: NEXT,
+      channel: "beta",
+      method: "powershell",
+      restartRequired: true,
+      command: null,
+      error: null
+    });
+    expect(json.envelope).toEqual(JSON.parse(json.stdout));
+    expect(/attest|gh release|install-beta\.ps1|EncodedCommand/iu.test(json.stdout)).toBe(false);
+    expect(starts).toEqual([
+      {
+        channel: "beta",
+        updateChannel: true,
+        currentVersion: CURRENT,
+        targetVersion: NEXT,
+        candidateVersion: NEXT
+      },
+      {
+        channel: "beta",
+        updateChannel: true,
+        currentVersion: CURRENT,
+        targetVersion: NEXT,
+        candidateVersion: NEXT
+      }
+    ]);
+  } finally {
+    for (const workRoot of workRoots) {
+      rmSync(workRoot, { recursive: true, force: true });
+    }
+    rmSync(scratch, { recursive: true, force: true });
+  }
+});
+
+test("a PowerShell beta check is read-only", async () => {
+  let handoffs = 0;
+  let downloads = 0;
+  const checked = await executeUpgradeCli(["--check", "--channel=beta", "--json"], {
+    observation: { currentVersion: CURRENT, platformPackage: PACKAGE },
+    authority: {
+      kind: "powershell",
+      channel: "stable",
+      installRoot: "C:\\Program Files\\1667",
+      executable: "C:\\Program Files\\1667\\1667.exe"
+    },
+    registry: fakeManagedRegistry(
+      NEXT,
+      PACKAGE,
+      `sha512-${"A".repeat(86)}==`,
+      "https://registry.npmjs.org/@1667-ai/cli-win32-x64/-/cli-win32-x64-2.0.0-beta.1.tgz"
+    ),
+    fetcher: async () => {
+      downloads += 1;
+      throw new Error("a check must not download a package");
+    },
+    startWindowsUpgradeHandoff: () => {
+      handoffs += 1;
+      throw new Error("a check must not start a handoff");
+    }
+  });
+
+  expect(checked).toMatchObject({ exitCode: 0, stderr: "" });
+  expect(JSON.parse(checked.stdout)).toMatchObject({
+    status: "available",
+    current: CURRENT,
+    latest: NEXT,
+    target: NEXT,
+    channel: "beta",
+    method: "powershell",
+    restartRequired: false,
+    command: null,
+    error: null
+  });
+  expect(downloads).toBe(0);
+  expect(handoffs).toBe(0);
+});
+
+test("a same-version PowerShell beta switch saves the channel without a handoff", async () => {
+  const scratch = mkdtempSync(path.join(tmpdir(), "1667-windows-channel-test-"));
+  let downloads = 0;
+  let handoffs = 0;
+  const saved: string[] = [];
+  try {
+    const installRoot = process.platform === "win32"
+      ? path.join(scratch, "installed")
+      : "C:\\Program Files\\1667";
+    const executable = path.win32.join(installRoot, "1667.exe");
+    if (process.platform === "win32") {
+      mkdirSync(installRoot);
+      writeFileSync(path.join(installRoot, INSTALL_OWNERSHIP_FILE), `${JSON.stringify({
+        schemaVersion: 1,
+        product: "1667",
+        installationId: "0123456789abcdef0123456789abcdef",
+        method: "powershell",
+        channel: "stable",
+        installRoot,
+        executable,
+        artifactTarget: TARGET
+      })}\n`);
+    }
+    const switched = await executeUpgradeCli(["--channel=beta", "--json"], {
+      observation: { currentVersion: NEXT, platformPackage: PACKAGE },
+      authority: {
+        kind: "powershell",
+        channel: "stable",
+        installRoot,
+        executable
+      },
+      registry: fakeManagedRegistry(
+        NEXT,
+        PACKAGE,
+        `sha512-${"A".repeat(86)}==`,
+        "https://registry.npmjs.org/@1667-ai/cli-win32-x64/-/cli-win32-x64-2.0.0-beta.1.tgz"
+      ),
+      fetcher: async () => {
+        downloads += 1;
+        throw new Error("a same-version channel switch must not download a package");
+      },
+      startWindowsUpgradeHandoff: () => {
+        handoffs += 1;
+        throw new Error("a same-version channel switch must not start a handoff");
+      },
+      ...(process.platform === "win32"
+        ? {}
+        : {
+            saveWindowsUpgradeChannel: (_authority: unknown, channel: string) => {
+              saved.push(channel);
+            }
+          })
+    });
+
+    expect(switched).toMatchObject({ exitCode: 0, stderr: "" });
+    expect(JSON.parse(switched.stdout)).toEqual({
+      status: "up-to-date",
+      current: NEXT,
+      latest: NEXT,
+      target: null,
+      channel: "beta",
+      method: "powershell",
+      restartRequired: false,
+      command: null,
+      error: null
+    });
+    if (process.platform === "win32") {
+      expect(JSON.parse(
+        readFileSync(path.join(installRoot, INSTALL_OWNERSHIP_FILE), "utf8")
+      )).toMatchObject({ channel: "beta" });
+    } else {
+      expect(saved).toEqual(["beta"]);
+    }
+    expect(downloads).toBe(0);
+    expect(handoffs).toBe(0);
+  } finally {
+    rmSync(scratch, { recursive: true, force: true });
+  }
+});
+
+test("the detached Windows handoff waits for running 1667, then replaces it", async () => {
+  if (process.platform !== "win32") return;
+
+  const scratch = mkdtempSync(path.join(tmpdir(), "1667-windows-handoff-test-"));
+  let activeProcess: ChildProcess | undefined;
+  try {
+    const installRoot = path.join(scratch, "installed");
+    const activePath = path.join(installRoot, "1667.exe");
+    const workRoot = path.join(installRoot, ".1667-upgrade.integration");
+    const candidatePath = path.join(workRoot, "1667-candidate.exe");
+    mkdirSync(workRoot, { recursive: true });
+    const currentExecutable = windowsTestExecutable(scratch, CURRENT, "current");
+    const currentBytes = Buffer.isBuffer(currentExecutable)
+      ? currentExecutable
+      : Buffer.from(currentExecutable);
+    writeFileSync(activePath, currentBytes);
+    writeFileSync(candidatePath, windowsTestExecutable(scratch, NEXT, "candidate"));
+    chmodSync(activePath, 0o755);
+    chmodSync(candidatePath, 0o755);
+    const ownershipPath = path.join(installRoot, INSTALL_OWNERSHIP_FILE);
+    writeFileSync(ownershipPath, `${JSON.stringify({
+      schemaVersion: 1,
+      product: "1667",
+      installationId: "0123456789abcdef0123456789abcdef",
+      method: "powershell",
+      channel: "stable",
+      installRoot,
+      executable: activePath,
+      artifactTarget: TARGET
+    })}\n`);
+    activeProcess = spawn(activePath, ["--hold"], {
+      stdio: ["ignore", "pipe", "pipe"],
+      windowsHide: true
+    });
+    await once(activeProcess.stdout!, "data");
+    const requestPath = path.join(scratch, "handoff-request.json");
+    writeFileSync(requestPath, JSON.stringify({
+      authority: {
+        kind: "powershell",
+        channel: "stable",
+        installRoot,
+        executable: activePath
+      },
+      currentVersion: CURRENT,
+      targetVersion: NEXT,
+      channel: "beta",
+      updateChannel: true,
+      candidatePath,
+      candidateSha256: createHash("sha256")
+        .update(readFileSync(candidatePath))
+        .digest("hex"),
+      workRoot
+    }));
+    const starterPath = path.join(scratch, "start-handoff.ts");
+    const handoffModule = pathToFileURL(fileURLToPath(
+      new URL("../src/windows-upgrade-handoff.ts", import.meta.url)
+    )).href;
+    writeFileSync(starterPath, `import { readFileSync } from "node:fs";
+import { startWindowsUpgradeHandoff } from ${JSON.stringify(handoffModule)};
+const request = JSON.parse(readFileSync(process.argv[2], "utf8"));
+await startWindowsUpgradeHandoff(request);
+process.stdout.write(String(process.pid));
+`);
+
+    const starterPid = Number(execFileSync(process.execPath, [starterPath, requestPath], {
+      encoding: "utf8",
+      timeout: 10_000
+    }));
+    expect(Number.isSafeInteger(starterPid)).toBe(true);
+    expect(starterPid).not.toBe(process.pid);
+
+    await waitForHandoffAttempt(workRoot);
+    expect(activeProcess.exitCode).toBe(null);
+    expect(readFileSync(activePath).equals(currentBytes)).toBe(true);
+    expect(JSON.parse(readFileSync(ownershipPath, "utf8"))).toMatchObject({
+      channel: "stable"
+    });
+
+    const activeClose = once(activeProcess, "close");
+    expect(activeProcess.kill()).toBe(true);
+    await activeClose;
+    activeProcess = undefined;
+
+    await waitForHandoff(activePath, ownershipPath, workRoot, starterPid);
+    expect((await readReleaseExecutableIdentity(activePath)).productVersion).toBe(NEXT);
+    expect(JSON.parse(readFileSync(ownershipPath, "utf8"))).toMatchObject({
+      channel: "beta",
+      executable: activePath
+    });
+  } finally {
+    if (activeProcess?.exitCode === null) {
+      const activeClose = once(activeProcess, "close");
+      activeProcess.kill();
+      await activeClose;
+    }
+    await removeWindowsHandoffScratch(scratch);
+  }
+}, 75_000);
+
+async function waitForHandoffAttempt(workRoot: string): Promise<void> {
+  const transactionPath = path.join(workRoot, "transaction.json");
+  const errorPath = path.join(workRoot, "error.txt");
+  const deadline = Date.now() + 15_000;
+  while (Date.now() < deadline) {
+    if (existsSync(transactionPath)) return;
+    if (existsSync(errorPath)) {
+      throw new Error(readFileSync(errorPath, "utf8").trim());
+    }
+    await new Promise<void>((resolve) => setTimeout(resolve, 25));
+  }
+  throw new Error("Windows handoff did not reach the replacement attempt");
+}
+
+async function waitForHandoff(
+  activePath: string,
+  ownershipPath: string,
+  workRoot: string,
+  starterPid: number
+): Promise<void> {
+  const deadline = Date.now() + 65_000;
+  let lastFailure = "handoff did not start";
+  while (Date.now() < deadline) {
+    try {
+      const ownership = JSON.parse(readFileSync(ownershipPath, "utf8")) as {
+        channel?: unknown;
+      };
+      if (ownership.channel === "beta") {
+        const identity = await readReleaseExecutableIdentity(activePath, { timeoutMs: 2_000 });
+        if (identity.productVersion === NEXT && !existsSync(workRoot)) return;
+        lastFailure = `active=${identity.productVersion}, channel=beta`;
+      } else {
+        lastFailure = `channel=${String(ownership.channel)}`;
+      }
+    } catch (error) {
+      lastFailure = error instanceof Error ? error.message : String(error);
+    }
+    await new Promise<void>((resolve) => setTimeout(resolve, 50));
+  }
+  const errorPath = path.join(workRoot, "error.txt");
+  const helperFailure = existsSync(errorPath)
+    ? readFileSync(errorPath, "utf8").trim()
+    : "no helper error file";
+  throw new Error(
+    `Windows handoff from exited PID ${starterPid} timed out: ${lastFailure}; ${helperFailure}`
+  );
+}


### PR DESCRIPTION
Automates verified Windows beta upgrades from 1667.exe, including deferred locked-file replacement, rollback-safe failure recovery, truthful CLI output, and concurrent-helper convergence. Adds real Windows integration coverage and the Windows CI entries. Local gate: 63 tests passed; root and TUI typechecks passed. Tracks #351.