### PR TITLE
chore(release): prepare 0.10.5-rc.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This file records notable changes to 1667. Product terms use the definitions in
 
 ## Unreleased
 
+## 0.10.5-rc.2 - 2026-08-30
+
 - **Facts can change with the story line.** Add Fact States at story-part
   Anchors. The nearest Fact State on the selected story line supplies the Fact
   body. An End State stops the Fact on that line. Existing Facts keep their

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "1667-workspace",
-  "version": "0.10.5-rc.1",
+  "version": "0.10.5-rc.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "1667-workspace",
-      "version": "0.10.5-rc.1",
+      "version": "0.10.5-rc.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@earendil-works/pi-ai": "0.84.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667-workspace",
-  "version": "0.10.5-rc.1",
+  "version": "0.10.5-rc.2",
   "private": true,
   "description": "Source workspace for the 1667 terminal writing environment",
   "license": "Apache-2.0",

--- a/shared/release-notes.ts
+++ b/shared/release-notes.ts
@@ -11,6 +11,11 @@ export interface ReleaseNote {
  *  a release, and is not included. */
 export const RELEASE_NOTES: readonly ReleaseNote[] = [
   {
+    version: "0.10.5-rc.2",
+    date: "2026-08-30",
+    body: "- **Facts can change with the story line.** Add Fact States at story-part\n  Anchors. The nearest Fact State on the selected story line supplies the Fact\n  body. An End State stops the Fact on that line. Existing Facts keep their\n  current behavior.\n- **Facts can have an optional name.** The Facts overview shows the Fact Name\n  when it is set. Basic view keeps the common options concise. Advanced view\n  shows state and activation controls. The new controls work with the keyboard\n  and mouse.\n- **`q` now closes 1667 from Aside.** This works from the main Aside view and\n  from its nested menus and text fields."
+  },
+  {
     version: "0.10.5-rc.1",
     date: "2026-08-30",
     body: "- **Aside retakes now work like story retakes.** Stop keeps generated text.\n  Press `r` to repeat the newest question. Press `Shift+R` to edit it. Escape\n  closes the active prompt layer before it exits Aside. Tab switches between\n  the composer and saved turns."

--- a/tui/package.json
+++ b/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667",
-  "version": "0.10.5-rc.1",
+  "version": "0.10.5-rc.2",
   "private": true,
   "description": "A terminal environment for writing fiction with language models",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Outcome

Prepare the Fact States beta release as version 0.10.5-rc.2.

## Changes

- Set the root, TUI, and lockfile versions to 0.10.5-rc.2.
- Add the 0.10.5-rc.2 changelog entry.
- Generate the matching embedded release notes.

## Verification

- npm run build
- npm test: 3,044 tests; 2,815 passed; 229 skipped; 0 failed
- tui: bun run typecheck
- tui: bun run test; all 16 shards passed
- tui: bun run build:standalone
- tui: bun bench/perf.ts; existing 500-part repaint budget misses reproduce on the pre-change commit

## Risk

Low. This PR changes release metadata only. The release workflow will publish this prerelease with the npm beta tag after the merged main commit receives the version tag.

Tracks #372