### PR TITLE
fix(demo): match the new-install theme

### DIFF
--- a/docs/write-without-a-model.md
+++ b/docs/write-without-a-model.md
@@ -44,6 +44,9 @@ version of the same story part.
 Press `e` to edit the focused story part. A normal save keeps the earlier text
 as another take. The editor also has an action to update the current take.
 
+A direction is optional in the editor. Put it above the first `---` line. To
+write only prose, put `---` on the first line and write the prose below it.
+
 Use these keys to move and choose text:
 
 | Task | Keys |
@@ -96,8 +99,9 @@ The following actions request model output:
 - Generate a chapter summary.
 - Send a question in Aside.
 
-Do not use these actions during a manual session. Editing, take selection,
-chapters, Facts, maps, import, and export remain available.
+If you do not use these actions, the workflow in this guide stays manual.
+Editing, take selection, chapters, Facts, maps, import, and export remain
+available.
 
 ## Find your files
 

--- a/tui/src/config.ts
+++ b/tui/src/config.ts
@@ -24,6 +24,8 @@ export type ThemeName =
   | "hi-contrast dark"
   | "hi-contrast light";
 
+export const NEW_INSTALL_THEME: ThemeName = "graphite";
+
 export const THEME_NAMES: readonly ThemeName[] = [
   "lantern",
   "iron gall",
@@ -80,7 +82,7 @@ export interface UserConfig {
 const DEFAULTS: UserConfig = {
   schemaVersion: 1,
   // Keep this legacy fallback for an existing config without a theme. A new
-  // install gets Graphite only when `loadConfigWithStatus` finds no file.
+  // install gets `NEW_INSTALL_THEME` when `loadConfigWithStatus` finds no file.
   theme: "lantern",
   factsRail: "auto",
   composeFocus: "off",
@@ -206,7 +208,7 @@ export function loadConfigWithStatus(
     const config = normalizeUserConfig(null);
     return {
       status,
-      config: status === "absent" ? { ...config, theme: "graphite" } : config
+      config: status === "absent" ? { ...config, theme: NEW_INSTALL_THEME } : config
     };
   }
   try {

--- a/tui/src/demo.ts
+++ b/tui/src/demo.ts
@@ -45,7 +45,7 @@ import {
 } from "../../shared/story-search.js";
 import type { RemovedChapterBreak, StoryApi } from "./api.js";
 import type { AppSource } from "./app.js";
-import { normalizeUserConfig } from "./config.js";
+import { NEW_INSTALL_THEME, normalizeUserConfig } from "./config.js";
 import { demoResolveSamplingBias } from "./demo-token-ids.js";
 import { discoverDemoModels } from "./demo-model-discovery.js";
 import { streamFake } from "./fake-stream.js";
@@ -889,7 +889,10 @@ export function demoAppSource(dense = false): AppSource {
     // had not started yet would be captured for ever as `searching…`.
     searchDebounceMs: 0,
     contextProbeDebounceMs: 0,
-    config: normalizeUserConfig({ updates: { mode: "notify" } }),
+    config: normalizeUserConfig({
+      theme: NEW_INSTALL_THEME,
+      updates: { mode: "notify" }
+    }),
     readingPositions: {}
   };
 }

--- a/tui/test/demo-model-discovery.test.ts
+++ b/tui/test/demo-model-discovery.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "bun:test";
 import type { SettingsDocumentV2 } from "../../shared/settings-v2-types.js";
+import { NEW_INSTALL_THEME } from "../src/config.js";
 import { demoAppSource, DEMO_SETTINGS_DOCUMENT } from "../src/demo.js";
 import { providerProbeRouteFromV5Route } from "../../shared/provider-probe-route-v1.js";
 import { selectSettingsRoute } from "../../shared/settings-route.js";
@@ -7,6 +8,10 @@ import {
   discoverDemoModels,
   type DemoSubscriptionCatalogs
 } from "../src/demo-model-discovery.js";
+
+test("demo recordings use the new-install theme", () => {
+  expect(demoAppSource().config.theme).toBe(NEW_INSTALL_THEME);
+});
 
 test("demo discovery resolves one non-default route for provider and source", async () => {
   const document = {

--- a/tui/test/golden-panels.test.ts
+++ b/tui/test/golden-panels.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { RGBA, type KeyEvent } from "@opentui/core";
 import { handleKey, initialState, renderOnce, renderOnceSpans } from "../src/app.js";
+import { NEW_INSTALL_THEME } from "../src/config.js";
 import { createDemoController, demoAppSource, demoStoryApi, DEMO_SETTINGS_DOCUMENT } from "../src/demo.js";
 import { createStoryViewModel, rowIndexForNode } from "../src/model.js";
 import { createPalette } from "../src/palette.js";
@@ -238,7 +239,7 @@ describe("run C overlay frames", () => {
     expect(grouped).toContain("direct take");
     expect(grouped).toContain("generation settings");
     expect(grouped).not.toContain("acknowledge unknown");
-    expect(grouped).toContain("theme: lantern");
+    expect(grouped).toContain(`theme: ${NEW_INSTALL_THEME}`);
     expect(grouped).toContain("↑↓ move · ↵ run · esc close");
 
     const filtered = await renderOnce(demoAppSource(), 120, 36, ":sum");
@@ -342,7 +343,7 @@ describe("run C overlay frames", () => {
   test("simple settings shows the theme switcher and editable fields", async () => {
     const frame = await renderWithKeys(demoAppSource(), 120, 36, [key(",")]);
     expect(frame).toContain("┏━ settings ━");
-    expect(frame).toContain("‹ lantern ›");
+    expect(frame).toContain(`‹ ${NEW_INSTALL_THEME} ›`);
     expect(frame).toContain("provider");
     expect(frame).toContain("↑↓ move · ←→ choose · ↵ next · s save");
     expect(frame).toContain("SETTINGS");

--- a/tui/test/settings-inline.test.ts
+++ b/tui/test/settings-inline.test.ts
@@ -20,6 +20,7 @@ import {
   selectedComposerText,
   setComposerText
 } from "../src/composer-model.js";
+import { THEME_NAMES } from "../src/config.js";
 import { pasteInto } from "../src/keys.js";
 import {
   beginSettingsPasteEdit,
@@ -190,15 +191,18 @@ describe("inline settings menu", () => {
     const { source, state, press } = harness();
     await openSettings(press);
     await selectRow(press, state, "theme");
+    const expectedTheme = THEME_NAMES[
+      (THEME_NAMES.indexOf(state.config.theme) + 3) % THEME_NAMES.length
+    ]!;
 
     await press(key("right"));
     await press(key("right"));
     await press(key("right"));
-    expect(state.config.theme).toBe("bond");
-    expect(source.config.theme).toBe("bond");
+    expect(state.config.theme).toBe(expectedTheme);
+    expect(source.config.theme).toBe(expectedTheme);
     await selectRow(press, state, "model");
     await press(key("left"));
-    expect(state.config.theme).toBe("bond");
+    expect(state.config.theme).toBe(expectedTheme);
     await selectRow(press, state, "compose-focus");
     expect(state.config.composeFocus).toBe("off");
     await press(key("return"));
@@ -282,11 +286,14 @@ describe("inline settings menu", () => {
     source.api.getSettings = async () => legacy;
     await openSettings(press);
     await selectRow(press, state, "theme");
+    const expectedTheme = THEME_NAMES[
+      (THEME_NAMES.indexOf(state.config.theme) + 3) % THEME_NAMES.length
+    ]!;
 
     await press(key("right"));
     await press(key("right"));
     await press(key("right"));
-    expect(state.config.theme).toBe("bond");
+    expect(state.config.theme).toBe(expectedTheme);
     await selectRow(press, state, "provider");
     await press(key("return"));
     expect(state.settings?.edit).toBe(null);

--- a/tui/test/settings-view-mode.test.ts
+++ b/tui/test/settings-view-mode.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "bun:test";
+import { THEME_NAMES } from "../src/config.js";
 import { SETTINGS_ROW_IDS, settingsRowIds } from "../src/settings-row-navigation.js";
 import { settingsCursorRowIdentity } from "../src/settings-row-navigation.js";
 import { settingsDraftChanged } from "../src/settings-overlay-model.js";
@@ -103,10 +104,13 @@ test("simple mode can change the theme", async () => {
   await openSettings(press);
 
   expect(settingsRowIds(state.settings!)[state.settings!.cursor]).toBe("theme");
+  const expectedTheme = THEME_NAMES[
+    (THEME_NAMES.indexOf(state.config.theme) + 1) % THEME_NAMES.length
+  ]!;
   await press(key("right"));
 
-  expect(state.config.theme).toBe("iron gall");
-  expect(source.config.theme).toBe("iron gall");
+  expect(state.config.theme).toBe(expectedTheme);
+  expect(source.config.theme).toBe(expectedTheme);
 });
 
 test("base-url and api-key stay visible in simple mode until a fixed subscription connection hides them", async () => {


### PR DESCRIPTION
## Outcome

Demo mode now uses the same theme as a new installation, so README recordings show the product default.

## Changes

- Define one new-install theme value and use it in config loading and demo mode.
- Keep theme-navigation tests relative to their starting theme.
- Correct the manual-writing guide to match the editor separator contract.

## Verification

- `npm run typecheck`
- `npm test` — 3,008 tests; 2,781 passed, 227 skipped, 0 failed
- `bun run typecheck`
- TUI full shards plus affected-shard reruns — all 16 shards passed
- 106 focused editor, demo, config, and theme tests passed
- Slopless 0.2.36 — no findings
- Autoreview — no actionable findings

## Risk

Existing saved themes do not change. Only fresh-install config selection and deterministic demo mode share the default.

Closes #357