### PR TITLE
chore(release): prepare 0.10.5-rc.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ This file records notable changes to 1667. Product terms use the definitions in
 
 ## Unreleased
 
+## 0.10.5-rc.3 - 2026-08-31
+
+- **Paste now works consistently in text inputs.** Press `Ctrl+V` or `Cmd+V`
+  in Aside, search, filters, Settings prompts, and other text fields. Multiline
+  editors keep line breaks. Single-line fields flatten them. Direct keeps image
+  paste. Right-click paste works in Aside when its prompt is available.
+- **The Fact State re-anchor control is now visible.** Focus the state controls,
+  then press `a` or click `re-anchor` to move the state to the current story
+  cursor. The control stays hidden when the Fact has no eligible state.
+
 ## 0.10.5-rc.2 - 2026-08-30
 
 - **Facts can change with the story line.** Add Fact States at story-part

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "1667-workspace",
-  "version": "0.10.5-rc.2",
+  "version": "0.10.5-rc.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "1667-workspace",
-      "version": "0.10.5-rc.2",
+      "version": "0.10.5-rc.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@earendil-works/pi-ai": "0.84.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667-workspace",
-  "version": "0.10.5-rc.2",
+  "version": "0.10.5-rc.3",
   "private": true,
   "description": "Source workspace for the 1667 terminal writing environment",
   "license": "Apache-2.0",

--- a/shared/release-notes.ts
+++ b/shared/release-notes.ts
@@ -11,6 +11,11 @@ export interface ReleaseNote {
  *  a release, and is not included. */
 export const RELEASE_NOTES: readonly ReleaseNote[] = [
   {
+    version: "0.10.5-rc.3",
+    date: "2026-08-31",
+    body: "- **Paste now works consistently in text inputs.** Press `Ctrl+V` or `Cmd+V`\n  in Aside, search, filters, Settings prompts, and other text fields. Multiline\n  editors keep line breaks. Single-line fields flatten them. Direct keeps image\n  paste. Right-click paste works in Aside when its prompt is available.\n- **The Fact State re-anchor control is now visible.** Focus the state controls,\n  then press `a` or click `re-anchor` to move the state to the current story\n  cursor. The control stays hidden when the Fact has no eligible state."
+  },
+  {
     version: "0.10.5-rc.2",
     date: "2026-08-30",
     body: "- **Facts can change with the story line.** Add Fact States at story-part\n  Anchors. The nearest Fact State on the selected story line supplies the Fact\n  body. An End State stops the Fact on that line. Existing Facts keep their\n  current behavior.\n- **Facts can have an optional name.** The Facts overview shows the Fact Name\n  when it is set. Basic view keeps the common options concise. Advanced view\n  shows state and activation controls. The new controls work with the keyboard\n  and mouse.\n- **`q` now closes 1667 from Aside.** This works from the main Aside view and\n  from its nested menus and text fields."

--- a/tui/package.json
+++ b/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667",
-  "version": "0.10.5-rc.2",
+  "version": "0.10.5-rc.3",
   "private": true,
   "description": "A terminal environment for writing fiction with language models",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Outcome

Prepare the consistent-input beta release as version 0.10.5-rc.3.

## Changes

- Set the root, TUI, and lockfile versions to 0.10.5-rc.3.
- Add the 0.10.5-rc.3 changelog entry.
- Generate the matching embedded release notes.

## Verification

- npm run build
- npm test: 3,044 tests; 2,815 passed; 229 skipped; 0 failed
- tui: bun run typecheck
- tui: bun run test; all 16 shards passed
- tui: bun run build:standalone
- tui: bun bench/perf.ts; existing 500-part repaint budget misses reproduce on the pre-change commit
- npm run notes:check
- npm run notes:check-version -- 0.10.5-rc.3

## Risk

Low. This PR changes release metadata only. The hosted workflow will publish this prerelease with the npm beta tag after the merged main commit receives the version tag.

Tracks #372