### PR TITLE
fix(aside): align retake and cancel behavior

### DIFF
--- a/docs/generation-boundaries.md
+++ b/docs/generation-boundaries.md
@@ -43,7 +43,9 @@ presentation interval.
 The received text remains authoritative for Stop, deadline handling, partial
 commit, and the final provider payload. Stop hides a Continue presentation at
 once. A stopped Rewrite keeps its partial replacement visible until its
-partial-save settlement. The TUI keeps the received text for settlement.
+partial-save settlement. Aside also keeps the visible answer prefix until the
+stopped answer becomes a saved turn. The TUI keeps the received text for
+settlement.
 Before a successful result replaces the live view, the TUI starts a bounded
 catch-up interval. The TUI stops the catch-up work at its deadline. The final
 payload then replaces presentation text that remains.
@@ -183,7 +185,7 @@ generation ID. Stop closes the provider record. If model text arrived before
 Stop, the TUI waits for terminal settlement. It then saves that text with the
 same generation ID. If Keep thought is on, it also saves the thought that the
 model sent before Stop. A clean timeout uses the same save behavior.
-Stop hides the stream immediately. The main process gives local durable
+Stop ends live stream updates immediately. The main process gives local durable
 cancellation work 2 seconds to finish. It then gives the embedded backend 10
 seconds to close the provider stream and publish its terminal state. If the
 operation is still active, the main process checks its status every 10 seconds.
@@ -316,3 +318,8 @@ session uses the active story line. The Aside prompt includes the questions
 and answers from the current session. It does not include a stored Thought.
 1667 can show a stored Thought in Aside, but it cannot send that Thought in a
 later request.
+
+The newest Aside turn uses the same Retake keys as a story part. Press `r` to
+use the saved question again. Press `R` to edit the saved question before the
+Retake. Press `Esc` in the Aside prompt to return to the turns. Press `Esc`
+again to exit Aside.

--- a/server/aside-session-http.ts
+++ b/server/aside-session-http.ts
@@ -150,7 +150,7 @@ export async function askAsideSession(
     onDelta,
     signal,
     hooks,
-    { retakeTurnIndex: null }
+    { kind: "ask" }
   );
 }
 
@@ -176,13 +176,23 @@ export async function retakeAsideSession(
     onDelta,
     signal,
     hooks,
-    { retakeTurnIndex: requireTurnIndex(body.turnIndex) }
+    {
+      kind: "retake",
+      turnIndex: requireTurnIndex(body.turnIndex),
+      ...(body.question === undefined ? {} : {
+        questionOverride: requireAsideQuestion(body.question)
+      })
+    }
   );
 }
 
-interface AsideGenerationMode {
-  readonly retakeTurnIndex: number | null;
-}
+type AsideGenerationMode =
+  | { readonly kind: "ask" }
+  | {
+      readonly kind: "retake";
+      readonly turnIndex: number;
+      readonly questionOverride?: string;
+    };
 
 async function runAsideSession(
   id: string,
@@ -211,7 +221,7 @@ async function runAsideSession(
   const anchor = asideAnchorFromBody(body);
   const requestedSessionId = body.sessionId;
   const sessionId = requestedSessionId === undefined
-    ? mode.retakeTurnIndex === null
+    ? mode.kind === "ask"
       ? `session-${randomUUID()}`
       : requireAsideSessionId(requestedSessionId)
     : requireAsideSessionId(requestedSessionId);
@@ -245,9 +255,13 @@ async function runAsideSession(
   }
   const loaded = await loadSession(story, sessionId);
   if (signal.aborted) return null;
-  const question = mode.retakeTurnIndex === null
-    ? requireAsideQuestion("question" in body ? body.question : undefined)
-    : requireRetakeQuestion(loaded, mode.retakeTurnIndex);
+  let question: string;
+  if (mode.kind === "ask") {
+    question = requireAsideQuestion(body.question);
+  } else {
+    const savedQuestion = requireRetakeQuestion(loaded, mode.turnIndex);
+    question = mode.questionOverride ?? savedQuestion;
+  }
   const expectedAnchor = ref === null
     ? anchor
     : effectiveAsideSessionAnchor(story, ref, loaded?.anchor);
@@ -262,15 +276,17 @@ async function runAsideSession(
   // A retake is an in-place replacement. Do not feed the answer being
   // replaced (or its stored Thoughts) back to the provider; it is retained
   // only as the CAS predecessor and replacement source below.
-  const promptDocument = mode.retakeTurnIndex === null
+  const promptDocument = mode.kind === "ask"
     ? document
     : {
         ...document,
-        turns: document.turns.slice(0, mode.retakeTurnIndex)
+        title: mode.turnIndex === 0 && mode.questionOverride !== undefined
+          ? asideTitleFromQuestion(question) : document.title,
+        turns: document.turns.slice(0, mode.turnIndex)
       };
   const replacementTurnCount = loaded === null
     ? 1
-    : loaded.turns.length + (mode.retakeTurnIndex === null ? 1 : 0);
+    : loaded.turns.length + (mode.kind === "ask" ? 1 : 0);
   stories.declareAsideSessionResolution?.(
     sessionId,
     ref?.documentId ?? null,
@@ -433,7 +449,7 @@ async function runAsideSession(
       safeThoughts,
       safeThoughtTokens
     );
-    replacement = mode.retakeTurnIndex === null
+    replacement = mode.kind === "ask"
       ? appendAsideTurn(
           document,
           question,
@@ -443,10 +459,17 @@ async function runAsideSession(
         )
       : replaceAsideTurn(
           document,
-          mode.retakeTurnIndex,
-          answer,
-          fittedThoughts,
-          fittedThoughts === undefined ? undefined : safeThoughtTokens
+          mode.turnIndex,
+          {
+            answer,
+            ...(fittedThoughts === undefined ? {} : {
+              thoughts: fittedThoughts,
+              thoughtTokens: safeThoughtTokens,
+            }),
+            ...(mode.questionOverride === undefined ? {} : {
+              question: mode.questionOverride
+            })
+          }
         );
   } catch (error) {
     if (error instanceof AsideDocumentError) throw new GenerationResultError(422, error.message);

--- a/server/http-operation-mutation.ts
+++ b/server/http-operation-mutation.ts
@@ -1,6 +1,8 @@
 import {
   MUTATION_INPUT_PROTOCOL_VERSION,
+  PRE_ASIDE_REPROMPT_WORKER_PROTOCOL_VERSION,
   PRE_ASIDE_WORKER_PROTOCOL_VERSION,
+  PRE_SETTINGS_SCHEMA5_WORKER_PROTOCOL_VERSION,
   type MutatingWorkerMethod,
   type WorkerOutput
 } from "../shared/worker-protocol.js";
@@ -83,20 +85,27 @@ export async function runHttpOperationMutation<
   );
 }
 
-/** A protocol bump added Aside methods in v11. Keep an exact HTTP retry of a
- * retained v10 receipt on the protocol that created its fingerprint and
- * parsed its input. New mutations and all Aside methods stay on v11. */
+/** Keep an exact HTTP retry on the retained protocol that created its
+ * fingerprint and parsed its input. Protocol 10 predates Aside. Protocol 11
+ * predates Settings schema 5. Protocol 12 predates edited Aside retakes. New
+ * mutations use the current protocol. */
 async function acceptedHttpMutationProtocolVersion(
   service: StoryService,
   mutationId: string,
   method: MutatingWorkerMethod
 ): Promise<number> {
   const receipt = await service.inspectMutationReceipt(mutationId, method);
+  const retainedProtocol = receipt !== null && "protocolVersion" in receipt
+    ? receipt.protocolVersion
+    : null;
+  const retainedPreAside = retainedProtocol === PRE_ASIDE_WORKER_PROTOCOL_VERSION
+    && method !== "askAside"
+    && method !== "clearAside";
   return receipt !== null
     && receipt.method === method
-    && receipt.protocolVersion === PRE_ASIDE_WORKER_PROTOCOL_VERSION
-    && method !== "askAside"
-    && method !== "clearAside"
-    ? PRE_ASIDE_WORKER_PROTOCOL_VERSION
+    && (retainedPreAside
+      || retainedProtocol === PRE_SETTINGS_SCHEMA5_WORKER_PROTOCOL_VERSION
+      || retainedProtocol === PRE_ASIDE_REPROMPT_WORKER_PROTOCOL_VERSION)
+    ? retainedProtocol
     : MUTATION_INPUT_PROTOCOL_VERSION;
 }

--- a/server/worker-mutations.ts
+++ b/server/worker-mutations.ts
@@ -13,6 +13,7 @@ import {
 import {
   LEGACY_WORKER_PROTOCOL_VERSION,
   PREDECESSOR_WORKER_PROTOCOL_VERSION,
+  WORKER_PROTOCOL_VERSION,
   isCurrentWorkerInputProtocolVersion,
   type MutatingWorkerMethod,
   type WorkerInput,
@@ -1068,10 +1069,20 @@ const MUTATIONS: MutationRegistry = {
     }
   }),
   retakeAside: define<"retakeAside">({
-    parse: (value) => parseTransportInput(
-      () => parseAsideRetakeRequest(value),
-      "retakeAside input"
-    ),
+    parse: (value, protocolVersion) => {
+      const parsed = parseTransportInput(
+        () => parseAsideRetakeRequest(value),
+        "retakeAside input"
+      );
+      if (
+        protocolVersion !== undefined
+        && protocolVersion < WORKER_PROTOCOL_VERSION
+        && parsed.question !== undefined
+      ) {
+        throw badInput("Edited Aside retakes require worker protocol 13");
+      }
+      return parsed;
+    },
     storyId: (input) => input.storyId,
     execute: async (service, input, plan, context) =>
       await service.retakeAside(
@@ -1079,7 +1090,8 @@ const MUTATIONS: MutationRegistry = {
         {
           sessionId: input.sessionId,
           anchor: input.anchor,
-          turnIndex: input.turnIndex
+          turnIndex: input.turnIndex,
+          ...(input.question === undefined ? {} : { question: input.question })
         },
         context.onDelta,
         context.signal,

--- a/server/worker-request-size.ts
+++ b/server/worker-request-size.ts
@@ -12,6 +12,7 @@ import { hasUnpairedSurrogate, unicodeScalarLength } from "../shared/unicode.js"
 import {
   PREDECESSOR_WORKER_PROTOCOL_VERSION,
   PRE_SETTINGS_SCHEMA5_WORKER_PROTOCOL_VERSION,
+  WORKER_PROTOCOL_VERSION,
   isCurrentWorkerInputProtocolVersion,
   messageByteLength,
   type WorkerMethod
@@ -197,10 +198,22 @@ function logicalRequestBody(
         anchor: input.anchor
       };
     case "retakeAside":
+      if (
+        protocolVersion !== undefined
+        && protocolVersion < WORKER_PROTOCOL_VERSION
+        && input.question !== undefined
+      ) {
+        throw new ServiceError(
+          400,
+          "Edited Aside retakes require worker protocol 13",
+          "invalid_request"
+        );
+      }
       return {
         sessionId: input.sessionId,
         turnIndex: input.turnIndex,
-        anchor: input.anchor
+        anchor: input.anchor,
+        question: input.question
       };
     case "listStories":
     case "listStoriesPage":

--- a/shared/aside-session.ts
+++ b/shared/aside-session.ts
@@ -303,30 +303,45 @@ export function appendAsideTurn(
   return next;
 }
 
-/** Replace one turn's answer and optional thoughts, preserving its question. */
+export interface AsideTurnReplacement {
+  readonly answer: string;
+  readonly thoughts?: string;
+  readonly thoughtTokens?: number;
+  /** A supplied question also replaces the saved question. */
+  readonly question?: string;
+}
+
+/** Replace one turn from one explicit replacement value. */
 export function replaceAsideTurn(
   document: AsideSessionDocument,
   index: number,
-  answer: string,
-  thoughts?: string,
-  thoughtTokens?: number
+  replacement: AsideTurnReplacement
 ): AsideSessionDocument {
   assertAsideSessionDocument(document);
   assertAsideIndex(document, index);
-  assertAsideAnswer(answer);
-  if (thoughts !== undefined) assertAsideThoughts(thoughts);
-  assertAsideThoughtTokens(thoughtTokens, thoughts);
+  assertAsideAnswer(replacement.answer);
+  if (replacement.thoughts !== undefined) {
+    assertAsideThoughts(replacement.thoughts);
+  }
+  assertAsideThoughtTokens(replacement.thoughtTokens, replacement.thoughts);
   const prior = document.turns[index]!;
+  const nextQuestion = replacement.question ?? prior.q;
+  assertAsideQuestion(nextQuestion);
   const turn: AsideTurn = {
-    q: prior.q,
-    a: answer,
-    ...(thoughts === undefined ? {} : { thoughts }),
-    ...(thoughtTokens === undefined ? {} : { thoughtTokens })
+    q: nextQuestion,
+    a: replacement.answer,
+    ...(replacement.thoughts === undefined ? {} : {
+      thoughts: replacement.thoughts
+    }),
+    ...(replacement.thoughtTokens === undefined ? {} : {
+      thoughtTokens: replacement.thoughtTokens
+    })
   };
   const next = {
     schemaVersion: ASIDE_SESSION_SCHEMA_VERSION,
     anchor: document.anchor === null ? null : { ...document.anchor },
-    title: document.title,
+    title: index === 0 && replacement.question !== undefined
+      ? asideTitleFromQuestion(nextQuestion) : document.title,
     turns: document.turns.map((candidate, position) => position === index ? turn : candidate)
   } satisfies AsideSessionDocument;
   assertAsideSessionDocument(next);
@@ -372,7 +387,11 @@ export function retakeAsideSession(
   if (document.turns.length === 0) {
     throw new AsideDocumentError("Aside session has no turn to retake");
   }
-  return replaceAsideTurn(document, document.turns.length - 1, answer, thoughts, thoughtTokens);
+  return replaceAsideTurn(document, document.turns.length - 1, {
+    answer,
+    ...(thoughts === undefined ? {} : { thoughts }),
+    ...(thoughtTokens === undefined ? {} : { thoughtTokens })
+  });
 }
 
 function assertAsideIndex(document: AsideSessionDocument, index: number): void {

--- a/shared/aside-transport-codec.ts
+++ b/shared/aside-transport-codec.ts
@@ -344,11 +344,15 @@ export function parseAsideRetakeRequest(value: unknown): AsideRetakeRequest {
   const storyId = parseStoryId(entry, "Aside retake request");
   const sessionId = parseSessionId(entry.sessionId);
   const anchor = parseRequiredAnchor(entry, "Aside retake request");
+  const question = has(entry, "question")
+    ? nonEmptyString(entry.question, "Aside retake request.question")
+    : undefined;
   return {
     storyId,
     sessionId,
     anchor,
-    turnIndex: parseTurnIndex(entry.turnIndex)
+    turnIndex: parseTurnIndex(entry.turnIndex),
+    ...(question === undefined ? {} : { question })
   };
 }
 

--- a/shared/aside-transport.ts
+++ b/shared/aside-transport.ts
@@ -114,8 +114,11 @@ export interface AsideSessionMutationResponse extends AsideSessionResponse {
   readonly payload?: StoryPayload;
 }
 
-/** Retake the selected session's last answer. */
-export interface AsideRetakeRequest extends AsideTurnMutationRequest {}
+/** Retake the selected session's last answer. A question replaces the saved
+ * question for a prompted retake; absence keeps the saved question. */
+export interface AsideRetakeRequest extends AsideTurnMutationRequest {
+  readonly question?: string;
+}
 
 /** Service projection after the story id has been selected by the route. */
 export type AsideRetakeInput = Omit<AsideRetakeRequest, "storyId">;

--- a/shared/build-identity.ts
+++ b/shared/build-identity.ts
@@ -76,10 +76,12 @@ export const AI_1667_PRODUCT = "1667" as const;
  * use the rest of Settings. v26 adds the required closed `activeWriting`
  * projection, replaces full-document provider probes with
  * `ProviderProbeRouteV1`, and publishes Settings schema 5. Mixed 0.10.1 and
- * 0.10.2 HTTP processes refuse during negotiation. */
-export const HTTP_API_PROTOCOL_VERSION = 26;
-export const HTTP_MIN_CLIENT_PROTOCOL_VERSION = 26;
-export const HTTP_MAX_CLIENT_PROTOCOL_VERSION = 26;
+ * 0.10.2 HTTP processes refuse during negotiation. v27 adds an optional
+ * edited question to Aside retake requests. A v27 client against a v26
+ * server would have that question ignored and repeat the old prompt. */
+export const HTTP_API_PROTOCOL_VERSION = 27;
+export const HTTP_MIN_CLIENT_PROTOCOL_VERSION = 27;
+export const HTTP_MAX_CLIENT_PROTOCOL_VERSION = 27;
 
 export type ArtifactTarget = "source" | BuiltArtifactTarget;
 

--- a/shared/worker-protocol.ts
+++ b/shared/worker-protocol.ts
@@ -75,7 +75,8 @@ export const PRE_FACT_ACTIVATION_WORKER_PROTOCOL_VERSION = 8;
 export const PRE_FACT_ORDER_PRIORITY_BUDGET_WORKER_PROTOCOL_VERSION = 9;
 export const PRE_ASIDE_WORKER_PROTOCOL_VERSION = 10;
 export const PRE_SETTINGS_SCHEMA5_WORKER_PROTOCOL_VERSION = 11;
-export const WORKER_PROTOCOL_VERSION = 12;
+export const PRE_ASIDE_REPROMPT_WORKER_PROTOCOL_VERSION = 12;
+export const WORKER_PROTOCOL_VERSION = 13;
 /** Exact provider recovery changes the status and acknowledgement inputs. */
 export const MUTATION_INPUT_PROTOCOL_VERSION = WORKER_PROTOCOL_VERSION;
 export const WORKER_BUILD_IDENTITY = AI_1667_BUILD_IDENTITY;
@@ -93,9 +94,9 @@ export const WORKER_TERMINATION_CONFIRM_MS = 2_000;
 export const WORKER_SHUTDOWN_GRACE_MS = 5_000;
 /** Bound local durable work that must finish before cancellation delivery. */
 export const WORKER_CANCEL_PERSISTENCE_TIMEOUT_MS = 2_000;
-/** Stop hides the stream immediately. Give the provider, retained stream
- *  tail, and durable terminal settlement time to unwind before the main
- *  process treats the worker as unsafe. */
+/** Stop ends live stream updates immediately. Give the provider, retained
+ *  stream tail, and durable terminal settlement time to unwind before the
+ *  main process treats the worker as unsafe. */
 export const WORKER_CANCEL_GRACE_MS = 10_000;
 export const WORKER_OPERATION_CAPACITY = 1_024;
 export const WORKER_TERMINAL_RETENTION_MS = 5 * 60_000;
@@ -116,6 +117,7 @@ export function isCurrentWorkerInputProtocolVersion(
     || value === PRE_FACT_ORDER_PRIORITY_BUDGET_WORKER_PROTOCOL_VERSION
     || value === PRE_ASIDE_WORKER_PROTOCOL_VERSION
     || value === PRE_SETTINGS_SCHEMA5_WORKER_PROTOCOL_VERSION
+    || value === PRE_ASIDE_REPROMPT_WORKER_PROTOCOL_VERSION
     || value === WORKER_PROTOCOL_VERSION;
 }
 

--- a/test/aside-v2-mutations.integration.test.ts
+++ b/test/aside-v2-mutations.integration.test.ts
@@ -1167,6 +1167,17 @@ test("retake streams reasoning and replaces the same last turn", async (t) => {
   assert.ok(prose.join("").length > 0);
   assert.ok(thoughts.join("").length > 0);
   assert.equal((await service.getAsideV2(created.id, anchor)).sessions[0]!.turns.length, 1);
+
+  const reprompted = await service.retakeAside(
+    created.id,
+    { sessionId: answer.id, turnIndex: 0, anchor, question: "What rang?" },
+    async () => {},
+    new AbortController().signal
+  );
+  assert.ok(reprompted !== null);
+  assert.equal(reprompted.turns.length, 1);
+  assert.equal(reprompted.turns[0]!.q, "What rang?");
+  assert.equal(reprompted.title, "What rang?");
 });
 
 test("retake prompt excludes the replaced turn and its stored thoughts", async (t) => {
@@ -1194,6 +1205,26 @@ test("retake prompt excludes the replaced turn and its stored thoughts", async (
   assert.ok(earlier !== null && existing !== null);
   const oldThought = existing.turns.at(-1)?.thoughts;
   assert.ok(oldThought !== undefined);
+
+  let invalidProviderStarted = false;
+  await assert.rejects(
+    service.retakeAside(
+      created.id,
+      {
+        sessionId: "prompt-test",
+        turnIndex: 0,
+        anchor,
+        question: "INVALID_EARLIER_REPROMPT"
+      },
+      async () => {},
+      new AbortController().signal,
+      {
+        providerStarted: async () => { invalidProviderStarted = true; }
+      }
+    ),
+    hasCode("conflict")
+  );
+  assert.equal(invalidProviderStarted, false);
 
   let prompt = "";
   const retaken = await service.retakeAside(

--- a/test/build-identity.test.ts
+++ b/test/build-identity.test.ts
@@ -44,11 +44,12 @@ test("source identity is explicit and cannot masquerade as a packaged build", ()
   // adds machine-tier subscription sign-in state to Settings. v24 adds the
   // closed `pi-catalog` model-discovery source. v25 adds the Settings
   // read-only reason. v26 adds required activeWriting, ProviderProbeRouteV1,
-  // and Settings schema 5. An older peer must fail at preflight.
+  // and Settings schema 5. v27 adds edited questions to Aside retakes. An
+  // older peer must fail at preflight.
   assert.equal(
     HTTP_API_PROTOCOL_VERSION,
-    26,
-    "Configurable writing prompts require HTTP API v26"
+    27,
+    "Aside reprompts require HTTP API v27"
   );
   const source = createSourceBuildIdentity("1.2.3");
   assert.deepEqual(source, {

--- a/test/http-operation-mutation.integration.test.ts
+++ b/test/http-operation-mutation.integration.test.ts
@@ -5,7 +5,9 @@ import { tmpdir } from "node:os";
 import test from "node:test";
 import {
   MUTATION_INPUT_PROTOCOL_VERSION,
-  PRE_ASIDE_WORKER_PROTOCOL_VERSION
+  PRE_ASIDE_REPROMPT_WORKER_PROTOCOL_VERSION,
+  PRE_ASIDE_WORKER_PROTOCOL_VERSION,
+  PRE_SETTINGS_SCHEMA5_WORKER_PROTOCOL_VERSION
 } from "../shared/worker-protocol.js";
 import { createDurableMutationId } from "../shared/durable-mutation-id.js";
 import { StoryService } from "../server/story-service.js";
@@ -17,7 +19,7 @@ import {
 import { runHttpOperationMutation } from "../server/http-operation-mutation.js";
 import { storyIdForMutation } from "../server/story-identity.js";
 
-test("HTTP retries a retained pre-Aside receipt on protocol 10", async (t) => {
+test("HTTP retries receipts retained across worker protocol bumps", async (t) => {
   const root = await mkdtemp(path.join(tmpdir(), "1667-http-protocol-replay-"));
   const dataDir = path.join(root, "project");
   const service = StoryService.withoutDiagnostics({
@@ -30,58 +32,63 @@ test("HTTP retries a retained pre-Aside receipt on protocol 10", async (t) => {
     await rm(root, { recursive: true, force: true });
   });
 
-  const mutationId = createDurableMutationId();
-  const input = { title: "Retained before Aside" };
-  const legacyProtocol = PRE_ASIDE_WORKER_PROTOCOL_VERSION;
-  const parsed = parseWorkerMutation("createStory", input, legacyProtocol);
   const signal = new AbortController().signal;
-  await service.runMutation(
-    mutationId,
-    "createStory",
-    input,
-    async (plan) => {
-      const storyId = storyIdForMutation(mutationId);
-      return await executeWorkerMutation(
-        service,
-        parsed,
-        plan,
-        {
-          onDelta: () => {},
-          onReasoning: () => {},
-          signal,
-          storyMutationRequest: {
-            transportOperationId: "retained-http-request",
-            mutationId,
-            fingerprint: mutationFingerprint("createStory", input, legacyProtocol),
-            scope: `story:${storyId}`,
-            expectedAggregateVersion: { kind: "absent" }
+  for (const [legacyProtocol, title] of [
+    [PRE_ASIDE_WORKER_PROTOCOL_VERSION, "Retained before Aside"],
+    [PRE_SETTINGS_SCHEMA5_WORKER_PROTOCOL_VERSION, "Retained before Settings schema 5"],
+    [PRE_ASIDE_REPROMPT_WORKER_PROTOCOL_VERSION, "Retained before Reprompt"]
+  ] as const) {
+    const mutationId = createDurableMutationId();
+    const input = { title };
+    const parsed = parseWorkerMutation("createStory", input, legacyProtocol);
+    await service.runMutation(
+      mutationId,
+      "createStory",
+      input,
+      async (plan) => {
+        const storyId = storyIdForMutation(mutationId);
+        return await executeWorkerMutation(
+          service,
+          parsed,
+          plan,
+          {
+            onDelta: () => {},
+            onReasoning: () => {},
+            signal,
+            storyMutationRequest: {
+              transportOperationId: "retained-http-request",
+              mutationId,
+              fingerprint: mutationFingerprint("createStory", input, legacyProtocol),
+              scope: `story:${storyId}`,
+              expectedAggregateVersion: { kind: "absent" }
+            }
           }
-        }
-      );
-    },
-    legacyProtocol,
-    () => undefined
-  );
+        );
+      },
+      legacyProtocol,
+      () => undefined
+    );
 
-  const retained = await service.inspectMutationReceipt(mutationId, "createStory");
-  assert.equal(
-    retained !== null && "protocolVersion" in retained
-      ? retained.protocolVersion
-      : null,
-    legacyProtocol
-  );
+    const retained = await service.inspectMutationReceipt(mutationId, "createStory");
+    assert.equal(
+      retained !== null && "protocolVersion" in retained
+        ? retained.protocolVersion
+        : null,
+      legacyProtocol
+    );
 
-  const replayed = await runHttpOperationMutation(
-    service,
-    mutationId,
-    "createStory",
-    input,
-    signal,
-    "current-http-retry",
-    { kind: "absent" }
-  );
-  assert.equal(replayed.id, storyIdForMutation(mutationId));
-  assert.equal((await service.listStories()).length, 1);
+    const replayed = await runHttpOperationMutation(
+      service,
+      mutationId,
+      "createStory",
+      input,
+      signal,
+      "current-http-retry",
+      { kind: "absent" }
+    );
+    assert.equal(replayed.id, storyIdForMutation(mutationId));
+  }
+  assert.equal((await service.listStories()).length, 3);
 
   const freshMutationId = createDurableMutationId();
   const fresh = await runHttpOperationMutation(

--- a/test/settings-protocol-v26.test.ts
+++ b/test/settings-protocol-v26.test.ts
@@ -18,10 +18,10 @@ import {
 } from "../shared/settings-v5-limits.js";
 import { INITIAL_SETTINGS_DOCUMENT_V2 } from "../server/settings-v2-default.js";
 
-test("HTTP protocol 26 refuses mixed 0.10.1 clients", () => {
-  assert.equal(HTTP_API_PROTOCOL_VERSION, 26);
-  assert.equal(HTTP_MIN_CLIENT_PROTOCOL_VERSION, 26);
-  assert.equal(HTTP_MAX_CLIENT_PROTOCOL_VERSION, 26);
+test("HTTP protocol 27 refuses servers that ignore Aside reprompts", () => {
+  assert.equal(HTTP_API_PROTOCOL_VERSION, 27);
+  assert.equal(HTTP_MIN_CLIENT_PROTOCOL_VERSION, 27);
+  assert.equal(HTTP_MAX_CLIENT_PROTOCOL_VERSION, 27);
 });
 
 test("protocol-11 saveSettings refuses before document decode", () => {

--- a/test/worker-request-size.test.ts
+++ b/test/worker-request-size.test.ts
@@ -6,6 +6,7 @@ import {
   MAX_STORED_TITLE_CHARS
 } from "../shared/types.js";
 import {
+  PRE_ASIDE_REPROMPT_WORKER_PROTOCOL_VERSION,
   PRE_ASIDE_WORKER_PROTOCOL_VERSION,
   PRE_DIAGNOSTIC_WORKER_PROTOCOL_VERSION,
   PRE_PROVIDER_RECOVERY_WORKER_PROTOCOL_VERSION,
@@ -14,6 +15,7 @@ import {
   WORKER_PROTOCOL_VERSION
 } from "../shared/worker-protocol.js";
 import { ServiceError } from "../server/errors.js";
+import { parseWorkerMutation } from "../server/worker-mutations.js";
 import { validateWorkerRequestSize } from "../server/worker-request-size.js";
 import { parseWorkerRequest } from "../server/worker-message.js";
 
@@ -73,7 +75,59 @@ test("protocol-v10 mutation inputs survive the Aside protocol bump", () => {
   assert.equal(parsed.protocolVersion, PRE_ASIDE_WORKER_PROTOCOL_VERSION);
   assert.equal(
     WORKER_PROTOCOL_VERSION,
-    PRE_SETTINGS_SCHEMA5_WORKER_PROTOCOL_VERSION + 1
+    PRE_ASIDE_REPROMPT_WORKER_PROTOCOL_VERSION + 1
+  );
+});
+
+test("pre-v13 Aside retakes retain the prior request shape", () => {
+  const input = {
+    storyId: "story",
+    sessionId: "session",
+    turnIndex: 0,
+    anchor: null
+  };
+
+  assert.doesNotThrow(() => validateWorkerRequestSize(
+    "retakeAside",
+    input,
+    PRE_ASIDE_REPROMPT_WORKER_PROTOCOL_VERSION
+  ));
+  assert.deepEqual(
+    parseWorkerMutation(
+      "retakeAside",
+      input,
+      PRE_ASIDE_REPROMPT_WORKER_PROTOCOL_VERSION
+    ),
+    input
+  );
+  for (const protocolVersion of [
+    PRE_SETTINGS_SCHEMA5_WORKER_PROTOCOL_VERSION,
+    PRE_ASIDE_REPROMPT_WORKER_PROTOCOL_VERSION
+  ]) {
+    assert.throws(
+      () => validateWorkerRequestSize(
+        "retakeAside",
+        { ...input, question: "New prompt" },
+        protocolVersion
+      ),
+      (error: unknown) => error instanceof ServiceError && error.status === 400
+    );
+    assert.throws(
+      () => parseWorkerMutation(
+        "retakeAside",
+        { ...input, question: "New prompt" },
+        protocolVersion
+      ),
+      (error: unknown) => error instanceof ServiceError && error.status === 400
+    );
+  }
+  assert.deepEqual(
+    parseWorkerMutation(
+      "retakeAside",
+      { ...input, question: "New prompt" },
+      WORKER_PROTOCOL_VERSION
+    ),
+    { ...input, question: "New prompt" }
   );
 });
 
@@ -224,6 +278,31 @@ test("Aside v2 worker methods measure their logical HTTP bodies", () => {
       sessionId: oversizedSessionId,
       turnIndex: 0,
       anchor: null
+    }),
+    (error: unknown) => error instanceof ServiceError && error.status === 413
+  );
+
+  const retakeBodyBytes = bytes(JSON.stringify({
+    sessionId: "session",
+    turnIndex: 0,
+    anchor: null,
+    question: ""
+  }));
+  const question = "x".repeat(MAX_JSON_BODY_BYTES - retakeBodyBytes);
+  assert.doesNotThrow(() => validateWorkerRequestSize("retakeAside", {
+    storyId: routeOnlyStoryId,
+    sessionId: "session",
+    turnIndex: 0,
+    anchor: null,
+    question
+  }));
+  assert.throws(
+    () => validateWorkerRequestSize("retakeAside", {
+      storyId: routeOnlyStoryId,
+      sessionId: "session",
+      turnIndex: 0,
+      anchor: null,
+      question: `${question}x`
     }),
     (error: unknown) => error instanceof ServiceError && error.status === 413
   );

--- a/tui/src/api.ts
+++ b/tui/src/api.ts
@@ -1096,7 +1096,8 @@ export function createApi(
         {
           sessionId: mutation.sessionId,
           turnIndex: mutation.turnIndex,
-          anchor: mutation.anchor
+          anchor: mutation.anchor,
+          ...(mutation.question === undefined ? {} : { question: mutation.question })
         },
         (text) => {
           callbacks?.onPhase?.("writing");

--- a/tui/src/aside-actions.ts
+++ b/tui/src/aside-actions.ts
@@ -894,8 +894,10 @@ export function stopAsideAsk(state: RuntimeState): boolean {
     active.stopInteractionVersion = state.interactionVersion;
   }
   active.controller.abort();
-  surface.streamHidden = true;
-  surface.presentation?.dispose();
+  // Keep the visible prefix in place while the stopped answer settles into a
+  // saved turn. Provider text that arrives after Stop remains transport-only.
+  surface.streamHidden = false;
+  surface.presentation?.suspend();
   return true;
 }
 

--- a/tui/src/aside-footer.ts
+++ b/tui/src/aside-footer.ts
@@ -15,16 +15,21 @@ export function asideFooterHint(surface: AsideSurfaceState): string {
       return "⌫ confirms · esc keeps";
     }
     if (surface.busy) return "t Thoughts · esc stops · the composer waits";
+    if (surface.retakePrompt !== null) {
+      return "↵ retake with this prompt · ⇧↵ newline · esc keeps answer";
+    }
     if (surface.useMenu !== null) return "↑↓ · Enter · Esc turns";
     if (surface.focus === "turns" || surface.focus === "notes") {
       const turns = currentAsideTurns(surface);
       const reset = surface.turnCursor < Math.max(0, turns.length - 1)
-        ? "⌫ reset here" : "r retake";
+        ? "⌫ reset here" : "r retake · R reprompt";
       const hops = surface.anchors.length > 1
         ? " · [ ] hop asides · g go to this take" : "";
       return `↑↓ turn · ←→ session · n new · ↵ use · ${reset} · D delete · t Thoughts · tab ask · esc exit${hops}`;
     }
-    return "↵ ask · ⇧↵ newline · tab turns · esc exit";
+    return currentAsideTurns(surface).length > 0
+      ? "↵ ask · ⇧↵ newline · tab turns · esc turns"
+      : "↵ ask · ⇧↵ newline · esc exit";
   }
   if (surface.confirmClear) return "Clear all Side Notes? Enter confirms · Esc cancels";
   if (surface.busy && surface.inflightQuestion === null) return "Clearing…";

--- a/tui/src/aside-overlay-actions.ts
+++ b/tui/src/aside-overlay-actions.ts
@@ -1,0 +1,245 @@
+/** Aside-specific overlay dispatch and modal-layer policy. */
+import type { AppSource } from "./app.js";
+import type { ActionContext } from "./action-context.js";
+import {
+  asideBodyHeight,
+  asideComposerRows,
+  clearAsideSurface,
+  closeAside,
+  noteAsideDisplayScroll,
+  revealAsideFocusedNote,
+  scrollAside,
+  sendAsideQuestion,
+  stopAsideAsk
+} from "./aside-actions.js";
+import {
+  applyAsideUseMenu,
+  closeAsideUseMenu,
+  cycleAsideFocus,
+  focusAsideUseMenuIndex,
+  moveAsideNoteFocus,
+  moveAsideUseMenuCursor,
+  openAsideUseMenu
+} from "./aside-use.js";
+import { composerMotion } from "./composer-motion.js";
+import { directComposerWrapWidth } from "./composer-geometry.js";
+import { composerPageRows } from "./composer-viewport.js";
+import { composerSurfaceAction } from "./composer-surface-action.js";
+import { insertComposerText, setComposerText } from "./composer-model.js";
+import { applyTextKey, type ResolvedKey } from "./keys.js";
+import type { RuntimeState } from "./state.js";
+import {
+  asideCursor,
+  currentAsideTurns,
+  disarmAsideClear,
+  isAsideV2,
+  type AsideSurfaceState
+} from "./aside-surface.js";
+import { asideV2KeyAction } from "./aside-v2-actions.js";
+
+type AsideOverlayContext = ActionContext;
+
+function asideViewportBodyRows(
+  surface: AsideSurfaceState,
+  context: AsideOverlayContext,
+  toast?: string | null
+): { width: number; bodyRows: number } {
+  const width = context.renderer?.width ?? 80;
+  const height = context.renderer?.height ?? 24;
+  const composerRows = asideComposerRows(height);
+  return {
+    width,
+    bodyRows: asideBodyHeight(surface, width, height, composerRows, toast)
+  };
+}
+
+/** Handle the Aside overlay, including its nested use-menu and composer. */
+export async function asideKeyAction(
+  resolved: ResolvedKey,
+  state: RuntimeState,
+  source: AppSource,
+  context: AsideOverlayContext
+): Promise<void> {
+  const surface = state.aside;
+  if (surface === null) return;
+  if (isAsideV2(surface) && await asideV2KeyAction(resolved, state, surface, {
+      source,
+      backend: context.backend,
+      cache: context.cache,
+      repaint: context.repaint,
+      renderer: context.renderer,
+      toast: state.toast
+  })) return;
+  if (resolved.action === "cancel") {
+    // A busy Aside owns Escape for cancellation. Check this before the
+    // turns-to-composer focus transition, or a v2 retake loses its stop path.
+    if (surface.busy) {
+      // Clear has no abort path. Its missing in-flight question is the
+      // existing distinction from an Ask, so Esc remains a no-op while it
+      // commits instead of pretending to stop anything.
+      if (surface.inflightQuestion !== null) {
+        stopAsideAsk(state);
+        context.repaint();
+      }
+      return;
+    }
+    if (surface.useMenu !== null) {
+      closeAsideUseMenu(surface);
+      return;
+    }
+    if (surface.focus === "notes" || surface.focus === "turns") {
+      if (isAsideV2(surface)) {
+        closeAside(state);
+        return;
+      }
+      surface.focus = "composer";
+      return;
+    }
+    if (isAsideV2(surface) && currentAsideTurns(surface).length > 0) {
+      // Match story mode: close the prompt layer before leaving its parent.
+      // The draft remains available when the writer opens the prompt again.
+      surface.focus = "turns";
+      return;
+    }
+    if (isAsideV2(surface)) {
+      if (surface.confirmReset !== null) {
+        surface.confirmReset = null;
+        return;
+      }
+    } else if (surface.confirmClear) {
+      surface.confirmClear = false;
+      return;
+    }
+    // Esc when idle returns to Write.
+    closeAside(state);
+    return;
+  }
+  if (surface.useMenu !== null) {
+    if (resolved.action === "focus-next") {
+      moveAsideUseMenuCursor(surface, 1);
+      return;
+    }
+    if (resolved.action === "focus-previous") {
+      moveAsideUseMenuCursor(surface, -1);
+      return;
+    }
+    if (resolved.action === "focus-index") {
+      focusAsideUseMenuIndex(surface, resolved.index ?? surface.useMenu.cursor);
+      return;
+    }
+    if (resolved.action === "apply" || resolved.action === "open-selected") {
+      if (resolved.index !== undefined) {
+        focusAsideUseMenuIndex(surface, resolved.index);
+      }
+      await applyAsideUseMenu(state);
+      return;
+    }
+    // Use menu owns the surface: scrim/cancel stay authoritative; compose does
+    // not steal focus from under the modal.
+    return;
+  }
+
+  if (resolved.action === "cycle") {
+    if (cycleAsideFocus(surface)
+      && (surface.focus === "notes" || surface.focus === "turns")) {
+      const { width, bodyRows } = asideViewportBodyRows(surface, context, state.toast);
+      revealAsideFocusedNote(surface, width, bodyRows);
+    }
+    return;
+  }
+  if (resolved.action === "scroll-line-down" || resolved.action === "scroll-line-up"
+    || resolved.action === "scroll-down" || resolved.action === "scroll-up") {
+    const width = context.renderer?.width ?? 80;
+    const height = context.renderer?.height ?? 24;
+    const composerRows = asideComposerRows(height);
+    const page = asideBodyHeight(surface, width, height, composerRows, state.toast);
+    const delta = resolved.action === "scroll-line-down" || resolved.action === "scroll-down"
+      ? resolved.action === "scroll-down" ? page : 1
+      : resolved.action === "scroll-up" ? -page : -1;
+    scrollAside(surface, delta, width, height, composerRows, state.toast);
+    if (surface.busy) noteAsideDisplayScroll(state);
+    return;
+  }
+  if (surface.focus === "notes" || surface.focus === "turns") {
+    // Left-click on the visible prompt claims composer focus so paste/text
+    // target it. Use menu already returned above.
+    if (resolved.action === "compose") {
+      surface.focus = "composer";
+      return;
+    }
+    if (resolved.action === "focus-next" || resolved.action === "focus-previous") {
+      moveAsideNoteFocus(surface, resolved.action === "focus-next" ? 1 : -1);
+      const { width, bodyRows } = asideViewportBodyRows(surface, context, state.toast);
+      revealAsideFocusedNote(surface, width, bodyRows);
+      return;
+    }
+    if (resolved.action === "open-selected" || resolved.action === "apply") {
+      // Re-anchor under the current terminal size: a stale scrollTop from a
+      // prior width/header layout can hide noteCursor while Enter still uses it.
+      const { width, bodyRows } = asideViewportBodyRows(surface, context, state.toast);
+      revealAsideFocusedNote(surface, width, bodyRows);
+      openAsideUseMenu(surface, asideCursor(surface));
+      return;
+    }
+    return;
+  }
+  const width = context.renderer?.width ?? 80;
+  const height = context.renderer?.height ?? 24;
+  const motion = composerMotion(true, () => directComposerWrapWidth(width, state.config, true));
+  if (resolved.action === "cursor-up" || resolved.action === "cursor-down") {
+    motion.vertical(
+      surface.composer,
+      resolved.action === "cursor-up" ? -1 : 1,
+      resolved.extendSelection
+    );
+    return;
+  }
+  if (resolved.action === "send") {
+    if (surface.busy) return;
+    if (!isAsideV2(surface) && surface.confirmClear) {
+      context.backend.observe(context.backend.run("clearing Aside", (task) =>
+        clearAsideSurface(state, source.api, context.cache, { task })
+      ));
+      return;
+    }
+    const text = surface.composer.text;
+    if (text.trim() === "/clear") {
+      setComposerText(surface.composer, "");
+      if (!isAsideV2(surface)) surface.confirmClear = true;
+      return;
+    }
+    context.backend.observe(context.backend.run("asking Aside", (task) =>
+      sendAsideQuestion(state, source.api, text, {
+        task,
+        repaint: context.repaint,
+        cache: context.cache
+      })
+    ));
+    return;
+  }
+  if (resolved.action === "newline") {
+    disarmAsideClear(surface);
+    insertComposerText(surface.composer, "\n");
+    return;
+  }
+  if (resolved.action === "input" && resolved.text !== undefined) {
+    disarmAsideClear(surface);
+    insertComposerText(surface.composer, resolved.text);
+    return;
+  }
+  if (await composerSurfaceAction(resolved, state, surface.composer, {
+    isCurrent: () => state.mode === "ASIDE" && state.aside === surface,
+    pageRows: composerPageRows(height, true),
+    motion,
+    onEdit: (kind) => {
+      if (kind !== "move") disarmAsideClear(surface);
+    }
+  })) return;
+  // Keep the fallback for plain text actions that do not belong to the shared
+  // composer reducer. All structural edits above preserve cursor state.
+  const next = applyTextKey(surface.composer.text, resolved);
+  if (next !== null) {
+    disarmAsideClear(surface);
+    setComposerText(surface.composer, next);
+  }
+}

--- a/tui/src/aside-surface.ts
+++ b/tui/src/aside-surface.ts
@@ -5,8 +5,7 @@
  * calls the same exchange a turn and groups turns in an anchored session.
  * Variant state is canonical; selectors adapt v2 turns for old consumers.
  */
-import type { ComposerState } from "./composer-model.js";
-import { createComposer } from "./composer-model.js";
+import { createComposer, type ComposerState } from "./composer-model.js";
 import type { TextPresentation } from "./text-presentation.js";
 import { asideHopAnchorIndex } from "./aside-hop.js";
 import type { StorySelectionSpan } from "./selection-projection.js";
@@ -117,6 +116,14 @@ export interface AsideDeleteUndo {
   readonly turn: AsideTurnView;
 }
 
+/** The saved turn and original Ask composer held during Reprompt. */
+export interface AsideRetakePromptState {
+  readonly sessionId: string;
+  readonly turnIndex: number;
+  /** Keep the object so its cursor, selection, cut state, and edit history survive. */
+  readonly askComposer: ComposerState;
+}
+
 export type AsideStreamPhase = "thinking" | "writing" | null;
 
 interface AsideSurfaceBase {
@@ -127,7 +134,7 @@ interface AsideSurfaceBase {
   streamText: string;
   /** Visible prefix controller; `streamText` remains authoritative. */
   presentation?: TextPresentation;
-  /** Stop hides the live answer before the backend confirms its result. */
+  /** Stop freezes the visible answer prefix until the backend settles. */
   streamHidden?: boolean;
   /** Reasoning channel streamed separately from the answer channel. */
   streamThoughts: string;
@@ -172,6 +179,8 @@ export interface AsideSessionSurfaceState extends AsideSurfaceBase {
   /** Stable answer identity armed by the first destructive keypress. */
   confirmDelete: { rowId: string } | null;
   deleteUndo: AsideDeleteUndo | null;
+  /** Capital-R Reprompt target. Null means the composer will add a turn. */
+  retakePrompt: AsideRetakePromptState | null;
   anchor: AsideSessionAnchor | null;
 }
 
@@ -402,6 +411,7 @@ export function createAsideSurface(
       confirmReset: null,
       confirmDelete: null,
       deleteUndo: null,
+      retakePrompt: null,
       anchor
     } as AsideSessionSurfaceState;
   }

--- a/tui/src/aside-use.ts
+++ b/tui/src/aside-use.ts
@@ -13,6 +13,7 @@ import {
   asideCursor,
   asideNotes,
   disarmAsideClear,
+  isAsideV2,
   setAsideCursor,
   type AsideSurfaceState
 } from "./aside-surface.js";
@@ -106,6 +107,9 @@ export function openAsideUseMenu(
   selectionSpans: readonly StorySelectionSpan[] = []
 ): boolean {
   if (surface.busy) return false;
+  // Reprompt owns the composer. A mouse menu would create a second modal
+  // layer with no unambiguous Escape target, so keep the two modes exclusive.
+  if (isAsideV2(surface) && surface.retakePrompt !== null) return false;
   const notes = asideNotes(surface);
   if (noteIndex < 0 || noteIndex >= notes.length) return false;
   const actions = asideUseActions(selectionText);

--- a/tui/src/aside-v2-actions.ts
+++ b/tui/src/aside-v2-actions.ts
@@ -28,6 +28,8 @@ import { recordNotice } from "./notice-log.js";
 import { saveConfig } from "./config.js";
 import type { ReasoningDelta } from "./worker-pending.js";
 import type { ProseStyle, WrapCache } from "./wrap.js";
+import { createComposer } from "./composer-model.js";
+import { createTextPresentation, drainTextPresentation } from "./text-presentation.js";
 import { createStoryViewModel, rowIndexForNode } from "./model.js";
 import { followStoryViewport } from "./viewport-intent.js";
 import type { AsideAnchor } from "../../shared/aside-session.js";
@@ -97,6 +99,14 @@ function currentAnchor(surface: AsideSessionSurfaceState): AsideAnchor | null {
   return anchor === null ? null : { partId: anchor.partId, takeId: anchor.takeId };
 }
 
+function closeAsideRetakePrompt(surface: AsideSessionSurfaceState): boolean {
+  const prompt = surface.retakePrompt;
+  if (prompt === null) return false;
+  surface.retakePrompt = null;
+  surface.composer = prompt.askComposer;
+  return true;
+}
+
 function asideAnchorIsCurrent(
   surface: AsideSessionSurfaceState,
   anchor: AsideAnchorView
@@ -140,6 +150,7 @@ function hopToAsideAnchor(
   // Clicking the selected hop is a safe no-op. It must not clear or reload the
   // current session.
   if (asideAnchorIsCurrent(surface, anchor)) return true;
+  closeAsideRetakePrompt(surface);
   const getAsideV2 = context.source.api.getAsideV2;
   if (getAsideV2 === undefined) {
     throw new Error("This transport cannot hop Aside sessions.");
@@ -229,6 +240,7 @@ export function cycleAsideSession(surface: AsideSessionSurfaceState, delta: numb
   surface.useMenu = null;
   surface.confirmReset = null;
   surface.confirmDelete = null;
+  closeAsideRetakePrompt(surface);
   surface.scrollTop = null;
   return true;
 }
@@ -249,6 +261,7 @@ export function newAsideSession(surface: AsideSessionSurfaceState): boolean {
   surface.useMenu = null;
   surface.confirmReset = null;
   surface.confirmDelete = null;
+  closeAsideRetakePrompt(surface);
   surface.scrollTop = null;
   return true;
 }
@@ -397,14 +410,17 @@ async function retakeAside(
   state: RuntimeState,
   surface: AsideSessionSurfaceState,
   context: AsideContext,
-  task: ActionTask
+  task: ActionTask,
+  question?: string
 ): Promise<void> {
   const session = currentAsideSession(surface);
   const turn = currentAsideTurns(surface)[surface.turnCursor];
   if (session === null || turn === undefined
     || surface.turnCursor !== session.turns.length - 1) return;
+  const prompted = question !== undefined;
   const method = context.source.api.retakeAside;
   if (method === undefined) {
+    if (prompted) closeAsideRetakePrompt(surface);
     throw new Error("This transport cannot retake an Aside answer.");
   }
   if (state.abort !== null) return;
@@ -412,13 +428,24 @@ async function retakeAside(
     && state.payload.id === surface.storyId
     && task.owns()
     && task.storyCurrent();
+  const effectiveQuestion = question?.trim() ?? turn.q;
+  if (effectiveQuestion.length === 0) {
+    if (prompted) closeAsideRetakePrompt(surface);
+    return;
+  }
   surface.busy = true;
-  surface.inflightQuestion = turn.q;
+  surface.inflightQuestion = effectiveQuestion;
   surface.streamText = "";
   surface.streamThoughts = "";
   surface.streamThoughtTokens = 0;
   surface.streamPhase = "thinking";
   surface.streamHidden = false;
+  surface.presentation?.dispose();
+  surface.presentation = createTextPresentation({
+    onPresented: () => {
+      if (current()) context.repaint?.();
+    }
+  });
   const controller = new AbortController();
   const active = {
     kind: "generation" as const,
@@ -432,12 +459,14 @@ async function retakeAside(
       storyId: surface.storyId,
       sessionId: session.id,
       turnIndex: surface.turnCursor,
-      anchor: currentAnchor(surface)
+      anchor: currentAnchor(surface),
+      ...(prompted ? { question: effectiveQuestion } : {})
     }, (text) => {
       if (!current()) return;
       surface.streamPhase = "writing";
       surface.streamText += text;
-      context.repaint?.();
+      surface.presentation?.receive(text);
+      if (surface.presentation === undefined) context.repaint?.();
     }, {
       onReasoning: (delta) => {
         if (!current()) return;
@@ -456,6 +485,10 @@ async function retakeAside(
     // Thoughts visibility is display-only and may advance interactionVersion
     // after Stop, so do not use that version to discard a committed retake.
     if (result === null) return;
+    if (surface.presentation !== undefined && !surface.presentation.suspended) {
+      await drainTextPresentation(surface.presentation);
+      if (!current()) return;
+    }
     recordNotice(
       state.notices,
       "toast",
@@ -464,9 +497,14 @@ async function retakeAside(
       state.now
     );
     applySessionResponse(state, surface, result, context.cache);
+    if (prompted) {
+      closeAsideRetakePrompt(surface);
+      surface.focus = "turns";
+    }
   } finally {
     if (state.abort === active) state.abort = null;
     if (current()) {
+      if (prompted) closeAsideRetakePrompt(surface);
       clearAsideStream(surface);
       surface.busy = false;
       context.repaint?.();
@@ -482,6 +520,16 @@ export async function asideV2KeyAction(
   context: AsideContext
 ): Promise<boolean> {
   if (!isAsideV2(surface)) return false;
+  if (!surface.busy && resolved.action === "cancel" && surface.retakePrompt !== null) {
+    closeAsideRetakePrompt(surface);
+    surface.focus = currentAsideTurns(surface).length > 0 ? "turns" : "composer";
+    return true;
+  }
+  if (!surface.busy && resolved.action === "cycle" && surface.retakePrompt !== null) {
+    closeAsideRetakePrompt(surface);
+    surface.focus = currentAsideTurns(surface).length > 0 ? "turns" : "composer";
+    return true;
+  }
   if (resolved.action === "cancel" && surface.confirmDelete !== null) {
     surface.confirmDelete = null;
     return true;
@@ -561,6 +609,23 @@ export async function asideV2KeyAction(
   // Streaming owns editing and navigation, but scrolling only changes the
   // displayed history window and remains safe while the answer grows.
   if (surface.busy && resolved.action !== "cancel" && !displayScroll) return true;
+  if (resolved.action === "send" && surface.retakePrompt !== null) {
+    const target = surface.retakePrompt;
+    const session = currentAsideSession(surface);
+    const question = surface.composer.text.trim();
+    if (question.length === 0) return true;
+    if (session === null || session.id !== target.sessionId
+      || target.turnIndex !== session.turns.length - 1
+      || surface.turnCursor !== target.turnIndex) {
+      closeAsideRetakePrompt(surface);
+      state.toast = "that Aside turn is no longer available to retake · ask draft restored";
+      return true;
+    }
+    context.backend.observe(context.backend.run("retaking Aside answer", (task) =>
+      retakeAside(state, surface, context, task, question)
+    ));
+    return true;
+  }
   if (resolved.action === "aside-session-next") return cycleAsideSession(surface, 1);
   if (resolved.action === "aside-session-previous") return cycleAsideSession(surface, -1);
   if (resolved.action === "aside-new-session") return newAsideSession(surface);
@@ -615,6 +680,23 @@ export async function asideV2KeyAction(
     context.backend.observe(context.backend.run("retaking Aside answer", (task) =>
       retakeAside(state, surface, context, task)
     ));
+    return true;
+  }
+  if (resolved.action === "aside-retake-with-prompt") {
+    const session = currentAsideSession(surface);
+    const turn = currentAsideTurns(surface)[surface.turnCursor];
+    if (session === null || turn === undefined
+      || surface.turnCursor !== session.turns.length - 1) return true;
+    surface.retakePrompt = {
+      sessionId: session.id,
+      turnIndex: surface.turnCursor,
+      askComposer: surface.composer
+    };
+    surface.composer = createComposer(turn.q);
+    surface.focus = "composer";
+    surface.confirmReset = null;
+    surface.confirmDelete = null;
+    surface.scrollTop = null;
     return true;
   }
   const currentSession = currentAsideSession(surface);

--- a/tui/src/keys.ts
+++ b/tui/src/keys.ts
@@ -61,7 +61,7 @@ export type KeyAction =
   | "open-selected" | "new-item" | "duplicate-item" | "rename-item" | "delete-item"
   | "move-item-up" | "move-item-down"
   | "open-aside" | "open-authors-note" | "note-depth-decrease" | "note-depth-increase"
-  | "aside-retake" | "aside-delete" | "aside-reset" | "aside-new-session"
+  | "aside-retake" | "aside-retake-with-prompt" | "aside-delete" | "aside-reset" | "aside-new-session"
   | "aside-session-next" | "aside-session-previous" | "aside-anchor-next" | "aside-anchor-previous"
   | "aside-go-anchor" | "aside-hop-to" | "aside-undo-delete"
   | "filter" | "cycle" | "check" | "detect-context" | "discard-pending" | "retry" | "continue"
@@ -526,6 +526,7 @@ export function resolveKey(key: KeyEvent, mode: AppMode, options: ResolveOptions
       if (name === "up") return { action: "focus-previous" };
       if (name === "down") return { action: "focus-next" };
       if (key.name === "return") return { action: "open-selected" };
+      if (plainShiftedLetter(key, "r")) return { action: "aside-retake-with-prompt" };
       if (name === "r") return { action: "aside-retake" };
       if (plainShiftedLetter(key, "d")) return { action: "aside-delete" };
       if (name === "t") return { action: "toggle-thought" };

--- a/tui/src/overlay-actions.ts
+++ b/tui/src/overlay-actions.ts
@@ -29,41 +29,20 @@ import { createStoryViewModel, lastPartRowIndex } from "./model.js";
 import { rememberFocus } from "./reading-position-persist.js";
 import { adoptSameStoryPayload } from "./story-adoption.js";
 import { cancelSummary, startSummary } from "./summary-action.js";
-import {
-  asideBodyHeight,
-  asideComposerRows,
-  clearAsideSurface,
-  closeAside,
-  openAside,
-  revealAsideFocusedNote,
-  noteAsideDisplayScroll,
-  scrollAside,
-  sendAsideQuestion,
-  stopAsideAsk
-} from "./aside-actions.js";
-import {
-  applyAsideUseMenu,
-  cycleAsideFocus,
-  focusAsideUseMenuIndex,
-  moveAsideNoteFocus,
-  moveAsideUseMenuCursor,
-  openAsideUseMenu,
-  openAsideUseMenuFromMouse,
-  closeAsideUseMenu
-} from "./aside-use.js";
+import { openAside } from "./aside-actions.js";
+import { openAsideUseMenuFromMouse } from "./aside-use.js";
 import {
   cancelPlacement,
   confirmPlacement,
   movePlacementCursor,
   placementInputLocked
 } from "./aside-placement.js";
-import { insertComposerText, setComposerText } from "./composer-model.js";
 import { composerMotion } from "./composer-motion.js";
 import { directComposerWrapWidth } from "./composer-geometry.js";
 import { composerPageRows } from "./composer-viewport.js";
 import { composerSurfaceAction } from "./composer-surface-action.js";
-import { asideCursor, disarmAsideClear, isAsideV2 } from "./aside-surface.js";
-import { asideV2KeyAction } from "./aside-v2-actions.js";
+import { asideCursor } from "./aside-surface.js";
+import { asideKeyAction } from "./aside-overlay-actions.js";
 import { openRewriteComposer, partIdFromTextSelection, resolveRewriteTarget } from "./rewrite-action.js";
 import type { AppSource } from "./app.js";
 import { canRewriteSelection, type ProjectedStorySelection } from "./selection-projection.js";
@@ -772,20 +751,6 @@ async function reconnect(state: RuntimeState, source: AppSource, context: Overla
   });
 }
 
-function asideViewportBodyRows(
-  surface: NonNullable<RuntimeState["aside"]>,
-  context: OverlayActionContext,
-  toast?: string | null
-): { width: number; bodyRows: number } {
-  const width = context.renderer?.width ?? 80;
-  const height = context.renderer?.height ?? 24;
-  const composerRows = asideComposerRows(height);
-  return {
-    width,
-    bodyRows: asideBodyHeight(surface, width, height, composerRows, toast)
-  };
-}
-
 async function placementKeyAction(
   resolved: ResolvedKey,
   state: RuntimeState,
@@ -809,189 +774,5 @@ async function placementKeyAction(
   }
   if (resolved.action === "apply" || resolved.action === "open-selected") {
     await confirmPlacement(state, source, context);
-  }
-}
-
-async function asideKeyAction(
-  resolved: ResolvedKey,
-  state: RuntimeState,
-  source: AppSource,
-  context: OverlayActionContext
-): Promise<void> {
-  const surface = state.aside;
-  if (surface === null) return;
-  if (isAsideV2(surface) && await asideV2KeyAction(resolved, state, surface, {
-      source,
-      backend: context.backend,
-      cache: context.cache,
-      repaint: context.repaint,
-      renderer: context.renderer,
-      toast: state.toast
-  })) return;
-  if (resolved.action === "cancel") {
-    // A busy Aside owns Escape for cancellation. Check this before the
-    // turns-to-composer focus transition, or a v2 retake loses its stop path.
-    if (surface.busy) {
-      // Clear has no abort path. Its missing in-flight question is the
-      // existing distinction from an Ask, so Esc remains a no-op while it
-      // commits instead of pretending to stop anything.
-      if (surface.inflightQuestion !== null) {
-        stopAsideAsk(state);
-        context.repaint();
-      }
-      return;
-    }
-    if (surface.useMenu !== null) {
-      closeAsideUseMenu(surface);
-      return;
-    }
-    if (surface.focus === "notes" || surface.focus === "turns") {
-      if (isAsideV2(surface)) {
-        closeAside(state);
-        return;
-      }
-      surface.focus = "composer";
-      return;
-    }
-    if (isAsideV2(surface)) {
-      if (surface.confirmReset !== null) {
-        surface.confirmReset = null;
-        return;
-      }
-    } else if (surface.confirmClear) {
-      surface.confirmClear = false;
-      return;
-    }
-    // Esc when idle returns to Write.
-    closeAside(state);
-    return;
-  }
-  if (surface.useMenu !== null) {
-    if (resolved.action === "focus-next") {
-      moveAsideUseMenuCursor(surface, 1);
-      return;
-    }
-    if (resolved.action === "focus-previous") {
-      moveAsideUseMenuCursor(surface, -1);
-      return;
-    }
-    if (resolved.action === "focus-index") {
-      focusAsideUseMenuIndex(surface, resolved.index ?? surface.useMenu.cursor);
-      return;
-    }
-    if (resolved.action === "apply" || resolved.action === "open-selected") {
-      if (resolved.index !== undefined) {
-        focusAsideUseMenuIndex(surface, resolved.index);
-      }
-      await applyAsideUseMenu(state);
-      return;
-    }
-    // Use menu owns the surface: scrim/cancel stay authoritative; compose does
-    // not steal focus from under the modal.
-    return;
-  }
-
-  if (resolved.action === "cycle") {
-    if (cycleAsideFocus(surface)
-      && (surface.focus === "notes" || surface.focus === "turns")) {
-      const { width, bodyRows } = asideViewportBodyRows(surface, context, state.toast);
-      revealAsideFocusedNote(surface, width, bodyRows);
-    }
-    return;
-  }
-  if (resolved.action === "scroll-line-down" || resolved.action === "scroll-line-up"
-    || resolved.action === "scroll-down" || resolved.action === "scroll-up") {
-    const width = context.renderer?.width ?? 80;
-    const height = context.renderer?.height ?? 24;
-    const composerRows = asideComposerRows(height);
-    const page = asideBodyHeight(surface, width, height, composerRows, state.toast);
-    const delta = resolved.action === "scroll-line-down" || resolved.action === "scroll-down"
-      ? resolved.action === "scroll-down" ? page : 1
-      : resolved.action === "scroll-up" ? -page : -1;
-    scrollAside(surface, delta, width, height, composerRows, state.toast);
-    if (surface.busy) noteAsideDisplayScroll(state);
-    return;
-  }
-  if (surface.focus === "notes" || surface.focus === "turns") {
-    // Left-click on the visible prompt claims composer focus so paste/text
-    // target it. Use menu already returned above.
-    if (resolved.action === "compose") {
-      surface.focus = "composer";
-      return;
-    }
-    if (resolved.action === "focus-next" || resolved.action === "focus-previous") {
-      moveAsideNoteFocus(surface, resolved.action === "focus-next" ? 1 : -1);
-      const { width, bodyRows } = asideViewportBodyRows(surface, context, state.toast);
-      revealAsideFocusedNote(surface, width, bodyRows);
-      return;
-    }
-    if (resolved.action === "open-selected" || resolved.action === "apply") {
-      // Re-anchor under the current terminal size: a stale scrollTop from a
-      // prior width/header layout can hide noteCursor while Enter still uses it.
-      const { width, bodyRows } = asideViewportBodyRows(surface, context, state.toast);
-      revealAsideFocusedNote(surface, width, bodyRows);
-      openAsideUseMenu(surface, asideCursor(surface));
-      return;
-    }
-    return;
-  }
-  const width = context.renderer?.width ?? 80;
-  const height = context.renderer?.height ?? 24;
-  const motion = composerMotion(true, () => directComposerWrapWidth(width, state.config, true));
-  if (resolved.action === "cursor-up" || resolved.action === "cursor-down") {
-    motion.vertical(
-      surface.composer,
-      resolved.action === "cursor-up" ? -1 : 1,
-      resolved.extendSelection
-    );
-    return;
-  }
-  if (resolved.action === "send") {
-    if (surface.busy) return;
-    if (!isAsideV2(surface) && surface.confirmClear) {
-      context.backend.observe(context.backend.run("clearing Aside", (task) =>
-        clearAsideSurface(state, source.api, context.cache, { task })
-      ));
-      return;
-    }
-    const text = surface.composer.text;
-    if (text.trim() === "/clear") {
-      setComposerText(surface.composer, "");
-      if (!isAsideV2(surface)) surface.confirmClear = true;
-      return;
-    }
-    context.backend.observe(context.backend.run("asking Aside", (task) =>
-      sendAsideQuestion(state, source.api, text, {
-        task,
-        repaint: context.repaint,
-        cache: context.cache
-      })
-    ));
-    return;
-  }
-  if (resolved.action === "newline") {
-    disarmAsideClear(surface);
-    insertComposerText(surface.composer, "\n");
-    return;
-  }
-  if (resolved.action === "input" && resolved.text !== undefined) {
-    disarmAsideClear(surface);
-    insertComposerText(surface.composer, resolved.text);
-    return;
-  }
-  if (await composerSurfaceAction(resolved, state, surface.composer, {
-    isCurrent: () => state.mode === "ASIDE" && state.aside === surface,
-    pageRows: composerPageRows(height, true),
-    motion,
-    onEdit: (kind) => {
-      if (kind !== "move") disarmAsideClear(surface);
-    }
-  })) return;
-  // Keep the fallback for plain text actions that do not belong to the shared
-  // composer reducer. All structural edits above preserve cursor state.
-  const next = applyTextKey(surface.composer.text, resolved);
-  if (next !== null) {
-    disarmAsideClear(surface);
-    setComposerText(surface.composer, next);
   }
 }

--- a/tui/src/screens/story/aside-screen.ts
+++ b/tui/src/screens/story/aside-screen.ts
@@ -140,7 +140,7 @@ function renderAsideV2Composer(
     terminalWidth: width,
     terminalHeight: Math.max(4, Math.min(asideComposerRows(height), height - 3)),
     measure: width,
-    title: "aside · prompt",
+    title: surface.retakePrompt === null ? "aside · prompt" : "aside · reprompt",
     caret: surface.busy ? "streaming" : "focused",
     footerNotice: surface.busy ? null : state.toast,
     footerHints: asideV2FooterHint(surface, width),
@@ -159,15 +159,20 @@ function asideV2FooterHint(surface: AsideSessionSurfaceState, width: number): st
       : "⌫ confirms · esc keeps";
   }
   if (surface.busy) return "t Thoughts · esc stops";
+  if (surface.retakePrompt !== null) {
+    return "↵ retake with this prompt · ⇧↵ newline · esc keeps answer";
+  }
   const full = asideFooterHint(surface);
   if (visibleWidth(full) <= width) return full;
   if (surface.focus === "turns" || surface.focus === "notes") {
     const turns = currentAsideTurns(surface);
     const history = surface.turnCursor < Math.max(0, turns.length - 1)
-      ? "⌫ reset" : "r retake";
+      ? "⌫ reset" : "r retake · R reprompt";
     return `↑↓ turn · ←→ session · n new · ↵ use · ${history} · D delete · t Thoughts · tab ask · [ ] hop · g go · esc exit`;
   }
-  return "↵ ask · ⇧↵ newline · tab turns · esc exit";
+  return currentAsideTurns(surface).length > 0
+    ? "↵ ask · ⇧↵ newline · tab turns · esc turns"
+    : "↵ ask · ⇧↵ newline · esc exit";
 }
 
 function asideV2StandaloneFooterLines(
@@ -184,7 +189,7 @@ function asideV2StandaloneFooterLines(
   }
   const turns = currentAsideTurns(surface);
   const history = surface.turnCursor < Math.max(0, turns.length - 1)
-    ? "⌫ reset" : "r retake";
+    ? "⌫ reset" : "r retake · R reprompt";
   return [
     `↑↓ turn · ←→ session · n new · ↵ use · ${history} · D delete`,
     "t Thoughts · tab ask · [ ] hop · g go · esc exit"

--- a/tui/test/aside-input-queue.test.ts
+++ b/tui/test/aside-input-queue.test.ts
@@ -11,6 +11,8 @@ import {
 import { createWrapCache, type ProseStyle } from "../src/wrap.js";
 import { setComposerText } from "../src/composer-model.js";
 import { pasteInto } from "../src/keys.js";
+import { renderAsideScreen } from "../src/screens/story/aside-screen.js";
+import { frameText } from "../src/screens/story/frame.js";
 
 function key(name: string): KeyEvent {
   return { name, sequence: name, shift: false, ctrl: false, meta: false } as KeyEvent;
@@ -36,7 +38,7 @@ describe("Aside presented input", () => {
         requestSignal.addEventListener("abort", () => { aborted.push(true); }, { once: true });
         await gate;
         return requestSignal.aborted
-          ? { notes: [{ question: "Why did it change?", answer: "partial answer" }] }
+          ? { notes: [{ question: "Why did it change?", answer: "partial answer." }] }
           : { notes: [] };
       }
     };
@@ -73,14 +75,17 @@ describe("Aside presented input", () => {
     expect(signal).not.toBeNull();
     expect(repaintEvents.length).toBeGreaterThan(1);
 
-    emitDelta!("partial answer");
-    expect(state.aside.streamText).toBe("partial answer");
-    expect(repaintEvents.at(-1)).toBe("busy:partial answer");
+    emitDelta!("partial answer.");
+    expect(state.aside.streamText).toBe("partial answer.");
+    expect(repaintEvents.at(-1)).toBe("busy:partial answer.");
 
     enqueue(key("escape"));
     await drainMicrotasks();
     expect(signal!.aborted).toBeTrue();
     expect(aborted).toHaveLength(1);
+    expect(state.aside!.streamHidden).toBeFalse();
+    expect(frameText(renderAsideScreen(state, state.aside!, 80, 24).lines))
+      .toContain("partial answer");
 
     release();
     await backend.whenIdle();
@@ -90,7 +95,7 @@ describe("Aside presented input", () => {
     expect(state.aside.composer.text).toBe("");
     expect(asideNotes(state.aside!)).toEqual([{
       question: "Why did it change?",
-      answer: "partial answer"
+      answer: "partial answer."
     }]);
     expect(state.toast).toBe("Aside stopped · answer kept");
     expect(state.abort).toBeNull();

--- a/tui/test/aside-readability.test.ts
+++ b/tui/test/aside-readability.test.ts
@@ -127,7 +127,7 @@ describe("Aside readability and navigation", () => {
     ))).toBeTrue();
   });
 
-  test("labels the turns exit action as esc exit", () => {
+  test("labels the turns exit action and composer layer as esc turns", () => {
     const source = demoAppSource();
     const state = initialState(source, false);
     const surface = v2Surface(state, "Why?", "Because.");
@@ -137,7 +137,8 @@ describe("Aside readability and navigation", () => {
 
     surface.focus = "composer";
     const composerText = frameText(renderAsideScreen(state, surface, 120, 24).lines);
-    expect(composerText).toContain("esc exit");
+    expect(composerText).toContain("esc turns");
+    expect(composerText).not.toContain("esc exit");
     expect(composerText).not.toContain("esc read");
   });
 

--- a/tui/test/aside-use-placement.test.ts
+++ b/tui/test/aside-use-placement.test.ts
@@ -66,6 +66,10 @@ describe("Aside use menu and Placement", () => {
       .toBe("open-selected");
     expect(resolveKey(key("up"), "ASIDE", { asideLayer: "notes" }).action)
       .toBe("focus-previous");
+    expect(resolveKey(key("r"), "ASIDE", { asideLayer: "notes" }).action)
+      .toBe("aside-retake");
+    expect(resolveKey(key("R"), "ASIDE", { asideLayer: "notes" }).action)
+      .toBe("aside-retake-with-prompt");
     expect(resolveKey(key("return"), "ASIDE", { asideLayer: "use-menu" }).action)
       .toBe("apply");
     expect(resolveKey(key("up"), "ASIDE", { asideLayer: "use-menu" }).action)

--- a/tui/test/aside-v2.test.ts
+++ b/tui/test/aside-v2.test.ts
@@ -26,6 +26,12 @@ import { asideV2KeyAction, cycleAsideSession } from "../src/aside-v2-actions.js"
 import { recordHumanWords } from "../src/config.js";
 import { ActionRuntime } from "../src/action-runtime.js";
 import { cycleAsideFocus, openAsideUseMenu } from "../src/aside-use.js";
+import {
+  insertComposerText,
+  redoComposerEdit,
+  setComposerText,
+  undoComposerEdit
+} from "../src/composer-model.js";
 import { renderAsideScreen } from "../src/screens/story/aside-screen.js";
 import { frameText, plainLine, visibleWidth } from "../src/screens/story/frame.js";
 import { createStoryViewModel, rowIndexForNode } from "../src/model.js";
@@ -399,6 +405,44 @@ describe("Aside v2 surface", () => {
     await asideV2KeyAction({ action: "aside-undo-delete" }, state, surface, context);
     expect(currentAsideTurns(surface)).toHaveLength(1);
     expect(deletes).toBe(0);
+  });
+
+  test("use-menu ownership still flushes an optimistic delete", async () => {
+    const { source, state, surface } = surfaceWithTurns([
+      { q: "First?", a: "One." },
+      { q: "Second?", a: "Two." }
+    ]);
+    surface.focus = "turns";
+    surface.turnCursor = 1;
+    let deletes = 0;
+    const api = {
+      ...source.api,
+      deleteAsideTurn: async () => {
+        deletes += 1;
+        return {
+          schemaVersion: 2 as const,
+          id: "s1",
+          anchor: null,
+          title: "why the lantern",
+          turns: [{ q: "First?", a: "One." }]
+        };
+      }
+    } as unknown as StoryApi;
+    const backend = new ActionRuntime(state, () => undefined);
+    const context = { source: { api, config: state.config }, backend };
+
+    await asideV2KeyAction({ action: "aside-delete" }, state, surface, context);
+    await asideV2KeyAction({ action: "aside-delete" }, state, surface, context);
+    expect(surface.deleteUndo).not.toBeNull();
+    expect(openAsideUseMenu(surface, 0)).toBeTrue();
+
+    expect(await asideV2KeyAction(
+      { action: "aside-retake-with-prompt" }, state, surface, context
+    )).toBeFalse();
+    expect(surface.retakePrompt).toBeNull();
+    await backend.settle();
+    expect(deletes).toBe(1);
+    expect(surface.deleteUndo).toBeNull();
   });
 
   test("u during a durable delete does not restore the submitted turn", async () => {
@@ -1041,7 +1085,7 @@ describe("Aside v2 surface", () => {
     expect(currentAsideTurns(surface)).toEqual([]);
   });
 
-  test("Esc exits Aside from turns while Tab returns to the composer", async () => {
+  test("Esc closes the composer before a second Esc exits Aside", async () => {
     const { source, state, surface } = surfaceWithTurns([{ q: "Why?", a: "Because." }]);
     surface.focus = "composer";
     surface.composer.text = "unsent draft";
@@ -1058,16 +1102,153 @@ describe("Aside v2 surface", () => {
       async () => undefined, () => undefined, null, () => undefined, () => undefined, backend
     );
 
-    await press("tab");
-    expect(surface.focus).toBe("notes");
-    await press("tab");
-    expect(surface.focus).toBe("composer");
+    await press("escape");
+    expect(surface.focus).toBe("turns");
+    expect(state.mode).toBe("ASIDE");
     expect(surface.composer.text).toBe("unsent draft");
     await press("tab");
-    expect(surface.focus).toBe("notes");
+    expect(surface.focus).toBe("composer");
+    await press("escape");
+    expect(surface.focus).toBe("turns");
+    expect(surface.composer.text).toBe("unsent draft");
     await press("escape");
     expect(state.mode).toBe("NAV");
     expect(state.aside).toBeNull();
+  });
+
+  test("capital R edits the newest question and restores the ask draft", async () => {
+    const { source, state, surface } = surfaceWithTurns([{ q: "Why?", a: "Because." }]);
+    surface.focus = "turns";
+    surface.composer.text = "Follow-up draft";
+    surface.composer.cursor = surface.composer.text.length;
+    let request: unknown;
+    const api = {
+      ...source.api,
+      retakeAside: async (next: unknown) => {
+        request = next;
+        return {
+          schemaVersion: 2 as const,
+          id: "s1",
+          anchor: null,
+          title: "What changed?",
+          turns: [{ q: "What changed?", a: "A better answer." }]
+        };
+      }
+    } as unknown as StoryApi;
+    const sourceWithApi = { ...source, api };
+    const backend = new ActionRuntime(state, () => undefined);
+    const key = (name: string) => ({
+      name,
+      sequence: name,
+      shift: name === "R",
+      ctrl: false,
+      meta: false
+    }) as Parameters<typeof handleKey>[0];
+    const press = (name: string) => handleKey(
+      key(name), state, sourceWithApi, createWrapCache(), () => undefined,
+      async () => undefined, () => undefined, null, () => undefined, () => undefined, backend
+    );
+
+    expect(openAsideUseMenu(surface, 0)).toBeTrue();
+    await press("R");
+    expect(surface.useMenu).not.toBeNull();
+    expect(surface.retakePrompt).toBeNull();
+    await press("escape");
+    expect(surface.useMenu).toBeNull();
+
+    await press("R");
+    expect(surface.focus).toBe("composer");
+    expect(surface.composer.text).toBe("Why?");
+    expect(surface.retakePrompt).toEqual({
+      sessionId: "s1",
+      turnIndex: 0,
+      askComposer: expect.any(Object)
+    });
+    expect(surface.retakePrompt?.askComposer).not.toBe(surface.composer);
+    expect(openAsideUseMenu(surface, 0)).toBeFalse();
+    expect(surface.useMenu).toBeNull();
+
+    await press("escape");
+    expect(surface.focus).toBe("turns");
+    expect(surface.retakePrompt).toBeNull();
+    expect(surface.composer.text).toBe("Follow-up draft");
+
+    await press("R");
+
+    surface.composer.text = "What changed?";
+    surface.composer.cursor = surface.composer.text.length;
+    await press("return");
+    await backend.settle();
+
+    expect(request).toMatchObject({
+      storyId: state.payload.id,
+      sessionId: "s1",
+      turnIndex: 0,
+      anchor: null,
+      question: "What changed?"
+    });
+    expect(currentAsideTurns(surface)).toEqual([
+      { q: "What changed?", a: "A better answer." }
+    ]);
+    expect(surface.focus).toBe("turns");
+    expect(surface.retakePrompt).toBeNull();
+    expect(surface.composer.text).toBe("Follow-up draft");
+  });
+
+  test("reprompt restores the complete Ask composer, including edit history", async () => {
+    const { source, state, surface } = surfaceWithTurns([{ q: "Why?", a: "Because." }]);
+    const askComposer = surface.composer;
+    setComposerText(askComposer, "Follow-up draft");
+    insertComposerText(askComposer, "!");
+    insertComposerText(askComposer, "?");
+    expect(undoComposerEdit(askComposer)).toBeTrue();
+    askComposer.cursor = 3;
+    askComposer.anchor = 1;
+    askComposer.fullscreen = true;
+    askComposer.cutConfirmation = { start: 1, end: 3, text: "ol" };
+    const before = {
+      text: askComposer.text,
+      cursor: askComposer.cursor,
+      anchor: askComposer.anchor,
+      fullscreen: askComposer.fullscreen,
+      cutConfirmation: { ...askComposer.cutConfirmation }
+    };
+    surface.focus = "turns";
+    const api = {
+      ...source.api,
+      retakeAside: async () => ({
+        schemaVersion: 2 as const,
+        id: "s1",
+        anchor: null,
+        title: "Why?",
+        turns: [{ q: "Why?", a: "A new answer." }]
+      })
+    } as unknown as StoryApi;
+    const backend = new ActionRuntime(state, () => undefined);
+    const press = (name: string) => asideV2KeyAction(
+      { action: name === "R" ? "aside-retake-with-prompt" : "cancel" },
+      state,
+      surface,
+      { source: { api, config: state.config }, backend }
+    );
+
+    await press("R");
+    expect(surface.composer).not.toBe(askComposer);
+    expect(surface.composer.text).toBe("Why?");
+    await press("escape");
+
+    expect(surface.composer).toBe(askComposer);
+    expect({
+      text: askComposer.text,
+      cursor: askComposer.cursor,
+      anchor: askComposer.anchor,
+      fullscreen: askComposer.fullscreen,
+      cutConfirmation: askComposer.cutConfirmation
+    }).toEqual(before);
+    expect(undoComposerEdit(askComposer)).toBeTrue();
+    expect(askComposer.text).toBe("Follow-up draft");
+    expect(redoComposerEdit(askComposer)).toBeTrue();
+    expect(askComposer.text).toBe("Follow-up draft!");
   });
 
   test("empty current buckets use brackets for anchor hops", async () => {
@@ -1267,6 +1448,55 @@ describe("Aside v2 surface", () => {
     expect(surface.busy).toBeFalse();
     expect(surface.streamThoughts).toBe("");
     expect(surface.streamThoughtTokens).toBe(0);
+  });
+
+  test("stopping a retake freezes its visible answer prefix", async () => {
+    const { source, state, surface } = surfaceWithTurns([
+      { q: "Why?", a: "Because." }
+    ]);
+    let emitDelta!: (text: string) => void;
+    let finish!: (value: unknown) => void;
+    const api = {
+      ...source.api,
+      retakeAside: async (
+        _request: unknown,
+        onDelta: (text: string) => void
+      ) => {
+        emitDelta = onDelta;
+        return await new Promise<unknown>((resolve) => { finish = resolve; });
+      }
+    } as unknown as StoryApi;
+    const backend = new ActionRuntime(state, () => undefined);
+    const pending = asideV2KeyAction(
+      { action: "aside-retake" },
+      state,
+      surface,
+      { source: { api, config: state.config }, backend }
+    );
+    await Promise.resolve();
+    emitDelta("VISIBLE prefix");
+    expect(frameText(renderAsideScreen(state, surface, 80, 24).lines))
+      .toContain("VISIBLE");
+
+    expect(stopAsideAsk(state)).toBeTrue();
+    emitDelta(" TAIL");
+    const stopped = frameText(renderAsideScreen(state, surface, 80, 24).lines);
+    expect(stopped).toContain("VISIBLE");
+    expect(stopped).not.toContain("TAIL");
+
+    finish({
+      schemaVersion: 2 as const,
+      id: "s1",
+      anchor: null,
+      title: "Why?",
+      turns: [{ q: "Why?", a: "Committed replacement." }]
+    });
+    await pending;
+    await backend.settle();
+    expect(currentAsideTurns(surface)).toEqual([
+      { q: "Why?", a: "Committed replacement." }
+    ]);
+    expect(surface.streamText).toBe("");
   });
 
   test("dispatched Esc stops a busy retake before moving focus to the composer", async () => {
@@ -2018,7 +2248,7 @@ describe("Aside v2 surface", () => {
   test("labels every narrow turn-focus key across two rows", () => {
     const { state, surface } = surfaceWithTurns([{ q: "Why?", a: "Because." }]);
     const text = frameText(renderAsideScreen(state, surface, 80, 24).lines);
-    expect(text).toContain("↑↓ turn · ←→ session · n new · ↵ use · r retake · D delete");
+    expect(text).toContain("↑↓ turn · ←→ session · n new · ↵ use · r retake · R reprompt · D delete");
     expect(text).toContain("t Thoughts · tab ask · [ ] hop · g go · esc exit");
   });
 

--- a/tui/test/aside-v2.test.ts
+++ b/tui/test/aside-v2.test.ts
@@ -1159,11 +1159,9 @@ describe("Aside v2 surface", () => {
     await press("R");
     expect(surface.focus).toBe("composer");
     expect(surface.composer.text).toBe("Why?");
-    expect(surface.retakePrompt).toEqual({
-      sessionId: "s1",
-      turnIndex: 0,
-      askComposer: expect.any(Object)
-    });
+    expect(surface.retakePrompt?.sessionId).toBe("s1");
+    expect(surface.retakePrompt?.turnIndex).toBe(0);
+    expect(surface.retakePrompt?.askComposer).not.toBeNull();
     expect(surface.retakePrompt?.askComposer).not.toBe(surface.composer);
     expect(openAsideUseMenu(surface, 0)).toBeFalse();
     expect(surface.useMenu).toBeNull();


### PR DESCRIPTION
Aside now follows the story-mode interaction model. Stop keeps the visible generated prefix, Escape closes the prompt layer before Aside, and Shift+R opens an editable Reprompt while preserving the Ask draft.

The transport now replaces the latest question and answer atomically. Protocol negotiation fails closed, request sizing includes edited questions, and retained worker protocols replay with their original identity.

Tracks #368

Verification:
- `npm run typecheck`
- `npm --prefix tui test`
- `npm test`
- autoreview: clean
- thermo-nuclear review: clean

Risk:
- HTTP and worker protocol versions increase to 27 and 13. Mixed builds refuse negotiation.