### PR TITLE
chore(release): prepare 0.10.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ This file records notable changes to 1667. Product terms use the definitions in
 
 ## Unreleased
 
+## 0.10.5 - 2026-08-31
+
+- **This release has no additional product changes.** It contains the same
+  behavior as 0.10.5-rc.3.
+
 ## 0.10.5-rc.3 - 2026-08-31
 
 - **Paste now works consistently in text inputs.** Press `Ctrl+V` or `Cmd+V`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "1667-workspace",
-  "version": "0.10.5-rc.3",
+  "version": "0.10.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "1667-workspace",
-      "version": "0.10.5-rc.3",
+      "version": "0.10.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@earendil-works/pi-ai": "0.84.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667-workspace",
-  "version": "0.10.5-rc.3",
+  "version": "0.10.5",
   "private": true,
   "description": "Source workspace for the 1667 terminal writing environment",
   "license": "Apache-2.0",

--- a/shared/release-notes.ts
+++ b/shared/release-notes.ts
@@ -11,6 +11,11 @@ export interface ReleaseNote {
  *  a release, and is not included. */
 export const RELEASE_NOTES: readonly ReleaseNote[] = [
   {
+    version: "0.10.5",
+    date: "2026-08-31",
+    body: "- **This release has no additional product changes.** It contains the same\n  behavior as 0.10.5-rc.3."
+  },
+  {
     version: "0.10.5-rc.3",
     date: "2026-08-31",
     body: "- **Paste now works consistently in text inputs.** Press `Ctrl+V` or `Cmd+V`\n  in Aside, search, filters, Settings prompts, and other text fields. Multiline\n  editors keep line breaks. Single-line fields flatten them. Direct keeps image\n  paste. Right-click paste works in Aside when its prompt is available.\n- **The Fact State re-anchor control is now visible.** Focus the state controls,\n  then press `a` or click `re-anchor` to move the state to the current story\n  cursor. The control stays hidden when the Fact has no eligible state."

--- a/tui/package.json
+++ b/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667",
-  "version": "0.10.5-rc.3",
+  "version": "0.10.5",
   "private": true,
   "description": "A terminal environment for writing fiction with language models",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Outcome

Prepare the stable Fact States and consistent-input release as version 0.10.5.

## Changes

- Set the root, TUI, and lockfile versions to 0.10.5.
- Add the 0.10.5 changelog entry.
- Generate the matching embedded release notes.
- Keep product behavior identical to the verified 0.10.5-rc.3 beta.

## Verification

- npm run build
- npm test: 3,044 tests; 2,815 passed; 229 skipped; 0 failed
- tui: bun run typecheck
- tui: bun run test; all 16 shards passed
- tui: bun run build:standalone
- tui: bun bench/perf.ts; existing 500-part repaint budget misses reproduce on the pre-change commit
- npm run notes:check
- npm run notes:check-version -- 0.10.5
- 0.10.5-rc.3 immutable prerelease verified
- all six npm beta tags verified at 0.10.5-rc.3

## Risk

Low. This PR changes release metadata only. The product code is identical to the verified beta. The hosted workflow will publish this release with the npm latest tag after the merged main commit receives the version tag.

Tracks #372