### PR TITLE
chore(release): prepare 0.10.5-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ This file records notable changes to 1667. Product terms use the definitions in
 
 ## Unreleased
 
+## 0.10.5-rc.1 - 2026-08-30
+
+- **Aside retakes now work like story retakes.** Stop keeps generated text.
+  Press `r` to repeat the newest question. Press `Shift+R` to edit it. Escape
+  closes the active prompt layer before it exits Aside. Tab switches between
+  the composer and saved turns.
+
 ## 0.10.4 - 2026-08-29
 
 - **This release has no additional product changes.** It contains the same

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "1667-workspace",
-  "version": "0.10.4",
+  "version": "0.10.5-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "1667-workspace",
-      "version": "0.10.4",
+      "version": "0.10.5-rc.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@earendil-works/pi-ai": "0.84.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667-workspace",
-  "version": "0.10.4",
+  "version": "0.10.5-rc.1",
   "private": true,
   "description": "Source workspace for the 1667 terminal writing environment",
   "license": "Apache-2.0",

--- a/shared/release-notes.ts
+++ b/shared/release-notes.ts
@@ -11,6 +11,11 @@ export interface ReleaseNote {
  *  a release, and is not included. */
 export const RELEASE_NOTES: readonly ReleaseNote[] = [
   {
+    version: "0.10.5-rc.1",
+    date: "2026-08-30",
+    body: "- **Aside retakes now work like story retakes.** Stop keeps generated text.\n  Press `r` to repeat the newest question. Press `Shift+R` to edit it. Escape\n  closes the active prompt layer before it exits Aside. Tab switches between\n  the composer and saved turns."
+  },
+  {
     version: "0.10.4",
     date: "2026-08-29",
     body: "- **This release has no additional product changes.** It contains the same\n  behavior as 0.10.4-rc.3."

--- a/tui/package.json
+++ b/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667",
-  "version": "0.10.4",
+  "version": "0.10.5-rc.1",
   "private": true,
   "description": "A terminal environment for writing fiction with language models",
   "license": "Apache-2.0",


### PR DESCRIPTION
Prepare the next beta-channel release. The release uses version `0.10.5-rc.1` in the root package, TUI package, and lockfile. It adds the Aside behavior to the changelog and embedded release notes.

Tracks #368

Verification:
- `npm run notes:check`
- `npm run notes:check-version -- 0.10.5-rc.1`
- `npm run typecheck`
- `git diff --check`

Risk:
- Release metadata only. Publication remains gated by the hosted release workflow.