### PR TITLE
fix(tui): align paste and fact controls

### DIFF
--- a/tui/src/app.ts
+++ b/tui/src/app.ts
@@ -20,9 +20,7 @@ import {
   asideKeyboardLayer,
   isPlainNavigation,
   overlayTextInputActive,
-  pasteInto,
   resolveKey,
-  sanitizePastedText,
   type ResolvedKey
 } from "./keys.js";
 import { captureMouseActionState } from "./mouse-actions.js";
@@ -43,7 +41,6 @@ import {
   type ConfiguredUpdateStarter,
   type UpdateCheckSession
 } from "./update-runtime.js";
-import { openSettingsPasteTarget } from "./editor-open.js";
 import { createPalette } from "./palette.js";
 import {
   createPresentedInputQueue,
@@ -102,6 +99,9 @@ import {
   textActionsMenuAction
 } from "./text-actions.js";
 import { composerRangeFromProjection } from "./selection-projection.js";
+import { canClaimAsideComposer, claimAsideComposer } from "./aside-surface.js";
+import { pastePlainTextFromClipboard } from "./plain-text-paste.js";
+import { applyTerminalPaste } from "./terminal-paste.js";
 
 export { recoveryNotice } from "./recovery-orchestration.js";
 
@@ -514,7 +514,7 @@ export async function runInteractive(source: AppSource): Promise<void> {
     const text = new TextDecoder().decode(event.bytes);
     const queuedSelection = captureQueuedSelection();
     // Paste admission clears pending mouse click gestures at the same site.
-    inputAdmission.enqueueText(inputs, () => {
+    inputAdmission.enqueueText(inputs, async () => {
       const selection = reconcilePresentedSelection(queuedSelection, frames.version, state);
       if (selection.kind === "stale") {
         retirePresentedSelection(renderer, queuedSelection);
@@ -544,33 +544,9 @@ export async function runInteractive(source: AppSource): Promise<void> {
         clearNativeSelectionIfMatches(renderer, selection.native);
       }
       consumePresentedSelection(queuedSelection);
-      if (sanitizePastedText(text).length > 0
-        && state.mode === "SETTINGS"
-        && state.settings !== null) {
-        openSettingsPasteTarget(state);
-      }
-      if (state.mode === "SEARCH" && state.search !== null) {
-        const clean = sanitizePastedText(text);
-        if (clean.length > 0) {
-          const line = clean.replace(/\n+/g, " ");
-          void dispatch(
-            { action: "input", text: line },
-            state,
-            source,
-            wrapCache,
-            repaint,
-            cancelStream,
-            requestQuit,
-            renderer,
-            applyTheme,
-            previewTheme,
-            backend
-          );
-        }
-      } else if (pasteInto(state, text)) {
-        beginInteraction(state);
-        repaint();
-      }
+      await applyTerminalPaste(text, state, source, {
+        cache: wrapCache, repaint, backend, renderer, applyTheme, previewTheme
+      });
     }, () => retirePresentedSelection(renderer, queuedSelection));
   });
   surface.onMouse((event) => {
@@ -721,6 +697,12 @@ export async function dispatch(
     cancelChapterSummary(state, repaint);
     return;
   }
+  // A refused Aside paste is not an editor interaction. Keep the ask's
+  // restore fence intact so a failed or stopped question can return to the
+  // visible composer exactly as it does for bracketed paste.
+  if (resolved.action === "paste-clipboard"
+    && state.mode === "ASIDE"
+    && !canClaimAsideComposer(state.aside)) return;
   beginInteraction(state);
   // Aside keeps its top-level quit gesture even while a text-actions menu is
   // open; that menu must not turn `q` into a no-op.
@@ -758,6 +740,7 @@ export async function dispatch(
   }
   else if (resolved.action === "open-text-actions") {
     if (resolved.nativeSelection === undefined && resolved.composerEditable === false) return;
+    if (state.mode === "ASIDE" && !claimAsideComposer(state.aside)) return;
     let sync: ReturnType<typeof syncMouseComposerSelection> = "none";
     const projectedSelection = resolved.nativeSelection?.range === null
       || resolved.nativeSelection?.range === undefined
@@ -821,6 +804,8 @@ export async function dispatch(
   }
   else if (state.prune !== null) await pruneAction(resolved, state, source, context);
   else if (state.actions !== null) await actionsMenuAction(resolved, state, source, context);
+  else if (resolved.action === "paste-clipboard"
+    && await pastePlainTextFromClipboard(state, source, context)) { /* handled */ }
   else if (await handleOverlayAction(resolved, state, source, context)) { /* handled */ }
   else if (resolved.action === "toggle-context-meter" && (state.mode === "NAV" || state.mode === "COMPOSE")) {
     state.contextMeterExpanded = !state.contextMeterExpanded;

--- a/tui/src/aside-overlay-actions.ts
+++ b/tui/src/aside-overlay-actions.ts
@@ -30,8 +30,9 @@ import { applyTextKey, type ResolvedKey } from "./keys.js";
 import type { RuntimeState } from "./state.js";
 import {
   asideCursor,
+  claimAsideComposer,
   currentAsideTurns,
-  disarmAsideClear,
+  disarmAsideConfirmation,
   isAsideV2,
   type AsideSurfaceState
 } from "./aside-surface.js";
@@ -70,6 +71,9 @@ export async function asideKeyAction(
       renderer: context.renderer,
       toast: state.toast
   })) return;
+  if (resolved.action === "paste-clipboard") {
+    if (!claimAsideComposer(surface)) return;
+  }
   if (resolved.action === "cancel") {
     // A busy Aside owns Escape for cancellation. Check this before the
     // turns-to-composer focus transition, or a v2 retake loses its stop path.
@@ -164,7 +168,7 @@ export async function asideKeyAction(
     // Left-click on the visible prompt claims composer focus so paste/text
     // target it. Use menu already returned above.
     if (resolved.action === "compose") {
-      surface.focus = "composer";
+      claimAsideComposer(surface);
       return;
     }
     if (resolved.action === "focus-next" || resolved.action === "focus-previous") {
@@ -218,12 +222,12 @@ export async function asideKeyAction(
     return;
   }
   if (resolved.action === "newline") {
-    disarmAsideClear(surface);
+    disarmAsideConfirmation(surface);
     insertComposerText(surface.composer, "\n");
     return;
   }
   if (resolved.action === "input" && resolved.text !== undefined) {
-    disarmAsideClear(surface);
+    disarmAsideConfirmation(surface);
     insertComposerText(surface.composer, resolved.text);
     return;
   }
@@ -232,14 +236,14 @@ export async function asideKeyAction(
     pageRows: composerPageRows(height, true),
     motion,
     onEdit: (kind) => {
-      if (kind !== "move") disarmAsideClear(surface);
+      if (kind !== "move") disarmAsideConfirmation(surface);
     }
   })) return;
   // Keep the fallback for plain text actions that do not belong to the shared
   // composer reducer. All structural edits above preserve cursor state.
   const next = applyTextKey(surface.composer.text, resolved);
   if (next !== null) {
-    disarmAsideClear(surface);
+    disarmAsideConfirmation(surface);
     setComposerText(surface.composer, next);
   }
 }

--- a/tui/src/aside-surface.ts
+++ b/tui/src/aside-surface.ts
@@ -496,12 +496,30 @@ export function setAsideSessionTurns(
   }
 }
 
-/** Any composer edit makes an earlier Clear confirmation stale. */
-export function disarmAsideClear(
-  surface: object
-): void {
-  const value = surface as { readonly modelVersion?: 1 | 2; confirmClear?: boolean };
-  if (value.modelVersion !== 2 && "confirmClear" in value) value.confirmClear = false;
+/** Any prompt edit makes an earlier destructive confirmation stale. */
+export function disarmAsideConfirmation(surface: AsideSurfaceState): void {
+  if (isAsideV2(surface)) {
+    surface.confirmReset = null;
+    surface.confirmDelete = null;
+  } else {
+    surface.confirmClear = false;
+  }
+}
+
+/** True when an explicit prompt action can take Aside composer focus. */
+export function canClaimAsideComposer(
+  surface: Pick<AsideSurfaceState, "busy" | "useMenu"> | null | undefined
+): boolean {
+  return surface != null && !surface.busy && surface.useMenu === null;
+}
+
+/** Claim the Aside composer only while its prompt is available. */
+export function claimAsideComposer(
+  surface: Pick<AsideSurfaceState, "busy" | "focus" | "useMenu"> | null | undefined
+): boolean {
+  if (surface == null || !canClaimAsideComposer(surface)) return false;
+  surface.focus = "composer";
+  return true;
 }
 
 export function asideHeaderLine(storyTitle: string): string {

--- a/tui/src/aside-use.ts
+++ b/tui/src/aside-use.ts
@@ -12,7 +12,7 @@ import { openFactFromSelection } from "./editor-action.js";
 import {
   asideCursor,
   asideNotes,
-  disarmAsideClear,
+  disarmAsideConfirmation,
   isAsideV2,
   setAsideCursor,
   type AsideSurfaceState
@@ -113,7 +113,7 @@ export function openAsideUseMenu(
   const notes = asideNotes(surface);
   if (noteIndex < 0 || noteIndex >= notes.length) return false;
   const actions = asideUseActions(selectionText);
-  disarmAsideClear(surface);
+  disarmAsideConfirmation(surface);
   surface.focus = "notes";
   setAsideCursor(surface, noteIndex);
   surface.useMenu = {
@@ -181,7 +181,7 @@ export function cycleAsideFocus(surface: AsideSurfaceState): boolean {
   const notes = asideNotes(surface);
   if (notes.length === 0) return false;
   if (surface.focus === "composer") {
-    disarmAsideClear(surface);
+    disarmAsideConfirmation(surface);
     surface.focus = "notes";
     setAsideCursor(surface, Math.max(
       0,

--- a/tui/src/fact-editor-policy.ts
+++ b/tui/src/fact-editor-policy.ts
@@ -209,7 +209,7 @@ export function handleFactEditorCommand(
   }
   if (resolved.action === "reanchor-state") {
     editor.chromeFocus = "state";
-    const rowId = resolved.rowId;
+    const rowId = resolved.rowId ?? editor.stateCursorAnchorId ?? undefined;
     const validCursorPart = rowId !== undefined
       && state.payload.nodes.some(({ id, role }) => id === rowId && role !== "summary");
     if (editor.stateId !== undefined && editor.stateId !== null && validCursorPart) {

--- a/tui/src/keys.ts
+++ b/tui/src/keys.ts
@@ -1,6 +1,5 @@
 import type { KeyEvent } from "@opentui/core";
 import type { SettingsRoutePurpose } from "../../shared/settings-v2-types.js";
-import type { StorySummary } from "../../shared/types.js";
 import { insertComposerText, type ComposerState } from "./composer-model.js";
 import {
   editorInsertionPolicy,
@@ -23,18 +22,15 @@ import type {
   PendingGenerationDraft,
   RetakePromptSession,
   RuntimeState,
-  CardImportPrompt,
-  ArchiveImportPrompt,
   ImageAttachPrompt,
   SettingsInlineEditState,
   SettingsRowId
 } from "./state.js";
-import { setLibraryQuery } from "./library-model.js";
 import { resolveRequestViewerKey } from "./request-viewer-actions.js";
 import { resolveTokenProbabilitiesKey } from "./token-probabilities-actions.js";
 import { resolveGenerationRecordKey } from "./generation-record-actions.js";
 import { resolveLogKey } from "./notice-log.js";
-import { disarmAsideClear, type AsideSurfaceState } from "./aside-surface.js";
+import type { AsideSurfaceState } from "./aside-surface.js";
 
 export type KeyAction =
   | "focus-next" | "focus-previous" | "take-next" | "take-previous" | "take-at"
@@ -222,38 +218,19 @@ export function pasteInto(
     composer: ComposerState;
     editor: DocumentEditorSession | null;
     toast?: string | null;
-    tag: { choosingStatus: boolean; name: string } | null;
     library: {
-      stories: StorySummary[];
-      cursor: number;
-      query: string;
       prompt:
         | { kind: "filter" }
         | { kind: "rename"; composer: ComposerState }
         | { kind: "delete"; value: string }
         | null;
     } | null;
-    facts: { filtering: boolean; query: string; cursor: number } | null;
-    commands: { view: string; query: string } | null;
-    search: { query: string } | null;
     chapters?: { rename: { composer: ComposerState } | null } | null;
     settings: {
       edit: SettingsInlineEditState | null;
       sampling?: { edit: { composer: ComposerState } | null } | null;
-      profileTransfer?: {
-        phase: "source";
-        error: string | null;
-      } | {
-        phase: "file";
-        path: string;
-        candidates: string[];
-        error: string | null;
-      } | null;
       conflict: { armed: boolean } | null;
     } | null;
-    card: CardImportPrompt | null;
-    archive: ArchiveImportPrompt | null;
-    image?: ImageAttachPrompt | null;
     prune: unknown | null;
     chapterDeleteArmedId: string | null;
     actions: unknown | null;
@@ -265,7 +242,6 @@ export function pasteInto(
     pendingGenerationDraft: PendingGenerationDraft | null;
     composerClaimEpoch: number;
     stream: RuntimeState["stream"];
-    aside?: Pick<AsideSurfaceState, "composer" | "focus" | "useMenu"> | null;
   },
   raw: string
 ): boolean {
@@ -285,65 +261,12 @@ export function pasteInto(
     );
     return true;
   }
-  if (state.mode === "ASIDE" && state.aside !== null && state.aside !== undefined) {
-    if (asideKeyboardLayer(state.aside) !== "composer") return false;
-    disarmAsideClear(state.aside);
-    insertComposerText(state.aside.composer, clean);
-    return true;
-  }
   if (state.mode === "COMPOSE") { insertComposerText(state.composer, clean); return true; }
-  if (state.mode === "TAG" && state.tag !== null && !state.tag.choosingStatus) {
-    state.tag.name += line;
-    return true;
-  }
-  if (state.mode === "CARD" && state.card !== null) {
-    state.card.path += line;
-    state.card.error = null;
-    state.card.candidates = [];
-    return true;
-  }
-  if (state.mode === "ARCHIVE" && state.archive !== null) {
-    state.archive.path += line;
-    state.archive.error = null;
-    state.archive.candidates = [];
-    return true;
-  }
-  if (state.mode === "IMAGE" && state.image != null) {
-    state.image.path += line;
-    state.image.error = null;
-    state.image.candidates = [];
-    return true;
-  }
-  const profileTransfer = state.settings?.profileTransfer;
-  if (state.mode === "SETTINGS" && profileTransfer?.phase === "file") {
-    profileTransfer.path += line;
-    profileTransfer.error = null;
-    profileTransfer.candidates = [];
-    return true;
-  }
   if (state.mode === "LIBRARY" && state.library?.prompt != null) {
-    if (state.library.prompt.kind === "filter") {
-      setLibraryQuery(state.library, state.library.query + line);
-    } else if (state.library.prompt.kind === "rename") {
+    if (state.library.prompt.kind === "rename") {
       insertComposerText(state.library.prompt.composer, line);
-    } else {
-      state.library.prompt.value += line;
+      return true;
     }
-    return true;
-  }
-  if (state.mode === "FACTS" && state.facts?.filtering === true) {
-    state.facts.query += line;
-    // A paste can narrow the list without passing through the facts reducer;
-    // keep its stored cursor aligned with the newly painted result set.
-    state.facts.cursor = 0;
-    return true;
-  }
-  if (state.mode === "COMMANDS" && state.commands?.view === "commands") {
-    state.commands.query += line;
-    return true;
-  }
-  if (state.mode === "SEARCH" && state.search !== null) {
-    return false;
   }
   const chapterRename = state.mode === "CHAPTERS" ? state.chapters?.rename : null;
   if (chapterRename != null) {
@@ -499,6 +422,8 @@ export function resolveKey(key: KeyEvent, mode: AppMode, options: ResolveOptions
     if (key.name === "return") return { action: "apply" };
     return { action: "none" };
   }
+  if (mode === "ASIDE" && (key.ctrl || key.super)
+    && key.name.toLowerCase() === "v") return { action: "paste-clipboard" };
   const ownsText = textOwnsKeyboard(mode, {
     overlayTyping, commandsTags, tagChoosingStatus, asideLayer
   });
@@ -555,7 +480,6 @@ export function resolveKey(key: KeyEvent, mode: AppMode, options: ResolveOptions
       if (name === "[") return { action: "aside-anchor-previous" };
       if (name === "]") return { action: "aside-anchor-next" };
       if (name === "g") return { action: "aside-go-anchor" };
-      if ((key.ctrl || key.super) && name === "v") return { action: "none" };
       return { action: "none" };
     }
     // `Esc` remains the stop key while the provider owns the surface; the
@@ -567,8 +491,12 @@ export function resolveKey(key: KeyEvent, mode: AppMode, options: ResolveOptions
       && !key.ctrl && !key.meta && !key.option && !key.super) {
       return { action: name === "up" ? "cursor-up" : "cursor-down" };
     }
-    if ((key.ctrl || key.super) && name === "v") return { action: "paste-clipboard" };
     return textSurfaceKey(key) ?? textInput(key) ?? { action: "none" };
+  }
+  // Every other visible text field shares the same clipboard chord. Keep this
+  // after Aside's use-menu branch so a modal still owns Ctrl/Cmd+V.
+  if ((key.ctrl || key.super) && key.name.toLowerCase() === "v" && ownsText) {
+    return { action: "paste-clipboard" };
   }
   const shiftedReference = resolveReferenceBinding("nav-shifted", key, mode, mapView);
   if (shiftedReference !== null) return { action: shiftedReference.action };
@@ -595,7 +523,6 @@ export function resolveKey(key: KeyEvent, mode: AppMode, options: ResolveOptions
     }
     const composeChord = resolveReferenceBinding("compose-chord", key, mode, mapView);
     if (composeChord !== null) return { action: composeChord.action };
-    if ((key.ctrl || key.super) && name === "v") return { action: "paste-clipboard" };
     if (key.ctrl && name === "f") return { action: "toggle-compose-fullscreen" };
     // The rewrite composer's second fixed destination (issue #319, and
     // docs/generation-boundaries.md): plain `enter` always replaces in
@@ -625,6 +552,10 @@ export function resolveKey(key: KeyEvent, mode: AppMode, options: ResolveOptions
       && (name === "-" || name === "=")) {
       return { action: name === "-" ? "note-depth-decrease" : "note-depth-increase" };
     }
+    if (factEditor && !key.ctrl && !key.meta && !key.option && !key.super && !key.shift
+      && key.name === "a" && factEditorChromeFocus === "state") {
+      return { action: "reanchor-state" };
+    }
     if (factEditor && !key.ctrl && !key.meta && !key.option && !key.super
       && name === "m" && factEditorChromeFocus === "view") {
       return { action: "toggle-view-mode" };
@@ -652,7 +583,6 @@ export function resolveKey(key: KeyEvent, mode: AppMode, options: ResolveOptions
     if (key.ctrl && key.shift && name === "s") return { action: "save-edit-inplace" };
     if (key.ctrl && name === "s") return { action: "save-edit" };
     if ((key.ctrl || key.super) && name === "c") return { action: "copy-selection" };
-    if ((key.ctrl || key.super) && name === "v") return { action: "paste-clipboard" };
     if (key.super && name === "a") return { action: "select-all" };
     if (key.ctrl && key.shift && name === "d") return { action: "delete-line" };
     // The editor's own chords: emacs character motion, and ctrl+d forward
@@ -704,7 +634,6 @@ export function resolveKey(key: KeyEvent, mode: AppMode, options: ResolveOptions
   if (mode === "SETTINGS" && overlayTyping) {
     const name = key.name.toLowerCase();
     if (key.name === "return" || key.ctrl && name === "s") return { action: "commit-field" };
-    if ((key.ctrl || key.super) && name === "v") return { action: "paste-clipboard" };
     if (key.super && name === "a") return { action: "select-all" };
     // A settings field holds a base URL. It edits like every other surface.
     return composerBackedInput(key);
@@ -737,12 +666,10 @@ export function resolveKey(key: KeyEvent, mode: AppMode, options: ResolveOptions
     // motion of its own to give them instead.
     if (key.name === "down") return { action: "focus-next" };
     if (key.name === "up") return { action: "focus-previous" };
-    if ((key.ctrl || key.super) && key.name.toLowerCase() === "v") return { action: "paste-clipboard" };
     return composerBackedInput(key);
   }
   if (mode === "CHAPTERS" && overlayTyping) {
     if (key.name === "return") return { action: "open-selected" };
-    if ((key.ctrl || key.super) && key.name.toLowerCase() === "v") return { action: "paste-clipboard" };
     return composerBackedInput(key);
   }
   // A modified letter is a chord, never a plain hotkey. Keep unknown

--- a/tui/src/mouse-actions.ts
+++ b/tui/src/mouse-actions.ts
@@ -5,6 +5,7 @@ import type { ResolvedKey } from "./keys.js";
 import { generationBusy } from "./story-actions.js";
 import type { RuntimeState } from "./state.js";
 import { activeTextComposer } from "./text-actions.js";
+import { canClaimAsideComposer } from "./aside-surface.js";
 
 export type MouseGesture = Pick<
   MouseEvent,
@@ -333,11 +334,18 @@ export function mouseToAction(
 
   const selectedList = target.kind === "list"
     && (target.selected ?? listCursor(state) === target.index);
+  const activeComposer = activeTextComposer(state);
+  const asideComposerClaimable = state.mode === "ASIDE"
+    && target.kind === "composer"
+    && canClaimAsideComposer(state.aside);
+  const composerActionsAvailable = target.kind === "composer"
+    && (state.mode === "ASIDE"
+      ? asideComposerClaimable
+      : target.composerSourceId !== undefined || activeComposer !== null);
   if (state.textActions === null
     && event.button === 2
-    && (target.kind === "composer"
-      && (target.composerSourceId !== undefined || activeTextComposer(state) !== null)
-      || state.mode === "SETTINGS" && selectedList && activeTextComposer(state) !== null)) {
+    && (composerActionsAvailable
+      || state.mode === "SETTINGS" && selectedList && activeComposer !== null)) {
     return {
       action: "open-text-actions",
       ...(target.kind === "composer" && target.composerSourceId !== undefined

--- a/tui/src/plain-text-paste.ts
+++ b/tui/src/plain-text-paste.ts
@@ -1,0 +1,177 @@
+import type { AppSource } from "./app.js";
+import type { ActionContext } from "./action-context.js";
+import { readFromClipboard } from "./clipboard.js";
+import { sanitizePastedText } from "./keys.js";
+import { handleOverlayAction } from "./overlay-actions.js";
+import { searchAction } from "./search-actions.js";
+import type { RuntimeState } from "./state.js";
+import { tagAction } from "./story-actions.js";
+
+export interface PlainTextPasteTarget {
+  isCurrent(): boolean;
+  paste(line: string): void | Promise<void>;
+}
+
+function overlayInputTarget(
+  state: RuntimeState,
+  source: AppSource,
+  context: ActionContext,
+  isCurrent: () => boolean,
+  prepare: (line: string) => string | null = (line) => line
+): PlainTextPasteTarget {
+  return {
+    isCurrent,
+    async paste(line) {
+      const text = prepare(line);
+      if (text === null) return;
+      await handleOverlayAction({ action: "input", text }, state, source, context);
+    }
+  };
+}
+
+/** Capture the one non-composer field that owns plain-text paste. */
+export function plainTextPasteTarget(
+  state: RuntimeState,
+  source: AppSource,
+  context: ActionContext
+): PlainTextPasteTarget | null {
+  if (state.mode === "SETTINGS" && state.settings !== null) {
+    const overlay = state.settings;
+    const picker = overlay.modelPicker;
+    if (picker !== null) {
+      return overlayInputTarget(
+        state,
+        source,
+        context,
+        () => state.mode === "SETTINGS" && state.settings === overlay
+          && overlay.modelPicker === picker,
+        (line) => {
+          const clean = line.replace(/\s+/gu, " ").trim();
+          if (clean.length === 0) {
+            state.toast = "clipboard has no insertable text";
+            return null;
+          }
+          return clean;
+        }
+      );
+    }
+    const transfer = overlay.profileTransfer;
+    if (transfer?.phase === "file") {
+      return overlayInputTarget(
+        state,
+        source,
+        context,
+        () => state.mode === "SETTINGS" && state.settings === overlay
+          && overlay.profileTransfer === transfer
+      );
+    }
+  }
+  if (state.mode === "SEARCH" && state.search !== null) {
+    const owner = state.search;
+    return {
+      isCurrent: () => state.mode === "SEARCH" && state.search === owner,
+      paste: (line) => searchAction({ action: "input", text: line }, state, source, context)
+    };
+  }
+  if (state.mode === "COMMANDS" && state.commands?.view === "commands") {
+    const owner = state.commands;
+    return overlayInputTarget(
+      state,
+      source,
+      context,
+      () => state.mode === "COMMANDS" && state.commands === owner
+        && owner.view === "commands"
+    );
+  }
+  if (state.mode === "TAG" && state.tag !== null && !state.tag.choosingStatus) {
+    const owner = state.tag;
+    return {
+      isCurrent: () => state.mode === "TAG" && state.tag === owner && !owner.choosingStatus,
+      paste: (line) => tagAction({ action: "input", text: line }, state, source, context)
+    };
+  }
+  if (state.mode === "FACTS" && state.facts?.filtering === true) {
+    const owner = state.facts;
+    return overlayInputTarget(
+      state,
+      source,
+      context,
+      () => state.mode === "FACTS" && state.facts === owner && owner.filtering
+    );
+  }
+  if (state.mode === "CARD" && state.card !== null) {
+    const owner = state.card;
+    return overlayInputTarget(
+      state, source, context, () => state.mode === "CARD" && state.card === owner
+    );
+  }
+  if (state.mode === "ARCHIVE" && state.archive !== null) {
+    const owner = state.archive;
+    return overlayInputTarget(
+      state, source, context, () => state.mode === "ARCHIVE" && state.archive === owner
+    );
+  }
+  if (state.mode === "IMAGE" && state.image != null) {
+    const owner = state.image;
+    return overlayInputTarget(
+      state, source, context, () => state.mode === "IMAGE" && state.image === owner
+    );
+  }
+  if (state.mode === "LIBRARY" && state.library !== null) {
+    const owner = state.library;
+    const prompt = owner.prompt;
+    if (prompt?.kind === "filter") {
+      return overlayInputTarget(
+        state,
+        source,
+        context,
+        () => state.mode === "LIBRARY" && state.library === owner
+          && owner.prompt === prompt
+      );
+    }
+    if (prompt?.kind === "delete") {
+      return overlayInputTarget(
+        state,
+        source,
+        context,
+        () => state.mode === "LIBRARY" && state.library === owner
+          && owner.prompt === prompt
+      );
+    }
+  }
+  return null;
+}
+
+/** Apply terminal paste to a captured plain-text owner. */
+export async function pastePlainText(
+  target: PlainTextPasteTarget,
+  raw: string
+): Promise<boolean> {
+  const clean = sanitizePastedText(raw);
+  if (clean.length === 0 || !target.isCurrent()) return false;
+  await target.paste(clean.replace(/\n+/g, " "));
+  return true;
+}
+
+/** Read Ctrl/Cmd+V once, then apply it only to the captured field owner. */
+export async function pastePlainTextFromClipboard(
+  state: RuntimeState,
+  source: AppSource,
+  context: ActionContext
+): Promise<boolean> {
+  const target = plainTextPasteTarget(state, source, context);
+  if (target === null) return false;
+  const interactionVersion = state.interactionVersion;
+  const text = await readFromClipboard();
+  if (state.interactionVersion !== interactionVersion || !target.isCurrent()) return true;
+  if (text === null) {
+    state.toast = "clipboard unreadable · paste with ⌘V or ctrl+shift+v";
+    return true;
+  }
+  if (sanitizePastedText(text).length === 0) {
+    state.toast = "clipboard has no insertable text";
+    return true;
+  }
+  await pastePlainText(target, text);
+  return true;
+}

--- a/tui/src/profile-transfer-actions.ts
+++ b/tui/src/profile-transfer-actions.ts
@@ -11,8 +11,7 @@ import {
   restoreSettingsCursor,
   settingsCursorRowIdentity
 } from "./settings-row-navigation.js";
-import { readFromClipboard } from "./clipboard.js";
-import { pasteInto, type ResolvedKey } from "./keys.js";
+import type { ResolvedKey } from "./keys.js";
 import type {
   ProfileTransferPrompt,
   RuntimeState,
@@ -24,7 +23,6 @@ const PROFILE_TRANSFER_SOURCE_COUNT = FILE_SOURCE_INDEX + 1;
 
 export interface ProfileTransferDependencies {
   readonly readFile?: typeof readProfileTransferFile;
-  readonly readClipboard?: typeof readFromClipboard;
 }
 
 export function openProfileTransfer(overlay: SettingsOverlayState): void {
@@ -59,14 +57,6 @@ export async function profileTransferAction(
       prompt.error = null;
       prompt.candidates = [];
     }
-    else if (resolved.action === "paste-clipboard") {
-      await pasteProfileTransferClipboard(
-        state,
-        prompt,
-        overlay,
-        dependencies.readClipboard ?? readFromClipboard
-      );
-    }
     else if (resolved.action === "complete") await completeFilePath(prompt);
     else if (resolved.action === "apply-profile-transfer") {
       await applyFile(
@@ -88,26 +78,6 @@ export async function profileTransferAction(
   const candidate = STARTER_PROFILES[prompt.cursor];
   if (candidate === undefined) return;
   applyCandidate(candidate, state, prompt, overlay);
-}
-
-async function pasteProfileTransferClipboard(
-  state: RuntimeState,
-  prompt: Extract<ProfileTransferPrompt, { readonly phase: "file" }>,
-  overlay: SettingsOverlayState,
-  readClipboard: typeof readFromClipboard
-): Promise<void> {
-  const claim = { interactionVersion: state.interactionVersion, path: prompt.path };
-  const text = await readClipboard();
-  if (!profileTransferCurrent(state, prompt, overlay)
-    || state.interactionVersion !== claim.interactionVersion
-    || prompt.path !== claim.path) {
-    return;
-  }
-  if (text === null) {
-    state.toast = "clipboard unreadable · paste with ⌘V or ctrl+shift+v";
-  } else if (!pasteInto(state, text)) {
-    state.toast = "clipboard has no insertable text";
-  }
 }
 
 async function applyFile(

--- a/tui/src/screens/story/fact-editor-layout.ts
+++ b/tui/src/screens/story/fact-editor-layout.ts
@@ -237,7 +237,7 @@ function factEditorStateLine(
       }));
     }
     if (editor.stateCursorAnchorId !== undefined && editor.stateCursorAnchorId !== null) {
-      controls.push(segment(" · re-anchor ◆ cursor", "chrome", {
+      controls.push(segment(" · a re-anchor ◆ cursor", "chrome", {
         kind: "action", action: "reanchor-state", rowId: editor.stateCursorAnchorId
       }));
     }

--- a/tui/src/settings-field-actions.ts
+++ b/tui/src/settings-field-actions.ts
@@ -32,33 +32,6 @@ import type { ActionContext } from "./action-context.js";
 /** C-15's own keys. Typing narrows the column live; `↵` takes the focused
  *  option, or the text itself when nothing matches, so a model the provider
  *  never listed is still reachable from here. */
-/** Paste narrows the visible column. */
-export async function pasteIntoModelPicker(
-  state: RuntimeState,
-  overlay: SettingsOverlayState
-): Promise<void> {
-  const picker = overlay.modelPicker;
-  if (picker === null) return;
-  const claim = { interactionVersion: state.interactionVersion, query: picker.query };
-  const text = await readFromClipboard();
-  if (state.settings !== overlay || overlay.modelPicker !== picker) return;
-  if (state.interactionVersion !== claim.interactionVersion
-    || picker.query !== claim.query) {
-    return;
-  }
-  if (text === null) {
-    state.toast = "clipboard unreadable · paste with ⌘V or ctrl+shift+v";
-    return;
-  }
-  const clean = sanitizePastedText(text).replace(/\s+/gu, " ").trim();
-  if (clean.length === 0) {
-    state.toast = "clipboard has no insertable text";
-    return;
-  }
-  picker.query += clean;
-  picker.cursor = 0;
-}
-
 export function settingsModelPickerAction(
   resolved: ResolvedKey,
   state: RuntimeState,

--- a/tui/src/settings-overlay-actions.ts
+++ b/tui/src/settings-overlay-actions.ts
@@ -91,7 +91,6 @@ import {
 import { modelPickerRequired } from "./settings-model-picker.js";
 import { openProfileTransfer, profileTransferAction } from "./profile-transfer-actions.js";
 import {
-  pasteIntoModelPicker,
   settingsInlineEditAction,
   settingsModelPickerAction
 } from "./settings-field-actions.js";
@@ -208,10 +207,6 @@ export async function settingsOverlayAction(
       state.settings = null;
       state.mode = "NAV";
     }
-  } else if (resolved.action === "paste-clipboard" && overlay.modelPicker !== null) {
-    // The column is what the writer can see, so paste narrows it rather than
-    // filling a row editor hidden behind it.
-    await pasteIntoModelPicker(state, overlay);
   } else if (resolved.action === "paste-clipboard") {
     const row = settingsRowIds(overlay)[boundedSettingsCursor(overlay.cursor, overlay)]!;
     const target = openSettingsPasteTarget(state);

--- a/tui/src/settings-prompt-editor.ts
+++ b/tui/src/settings-prompt-editor.ts
@@ -66,7 +66,7 @@ export function openSettingsPasteTarget(
 ): "editor" | "inline" | null {
   const overlay = state.settings;
   if (overlay === null) return null;
-  if (overlay.profileTransfer !== null) return null;
+  if (overlay.profileTransfer !== null || overlay.modelPicker !== null) return null;
   if (overlay.sampling !== null) {
     return overlay.sampling.edit === null ? null : "inline";
   }

--- a/tui/src/terminal-paste.ts
+++ b/tui/src/terminal-paste.ts
@@ -1,0 +1,43 @@
+import { beginInteraction } from "./action-runtime.js";
+import type { ActionContext } from "./action-context.js";
+import type { AppSource } from "./app.js";
+import { claimAsideComposer } from "./aside-surface.js";
+import { sanitizePastedText, pasteInto } from "./keys.js";
+import { handleOverlayAction } from "./overlay-actions.js";
+import {
+  pastePlainText,
+  plainTextPasteTarget
+} from "./plain-text-paste.js";
+import { openSettingsPasteTarget } from "./settings-prompt-editor.js";
+import type { RuntimeState } from "./state.js";
+
+/** Apply one admitted terminal paste through the visible text owner's reducer. */
+export async function applyTerminalPaste(
+  raw: string,
+  state: RuntimeState,
+  source: AppSource,
+  context: ActionContext
+): Promise<boolean> {
+  const clean = sanitizePastedText(raw);
+  if (clean.length === 0) return false;
+  if (state.mode === "SETTINGS" && state.settings !== null) {
+    openSettingsPasteTarget(state);
+  }
+  const target = plainTextPasteTarget(state, source, context);
+  if (target !== null) {
+    beginInteraction(state);
+    if (await pastePlainText(target, clean)) context.repaint();
+    return true;
+  }
+  if (state.mode === "ASIDE") {
+    if (!claimAsideComposer(state.aside)) return false;
+    beginInteraction(state);
+    await handleOverlayAction({ action: "input", text: clean }, state, source, context);
+    context.repaint();
+    return true;
+  }
+  if (!pasteInto(state, clean)) return false;
+  beginInteraction(state);
+  context.repaint();
+  return true;
+}

--- a/tui/test/aside-input-queue.test.ts
+++ b/tui/test/aside-input-queue.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import type { KeyEvent } from "@opentui/core";
 import { asideNotes, createAsideSurface } from "../src/aside-surface.js";
 import { demoAppSource } from "../src/demo.js";
-import { ActionRuntime, beginInteraction, withActionAdmission } from "../src/action-runtime.js";
+import { ActionRuntime, withActionAdmission } from "../src/action-runtime.js";
 import { handleKey, initialState } from "../src/app.js";
 import {
   createPresentedInputQueue,
@@ -10,12 +10,17 @@ import {
 } from "../src/presented-input-queue.js";
 import { createWrapCache, type ProseStyle } from "../src/wrap.js";
 import { setComposerText } from "../src/composer-model.js";
-import { pasteInto } from "../src/keys.js";
 import { renderAsideScreen } from "../src/screens/story/aside-screen.js";
 import { frameText } from "../src/screens/story/frame.js";
 
-function key(name: string): KeyEvent {
-  return { name, sequence: name, shift: false, ctrl: false, meta: false } as KeyEvent;
+function key(name: string, options: { ctrl?: boolean } = {}): KeyEvent {
+  return {
+    name,
+    sequence: name,
+    shift: false,
+    ctrl: options.ctrl ?? false,
+    meta: false
+  } as KeyEvent;
 }
 
 async function drainMicrotasks(): Promise<void> {
@@ -157,7 +162,7 @@ describe("Aside presented input", () => {
     backend.dispose();
   });
 
-  test("settles a failed ask after scroll and paste without overwriting the newer draft", async () => {
+  test("settles a failed ask after scroll and refuses Ctrl+V while busy", async () => {
     const source = demoAppSource();
     let rejectAsk!: (error: Error) => void;
     const gate = new Promise<never>((_, reject) => { rejectAsk = reject; });
@@ -198,19 +203,10 @@ describe("Aside presented input", () => {
         withActionAdmission(backend, admit)
       ), (work) => backend.observe(work)));
     };
-    const enqueuePaste = (text: string) => {
-      queue.enqueue(() => {
-        if (pasteInto(state, text)) {
-          beginInteraction(state);
-          repaint();
-        }
-      });
-    };
-
     enqueue(key("return"));
     expect(state.aside.busy).toBeTrue();
     enqueue(key("pageup"));
-    enqueuePaste("newer draft");
+    enqueue(key("v", { ctrl: true }));
     await drainMicrotasks();
     expect(state.aside.scrollTop).not.toBeNull();
     rejectAsk(new Error("provider failed"));
@@ -220,7 +216,7 @@ describe("Aside presented input", () => {
     expect(state.aside.busy).toBeFalse();
     expect(state.aside.streamText).toBe("");
     expect(state.aside.inflightQuestion).toBeNull();
-    expect(state.aside.composer.text).toBe("newer draft");
+    expect(state.aside.composer.text).toBe("Submitted question");
     expect(state.abort).toBeNull();
     expect(state.toast).toBe("provider failed");
     backend.dispose();
@@ -324,7 +320,7 @@ describe("Aside presented input", () => {
     backend.dispose();
   });
 
-  test("settles a cancelled ask after later input without restoring the old question", async () => {
+  test("settles a cancelled ask after scroll and refuses Ctrl+V while busy", async () => {
     const source = demoAppSource();
     let resolveAsk!: () => void;
     const gate = new Promise<void>((resolve) => { resolveAsk = resolve; });
@@ -367,9 +363,7 @@ describe("Aside presented input", () => {
 
     enqueue(key("return"));
     enqueue(key("pageup"));
-    queue.enqueue(() => {
-      if (pasteInto(state, "newer draft")) beginInteraction(state);
-    });
+    enqueue(key("v", { ctrl: true }));
     await drainMicrotasks();
     expect(state.aside.scrollTop).not.toBeNull();
     resolveAsk();
@@ -379,7 +373,7 @@ describe("Aside presented input", () => {
     expect(state.aside.busy).toBeFalse();
     expect(state.aside.streamText).toBe("");
     expect(state.aside.inflightQuestion).toBeNull();
-    expect(state.aside.composer.text).toBe("newer draft");
+    expect(state.aside.composer.text).toBe("Submitted question");
     expect(state.abort).toBeNull();
     expect(state.toast).toBeNull();
     backend.dispose();

--- a/tui/test/aside-readability.test.ts
+++ b/tui/test/aside-readability.test.ts
@@ -13,7 +13,7 @@ import {
   type AsideSessionSurfaceState
 } from "../src/aside-surface.js";
 import { handleOverlayAction } from "../src/overlay-actions.js";
-import { ActionRuntime, beginInteraction } from "../src/action-runtime.js";
+import { ActionRuntime } from "../src/action-runtime.js";
 import type { StoryApi } from "../src/api.js";
 import { createWrapCache, type ProseStyle } from "../src/wrap.js";
 import { setComposerText } from "../src/composer-model.js";
@@ -385,7 +385,7 @@ describe("Aside readability and navigation", () => {
     expect(surface.scrollTop).toBe(selectedTop);
   });
 
-  test("newer draft survives API failure after a busy scroll", async () => {
+  test("busy paste is refused before API failure restores the question", async () => {
     const source = demoAppSource();
     const state = initialState(source, false);
     const surface = v2Surface(
@@ -411,8 +411,7 @@ describe("Aside readability and navigation", () => {
     await dispatchAsideAction({ action: "send" }, state, source, context);
     await Promise.resolve();
     expect(surface.busy).toBeTrue();
-    expect(pasteInto(state, "newer draft")).toBeTrue();
-    beginInteraction(state);
+    expect(pasteInto(state, "newer draft")).toBeFalse();
     await dispatchAsideAction({ action: "scroll-line-up" }, state, source, context);
     const selectedTop = surface.scrollTop;
     expect(selectedTop).not.toBeNull();
@@ -420,11 +419,11 @@ describe("Aside readability and navigation", () => {
     rejectAsk(new Error("provider failed"));
     await context.backend.whenIdle();
     expect(surface.busy).toBeFalse();
-    expect(surface.composer.text).toBe("newer draft");
+    expect(surface.composer.text).toBe("failed question");
     expect(surface.scrollTop).toBe(selectedTop);
   });
 
-  test("newer draft survives Stop after a busy scroll", async () => {
+  test("busy paste is refused before Stop restores the question", async () => {
     const source = demoAppSource();
     const state = initialState(source, false);
     const surface = v2Surface(
@@ -454,8 +453,7 @@ describe("Aside readability and navigation", () => {
     await dispatchAsideAction({ action: "send" }, state, source, context);
     await Promise.resolve();
     expect(surface.busy).toBeTrue();
-    expect(pasteInto(state, "newer draft")).toBeTrue();
-    beginInteraction(state);
+    expect(pasteInto(state, "newer draft")).toBeFalse();
     await dispatchAsideAction({ action: "scroll-line-up" }, state, source, context);
     const selectedTop = surface.scrollTop;
     expect(selectedTop).not.toBeNull();
@@ -464,7 +462,7 @@ describe("Aside readability and navigation", () => {
     expect(requestSignal.aborted).toBeTrue();
     await context.backend.whenIdle();
     expect(surface.busy).toBeFalse();
-    expect(surface.composer.text).toBe("newer draft");
+    expect(surface.composer.text).toBe("stopped question");
     expect(surface.scrollTop).toBe(selectedTop);
   });
 });

--- a/tui/test/aside-use-placement.test.ts
+++ b/tui/test/aside-use-placement.test.ts
@@ -3,7 +3,10 @@
  */
 import { describe, expect, test } from "bun:test";
 import type { KeyEvent } from "@opentui/core";
-import { asideNotes, createAsideSurface } from "../src/aside-surface.js";
+import {
+  asideNotes,
+  createAsideSurface
+} from "../src/aside-surface.js";
 import {
   openAside,
   sendAsideQuestion
@@ -15,9 +18,9 @@ import {
   PLACEMENT_STATUS_TEXT
 } from "../src/aside-placement.js";
 import { noteCursorAfterHistoryScroll } from "../src/aside-note-scroll.js";
-import { pasteInto, resolveKey } from "../src/keys.js";
+import { resolveKey } from "../src/keys.js";
 import { demoAppSource } from "../src/demo.js";
-import { initialState } from "../src/app.js";
+import { handleKey, initialState } from "../src/app.js";
 import { handleOverlayAction } from "../src/overlay-actions.js";
 import type { StoryApi } from "../src/api.js";
 import { ActionRuntime } from "../src/action-runtime.js";
@@ -26,6 +29,7 @@ import { openDirectComposer } from "../src/composer-ownership.js";
 import { moveComposerTo, setComposerText } from "../src/composer-model.js";
 import { renderStoryScreen } from "../src/screens/story.js";
 import { createStoryViewModel, rowIndexForNode, rowPart } from "../src/model.js";
+import { applyTerminalPaste } from "../src/terminal-paste.js";
 
 function key(
   name: string,
@@ -74,6 +78,8 @@ describe("Aside use menu and Placement", () => {
       .toBe("apply");
     expect(resolveKey(key("up"), "ASIDE", { asideLayer: "use-menu" }).action)
       .toBe("focus-previous");
+    expect(resolveKey(key("v", { ctrl: true }), "ASIDE", { asideLayer: "use-menu" }).action)
+      .toBe("paste-clipboard");
     expect(resolveKey(key("down"), "PLACE").action).toBe("focus-next");
     expect(resolveKey(key("return"), "PLACE").action).toBe("apply");
     expect(resolveKey(key("escape"), "PLACE").action).toBe("cancel");
@@ -104,9 +110,12 @@ describe("Aside use menu and Placement", () => {
     expect(notesFrame).toContain("▸ Q: Why the lantern?");
     expect(notesFrame).toContain("Tab ask");
     expect(notesFrame).toContain("Enter use");
-    expect(pasteInto(state, "hidden paste")).toBeFalse();
-    expect(surface.composer.text).toBe("");
+    expect(await applyTerminalPaste("visible paste", state, source, context)).toBeTrue();
+    expect(surface.focus).toBe("composer");
+    expect(surface.composer.text).toBe("visible paste");
     expect(state.composer.text).toBe("draft replace right");
+    await handleOverlayAction({ action: "cycle" }, state, source, context);
+    expect(surface.focus).toBe("notes");
 
     await handleOverlayAction({ action: "focus-previous" }, state, source, context);
     expect(surface.noteCursor).toBe(0);
@@ -127,6 +136,12 @@ describe("Aside use menu and Placement", () => {
     expect(menuFrame).toContain("insert as new Fact");
     expect(menuFrame).not.toContain("delete note");
     expect(menuFrame).not.toContain("author's note");
+
+    const interactionVersion = state.interactionVersion;
+    await handleKey(key("v", { ctrl: true }), state, source, context.cache,
+      () => undefined, async () => undefined, () => undefined);
+    expect(state.interactionVersion).toBe(interactionVersion);
+    expect(surface.useMenu).not.toBeNull();
 
     await handleOverlayAction({ action: "cancel" }, state, source, context);
     expect(surface.useMenu).toBeNull();

--- a/tui/test/aside.test.ts
+++ b/tui/test/aside.test.ts
@@ -19,9 +19,9 @@ import {
 } from "../src/aside-actions.js";
 import { parseAsideComposerInput } from "../src/aside-parse.js";
 import { commandPaletteModel } from "../src/command-model.js";
-import { pasteInto, resolveKey } from "../src/keys.js";
+import { resolveKey } from "../src/keys.js";
 import { demoAppSource } from "../src/demo.js";
-import { handleKey, initialState } from "../src/app.js";
+import { dispatch, handleKey, initialState } from "../src/app.js";
 import { handleOverlayAction } from "../src/overlay-actions.js";
 import type { StoryApi } from "../src/api.js";
 import { ActionRuntime } from "../src/action-runtime.js";
@@ -34,6 +34,7 @@ import { renderStoryScreen } from "../src/screens/story.js";
 import { activeTextComposer, openTextActions } from "../src/text-actions.js";
 import { mouseToAction } from "../src/mouse-actions.js";
 import { openAsideUseMenu } from "../src/aside-use.js";
+import { applyTerminalPaste } from "../src/terminal-paste.js";
 
 function key(
   name: string,
@@ -256,7 +257,7 @@ describe("Aside TUI contract", () => {
     expect(surface.composer.text).toBe("first\nsecond");
   });
 
-  test("bracketed paste sanitizes controls and keeps Aside newlines", () => {
+  test("bracketed paste sanitizes controls and keeps Aside newlines", async () => {
     const source = demoAppSource();
     const state = initialState(source, false);
     const surface = createAsideSurface("s1", "Lantern Story");
@@ -264,8 +265,53 @@ describe("Aside TUI contract", () => {
     state.mode = "ASIDE";
     setComposerText(surface.composer, "before");
 
-    expect(pasteInto(state, "first\r\nsecond\u0000\u001bthird")).toBeTrue();
+    expect(await applyTerminalPaste(
+      "first\r\nsecond\u0000\u001bthird",
+      state,
+      source,
+      overlayContext(state)
+    )).toBeTrue();
     expect(surface.composer.text).toBe("beforefirst\nsecondthird");
+  });
+
+  test("busy Aside refuses clipboard, bracketed paste, and the mouse paste menu", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const surface = createAsideSurface("s1", "Lantern Story", [
+      { question: "Why?", answer: "Because." }
+    ]);
+    surface.focus = "notes";
+    surface.busy = true;
+    state.aside = surface;
+    state.mode = "ASIDE";
+    setComposerText(surface.composer, "waiting");
+
+    await handleKey(
+      key("v", { ctrl: true }), state, source, createWrapCache(),
+      () => undefined, async () => undefined, () => undefined
+    );
+
+    expect(surface.focus).toBe("notes");
+    expect(surface.composer.text).toBe("waiting");
+    expect(await applyTerminalPaste(
+      "hidden paste", state, source, overlayContext(state)
+    )).toBeFalse();
+    expect(surface.composer.text).toBe("waiting");
+
+    surface.focus = "composer";
+    const frame = renderStoryScreen(state, { width: 80, height: 24 });
+    state.hitRows = frame.derived.hitRows;
+    const composerRow = state.hitRows.findIndex((row) => row?.target.kind === "composer");
+    expect(composerRow).toBeGreaterThan(-1);
+    const version = state.interactionVersion;
+    expect(mouseToAction({
+      type: "down",
+      button: 2,
+      x: 40,
+      y: composerRow,
+      modifiers: { shift: false, alt: false, ctrl: false }
+    }, state)).toBeNull();
+    expect(state.interactionVersion).toBe(version);
   });
 
   test("Command Palette keeps Aside closed in the predecessor release", () => {
@@ -390,7 +436,8 @@ describe("Aside TUI contract", () => {
     state.mode = "ASIDE";
     const context = overlayContext(state, 80, 24);
 
-    // Before the prompt click, text ownership is null and right-click refuses.
+    // Before the prompt click, text ownership is null, but the visible prompt
+    // itself can claim the composer for the standard text-actions menu.
     expect(activeTextComposer(state)).toBeNull();
     const notesFrame = renderStoryScreen(state, { width: 80, height: 24 });
     state.hitRows = notesFrame.derived.hitRows;
@@ -409,9 +456,14 @@ describe("Aside TUI contract", () => {
       y: composerHit!.y,
       modifiers: { shift: false, alt: false, ctrl: false }
     }, state);
-    expect(rightClick).toBeNull();
-    openTextActions(state);
-    expect(state.textActions).toBeNull();
+    expect(rightClick).toEqual({ action: "open-text-actions" });
+    await dispatch(rightClick!, state, source, createWrapCache(), () => undefined,
+      async () => undefined, () => undefined);
+    expect(surface.focus).toBe("composer");
+    expect(activeTextComposer(state)).toBe(surface.composer);
+    expect(state.textActions?.owner).toBe(surface.composer);
+    await dispatch({ action: "cancel" }, state, source, createWrapCache(), () => undefined,
+      async () => undefined, () => undefined);
 
     // Left-click on the visible prompt claims composer focus.
     const compose = mouseToAction({
@@ -429,7 +481,7 @@ describe("Aside TUI contract", () => {
     // Subsequent text and paste target the Aside composer.
     await handleOverlayAction({ action: "input", text: "typed " }, state, source, context);
     expect(surface.composer.text).toBe("typed ");
-    expect(pasteInto(state, "paste")).toBeTrue();
+    expect(await applyTerminalPaste("paste", state, source, context)).toBeTrue();
     expect(surface.composer.text).toBe("typed paste");
 
     // Esc/Tab ladder still moves notes → composer → leave.
@@ -650,7 +702,9 @@ describe("Aside TUI contract", () => {
     await handleOverlayAction({ action: "send" }, state, sourceWithApi, context);
     expect(asideConfirmClear(state.aside!)).toBeTrue();
 
-    expect(pasteInto(state, "pasted question")).toBeTrue();
+    expect(await applyTerminalPaste(
+      "pasted question", state, sourceWithApi, context
+    )).toBeTrue();
     expect(asideConfirmClear(state.aside!)).toBeFalse();
     expect(state.aside!.composer.text).toBe("pasted question");
     await handleOverlayAction({ action: "send" }, state, sourceWithApi, context);

--- a/tui/test/fact-editor.test.ts
+++ b/tui/test/fact-editor.test.ts
@@ -537,6 +537,41 @@ describe("Fact editor", () => {
     expect(editor.conflict).toBeNull();
   });
 
+  test("state chrome exposes a re-anchor shortcut and hides for legacy Facts", async () => {
+    const { state, press } = editorHarness();
+    const fact = state.payload.facts[0]!;
+    const initialAnchorPartId = state.payload.path[0]!.id;
+    const stateTwo = {
+      id: "fact-state-reanchor",
+      anchorPartId: initialAnchorPartId,
+      text: "anchored state",
+      createdAt: fact.updatedAt,
+      updatedAt: fact.updatedAt
+    };
+    state.payload = {
+      ...state.payload,
+      facts: [{ ...fact, states: [...fact.states, stateTwo] }, ...state.payload.facts.slice(1)]
+    };
+    openFactEditor(state, state.payload.facts[0]!, { stateId: stateTwo.id });
+    const editor = activeFactEditor(state);
+    editor.chromeFocus = "state";
+
+    expect(editor.stateAnchorPartId).toBe(initialAnchorPartId);
+    expect(editor.stateCursorAnchorId).not.toBeNull();
+    const cursorAnchorPartId = editor.stateCursorAnchorId!;
+    expect(cursorAnchorPartId).not.toBe(initialAnchorPartId);
+    expect(frameText(renderStoryScreen(state, { width: 100, height: 24 }).lines))
+      .toContain("a re-anchor ◆ cursor");
+    await press(key("A"));
+    expect(editor.stateAnchorPartId).toBe(initialAnchorPartId);
+    await press(key("a"));
+    expect(editor.stateAnchorPartId).toBe(cursorAnchorPartId);
+
+    openFactEditor(state, fact);
+    expect(frameText(renderStoryScreen(state, { width: 100, height: 24 }).lines))
+      .not.toContain("states");
+  });
+
   test("stateful recovery detects a dirty selected-state conflict and keeps remote text", async () => {
     const { source, state, press } = editorHarness();
     const fact = state.payload.facts[0]!;

--- a/tui/test/keys-paste.test.ts
+++ b/tui/test/keys-paste.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from "bun:test";
 import { createComposer } from "../src/composer-model.js";
 import { pasteInto } from "../src/keys.js";
 
-test("paste inserts at the composer cursor and flattens single-line prompts", () => {
+test("paste inserts at composer cursors and flattens composer-backed prompts", () => {
   const base = {
     composer: createComposer("ab"), tag: null, library: null, facts: null, commands: null, search: null,
     editor: null, settings: null, card: null, archive: null,
@@ -14,46 +14,6 @@ test("paste inserts at the composer cursor and flattens single-line prompts", ()
   const compose = { ...base, mode: "COMPOSE" as const };
   expect(pasteInto(compose, "line one\r\nline two")).toBeTrue();
   expect(compose.composer.text).toBe("aline one\nline twob");
-  const naming = {
-    ...base,
-    composer: createComposer(),
-    mode: "TAG" as const,
-    tag: { choosingStatus: false, name: "" }
-  };
-  expect(pasteInto(naming, "storm\ncanon")).toBeTrue();
-  expect(naming.tag.name).toBe("storm canon");
-  const facts = {
-    ...base,
-    composer: createComposer(),
-    mode: "FACTS" as const,
-    facts: { filtering: true, query: "", cursor: 6 }
-  };
-  expect(pasteInto(facts, "storm\ncanon")).toBeTrue();
-  expect(facts.facts).toEqual({ filtering: true, query: "storm canon", cursor: 0 });
-  const library = {
-    ...base,
-    composer: createComposer(),
-    mode: "LIBRARY" as const,
-    library: {
-      stories: [],
-      cursor: 6,
-      query: "",
-      prompt: {
-        kind: "filter" as const,
-        initial: { query: "", cursor: 6, storyId: null }
-      }
-    }
-  };
-  expect(pasteInto(library, "winter\norchard")).toBeTrue();
-  expect(library.library).toEqual({
-    stories: [],
-    cursor: 0,
-    query: "winter orchard",
-    prompt: {
-      kind: "filter",
-      initial: { query: "", cursor: 6, storyId: null }
-    }
-  });
   const settingsComposer = createComposer("ab");
   settingsComposer.cursor = 1;
   const settings = {

--- a/tui/test/library-filter.test.ts
+++ b/tui/test/library-filter.test.ts
@@ -133,7 +133,7 @@ describe("live Library filter", () => {
     expect(state.payload.id).toBe(match.id);
   });
 
-  test("preserves the selected matching story after paste", async () => {
+  test("preserves the selected matching story after filter input", async () => {
     const { source, state, press } = harness();
     await press("o");
     const selected = state.library!.stories.find(
@@ -144,7 +144,7 @@ describe("live Library filter", () => {
     );
     await press("/");
 
-    expect(pasteInto(state, "the")).toBeTrue();
+    for (const character of "the") await press(character);
     await press("return", "\r");
     source.api.loadStory = async (id) => ({
       ...source.payload,

--- a/tui/test/plain-text-paste.test.ts
+++ b/tui/test/plain-text-paste.test.ts
@@ -1,0 +1,365 @@
+import { describe, expect, test } from "bun:test";
+
+type ClipboardReader = () => Promise<string | null>;
+
+const bunTest = await import("bun:test") as unknown as {
+  mock: { module(path: string, factory: () => Record<string, unknown>): void };
+};
+let clipboardReader: ClipboardReader = async () => null;
+bunTest.mock.module("../src/clipboard.js", () => ({
+  readFromClipboard: () => clipboardReader(),
+  readClipboardContent: async () => {
+    const text = await clipboardReader();
+    return text === null ? null : { type: "text", text };
+  },
+  copyToClipboard: async () => "internal"
+}));
+
+const {
+  deferred,
+  key,
+  openSettings,
+  settingsHarness
+} = await import("./settings-test-harness.js");
+const { dispatch } = await import("../src/app.js");
+const { openSearch } = await import("../src/search-actions.js");
+const { openTag } = await import("../src/story-actions.js");
+const { openLibrary } = await import("../src/library-actions.js");
+const { openCardImport } = await import("../src/card-import-actions.js");
+const { openArchiveImport } = await import("../src/archive-import-actions.js");
+const {
+  createAsideSurface,
+  isAsideV2
+} = await import("../src/aside-surface.js");
+const { openSettingsPasteTarget } = await import("../src/settings-prompt-editor.js");
+const { handleOverlayAction } = await import("../src/overlay-actions.js");
+const { applyTerminalPaste } = await import("../src/terminal-paste.js");
+const { openAsideUseMenu } = await import("../src/aside-use.js");
+
+describe("plain-text paste", () => {
+  test("Ctrl/Cmd+V inserts into every plain-string prompt", async () => {
+    const paste = async (
+      setup: (harness: ReturnType<typeof settingsHarness>) => Promise<void> | void,
+      event: ReturnType<typeof key>,
+      expected: (harness: ReturnType<typeof settingsHarness>) => string | undefined
+    ): Promise<void> => {
+      const harness = settingsHarness();
+      await setup(harness);
+      clipboardReader = async () => "from\nclipboard";
+      await harness.press(event);
+      expect(expected(harness)).toBe("from clipboard");
+    };
+
+    await paste(
+      (harness) => {
+        harness.source.searchDebounceMs = 0;
+        openSearch(harness.state, harness.source);
+      },
+      key("v", { ctrl: true }),
+      (harness) => harness.state.search?.query
+    );
+    await paste(
+      async (harness) => {
+        await dispatch({ action: "open-facts" }, harness.state, harness.source, harness.cache,
+          () => undefined, async () => undefined, () => undefined);
+        await harness.press(key("/"));
+      },
+      key("v", { super: true }),
+      (harness) => harness.state.facts?.query
+    );
+    await paste(
+      async (harness) => {
+        await openLibrary(harness.state, harness.source, {
+          cache: harness.cache,
+          backend: harness.backend,
+          repaint: () => undefined,
+          renderer: null,
+          applyTheme: () => undefined,
+          previewTheme: () => undefined
+        });
+        await harness.press(key("/"));
+      },
+      key("v", { ctrl: true }),
+      (harness) => harness.state.library?.query
+    );
+    await paste(
+      async (harness) => {
+        await dispatch({ action: "open-commands" }, harness.state, harness.source, harness.cache,
+          () => undefined, async () => undefined, () => undefined);
+      },
+      key("v", { super: true }),
+      (harness) => harness.state.commands?.query
+    );
+    await paste(
+      (harness) => {
+        openTag(harness.state);
+        if (harness.state.tag !== null) {
+          harness.state.tag.name = "";
+          harness.state.tag.deleteArmed = true;
+        }
+      },
+      key("v", { ctrl: true }),
+      (harness) => {
+        expect(harness.state.tag?.deleteArmed).toBeFalse();
+        return harness.state.tag?.name;
+      }
+    );
+    await paste(
+      (harness) => openCardImport(harness.state),
+      key("v", { super: true }),
+      (harness) => harness.state.card?.path
+    );
+    await paste(
+      (harness) => openArchiveImport(harness.state),
+      key("v", { ctrl: true }),
+      (harness) => harness.state.archive?.path
+    );
+    await paste(
+      (harness) => {
+        harness.state.image = {
+          path: "",
+          storyId: harness.state.payload.id,
+          candidates: [],
+          error: null,
+          returnMode: "NAV"
+        };
+        harness.state.mode = "IMAGE";
+      },
+      key("v", { super: true }),
+      (harness) => harness.state.image?.path
+    );
+    await paste(
+      async (harness) => {
+        await openSettings(harness.press);
+        const overlay = harness.state.settings!;
+        overlay.modelPicker = { query: "", cursor: 3 };
+      },
+      key("v", { ctrl: true }),
+      (harness) => {
+        expect(harness.state.settings?.modelPicker?.cursor).toBe(0);
+        expect(harness.state.settings?.edit).toBeNull();
+        return harness.state.settings?.modelPicker?.query;
+      }
+    );
+    await paste(
+      async (harness) => {
+        await openSettings(harness.press);
+        harness.state.settings!.profileTransfer = {
+          phase: "file",
+          path: "",
+          error: "stale error",
+          candidates: ["/tmp/stale.preset"]
+        };
+      },
+      key("v", { super: true }),
+      (harness) => {
+        const transfer = harness.state.settings?.profileTransfer;
+        if (transfer?.phase !== "file") return undefined;
+        expect(transfer.error).toBeNull();
+        expect(transfer.candidates).toEqual([]);
+        return transfer.path;
+      }
+    );
+  });
+
+  test("bracketed paste targets the visible Settings model picker", async () => {
+    const harness = settingsHarness();
+    await openSettings(harness.press);
+    const overlay = harness.state.settings!;
+    overlay.modelPicker = { query: "existing ", cursor: 2 };
+
+    expect(openSettingsPasteTarget(harness.state)).toBeNull();
+    expect(await applyTerminalPaste(
+      "  chosen\n  model  ",
+      harness.state,
+      harness.source,
+      {
+      cache: harness.cache,
+      backend: harness.backend,
+      repaint: () => undefined,
+      renderer: null,
+      applyTheme: () => undefined,
+      previewTheme: () => undefined
+      }
+    )).toBeTrue();
+    expect(overlay.modelPicker.query).toBe("existing chosen model");
+    expect(overlay.modelPicker.cursor).toBe(0);
+    expect(overlay.edit).toBeNull();
+  });
+
+  test("Commands paste keeps selection and live theme preview in sync", async () => {
+    const harness = settingsHarness();
+    await dispatch({ action: "open-commands" }, harness.state, harness.source, harness.cache,
+      () => undefined, async () => undefined, () => undefined);
+    clipboardReader = async () => "theme: parchment";
+    const previews: Array<string | null> = [];
+
+    await dispatch(
+      { action: "paste-clipboard" },
+      harness.state,
+      harness.source,
+      harness.cache,
+      () => undefined,
+      async () => undefined,
+      () => undefined,
+      null,
+      () => undefined,
+      (theme) => previews.push(theme),
+      harness.backend
+    );
+
+    expect(harness.state.commands?.query).toBe("theme: parchment");
+    expect(harness.state.commands?.selectedId).toBe("theme:parchment");
+    expect(harness.state.commands?.cursor).toBeGreaterThan(-1);
+    expect(previews.at(-1)).toBe("parchment");
+  });
+
+  test("a late clipboard read cannot modify a closed plain prompt", async () => {
+    const harness = settingsHarness();
+    openCardImport(harness.state);
+    const read = deferred<string | null>();
+    const started = deferred<void>();
+    clipboardReader = async () => {
+      started.resolve();
+      return read.promise;
+    };
+
+    const paste = harness.press(key("v", { ctrl: true }));
+    await started.promise;
+    await harness.press(key("escape"));
+    read.resolve("stale path");
+    await paste;
+
+    expect(harness.state.mode).toBe("NAV");
+    expect(harness.state.card).toBeNull();
+  });
+
+  test("bracketed Aside paste disarms v2 destructive confirmations", async () => {
+    for (const confirmation of ["reset", "delete"] as const) {
+      const harness = settingsHarness();
+      const surface = createAsideSurface(
+        harness.state.payload.id,
+        harness.state.payload.title,
+        [{
+          id: "session-1",
+          title: "current",
+          anchor: null,
+          turns: [{ q: "Why?", a: "Because." }]
+        }],
+        null,
+        null,
+        { v2: true }
+      );
+      if (!isAsideV2(surface)) throw new Error("expected an Aside session surface");
+      surface.focus = "turns";
+      if (confirmation === "reset") surface.confirmReset = { turnIndex: 0 };
+      else surface.confirmDelete = { rowId: "answer-0" };
+      harness.state.aside = surface;
+      harness.state.mode = "ASIDE";
+
+      expect(await applyTerminalPaste(
+        "pasted question",
+        harness.state,
+        harness.source,
+        {
+          cache: harness.cache,
+          backend: harness.backend,
+          repaint: () => undefined,
+          renderer: null,
+          applyTheme: () => undefined,
+          previewTheme: () => undefined
+        }
+      )).toBeTrue();
+      expect(surface.focus).toBe("composer");
+      expect(surface.confirmReset).toBeNull();
+      expect(surface.confirmDelete).toBeNull();
+      expect(surface.composer.text).toBe("pasted question");
+    }
+  });
+
+  test("bracketed Aside paste commits an optimistic v2 deletion", async () => {
+    const harness = settingsHarness();
+    let deletes = 0;
+    harness.source.api.deleteAsideTurn = async () => {
+      deletes += 1;
+      return {
+        schemaVersion: 2,
+        id: "session-1",
+        anchor: null,
+        title: "current",
+        turns: [{ q: "First?", a: "One." }]
+      };
+    };
+    const surface = createAsideSurface(
+      harness.state.payload.id,
+      harness.state.payload.title,
+      [{
+        id: "session-1",
+        title: "current",
+        anchor: null,
+        turns: [{ q: "First?", a: "One." }, { q: "Second?", a: "Two." }]
+      }],
+      null,
+      null,
+      { v2: true }
+    );
+    if (!isAsideV2(surface)) throw new Error("expected an Aside session surface");
+    surface.focus = "turns";
+    surface.turnCursor = 1;
+    harness.state.aside = surface;
+    harness.state.mode = "ASIDE";
+    const context = {
+      cache: harness.cache,
+      backend: harness.backend,
+      repaint: () => undefined,
+      renderer: null,
+      applyTheme: () => undefined,
+      previewTheme: () => undefined
+    };
+
+    await handleOverlayAction({ action: "aside-delete" }, harness.state, harness.source, context);
+    await handleOverlayAction({ action: "aside-delete" }, harness.state, harness.source, context);
+    expect(surface.deleteUndo).not.toBeNull();
+
+    expect(await applyTerminalPaste(
+      "follow up", harness.state, harness.source, context
+    )).toBeTrue();
+    await harness.backend.settle();
+
+    expect(deletes).toBe(1);
+    expect(surface.deleteUndo).toBeNull();
+    expect(surface.composer.text).toBe("follow up");
+  });
+
+  test("terminal paste cannot pass an open Aside use menu", async () => {
+    const harness = settingsHarness();
+    const surface = createAsideSurface(
+      harness.state.payload.id,
+      harness.state.payload.title,
+      [{ question: "Why?", answer: "Because." }]
+    );
+    surface.focus = "notes";
+    expect(openAsideUseMenu(surface, 0)).toBeTrue();
+    harness.state.aside = surface;
+    harness.state.mode = "ASIDE";
+    const version = harness.state.interactionVersion;
+
+    expect(await applyTerminalPaste(
+      "must not paste",
+      harness.state,
+      harness.source,
+      {
+        cache: harness.cache,
+        backend: harness.backend,
+        repaint: () => undefined,
+        renderer: null,
+        applyTheme: () => undefined,
+        previewTheme: () => undefined
+      }
+    )).toBeFalse();
+
+    expect(surface.useMenu).not.toBeNull();
+    expect(surface.composer.text).toBe("");
+    expect(harness.state.interactionVersion).toBe(version);
+  });
+});

--- a/tui/test/settings-profile-transfer.test.ts
+++ b/tui/test/settings-profile-transfer.test.ts
@@ -17,7 +17,7 @@ import {
   selectRow,
   settingsHarness
 } from "./settings-test-harness.js";
-import { pasteInto, resolveKey } from "../src/keys.js";
+import { applyTerminalPaste } from "../src/terminal-paste.js";
 
 describe("Generation Profile transfer", () => {
   test("imports a Starter Profile into the draft and saves only on s", async () => {
@@ -116,7 +116,7 @@ describe("Generation Profile transfer", () => {
   });
 
   test("native Settings paste belongs to the transfer prompt and leaves no edit", async () => {
-    const { source, state, press } = settingsHarness();
+    const { source, state, press, cache, backend } = settingsHarness();
     const commands: SaveSettingsCommand[] = [];
     installSave(source, commands);
     const prompt = await openFilePrompt(state, press);
@@ -124,7 +124,19 @@ describe("Generation Profile transfer", () => {
     if (overlay === null) throw new Error("settings overlay missing");
 
     expect(openSettingsPasteTarget(state)).toBe(null);
-    expect(pasteInto(state, "/tmp/native.preset")).toBeTrue();
+    expect(await applyTerminalPaste(
+      "/tmp/native.preset",
+      state,
+      source,
+      {
+        cache,
+        backend,
+        repaint: () => undefined,
+        renderer: null,
+        applyTheme: () => undefined,
+        previewTheme: () => undefined
+      }
+    )).toBeTrue();
     expect(prompt.path).toBe("/tmp/native.preset");
     expect(overlay.edit).toBe(null);
 
@@ -138,37 +150,6 @@ describe("Generation Profile transfer", () => {
     expect(overlay.edit).toBe(null);
     await press(key("s"));
     expect(commands).toHaveLength(1);
-  });
-
-  test("Generation Profile file prompt routes Ctrl and Cmd V through the clipboard", async () => {
-    const { state, press } = settingsHarness();
-    const prompt = await openFilePrompt(state, press);
-    const overlay = state.settings;
-    if (overlay === null) throw new Error("settings overlay missing");
-    prompt.error = "stale error";
-    prompt.candidates = ["/tmp/stale.preset"];
-    const clipboard = ["/tmp/ctrl\u0007\nprofile.preset", "/cmd.profile.json"];
-    const readClipboard = async () => clipboard.shift() ?? null;
-
-    const ctrlPaste = resolveKey(
-      key("v", { ctrl: true }),
-      "SETTINGS",
-      { settingsProfileTransfer: "file" }
-    );
-    expect(ctrlPaste).toEqual({ action: "paste-clipboard" });
-    await profileTransferAction(ctrlPaste, state, overlay, { readClipboard });
-    expect(prompt.path).toBe("/tmp/ctrl profile.preset");
-    expect(prompt.error).toBe(null);
-    expect(prompt.candidates).toEqual([]);
-
-    const cmdPaste = resolveKey(
-      key("v", { super: true }),
-      "SETTINGS",
-      { settingsProfileTransfer: "file" }
-    );
-    expect(cmdPaste).toEqual({ action: "paste-clipboard" });
-    await profileTransferAction(cmdPaste, state, overlay, { readClipboard });
-    expect(prompt.path).toBe("/tmp/ctrl profile.preset/cmd.profile.json");
   });
 
   test("transfer applies a draft-only Starter Profile while generation is active", async () => {


### PR DESCRIPTION
## Outcome

Make text input, Fact controls, Aside exit behavior, and mouse behavior consistent across the TUI.

## Changes

- Route terminal and clipboard paste through one ownership and reducer path.
- Support Ctrl+V or Cmd+V in Aside and all plain-text prompts.
- Preserve multiline composer paste and Direct image paste.
- Reject paste while Aside is busy or its Use menu is open.
- Make right-click paste claim the idle Aside prompt.
- Close the app with q from every Aside layer.
- Show the Fact State re-anchor control on eligible state chrome.
- Keep keyboard and mouse actions equivalent.
- Keep the stored Fact and Settings formats unchanged.

## Verification

- `npm run build`
- `npm test`: 3,044 tests; 0 failures
- `cd tui && bun run typecheck`
- `cd tui && bun run test`: all 16 shards passed
- `cd tui && bun run build:standalone`
- affected integration tests: 65 passed
- autoreview: clean, 0 actionable findings
- thermo-nuclear maintainability review: clean, 0 actionable findings
- `git diff --check`

## Risk

The input dispatcher changes several prompt surfaces. Integration coverage exercises the visible target, busy-state, stale-read, keyboard, and mouse paths. Persistence schemas do not change.

The performance benchmark misses five existing 500-part repaint budgets on this machine. The unchanged base branch misses the same five budgets and is slower. This patch does not change rendering code.

Tracks #372