### PR TITLE
docs(readme): show Graphite demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ model when you want generated prose, or write every take yourself.
 
 This repository contains the terminal user interface (TUI) and the backend.
 
-[![1667 in a terminal: a direction is composed, the model streams the next part, two sibling takes are compared, and the path map opens](https://1667.ai/demo-3.gif)](https://1667.ai)
+[![1667 in a terminal: a direction is composed, the model streams the next part, two sibling takes are compared, and the path map opens](https://1667.ai/demo-4.gif)](https://1667.ai)
 
 ## What you can do
 


### PR DESCRIPTION
## Outcome

The README now shows the current product in the Graphite default theme.

Closes #361

## Changes

- Point the README image at the deployed, revisioned `demo-4.gif` asset.

## Verification

- Confirmed `https://1667.ai/demo-4.gif` returns HTTP 200.
- Confirmed the live bytes match the reviewed render.
- Confirmed `Content-Type: image/gif`.
- Confirmed immutable one-year caching.
- `npx -y slopless@0.2.36 README.md` — no findings.
- `git diff --check`.

## Risk

Documentation only. The previous revisioned asset remains available.