### PR TITLE
fix(aside): restore cancelled prompt

### DIFF
--- a/tui/src/aside-actions.ts
+++ b/tui/src/aside-actions.ts
@@ -542,6 +542,10 @@ export function scrollAside(
  *  this helper, so it remains newer than the submitted question. */
 export function noteAsideDisplayScroll(state: RuntimeState): void {
   const active = state.abort?.kind === "generation" ? state.abort : null;
+  if (active !== null && active.stopInteractionVersion !== null) {
+    active.stopInteractionVersion = state.interactionVersion;
+    return;
+  }
   if (active?.askInteractionVersion !== undefined
     && state.interactionVersion === active.askInteractionVersion + 1) {
     active.askInteractionVersion = state.interactionVersion;
@@ -705,6 +709,28 @@ export function clearAsideStream(surface: AsideSurfaceState): void {
   surface.inflightQuestion = null;
 }
 
+/** Remove a synchronous Stop restore when the provider committed the ask.
+ * Preserve any newer composer text written while the request was settling. */
+function clearAsideStopRestore(
+  active: {
+    stopInteractionVersion: number | null;
+    asideAsk?: {
+      composer: AsideSurfaceState["composer"];
+      question: string;
+      restored: boolean;
+    };
+  },
+  state: RuntimeState,
+  surface: AsideSurfaceState
+): void {
+  const ask = active.asideAsk;
+  if (ask?.restored !== true
+    || active.stopInteractionVersion !== state.interactionVersion
+    || surface.composer !== ask.composer
+    || surface.composer.text !== ask.question) return;
+  setComposerText(surface.composer, "");
+}
+
 export async function sendAsideQuestion(
   state: RuntimeState,
   api: StoryApi,
@@ -745,7 +771,12 @@ export async function sendAsideQuestion(
     kind: "generation" as const,
     controller,
     stopInteractionVersion: null as number | null,
-    askInteractionVersion: state.interactionVersion
+    askInteractionVersion: state.interactionVersion,
+    asideAsk: {
+      composer: surface.composer,
+      question: trimmed,
+      restored: false
+    }
   };
   state.abort = active;
   repaint();
@@ -823,7 +854,7 @@ export async function sendAsideQuestion(
       // Cancelled or stopped: return the question to the input.
       const restore = mayRestore();
       const preserveScroll = isAsideV2(surface) && surface.scrollTop !== null;
-      if (restore) setComposerText(surface.composer, trimmed);
+      if (restore && !active.asideAsk.restored) setComposerText(surface.composer, trimmed);
       clearAsideStream(surface);
       if (restore && !preserveScroll) surface.scrollTop = null;
       surface.busy = false;
@@ -831,6 +862,7 @@ export async function sendAsideQuestion(
     }
     const preserveScroll = isAsideV2(surface) && surface.scrollTop !== null;
     applyAsideResult(surface, result);
+    clearAsideStopRestore(active, state, surface);
     if (isAsideV2(surface)) {
       const turns = currentAsideTurns(surface);
       surface.turnCursor = Math.max(0, turns.length - 1);
@@ -863,7 +895,7 @@ export async function sendAsideQuestion(
     if (!current()) return;
     const restore = mayRestore();
     const preserveScroll = isAsideV2(surface) && surface.scrollTop !== null;
-    if (restore) setComposerText(surface.composer, trimmed);
+    if (restore && !active.asideAsk.restored) setComposerText(surface.composer, trimmed);
     clearAsideStream(surface);
     if (restore && !preserveScroll) surface.scrollTop = null;
     surface.busy = false;
@@ -893,10 +925,27 @@ export function stopAsideAsk(state: RuntimeState): boolean {
     || state.interactionVersion === askInteractionVersion + 1) {
     active.stopInteractionVersion = state.interactionVersion;
   }
+  const question = surface.inflightQuestion;
+  const ask = active.asideAsk;
+  if (ask !== undefined
+    && active.stopInteractionVersion === state.interactionVersion
+    && question !== null
+    && question === ask.question
+    && surface.composer === ask.composer
+    && surface.streamText.trim().length === 0
+    && surface.composer.text.length === 0) {
+    setComposerText(surface.composer, question);
+    ask.restored = true;
+    // Match regular story Stop: return control to the draft immediately.
+    // The abort fence remains until the provider settles.
+    surface.busy = false;
+    surface.inflightQuestion = null;
+    surface.streamHidden = true;
+  }
   active.controller.abort();
   // Keep the visible prefix in place while the stopped answer settles into a
   // saved turn. Provider text that arrives after Stop remains transport-only.
-  surface.streamHidden = false;
+  if (ask?.restored !== true) surface.streamHidden = false;
   surface.presentation?.suspend();
   return true;
 }

--- a/tui/src/state.ts
+++ b/tui/src/state.ts
@@ -715,6 +715,12 @@ export interface StoryScreenState extends OverlayState {
         /** Interaction epoch captured when an Aside ask started; display-only
          *  Aside scrolling may advance this restoration/Stop fence. */
         askInteractionVersion?: number;
+        /** Local Ask draft ownership while an Aside request settles. */
+        asideAsk?: {
+          composer: ComposerState;
+          question: string;
+          restored: boolean;
+        };
       }
     | { kind: "summary"; controller: AbortController }
     /** `committed` becomes true once the API call has minted a durable take,

--- a/tui/test/aside-v2.test.ts
+++ b/tui/test/aside-v2.test.ts
@@ -24,7 +24,7 @@ import { asideChatLayout, asideSessionsFromResponse } from "../src/aside-v2-layo
 import { asideHopEntries, asideHopStripText } from "../src/aside-hop.js";
 import { asideV2KeyAction, cycleAsideSession } from "../src/aside-v2-actions.js";
 import { recordHumanWords } from "../src/config.js";
-import { ActionRuntime } from "../src/action-runtime.js";
+import { ActionRuntime, beginInteraction } from "../src/action-runtime.js";
 import { cycleAsideFocus, openAsideUseMenu } from "../src/aside-use.js";
 import {
   insertComposerText,
@@ -63,6 +63,73 @@ function surfaceWithTurns(turns: AsideSessionView["turns"]) {
   state.aside = surface;
   state.mode = "ASIDE";
   return { source, state, surface: surface as AsideSessionSurfaceState };
+}
+
+async function startStoppedAsk(question: string, terminalAnswer: string | null = null) {
+  const { source, state, surface } = surfaceWithTurns([]);
+  let release!: () => void;
+  let requestSignal!: AbortSignal;
+  const gate = new Promise<void>((resolve) => { release = resolve; });
+  const api = {
+    ...source.api,
+    askAsideV2: async (
+      _request: unknown,
+      _onDelta: (text: string) => void,
+      _callbacks: unknown,
+      signal: AbortSignal
+    ) => {
+      requestSignal = signal;
+      await gate;
+      if (terminalAnswer === null) return null;
+      return {
+        schemaVersion: 2 as const,
+        id: "s1",
+        anchor: null,
+        title: "why the lantern",
+        turns: [{ q: question, a: terminalAnswer }],
+        payload: state.payload
+      };
+    }
+  } as unknown as StoryApi;
+  const backend = new ActionRuntime(state, () => undefined);
+  const key = (name: string) => ({
+    name,
+    sequence: name,
+    shift: false,
+    ctrl: false,
+    meta: false
+  }) as Parameters<typeof handleKey>[0];
+  const press = (name: string) => handleKey(
+    key(name),
+    state,
+    { ...source, api },
+    createWrapCache(),
+    () => undefined,
+    async () => undefined,
+    () => undefined,
+    null,
+    () => undefined,
+    () => undefined,
+    backend
+  );
+
+  setComposerText(surface.composer, question);
+  const pending = press("return");
+  await Promise.resolve();
+  const busyBeforeStop = surface.busy;
+  await press("escape");
+  return {
+    state,
+    surface,
+    requestSignal,
+    busyBeforeStop,
+    settle: async () => {
+      release();
+      await pending;
+      await backend.settle();
+      backend.dispose();
+    }
+  };
 }
 
 describe("Aside v2 surface", () => {
@@ -823,6 +890,55 @@ describe("Aside v2 surface", () => {
       sessionId: "s1"
     });
     expect(currentAsideTurns(surface)).toHaveLength(1);
+  });
+
+  test("restores a stopped ask before an unresolved provider settles", async () => {
+    const question = "What changed?";
+    const ask = await startStoppedAsk(question);
+    const { state, surface, requestSignal } = ask;
+
+    expect(ask.busyBeforeStop).toBeTrue();
+    expect(requestSignal.aborted).toBeTrue();
+    expect(surface.composer.text).toBe(question);
+    expect(surface.busy).toBeFalse();
+    expect(surface.inflightQuestion).toBeNull();
+    const stoppedFrame = frameText(renderAsideScreen(state, surface, 80, 24).lines);
+    expect(stoppedFrame).toContain(question);
+    expect(stoppedFrame).not.toContain("composer waits");
+
+    setComposerText(surface.composer, "newer draft");
+    beginInteraction(state);
+    await ask.settle();
+
+    expect(surface.busy).toBeFalse();
+    expect(surface.composer.text).toBe("newer draft");
+    expect(surface.inflightQuestion).toBeNull();
+  });
+
+  test("clears a synchronously restored ask when a stopped provider commits it", async () => {
+    const question = "Keep this answer?";
+    const ask = await startStoppedAsk(question, "Saved answer.");
+    expect(ask.requestSignal.aborted).toBeTrue();
+    expect(ask.surface.composer.text).toBe(question);
+
+    await ask.settle();
+
+    expect(ask.surface.composer.text).toBe("");
+    expect(currentAsideTurns(ask.surface)).toEqual([{ q: question, a: "Saved answer." }]);
+  });
+
+  test("keeps a retyped stopped ask when a late result has the same text", async () => {
+    const question = "Keep this draft?";
+    const ask = await startStoppedAsk(question, "Saved answer.");
+    expect(ask.requestSignal.aborted).toBeTrue();
+    expect(ask.surface.composer.text).toBe(question);
+
+    setComposerText(ask.surface.composer, question);
+    beginInteraction(ask.state);
+    await ask.settle();
+
+    expect(ask.surface.composer.text).toBe(question);
+    expect(currentAsideTurns(ask.surface)).toEqual([{ q: question, a: "Saved answer." }]);
   });
 
   test("reconciles first ask presence and keeps the opening take projection", async () => {
@@ -1745,7 +1861,7 @@ describe("Aside v2 surface", () => {
     expect(surface.busy).toBeFalse();
   });
 
-  test("Esc then Thought toggle restores an uncommitted ask", async () => {
+  test("Esc returns an uncommitted ask to editing before settlement", async () => {
     const { source, state, surface } = surfaceWithTurns([]);
     surface.composer.text = "Why?";
     surface.composer.cursor = surface.composer.text.length;
@@ -1798,12 +1914,12 @@ describe("Aside v2 surface", () => {
     await press("escape");
     expect(aborted).toBeTrue();
     await press("t");
-    expect(surface.thoughtsVisible).toBeTrue();
+    expect(surface.composer.text).toBe("Why?t");
     finish(null);
     await ask;
     await backend.settle();
 
-    expect(surface.composer.text).toBe("Why?");
+    expect(surface.composer.text).toBe("Why?t");
     expect(surface.busy).toBeFalse();
   });
 


### PR DESCRIPTION
Restores an immediately cancelled Aside prompt to the composer before the provider settles. This keeps the prompt visible and editable, preserves newer drafts, and clears the restored prompt only when a late durable answer commits without a newer interaction.

Tracks #368

Verification:
- `npm test`
- `cd tui && bun run test`
- `bun run typecheck`
- `git diff --check`

Risk: This change affects cancellation state only. Existing partial-answer and retake behavior remains unchanged.