### PR TITLE
chore(release): prepare 0.10.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ This file records notable changes to 1667. Product terms use the definitions in
 
 ## Unreleased
 
+## 0.10.4 - 2026-08-29
+
+- **This release has no additional product changes.** It contains the same
+  behavior as 0.10.4-rc.3.
+
 ## 0.10.4-rc.3 - 2026-08-29
 
 - **Manual writing no longer needs a model direction.** Double-click take prose

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "1667-workspace",
-  "version": "0.10.4-rc.3",
+  "version": "0.10.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "1667-workspace",
-      "version": "0.10.4-rc.3",
+      "version": "0.10.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@earendil-works/pi-ai": "0.84.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667-workspace",
-  "version": "0.10.4-rc.3",
+  "version": "0.10.4",
   "private": true,
   "description": "Source workspace for the 1667 terminal writing environment",
   "license": "Apache-2.0",

--- a/shared/release-notes.ts
+++ b/shared/release-notes.ts
@@ -11,6 +11,11 @@ export interface ReleaseNote {
  *  a release, and is not included. */
 export const RELEASE_NOTES: readonly ReleaseNote[] = [
   {
+    version: "0.10.4",
+    date: "2026-08-29",
+    body: "- **This release has no additional product changes.** It contains the same\n  behavior as 0.10.4-rc.3."
+  },
+  {
     version: "0.10.4-rc.3",
     date: "2026-08-29",
     body: "- **Manual writing no longer needs a model direction.** Double-click take prose\n  to edit it. A manual edit does not need a direction or a separator. Press\n  `w` in an empty story to write the first take.\n- **The demo now matches the new-project Graphite theme.** Starting 1667\n  without a project uses the same theme as a new project.\n- **Windows beta upgrades now use one command.** Run\n  `1667.exe upgrade --channel beta`. 1667 verifies the release and starts a\n  local update process. Windows installs the release after the command exits.\n  The user does not download or attest an Installer.\n- **Windows installation shows the exact start command.** The PowerShell\n  Installer tells the user to open a new PowerShell window and run `1667.exe`.\n  It warns that `1667` without `.exe` does not start the app."

--- a/tui/package.json
+++ b/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667",
-  "version": "0.10.4-rc.3",
+  "version": "0.10.4",
   "private": true,
   "description": "A terminal environment for writing fiction with language models",
   "license": "Apache-2.0",


### PR DESCRIPTION
Tracks #363.
References #351 and #347.

## Outcome

Prepare 0.10.4 for stable publication. This release promotes the tested 0.10.4-rc.3 behavior without additional product changes.

## Changes

- Set the root, lockfile, and TUI versions to 0.10.4.
- Add the dated 0.10.4 changelog section.
- Regenerate the embedded release notes.

## Verification

- `npm run notes:check-version -- 0.10.4`
- `npm run build`
- `npm test`: 2,781 passed, 227 platform skips, 0 failures
- `bun run typecheck`
- `bun run test`: all 16 shards passed
- `bun bench/perf.ts`: all budgets passed on isolated rerun
- `bun run build:standalone`

## Risk

This change updates release metadata only. Product behavior matches 0.10.4-rc.3.