### PR TITLE
chore(release): prepare 0.10.4-rc.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ This file records notable changes to 1667. Product terms use the definitions in
 
 ## Unreleased
 
+## 0.10.4-rc.3 - 2026-08-29
+
+- **Manual writing no longer needs a model direction.** Double-click take prose
+  to edit it. A manual edit does not need a direction or a separator. Press
+  `w` in an empty story to write the first take.
+- **The demo now matches the new-project Graphite theme.** Starting 1667
+  without a project uses the same theme as a new project.
 - **Windows beta upgrades now use one command.** Run
   `1667.exe upgrade --channel beta`. 1667 verifies the release and starts a
   local update process. Windows installs the release after the command exits.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "1667-workspace",
-  "version": "0.10.4-rc.2",
+  "version": "0.10.4-rc.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "1667-workspace",
-      "version": "0.10.4-rc.2",
+      "version": "0.10.4-rc.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@earendil-works/pi-ai": "0.84.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667-workspace",
-  "version": "0.10.4-rc.2",
+  "version": "0.10.4-rc.3",
   "private": true,
   "description": "Source workspace for the 1667 terminal writing environment",
   "license": "Apache-2.0",

--- a/shared/release-notes.ts
+++ b/shared/release-notes.ts
@@ -11,6 +11,11 @@ export interface ReleaseNote {
  *  a release, and is not included. */
 export const RELEASE_NOTES: readonly ReleaseNote[] = [
   {
+    version: "0.10.4-rc.3",
+    date: "2026-08-29",
+    body: "- **Manual writing no longer needs a model direction.** Double-click take prose\n  to edit it. A manual edit does not need a direction or a separator. Press\n  `w` in an empty story to write the first take.\n- **The demo now matches the new-project Graphite theme.** Starting 1667\n  without a project uses the same theme as a new project.\n- **Windows beta upgrades now use one command.** Run\n  `1667.exe upgrade --channel beta`. 1667 verifies the release and starts a\n  local update process. Windows installs the release after the command exits.\n  The user does not download or attest an Installer.\n- **Windows installation shows the exact start command.** The PowerShell\n  Installer tells the user to open a new PowerShell window and run `1667.exe`.\n  It warns that `1667` without `.exe` does not start the app."
+  },
+  {
     version: "0.10.4-rc.2",
     date: "2026-08-28",
     body: "- **Windows upgrades show the correct next command.** Stable update checks do\n  not show beta releases. A PowerShell Installation now gives the PowerShell\n  Installer command for a stable release. For beta, 1667 gives commands to\n  download and verify the release Installer before it runs. An exact\n  prerelease no longer names an Installer file that does not exist.\n- **New users start with the Graphite theme.** Existing users keep their saved\n  theme. An older config without a theme keeps the Lantern theme. The Theme row\n  now appears in Simple Settings.\n- **The starter tour ends with setup instructions.** It tells the user how to\n  delete the onboarding stories and select a model provider."

--- a/tui/package.json
+++ b/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667",
-  "version": "0.10.4-rc.2",
+  "version": "0.10.4-rc.3",
   "private": true,
   "description": "A terminal environment for writing fiction with language models",
   "license": "Apache-2.0",


### PR DESCRIPTION
Tracks #363
References #351 and #347.

## Outcome

Prepare 0.10.4-rc.3 for beta publication. This candidate includes the manual-writing workflow, Windows beta upgrades, and Graphite demo consistency.

## Changes

- Set root, lockfile, and TUI versions to 0.10.4-rc.3.
- Publish the Unreleased notes as the dated 0.10.4-rc.3 section.
- Regenerate embedded release notes.

## Verification

- npm run notes:check-version -- 0.10.4-rc.3
- npm run build
- npm test: 2,781 passed; 227 platform skips
- bun run typecheck
- bun run test: all 16 shards passed
- bun bench/perf.ts: all budgets passed
- bun run build:standalone

## Risk

Release preparation changes only version and release-note metadata. Keep the linked issues open until a stable release contains their changes.