### PR TITLE
fix(tui): align Fact editor controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ applies its subscription limits, terms, and data controls.
 | Open Aside | `a` |
 | Edit the Author's Note | `n` |
 | Generate a take with the same or a new prompt | `r` or `R` |
+| Summarize or refresh a chapter | `r` on a chapter marker or in Chapters |
 | Copy the selected story part or story line | `y` or `Y` |
 | Undo an added or removed chapter break | `u` |
 | Open the map, facts, chapters, or library | `m`, `f`, `c`, or `o` |

--- a/docs/model-providers.md
+++ b/docs/model-providers.md
@@ -32,6 +32,10 @@ priority, and budget rows. If an advanced value is not its default value, the
 editor keeps the advanced rows visible. You can click each visible row and
 control.
 
+Select a row to see a short explanation below it. The explanation states what
+the option does and what an empty value means. Use the `‹` and `›` controls
+with the mouse or the Left and Right Arrow keys.
+
 ### Scope a Fact to a story line
 
 A Fact contains one or more Fact States. A Fact State can have an Anchor. The
@@ -45,8 +49,11 @@ each story line. This is the behavior of a Fact from an older store.
 Create a Fact from the Facts panel to make an unscoped Fact. Its Scope row lets
 you change this choice before you save. Open the actions menu on a story part
 to create a scoped Fact from that part. The same Scope row lets you make it
-unscoped. The actions menu can also add a state to a Fact or end a Fact from
-that part.
+unscoped. To add or move a state, first select its destination story part.
+Open the Fact, then select the state row. Press `s` to add a state at that
+story part. The existing state keeps its current Anchor. Type the new state
+text, then save. Press `a` to move the selected state to that story part. The
+change takes effect when you save the Fact.
 
 Select the state row, and press `[` or `]` to select the previous or next
 state. You can also click a state in the state row. An End State stops the Fact
@@ -60,8 +67,9 @@ states. It includes states on other story lines.
 
 The Fact dossier shows one Fact along the selected story line. Press `[` or
 `]` to select a state. Press `Enter` to open its Anchor. Press `n` to add a
-state at the current story part. Press `x` to add an End State there. Press
-`d` to show a derived diff. You can click each state and footer action.
+state at the current story part. Press `e` to edit the selected state. Press
+`x` to add an End State there. Press `d` to show a derived diff. You can click
+each state and footer action.
 
 In the tree view of the map, press `f` to show the Fact lens. The Fact lens
 shows the reach of one Fact on all story lines. Press `Tab` to select another

--- a/tui/src/app.ts
+++ b/tui/src/app.ts
@@ -657,6 +657,12 @@ export async function handleKey(
     factEditorChromeFocus: state.editor?.kind === "fact"
       ? state.editor.chromeFocus
       : undefined,
+    factEditorChoiceFocus: state.editor?.kind === "fact"
+      && state.editor.chromeFocus === undefined
+      && (state.editor.focus === "activation"
+        || state.editor.focus === "match"
+        || state.editor.focus === "chain"
+        || state.editor.focus === "priority"),
     textActionsOpen: state.textActions !== null,
     asideLayer: state.mode === "ASIDE"
       ? asideKeyboardLayer(state.aside)

--- a/tui/src/chapter-actions.ts
+++ b/tui/src/chapter-actions.ts
@@ -94,7 +94,7 @@ export async function chaptersAction(
   else if (resolved.action === "open-selected" && selected !== null) {
     jumpToChapter(state, selected, source);
   }
-  else if (resolved.action === "summarize-chapter" && selected?.closedBy !== null && selected !== null) {
+  else if (resolved.action === "regenerate" && selected?.closedBy !== null && selected !== null) {
     await summarizeChapter(state, source, selected, context);
   } else if (resolved.action === "rename-item" && selected !== null) {
     beginRename(state, selected);

--- a/tui/src/choice-arrows.ts
+++ b/tui/src/choice-arrows.ts
@@ -1,0 +1,21 @@
+import { graphemeCells } from "./cell-width.js";
+
+/** Find the two visible arrow cells in a painted `‹ value ›` choice.
+ * Settings uses this geometry for the same controls that story choice rows
+ * own directly. */
+export function choiceArrowColumns(
+  drawn: string,
+  valueLeft: number
+): { readonly previous: number; readonly next: number } | null {
+  const cells = graphemeCells(drawn);
+  const opening = cells[0]?.text;
+  if (opening !== "‹" && opening !== "[") return null;
+  let column = 0;
+  for (const cell of cells) {
+    if (column > 0 && (cell.text === "›" || cell.text === "]")) {
+      return { previous: valueLeft, next: valueLeft + column };
+    }
+    column += cell.width;
+  }
+  return null;
+}

--- a/tui/src/editor-action.ts
+++ b/tui/src/editor-action.ts
@@ -30,6 +30,7 @@ import {
 import { blockUncertainFirstTakeRetry } from "./first-take-guard.js";
 import {
   factEditorBuffer,
+  factEditorChromeOwnsInput,
   factEditorComposerForSource,
   handleFactEditorVerticalMove,
   handleFactEditorCommand,
@@ -57,7 +58,7 @@ import {
 } from "./settings-overlay-model.js";
 import { writingPromptFieldDefinitionForRow } from "../../shared/settings-v5-writing.js";
 import { toggleFactEditorViewMode } from "./settings-view-mode.js";
-import { canonicalFactStates, firstFactText, isFactEndState } from "../../shared/fact-state.js";
+import { canonicalFactStates, firstFactText, isFactEndState, isFactStateful } from "../../shared/fact-state.js";
 
 export {
   openChapterSummaryEditor,
@@ -89,8 +90,9 @@ export async function inlineEditorAction(
   if (editor.kind === "fact" && resolved.composerSourceId !== undefined) {
     const source = factEditorComposerForSource(editor, resolved.composerSourceId);
     // Choice rows intentionally have no composer. They are still valid mouse
-    // targets because the source lookup sets their focus before this return.
-    if (source === null) return;
+    // targets because the source lookup sets their focus before the choice
+    // action continues through the Fact reducer.
+    if (source === null && resolved.action !== "take-previous" && resolved.action !== "take-next") return;
     if (resolved.action === "compose") return;
   }
 
@@ -141,8 +143,25 @@ export async function inlineEditorAction(
     return;
   }
 
+  if (editor.kind === "fact" && resolved.action === "new-state"
+    && source.api.createFactState === undefined) {
+    state.toast = "state creation requires a newer backend";
+    return;
+  }
+  if (editor.kind === "fact"
+    && (resolved.action === "reanchor-state" || resolved.action === "convert-state")
+    && source.api.patchFactState === undefined) {
+    state.toast = "state editing requires a newer backend";
+    return;
+  }
+
   // Fact header grammar owns its commands; the generic path stays target-agnostic.
   if (editor.kind === "fact" && handleFactEditorCommand(resolved, state, editor)) {
+    return;
+  }
+  if (editor.kind === "fact" && factEditorChromeOwnsInput(editor)
+    && !factEditorChromeAllows(resolved.action)) {
+    state.toast = "select a Fact field before typing";
     return;
   }
   if (editor.kind === "fact"
@@ -190,6 +209,16 @@ export async function inlineEditorAction(
   if (outcome === "save-inplace") {
     await saveInlineEditor(state, source, context, editor, "inplace");
   }
+}
+
+function factEditorChromeAllows(action: ResolvedKey["action"]): boolean {
+  return action === "cancel"
+    || action === "save-edit"
+    || action === "save-edit-inplace"
+    || action === "cursor-up"
+    || action === "cursor-down"
+    || action === "scroll-line-up"
+    || action === "scroll-line-down";
 }
 
 function closeInlineEditor(
@@ -446,11 +475,27 @@ async function saveFactEditor(
   context: ActionContext,
   editor: Extract<DocumentEditorSession, { kind: "fact" }>
 ): Promise<void> {
+  if (editor.stateCreating === true && source.api.createFactState === undefined) {
+    state.toast = "state creation requires a newer backend";
+    return;
+  }
+  if (editor.stateCreating !== true
+    && editor.target.factId !== null
+    && editor.target.base !== null
+    && isFactStateful(editor.target.base)
+    && source.api.patchFactState === undefined
+    && factEditorChanged(editor)) {
+    state.toast = "state editing requires a newer backend";
+    return;
+  }
   const stateMutationAvailable = editor.target.factId !== null
     && (editor.stateCreating === true
       ? source.api.createFactState !== undefined
       : editor.stateId !== undefined && editor.stateId !== null
-        && source.api.patchFactState !== undefined);
+        && source.api.patchFactState !== undefined
+        && (editor.target.base !== null && isFactStateful(editor.target.base)
+          || editor.stateAnchorPartId !== editor.stateInitialAnchorPartId
+          || editor.stateIsEnd !== editor.stateInitialEnds));
   if (stateMutationAvailable) {
     await saveFactStateEditor(state, source, context, editor);
     return;

--- a/tui/src/editor-open.ts
+++ b/tui/src/editor-open.ts
@@ -4,7 +4,6 @@ import {
   canonicalFactStates,
   firstFactText,
   isFactEndState,
-  isFactStateful,
   resolveFactState
 } from "../../shared/fact-state.js";
 import { resolveAuthorsNoteDepth } from "../../shared/authors-note.js";
@@ -111,10 +110,10 @@ export function openFactEditor(
     : states.find(({ id }) => id === options.stateId);
   const stateCreating = options.stateCreating === true;
   const returnMode = options.returnMode ?? "FACTS";
-  // A single story-wide text state is the canonical lift of a legacy flat
-  // Fact. Keep that case on the original editor surface; state chrome appears
-  // only once scope or multiplicity makes it user-visible.
-  const stateful = fact !== null && isFactStateful(fact);
+  // Every saved Fact can now add a state from this editor. Keep the canonical
+  // legacy state shape until a state action or other state feature needs more
+  // history; opening the editor alone does not rewrite storage.
+  const stateful = fact !== null;
   const text = stateCreating
     ? ""
     : selectedState === undefined || isFactEndState(selectedState)
@@ -176,8 +175,9 @@ export function openFactEditor(
   openFactSession(state, editor);
 }
 
-/** Open the existing Fact on a fresh state draft. The draft uses the current
- * path's leaf as its default anchor; the editor can re-anchor before save. */
+/** Open the existing Fact on a fresh state draft. The caller supplies the
+ * current story cursor as the default anchor; the editor can re-anchor before
+ * save. */
 export function openFactStateEditor(
   state: RuntimeState,
   fact: StoryFact,

--- a/tui/src/fact-editor-policy.ts
+++ b/tui/src/fact-editor-policy.ts
@@ -8,8 +8,9 @@ import {
   undoComposerEditOwner,
   type ComposerState
 } from "./composer-model.js";
-import { canonicalFactStates, isFactEndState, isFactStateful } from "../../shared/fact-state.js";
+import { canonicalFactStates, isFactEndState } from "../../shared/fact-state.js";
 import { FACT_PRIORITIES, FACT_RECURSIONS, FACT_SECONDARY_MODES } from "../../shared/fact-metadata.js";
+import { MAX_FACT_STATES } from "../../shared/types.js";
 import { graphemeCells } from "./cell-width.js";
 import type { ComposerVerticalMotion } from "./composer-motion.js";
 import { factEditorChanged, factEditorStateChanged, factEditorTag } from "./fact-editor-draft.js";
@@ -123,14 +124,21 @@ export function handleFactEditorCommand(
   state: RuntimeState,
   editor: FactEditorSession
 ): boolean {
+  if (resolved.action === "new-state") {
+    editor.chromeFocus = "state";
+    beginFactStateCreation(state, editor);
+    return true;
+  }
   if (resolved.action === "cycle-fact-scope" && isNewFactEditor(editor)) {
     setFactEditorFocus(editor, "scope");
     cycleFactEditorScope(editor);
     return true;
   }
   if (editor.chromeFocus === "scope") {
-    if (resolved.action === "cycle-fact-scope") {
-      cycleFactEditorScope(editor);
+    if (resolved.action === "cycle-fact-scope"
+      || resolved.action === "take-previous"
+      || resolved.action === "take-next") {
+      cycleFactEditorScope(editor, resolved.action === "take-previous" ? -1 : 1);
       return true;
     }
     if (resolved.action === "cursor-left") {
@@ -193,6 +201,11 @@ export function handleFactEditorCommand(
     cycleFactEditorTag(state, editor, resolved.index === -1 ? -1 : 1);
     return true;
   }
+  if (editor.chromeFocus === undefined && editor.focus === "tag"
+    && (resolved.action === "take-previous" || resolved.action === "take-next")) {
+    cycleFactEditorTag(state, editor, resolved.action === "take-next" ? 1 : -1);
+    return true;
+  }
   if (resolved.action === "cycle-state") {
     editor.chromeFocus = "state";
     cycleFactEditorState(state, editor, resolved.index, resolved.rowId !== undefined);
@@ -212,9 +225,20 @@ export function handleFactEditorCommand(
     const rowId = resolved.rowId ?? editor.stateCursorAnchorId ?? undefined;
     const validCursorPart = rowId !== undefined
       && state.payload.nodes.some(({ id, role }) => id === rowId && role !== "summary");
-    if (editor.stateId !== undefined && editor.stateId !== null && validCursorPart) {
-      editor.stateAnchorPartId = rowId;
-      disarmFactEditor(editor);
+    if ((editor.stateId !== undefined && editor.stateId !== null) || editor.stateCreating === true) {
+      if (validCursorPart) {
+        const fact = editor.target.base;
+        const occupied = fact !== null && canonicalFactStates(fact).some((candidate) =>
+          candidate.id !== editor.stateId
+          && (candidate.anchorPartId ?? null) === rowId
+        );
+        if (occupied) {
+          state.toast = "this Fact already has a state here";
+          return true;
+        }
+        editor.stateAnchorPartId = rowId ?? null;
+        disarmFactEditor(editor);
+      }
     }
     return true;
   }
@@ -232,22 +256,22 @@ export function handleFactEditorCommand(
     }
     return true;
   }
-  if (editor.focus === "activation"
+  if (editor.chromeFocus === undefined && editor.focus === "activation"
     && handleChoiceRowKeys(resolved, state, "activation", () => cycleFactEditorActivation(editor))) {
     return true;
   }
-  if (editor.focus === "priority"
+  if (editor.chromeFocus === undefined && editor.focus === "priority"
     && handleChoiceRowKeys(resolved, state, "priority", (direction) => cycleFactEditorPriority(editor, direction))) {
     return true;
   }
   if (
-    editor.focus === "match"
+    editor.chromeFocus === undefined && editor.focus === "match"
     && handleChoiceRowKeys(resolved, state, "secondary match", (direction) => cycleSecondaryMode(editor, direction))
   ) {
     return true;
   }
   if (
-    editor.focus === "chain"
+    editor.chromeFocus === undefined && editor.focus === "chain"
     && handleChoiceRowKeys(resolved, state, "recursion", (direction) => cycleRecursion(editor, direction))
   ) {
     return true;
@@ -269,11 +293,11 @@ function handleChoiceRowKeys(
   label: string,
   cycle: (direction: -1 | 1) => void
 ): boolean {
-  if (resolved.action === "cursor-left") {
+  if (resolved.action === "cursor-left" || resolved.action === "take-previous") {
     cycle(-1);
     return true;
   }
-  if (resolved.action === "cursor-right" || resolved.action === "newline") {
+  if (resolved.action === "cursor-right" || resolved.action === "take-next" || resolved.action === "newline") {
     cycle(1);
     return true;
   }
@@ -376,6 +400,58 @@ function isNewFactEditor(editor: FactEditorSession): boolean {
   return editor.target.factId === null && editor.stateCreating !== true;
 }
 
+/** Start a state draft from the cursor kept by the editor's opening story
+ * row. The existing Fact remains untouched until the normal save path posts
+ * the new state, so storage format and returnMode stay unchanged. */
+function beginFactStateCreation(
+  state: RuntimeState,
+  editor: FactEditorSession
+): void {
+  const fact = editor.target.base;
+  if (editor.target.factId === null || fact === null) {
+    state.toast = "save the Fact before adding a state";
+    return;
+  }
+  if (editor.stateCreating === true) {
+    state.toast = "finish this new state before adding another";
+    return;
+  }
+  if (factEditorStateChanged(editor)) {
+    state.toast = "save or cancel this state before adding another";
+    return;
+  }
+  const states = canonicalFactStates(fact);
+  if (states.length >= MAX_FACT_STATES) {
+    state.toast = `this Fact already has the maximum of ${MAX_FACT_STATES} states`;
+    return;
+  }
+  const anchor = editor.stateCursorAnchorId;
+  const validCursor = anchor !== undefined && anchor !== null
+    && state.payload.nodes.some(({ id, role }) => id === anchor && role !== "summary");
+  if (!validCursor) {
+    state.toast = "there is no story part at the cursor";
+    return;
+  }
+  if (states.some((candidate) => (candidate.anchorPartId ?? null) === anchor)) {
+    state.toast = "this Fact already has a state here";
+    return;
+  }
+  editor.stateCreating = true;
+  editor.stateId = null;
+  editor.stateIndex = states.length;
+  editor.stateAnchorPartId = anchor;
+  editor.stateInitialId = null;
+  editor.stateInitialAnchorPartId = anchor;
+  editor.stateInitialText = "";
+  editor.stateInitialEnds = false;
+  editor.stateIsEnd = false;
+  editor.stateDeleteArmedId = null;
+  editor.title = "new fact state";
+  setComposerText(editor.composer, "");
+  setFactEditorFocus(editor, "body");
+  disarmFactEditor(editor);
+}
+
 /** The only creation-time choice. The selected anchor is metadata for the
  *  new Fact itself; states acquire their own anchors later. */
 function cycleFactEditorScope(editor: FactEditorSession, direction: -1 | 1 = 1): void {
@@ -447,8 +523,19 @@ export function factEditorComposerForSource(
 export function factEditorActiveTextComposer(
   editor: FactEditorSession
 ): ComposerState | null {
+  if (factEditorChromeOwnsInput(editor)) return null;
   const spec = factEditorRowSpec(editor.focus);
   return spec.kind === "text" ? spec.composer(editor) : null;
+}
+
+/** Non-text Fact chrome must not leave the previous text row as an implicit
+ * input owner. Keyboard and paste callers use this same ownership check. */
+export function factEditorChromeOwnsInput(
+  editor: FactEditorSession
+): boolean {
+  return editor.chromeFocus === "view"
+    || editor.chromeFocus === "state"
+    || editor.chromeFocus === "scope";
 }
 
 function factEditorRowSpec(row: FactEditorRow): FactEditorRowSpec {
@@ -535,8 +622,7 @@ export function handleFactEditorVerticalMove(
   }
   const direction = resolved.action === "cursor-up" ? -1 : 1;
   const rows = factEditorVisibleRows(editor, viewMode, isNewFactEditor(editor));
-  const stateful = editor.stateCreating === true
-    || editor.target.base !== null && isFactStateful(editor.target.base);
+  const stateful = editor.stateCreating === true || editor.target.base !== null;
   if (editor.chromeFocus === "view") {
     if (direction > 0) {
       setFactEditorFocus(editor, rows[0] ?? "body");

--- a/tui/src/hit.ts
+++ b/tui/src/hit.ts
@@ -25,7 +25,14 @@ export type HitTarget =
   | { kind: "story-take"; take: number }
   /** Shortcut from story chrome into one exact Settings row. */
   | { kind: "settings-row"; row: SettingsRowId; profilePurpose?: SettingsRoutePurpose }
-  | { kind: "action"; action: KeyAction; index?: number; rowId?: string }
+  | {
+      kind: "action";
+      action: KeyAction;
+      index?: number;
+      rowId?: string;
+      /** Exact editor field for a choice arrow. */
+      composerSourceId?: string;
+    }
   /** Row control whose non-left clicks deliberately fall through to its row. */
   | {
       kind: "inline-action";

--- a/tui/src/keys.ts
+++ b/tui/src/keys.ts
@@ -7,7 +7,8 @@ import {
 } from "./editor-text-insertion.js";
 import { globalEditor } from "./editor-scope.js";
 import {
-  factEditorBuffer
+  factEditorBuffer,
+  factEditorChromeOwnsInput
 } from "./fact-editor-policy.js";
 import { textSurfaceKey } from "./keys-text-surface.js";
 import { openDirectComposer } from "./composer-ownership.js";
@@ -62,7 +63,7 @@ export type KeyAction =
   | "aside-go-anchor" | "aside-hop-to" | "aside-undo-delete"
   | "filter" | "cycle" | "check" | "detect-context" | "discard-pending" | "retry" | "continue"
   | "scroll-down" | "scroll-up" | "scroll-line-down" | "scroll-line-up" | "toggle-rail" | "copy-part" | "copy-line" | "open-actions" | "focus-index" | "open-aside-use"
-  | "open-chapters" | "create-chapter" | "summarize-chapter" | "chapter-previous" | "chapter-next"
+  | "open-chapters" | "create-chapter" | "chapter-previous" | "chapter-next"
   | "toggle-context-meter" | "open-search" | "toggle-search-case" | "open-request"
   | "complete" | "open-log" | "clear-log" | "row-action"
   | "open-probs" | "next-part" | "open-text-actions" | "import-profile" | "open-records"
@@ -134,7 +135,7 @@ export const MUTATING_ACTIONS: ReadonlySet<KeyAction> = new Set([
   "prune", "apply", "delete-tag", "edit", "write", "regenerate", "tag",
   "new-item", "duplicate-item", "rename-item", "delete-item", "discard-pending",
   "move-item-up", "move-item-down",
-  "create-chapter", "summarize-chapter", "open-aside", "open-authors-note", "save-edit", "save-edit-inplace"
+  "create-chapter", "open-aside", "open-authors-note", "save-edit", "save-edit-inplace"
 ]);
 
 /** Global-scope editor saves update local application state, not the story. */
@@ -251,6 +252,10 @@ export function pasteInto(
   if (state.mode === "EDITOR") {
     const editor = state.editor;
     if (editor === null) return false;
+    if (editor.kind === "fact" && factEditorChromeOwnsInput(editor)) {
+      state.toast = "select a Fact field before typing";
+      return true;
+    }
     const buffer = editor.kind === "fact" ? factEditorBuffer(editor) : editor;
     insertEditorText(
       state,
@@ -328,6 +333,8 @@ export interface ResolveOptions {
   factDossier?: boolean;
   /** Non-text Fact editor chrome currently owns focus. */
   factEditorChromeFocus?: "view" | "state" | "scope";
+  /** A closed Fact choice row owns the horizontal arrows, like Settings. */
+  factEditorChoiceFocus?: boolean;
   /** The open document editor targets the Author's Note, so its depth chord
    *  applies. No other editor target binds `⌥-`/`⌥=`. */
   authorsNoteEditor?: boolean;
@@ -397,7 +404,7 @@ export function asideKeyboardLayer(
 export function resolveKey(key: KeyEvent, mode: AppMode, options: ResolveOptions = {}): ResolvedKey {
   const { confirmingPrune = false, tagChoosingStatus = false, connectionDown = false,
     overlayTyping = false, settingsSampling = false, commandsTags = false,
-    factEditor = false, factEditorChromeFocus,
+    factEditor = false, factEditorChromeFocus, factEditorChoiceFocus = false,
     factDossier = false,
     authorsNoteEditor = false, settingsPicker = false,
     settingsProfileTransfer = null,
@@ -568,8 +575,18 @@ export function resolveKey(key: KeyEvent, mode: AppMode, options: ResolveOptions
       && name === "]" && factEditorChromeFocus === "state") {
       return { action: "cycle-state", index: 1 };
     }
+    if (factEditor && factEditorChoiceFocus
+      && !key.ctrl && !key.meta && !key.option && !key.super
+      && (name === "left" || name === "right")) {
+      return { action: name === "left" ? "take-previous" : "take-next" };
+    }
     if (factEditor && factEditorChromeFocus === "state" && key.name === "return") {
       return { action: "open-state-anchor" };
+    }
+    if (factEditor && factEditorChromeFocus === "state"
+      && !key.ctrl && !key.meta && !key.option && !key.super
+      && (name === "s" || name === "n")) {
+      return { action: "new-state" };
     }
     if (factEditor && key.name === "tab") {
       return { action: "cycle", index: key.shift ? -1 : 1 };
@@ -726,7 +743,11 @@ export function resolveKey(key: KeyEvent, mode: AppMode, options: ResolveOptions
     if (key.name === "down") return { action: "focus-next" };
     if (key.name === "up") return { action: "focus-previous" };
     if (key.name === "return") return { action: "open-selected" };
-    if (key.name === "s") return { action: "summarize-chapter" };
+    if (key.name === "r") return { action: "regenerate" };
+    // Keep the former chapter-menu shortcut as a compatibility alias. The
+    // rendered control and canonical action now match the inline chapter
+    // summary control: `r` / `regenerate`.
+    if (key.name === "s") return { action: "regenerate" };
     if (key.name === "e") return { action: "rename-item" };
     if (plainShiftedLetter(key, "d")) return { action: "delete-item" };
     if (key.name === "n") return { action: "new-item" };
@@ -745,6 +766,7 @@ export function resolveKey(key: KeyEvent, mode: AppMode, options: ResolveOptions
       if (key.name === "up") return { action: "focus-previous" };
       if (key.name === "[") return { action: "cycle-state", index: -1 };
       if (key.name === "]") return { action: "cycle-state", index: 1 };
+      if (key.name === "e") return { action: "edit" };
       if (key.name === "n") return { action: "new-state" };
       if (key.name === "x") return { action: "end-state" };
       if (key.name === "d") return { action: "toggle-fact-diff" };

--- a/tui/src/mouse-actions.ts
+++ b/tui/src/mouse-actions.ts
@@ -389,7 +389,10 @@ export function mouseToAction(
     return {
       action: target.action,
       ...(target.index === undefined ? {} : { index: target.index }),
-      ...(target.rowId === undefined ? {} : { rowId: target.rowId })
+      ...(target.rowId === undefined ? {} : { rowId: target.rowId }),
+      ...(target.composerSourceId === undefined
+        ? {}
+        : { composerSourceId: target.composerSourceId })
     };
   }
   if (target.kind === "inline-action" && event.button === 0) {

--- a/tui/src/overlay-actions.ts
+++ b/tui/src/overlay-actions.ts
@@ -19,7 +19,7 @@ import {
   factTags,
   isSingleUnscopedTextFact
 } from "./facts-model.js";
-import { canonicalFactStates } from "../../shared/fact-state.js";
+import { canonicalFactStates, isFactStateful } from "../../shared/fact-state.js";
 import { applyTextKey, type ResolvedKey } from "./keys.js";
 import {
   openAuthorBriefEditor,
@@ -400,13 +400,20 @@ function initialFacts() {
 }
 
 /** Facts stays over the story row that opened it. The focus index is not
- * changed by the overlay, so dossier state creation can use that persisted
- * part instead of silently falling back to the active path leaf. */
+ * changed by the overlay, so state creation can use that persisted part
+ * instead of silently falling back to the active path leaf. */
 function factsOpeningPartId(state: RuntimeState): string | null {
-  const part = rowPart(createStoryViewModel(state.payload), state.focusIndex);
-  return part?.node.role === "summary"
-    ? null
-    : part?.node.id ?? state.payload.path.at(-1)?.id ?? null;
+  const view = createStoryViewModel(state.payload);
+  const persistedPartId = (candidateId: string | undefined): string | null => {
+    if (candidateId === undefined) return null;
+    const node = state.payload.nodes.find(({ id }) => id === candidateId);
+    return node === undefined || node.role === "summary" ? null : node.id;
+  };
+  if (view.rows[state.focusIndex] === undefined) {
+    return persistedPartId(state.payload.path.at(-1)?.id);
+  }
+  const part = rowPart(view, state.focusIndex);
+  return persistedPartId(part?.node.id);
 }
 
 async function factsAction(
@@ -480,10 +487,17 @@ async function factsAction(
     || resolved.action === "open-selected" && overlay.pendingFactAction !== null
       && overlay.pendingFactAction !== undefined)
     && !overlay.filtering && selected !== undefined) {
+    if (source.api.createFactState === undefined) {
+      state.toast = "state creation requires a newer backend";
+      return true;
+    }
     const pending = overlay.pendingFactAction;
     const anchorPartId = pending?.anchorPartId
-      ?? state.payload.path.at(-1)?.id
-      ?? null;
+      ?? factsOpeningPartId(state);
+    if (anchorPartId === null) {
+      state.toast = "select a story part before adding a state";
+      return true;
+    }
     openFactStateEditor(state, selected, anchorPartId);
     if (pending?.kind === "end" && state.editor?.kind === "fact") {
       state.editor.stateIsEnd = true;
@@ -536,6 +550,13 @@ async function factsAction(
       });
     }
   } else if ((resolved.action === "edit" && selected !== undefined) || resolved.action === "new-item") {
+    if (resolved.action === "edit"
+      && selected !== undefined
+      && isFactStateful(selected)
+      && source.api.patchFactState === undefined) {
+      state.toast = "state editing requires a newer backend";
+      return true;
+    }
     if (resolved.action === "edit") overlay.cursor = selectedIndex;
     const selectedStateId = resolved.action === "edit"
       && selected !== undefined
@@ -624,9 +645,22 @@ async function factsDossierAction(
       release: (currentState) => { currentState.facts = null; }
     });
   } else if (resolved.action === "edit") {
+    if (isFactStateful(fact) && source.api.patchFactState === undefined) {
+      state.toast = "state editing requires a newer backend";
+      return true;
+    }
     openFactEditor(state, fact, { stateId: states[current]!.id });
   } else if (resolved.action === "new-state" || resolved.action === "end-state") {
-    openFactStateEditor(state, fact, factsOpeningPartId(state));
+    if (source.api.createFactState === undefined) {
+      state.toast = "state creation requires a newer backend";
+      return true;
+    }
+    const anchorPartId = factsOpeningPartId(state);
+    if (anchorPartId === null) {
+      state.toast = "select a story part before adding a state";
+      return true;
+    }
+    openFactStateEditor(state, fact, anchorPartId);
     if (resolved.action === "end-state" && state.editor?.kind === "fact") {
       state.editor.stateIsEnd = true;
       setComposerText(state.editor.composer, "");

--- a/tui/src/screens/facts-panel.ts
+++ b/tui/src/screens/facts-panel.ts
@@ -51,7 +51,7 @@ export const FACTS_FOOTER_ACTIONS = [
   { token: "↑", action: "focus-previous" }, { token: "↓", action: "focus-next" },
   { token: "tab", action: "cycle" }, { token: "↵ open", action: "open-selected" },
   { token: "/ filter", action: "filter" }, { token: "e edit", action: "edit" },
-  { token: "n new", action: "new-item" }, { token: "s state", action: "new-state" },
+  { token: "n new", action: "new-item" }, { token: "s new state", action: "new-state" },
   { token: "x delete", action: "delete-item" },
   { token: "esc", action: "cancel" }
 ] as const satisfies ReadonlyArray<{ token: string; action: KeyAction }>;
@@ -64,7 +64,7 @@ const FACTS_COMPACT_FOOTER_ACTIONS = [
   { token: "↑", action: "focus-previous" }, { token: "↓", action: "focus-next" },
   { token: "tab", action: "cycle" }, { token: "↵", action: "open-selected" },
   { token: "/", action: "filter" }, { token: "e", action: "edit" },
-  { token: "n", action: "new-item" }, { token: "s state", action: "new-state" },
+  { token: "n", action: "new-item" }, { token: "s new state", action: "new-state" },
   { token: "x", action: "delete-item" }, { token: "esc", action: "cancel" }
 ] as const satisfies ReadonlyArray<{ token: string; action: KeyAction }>;
 
@@ -72,7 +72,7 @@ const FACTS_COMPACT_CONFIRM_FOOTER_ACTIONS = [
   { token: "↑", action: "focus-previous" }, { token: "↓", action: "focus-next" },
   { token: "tab", action: "cycle" }, { token: "↵", action: "open-selected" },
   { token: "/", action: "filter" }, { token: "e", action: "edit" },
-  { token: "n", action: "new-item" }, { token: "s state", action: "new-state" },
+  { token: "n", action: "new-item" }, { token: "s new state", action: "new-state" },
   { token: "x confirms", action: "delete-item" }, { token: "esc keeps", action: "cancel" }
 ] as const satisfies ReadonlyArray<{ token: string; action: KeyAction }>;
 
@@ -84,6 +84,7 @@ const FILTER_FOOTER_ACTIONS = [
 const DOSSIER_FOOTER_ACTIONS = [
   { token: "↑", action: "focus-previous" },
   { token: "↓", action: "focus-next" },
+  { token: "e edit state", action: "edit" },
   { token: "↵ open", action: "open-selected" },
   { token: "[", action: "cycle-state", index: -1 },
   { token: "]", action: "cycle-state", index: 1 },
@@ -96,6 +97,7 @@ const DOSSIER_FOOTER_ACTIONS = [
 const DOSSIER_COMPACT_FOOTER_ACTIONS = [
   { token: "↑", action: "focus-previous" },
   { token: "↓", action: "focus-next" },
+  { token: "e", action: "edit" },
   { token: "↵", action: "open-selected" },
   { token: "[", action: "cycle-state", index: -1 },
   { token: "]", action: "cycle-state", index: 1 },
@@ -254,11 +256,11 @@ export function renderFactsPanel(
     ? "↵ done · esc done"
     : overlay.deleteArmedId === null
       ? width < 100
-        ? "↑·↓·tab·↵·/·e·n·s state·x·esc"
-        : "↑↓ · tab · ↵ open · / filter · e edit · n new · s state · x delete · esc"
+        ? "↑·↓·tab·↵·/·e·n·s new state·x·esc"
+        : "↑↓ · tab · ↵ open · / filter · e edit · n new · s new state · x delete · esc"
       : width < 100
-        ? "↑·↓·tab·↵·/·e·n·s state·x confirms·esc keeps"
-        : "↑↓ · tab · ↵ open · / filter · e edit · n new · s state · x confirms · esc keeps";
+        ? "↑·↓·tab·↵·/·e·n·s new state·x confirms·esc keeps"
+        : "↑↓ · tab · ↵ open · / filter · e edit · n new · s new state · x confirms · esc keeps";
   const activationCount = keyedFacts.length === 0
     ? ""
     : ` · ${activeKeyedCount}/${keyedFacts.length} keyed`;

--- a/tui/src/screens/panels.ts
+++ b/tui/src/screens/panels.ts
@@ -60,7 +60,7 @@ export { SETTINGS_FOOTER_ACTIONS } from "./settings-panel-footers.js";
 export { FACTS_FOOTER_ACTIONS } from "./facts-panel.js";
 
 export const CHAPTERS_FOOTER_ACTIONS = [
-  { token: "↵", action: "open-selected" }, { token: "s sum", action: "summarize-chapter" },
+  { token: "↵", action: "open-selected" }, { token: "r sum", action: "regenerate" },
   { token: "e rename", action: "rename-item" }, { token: "n break", action: "new-item" },
   { token: "D", action: "delete-item" }, { token: "esc", action: "cancel" }
 ] as const satisfies ReadonlyArray<{ token: string; action: KeyAction }>;
@@ -313,10 +313,10 @@ function renderChapters(
     : overlay.rename !== null
     ? "↵ saves the title · esc keeps the old one"
     : overlay.deleteArmedId !== null
-    ? "↵ jump · s sum · e rename · n break · D confirms · esc keeps"
+    ? "↵ jump · r sum · e rename · n break · D confirms · esc keeps"
     : width < 100
-      ? "↵ jump · s sum · e rename · n break · D rm · esc"
-      : "↵ jump · s summarize · e rename · n break · D remove · esc";
+      ? "↵ jump · r sum · e rename · n break · D rm · esc"
+      : "↵ jump · r summarize · e rename · n break · D remove · esc";
   return placePanel(base, `chapters · ${model.rows.length} on this storyline`, boundedContent(content, contentWidth),
     footer, width, height, 106, { rows: state.hitRows, targets,
       // Renaming accepts only save, cancel and text: advertising the other verbs

--- a/tui/src/screens/settings-field-row.ts
+++ b/tui/src/screens/settings-field-row.ts
@@ -1,4 +1,3 @@
-import { graphemeCells } from "../cell-width.js";
 import { composerPosition } from "../composer-model.js";
 import {
   settingsEditDisplayComposer,
@@ -13,6 +12,7 @@ import {
   type FrameLine
 } from "./story/frame.js";
 import { raisedSegment } from "./overlay.js";
+import { choiceArrowColumns } from "../choice-arrows.js";
 
 const SETTINGS_LEAD_WIDTH = 4;
 const SETTINGS_LABEL_WIDTH = 20;
@@ -48,7 +48,7 @@ export function settingsFieldRow(
         raisedSegment(drawn, selected ? "focus / accent" : "prose")
       ],
       arrows: settingsRowHasArrows(overlay, row.id)
-        ? bracketArrows(drawn, valueLeft)
+        ? choiceArrowColumns(drawn, valueLeft)
         : null
     };
   }
@@ -74,21 +74,4 @@ export function settingsFieldRow(
 
 function settingsValueLeft(label: string): number {
   return SETTINGS_LEAD_WIDTH + Math.max(SETTINGS_LABEL_WIDTH, visibleWidth(label) + 1);
-}
-
-function bracketArrows(
-  drawn: string,
-  valueLeft: number
-): PaintedSettingsRow["arrows"] {
-  const cells = graphemeCells(drawn);
-  const opening = cells[0]?.text;
-  if (opening !== "‹" && opening !== "[") return null;
-  let column = 0;
-  for (const cell of cells) {
-    if (column > 0 && (cell.text === "›" || cell.text === "]")) {
-      return { previous: valueLeft, next: valueLeft + column };
-    }
-    column += cell.width;
-  }
-  return null;
 }

--- a/tui/src/screens/settings-form.ts
+++ b/tui/src/screens/settings-form.ts
@@ -1,5 +1,5 @@
-import { graphemeCells } from "../cell-width.js";
 import { composerPosition } from "../composer-model.js";
+import { choiceArrowColumns } from "../choice-arrows.js";
 import type { HitRegion, HitTarget } from "../hit.js";
 import {
   scalarInvalidReason,
@@ -329,28 +329,20 @@ function withTick(run: string, tick: number | null, offset: number): string {
 
 /** A closed choice opens on its first cell and closes on its bracket. */
 function arrowRegions(drawn: string, valueLeft: number, index: number): HitRegion[] {
-  const cells = graphemeCells(drawn);
-  const opening = cells[0]?.text;
-  if (opening !== "‹" && opening !== "[") return [];
-  let column = 0;
-  for (const cell of cells) {
-    if (column > 0 && (cell.text === "›" || cell.text === "]")) {
-      return [
-        {
-          target: { kind: "action", action: "take-previous", index },
-          left: valueLeft,
-          right: valueLeft + 1
-        },
-        {
-          target: { kind: "action", action: "take-next", index },
-          left: valueLeft + column,
-          right: valueLeft + column + 1
-        }
-      ];
+  const columns = choiceArrowColumns(drawn, valueLeft);
+  if (columns === null) return [];
+  return [
+    {
+      target: { kind: "action", action: "take-previous", index },
+      left: columns.previous,
+      right: columns.previous + 1
+    },
+    {
+      target: { kind: "action", action: "take-next", index },
+      left: columns.next,
+      right: columns.next + 1
     }
-    column += cell.width;
-  }
-  return [];
+  ];
 }
 
 function padTo(value: string, width: number): string {

--- a/tui/src/screens/story/composer-choice.ts
+++ b/tui/src/screens/story/composer-choice.ts
@@ -36,7 +36,11 @@ export function renderComposerChoiceRow(options: {
     segment("┃ ", "compose accent"),
     segment(options.focused ? "▸ " : "  ", "focus / accent"),
     segment(label, options.focused ? "prose" : "chrome"),
-    segment("‹ ", valueRole),
+    segment("‹ ", valueRole, {
+      kind: "action",
+      action: "take-previous",
+      composerSourceId: options.sourceId
+    }),
     ...(mappedValue.length === 0 ? [] : clipped || options.sourceStart === null
       ? [{
           text: mappedValue,
@@ -56,6 +60,10 @@ export function renderComposerChoiceRow(options: {
             }
           }]),
     ...(clipped ? [segment("…", valueRole)] : []),
-    segment(" ›", valueRole)
+    segment(" ›", valueRole, {
+      kind: "action",
+      action: "take-next",
+      composerSourceId: options.sourceId
+    })
   ]);
 }

--- a/tui/src/screens/story/fact-editor-layout.ts
+++ b/tui/src/screens/story/fact-editor-layout.ts
@@ -2,7 +2,6 @@ import { MAX_FACT_TEXT_CHARS } from "../../../../shared/types.js";
 import {
   canonicalFactStates,
   isFactEndState,
-  isFactStateful,
   type FactState
 } from "../../../../shared/fact-state.js";
 import { unicodeScalarLength } from "../../../../shared/unicode.js";
@@ -26,6 +25,7 @@ import {
 import { factEditorAdvancedPinned, factEditorVisibleRows } from "../../fact-editor-rows.js";
 import type { ComposerState } from "../../composer-model.js";
 import type { FactEditorSession } from "../../state.js";
+import { wrapText } from "../../wrap.js";
 import {
   renderComposerInput,
   renderComposerLayout,
@@ -66,8 +66,10 @@ export function renderFactEditorLayout(
     : [...canonicalFactStates(editor.target.base)];
   const stateLine = factEditorStateLine(editor, states);
   const advancedPinned = viewMode === "simple" && factEditorAdvancedPinned(editor);
+  const helpTarget = factEditorHelpTarget(editor);
+  const helpLines = factEditorHelpLines(editor, helpTarget, options.width);
   const headerRows = 1 + (hasName ? 1 : 0) + (scopeLine === null ? 0 : 1) + (showAdvanced ? 8 : 0)
-    + (stateLine === null ? 0 : 1);
+    + (stateLine === null ? 0 : 1) + helpLines.length;
   const body = renderComposerLayout({
     composer: editor.composer,
     fullscreen: true,
@@ -150,15 +152,29 @@ export function renderFactEditorLayout(
     body.fieldWidth,
     FACT_BUDGET_COMPOSER_SOURCE
   );
+  const withHelp = (line: FrameLine, target: FactEditorHelpTarget): FrameLine[] => [
+    line,
+    ...(helpTarget === target ? helpLines : [])
+  ];
   const header: FrameLine[] = [
-    viewHeader,
-    ...(name === null ? [] : [name]),
-    tag,
-    ...(scope === null ? [] : [scope]),
+    ...withHelp(viewHeader, "view"),
+    ...(name === null ? [] : withHelp(name, "name")),
+    ...withHelp(tag, "tag"),
+    ...(scope === null ? [] : withHelp(scope, "scope")),
     ...(showAdvanced
-      ? [activation, keys, secondary, match, scan, chain, priority, budget]
+      ? [
+          ...withHelp(activation, "activation"),
+          ...withHelp(keys, "keys"),
+          ...withHelp(secondary, "secondary"),
+          ...withHelp(match, "match"),
+          ...withHelp(scan, "scan"),
+          ...withHelp(chain, "chain"),
+          ...withHelp(priority, "priority"),
+          ...withHelp(budget, "budget")
+        ]
       : []),
-    ...(stateLine === null ? [] : [stateLine])
+    ...(stateLine === null ? [] : withHelp(stateLine, "state")),
+    ...(helpTarget === "body" ? helpLines : [])
   ];
   return {
     ...body,
@@ -200,16 +216,70 @@ function factEditorScopeLine(editor: FactEditorSession, fieldWidth: number): Fra
   }), FACT_SCOPE_COMPOSER_SOURCE, false);
   return line.map((part) => ({
     ...part,
-    hit: { kind: "action", action: "cycle-fact-scope" }
+    hit: part.hit ?? { kind: "action", action: "cycle-fact-scope" }
   }));
+}
+
+type FactEditorHelpTarget = "view" | "name" | "tag" | "scope" | "activation"
+  | "keys" | "secondary" | "match" | "scan" | "chain" | "priority" | "budget"
+  | "state" | "body";
+
+function factEditorHelpTarget(editor: FactEditorSession): FactEditorHelpTarget {
+  if (editor.chromeFocus === "view") return "view";
+  if (editor.chromeFocus === "state") return "state";
+  if (editor.chromeFocus === "scope") return "scope";
+  return editor.focus;
+}
+
+/** Show one short, selected-row explanation. The note uses the same visual
+ * treatment as Settings so every Fact option has a plain-English answer. */
+function factEditorHelpLines(
+  editor: FactEditorSession,
+  target: FactEditorHelpTarget,
+  width: number
+): FrameLine[] {
+  const inset = visibleWidth("┃     · ");
+  const measure = Math.max(1, width - inset - 1);
+  return wrapText(factEditorHelpText(editor, target), [], measure).map(({ text }) => [
+    segment("┃     ", "chrome"),
+    segment(`· ${text}`, "context note")
+  ]);
+}
+
+function factEditorHelpText(
+  editor: FactEditorSession,
+  target: FactEditorHelpTarget
+): string {
+  if (target === "view") return "Show the controls that decide when and where this Fact is used.";
+  if (target === "name") return "Optional name shown in the Facts list.";
+  if (target === "tag") return "Groups similar Facts together.";
+  if (target === "scope") return "Choose whether this Fact applies everywhere or starts from this story part.";
+  if (target === "activation") {
+    return editor.activation === "always"
+      ? "Always sends this Fact when a request is made."
+      : "Sends this Fact only when its keys match the story.";
+  }
+  if (target === "keys") return "Words or phrases that activate a keyed Fact. Separate entries with commas.";
+  if (target === "secondary") return "An optional second key list for the match rule below.";
+  if (target === "match") {
+    return editor.secondaryMode === "not"
+      ? "Needs a primary key and no matching secondary key."
+      : "Needs one primary key and one secondary key.";
+  }
+  if (target === "scan") return "How many recent story parts to check. Empty uses three parts.";
+  if (target === "chain") return "Let this Fact activate other keyed Facts.";
+  if (target === "priority") return "When the request is full, low priority Facts drop first.";
+  if (target === "budget") return "Optional token limit for this Fact. Empty means no limit.";
+  if (target === "body") return "Write the names, places, items, or rules the provider should remember.";
+  if (editor.stateCreating) return "New state starts at the story cursor. Type its text, then save.";
+  return "A state keeps one Fact text at a story point. Add one here or move the selected state here.";
 }
 
 function factEditorStateLine(
   editor: FactEditorSession,
   states: readonly FactState[]
 ): FrameLine | null {
-  const stateful = editor.stateCreating === true
-    || editor.target.base !== null && isFactStateful(editor.target.base);
+  const stateful = editor.stateCreating === true || editor.target.base !== null;
   if (!stateful) return null;
   const selected = editor.stateIndex ?? 0;
   const controls: FrameLine = [segment(
@@ -236,11 +306,19 @@ function factEditorStateLine(
         kind: "action", action: "open-state-anchor", rowId: anchor
       }));
     }
-    if (editor.stateCursorAnchorId !== undefined && editor.stateCursorAnchorId !== null) {
-      controls.push(segment(" · a re-anchor ◆ cursor", "chrome", {
-        kind: "action", action: "reanchor-state", rowId: editor.stateCursorAnchorId
+  }
+  if (editor.target.factId !== null
+    && editor.stateCursorAnchorId !== undefined && editor.stateCursorAnchorId !== null) {
+    if (!editor.stateCreating) {
+      controls.push(segment(" · s add state here ◆", "chrome", {
+        kind: "action", action: "new-state"
       }));
     }
+    controls.push(segment(" · a move here ◆", "chrome", {
+      kind: "action", action: "reanchor-state", rowId: editor.stateCursorAnchorId
+    }));
+  }
+  if (editor.stateId !== undefined && editor.stateId !== null) {
     controls.push(segment(` · ${editor.stateIsEnd === true ? "convert text" : "convert ✕"}`, "chrome", {
       kind: "action", action: "convert-state", rowId: editor.stateId
     }));

--- a/tui/src/screens/story/status.ts
+++ b/tui/src/screens/story/status.ts
@@ -110,20 +110,25 @@ export function renderStatus(
   // Only work in flight earns a cell. The backend is local unless someone went
   // out of their way to point it elsewhere for debugging, so saying so on every
   // frame reports the default back to the writer and nothing more.
-  const summaryStage = state.chapterSummary?.stage === "writing" ? "writing · model progress unavailable"
-    : state.chapterSummary?.stage === "stopping" ? "stopping · waiting for backend"
-    : null;
+  const summaryStage = state.chapterSummary?.stage === "stopping" ? "stopping · waiting for backend" : null;
   const summaryCancel = state.textActions === null
     && (isPlainNavigation(state) || state.mode === "CHAPTERS")
     ? " · esc cancels"
     : "";
-  const backendStatus = state.chapterSummary != null
-    ? `working · Chapter ${state.chapterSummary.chapterNumber} summary · ${summaryStage}${summaryCancel}`
-    : state.backendTask === null
+  const summaryStatus = state.chapterSummary == null ? null
+    : `working · Chapter ${state.chapterSummary.chapterNumber} summary`
+      + (summaryStage === null ? "" : ` · ${summaryStage}`);
+  const summaryNarrowStatus = state.chapterSummary == null ? null
+    : summaryStage === null
+      ? `working · ch ${state.chapterSummary.chapterNumber}${summaryCancel}`
+      : `ch ${state.chapterSummary.chapterNumber} · ${summaryStage}${summaryCancel}`;
+  const backendStatus = summaryStatus === null
+    ? state.backendTask === null
       ? null
-      : `working · ${truncate(state.backendTask.label, narrow ? 18 : 28)}`;
-  let narrowRight = state.chapterSummary != null
-    ? `ch ${state.chapterSummary.chapterNumber} · ${summaryStage}${summaryCancel}`
+      : `working · ${truncate(state.backendTask.label, narrow ? 18 : 28)}`
+    : `${summaryStatus}${summaryCancel}`;
+  let narrowRight = summaryNarrowStatus !== null
+    ? summaryNarrowStatus
     : state.backendTask === null
     ? `${chapterPrefix}${requestMeter}${centered}`
     : `${backendStatus} · ${requestMeter}${centered}`;
@@ -135,18 +140,18 @@ export function renderStatus(
     ? visibleWidth(plainLine(left))
     : minimumLeftWidth;
   if (priorityLeftWidth + visibleWidth(narrowRight) + 2 > width) {
-    narrowRight = state.chapterSummary != null
-      ? `ch ${state.chapterSummary.chapterNumber} · ${state.chapterSummary.stage}${summaryCancel}`
+    narrowRight = summaryNarrowStatus !== null
+      ? summaryNarrowStatus
       : state.backendTask === null
       ? `${requestMeter}${centered}`
       : `working · ${requestMeter}${centered}`;
   }
   if (minimumLeftWidth + visibleWidth(narrowRight) + 2 > width && centered.length > 0) {
-    narrowRight = state.chapterSummary != null ? `working${summaryCancel}`
+    narrowRight = summaryNarrowStatus !== null ? `working${summaryCancel}`
       : state.backendTask === null ? requestMeter : `working · ${requestMeter}`;
   }
   if (minimumLeftWidth + visibleWidth(narrowRight) + 2 > width) {
-    narrowRight = state.chapterSummary != null ? summaryCancel.slice(3) || "working" : requestMeter;
+    narrowRight = summaryNarrowStatus !== null ? summaryCancel.slice(3) || "working" : requestMeter;
   }
   // Which build is running, in the corner where it stays out of the way. It is
   // reference rather than status, so it takes slack and nothing else: never a

--- a/tui/test/actions-runtime.test.ts
+++ b/tui/test/actions-runtime.test.ts
@@ -780,7 +780,7 @@ test("a chapter rename records nothing to undo", async () => {
 
     await press("c");
     await press("up");
-    const pending = press("s");
+    const pending = press("r");
     await Promise.resolve();
 
     expect(state.chapterSummary).toMatchObject({ chapterNumber: 2, stage: "writing" });
@@ -788,12 +788,14 @@ test("a chapter rename records nothing to undo", async () => {
     state.chapters = null;
     const frame = renderStoryScreen(state, { width: 120, height: 30 });
     expect(frameText(frame.lines)).toContain("ch 2");
-    expect(frameText(frame.lines)).toContain("model progress unavailable");
+    expect(frameText(frame.lines)).not.toContain("model progress unavailable");
     expect(frameText(frame.lines)).toContain("esc cancels");
 
     await press("escape", "\u001b");
     expect(signal?.aborted).toBeTrue();
     expect(state.chapterSummary?.stage).toBe("stopping");
+    const stoppingFrame = renderStoryScreen(state, { width: 120, height: 30 });
+    expect(frameText(stoppingFrame.lines)).toContain("stopping · waiting for backend");
     entered.resolve();
     await pending;
 
@@ -815,7 +817,7 @@ test("a chapter rename records nothing to undo", async () => {
 
     await press("c");
     await press("up");
-    const pending = press("s");
+    const pending = press("r");
     await entered.promise;
     const interactionVersion = state.interactionVersion;
     const cursor = state.chapters!.cursor;
@@ -844,7 +846,7 @@ test("a chapter rename records nothing to undo", async () => {
 
     await press("c");
     await press("up");
-    const pending = press("s");
+    const pending = press("r");
     await entered.promise;
     state.mode = "NAV";
     state.chapters = null;
@@ -877,7 +879,7 @@ test("a chapter rename records nothing to undo", async () => {
 
     await press("c");
     await press("up");
-    const pending = press("s");
+    const pending = press("r");
     await entered.promise;
     state.mode = "NAV";
     state.chapters = null;
@@ -915,7 +917,7 @@ test("a chapter rename records nothing to undo", async () => {
 
     await press("c");
     await press("up");
-    const pending = press("s");
+    const pending = press("r");
     await entered.promise;
     await press("escape", "\u001b");
     release.resolve();
@@ -956,7 +958,7 @@ test("a chapter rename records nothing to undo", async () => {
     await press("c");
     expect(state.mode).toBe("CHAPTERS");
     await press("up");
-    await press("s");
+    await press("r");
     expect(state.payload.nodes.some((node) => node.chapterBreakId === "chapter-break-2")).toBeTrue();
     await press("return", "\r");
     expect(state.mode).toBe("NAV");
@@ -964,6 +966,48 @@ test("a chapter rename records nothing to undo", async () => {
       kind: "chapter-divider",
       break: { id: "chapter-break-1" }
     });
+  });
+
+  test("chapter overlay uses the inline r summary action by mouse", async () => {
+    const { source, state, press } = harness();
+    await press("c");
+    await press("up");
+    const rendered = renderStoryScreen(state, { width: 120, height: 30, wrapCache: createWrapCache() });
+    Object.assign(state, rendered.derived);
+    const footerRow = rendered.lines.findIndex((line) => plainLine(line).includes("r sum"));
+    expect(footerRow).toBeGreaterThan(-1);
+    const footer = plainLine(rendered.lines[footerRow]!);
+    const token = "r sum";
+    const tokenColumn = visibleWidth(footer.slice(0, footer.indexOf(token)));
+    const resolved = mouseToAction(
+      { type: "down", button: 0, x: tokenColumn + 1, y: footerRow,
+        modifiers: { shift: false, alt: false, ctrl: false } } as never,
+      captureMouseActionState(state)
+    );
+    expect(resolved).toEqual({ action: "regenerate" });
+    await dispatch(resolved!, state, source, createWrapCache(), () => {}, async () => {}, () => {});
+    expect(state.payload.nodes.some((node) => node.chapterBreakId === "chapter-break-2")).toBeTrue();
+  });
+
+  test("story status stays empty when summary progress is unavailable", () => {
+    const { state } = harness();
+    Reflect.deleteProperty(state, "chapterSummary");
+    const rendered = renderStoryScreen(state, { width: 120, height: 30, wrapCache: createWrapCache() });
+    expect(frameText(rendered.lines)).not.toContain("model progress unavailable");
+    expect(frameText(rendered.lines)).not.toContain("working · Chapter");
+  });
+
+  test("compact chapter summary status keeps its working marker", () => {
+    const { state } = harness();
+    state.chapterSummary = {
+      chapterNumber: 2,
+      stage: "writing",
+      controller: new AbortController()
+    };
+    const rendered = renderStoryScreen(state, { width: 80, height: 30, wrapCache: createWrapCache() });
+    const text = frameText(rendered.lines);
+    expect(text).toContain("working · ch 2");
+    expect(text).not.toContain("model progress unavailable");
   });
 
   test("enter expands and collapses a focused chapter summary", async () => {

--- a/tui/test/fact-editor.test.ts
+++ b/tui/test/fact-editor.test.ts
@@ -12,7 +12,7 @@ import {
   factDraftToFactPatch,
   factEditorChanged
 } from "../src/fact-editor-draft.js";
-import { resetFactEditorHistory } from "../src/fact-editor-policy.js";
+import { resetFactEditorHistory, setFactEditorFocus } from "../src/fact-editor-policy.js";
 import { captureMouseActionState, mouseToAction } from "../src/mouse-actions.js";
 import { pasteInto } from "../src/keys.js";
 import { nextRequestEstimate } from "../src/request-projection.js";
@@ -194,6 +194,8 @@ describe("Fact editor", () => {
 
     await press(key("up"));
 
+    expect(editor.chromeFocus).toBe("state");
+    await press(key("up"));
     expect(editor.focus).toBe("budget");
     expect(composerPosition(editor.budget).column).toBe(0);
     await press(key("5"));
@@ -537,7 +539,7 @@ describe("Fact editor", () => {
     expect(editor.conflict).toBeNull();
   });
 
-  test("state chrome exposes a re-anchor shortcut and hides for legacy Facts", async () => {
+  test("state chrome exposes add and move actions for every saved Fact", async () => {
     const { state, press } = editorHarness();
     const fact = state.payload.facts[0]!;
     const initialAnchorPartId = state.payload.path[0]!.id;
@@ -561,7 +563,7 @@ describe("Fact editor", () => {
     const cursorAnchorPartId = editor.stateCursorAnchorId!;
     expect(cursorAnchorPartId).not.toBe(initialAnchorPartId);
     expect(frameText(renderStoryScreen(state, { width: 100, height: 24 }).lines))
-      .toContain("a re-anchor ◆ cursor");
+      .toContain("a move here ◆");
     await press(key("A"));
     expect(editor.stateAnchorPartId).toBe(initialAnchorPartId);
     await press(key("a"));
@@ -569,7 +571,297 @@ describe("Fact editor", () => {
 
     openFactEditor(state, fact);
     expect(frameText(renderStoryScreen(state, { width: 100, height: 24 }).lines))
-      .not.toContain("states");
+      .toContain("states");
+    expect(frameText(renderStoryScreen(state, { width: 100, height: 24 }).lines))
+      .toContain("s add state here ◆");
+  });
+
+  test("a legacy Fact reaches its state chrome with Up and Down", async () => {
+    const { state, press } = editorHarness();
+    const fact = state.payload.facts[0]!;
+    openFactEditor(state, fact);
+    const editor = activeFactEditor(state);
+    editor.composer.anchor = null;
+    editor.composer.cursor = 0;
+
+    await press(key("up"));
+    expect(editor.chromeFocus).toBe("state");
+    await press(key("down"));
+    expect(editor.focus).toBe("body");
+    expect(editor.chromeFocus).toBe(undefined);
+  });
+
+  test("state chrome does not route keyboard or paste input to a stale Fact field", async () => {
+    const { state, press } = editorHarness();
+    const fact = state.payload.facts[0]!;
+    openFactEditor(state, fact);
+    const editor = activeFactEditor(state);
+    setComposerText(editor.budget, "42");
+    editor.focus = "budget";
+    editor.chromeFocus = "state";
+    const body = editor.composer.text;
+
+    await press(key("x"));
+    await press(key("backspace"));
+    expect(editor.budget.text).toBe("42");
+    expect(editor.composer.text).toBe(body);
+
+    expect(pasteInto(state, "hidden input")).toBeTrue();
+    expect(editor.budget.text).toBe("42");
+    expect(editor.composer.text).toBe(body);
+    expect(state.toast).toBe("select a Fact field before typing");
+  });
+
+  test("Fact choice arrows work by mouse and by Left or Right Arrow", async () => {
+    const { source, state, cache, press } = editorHarness();
+    await press(key("f"));
+    await press(key("return"));
+    const editor = activeFactEditor(state);
+    setFactEditorFocus(editor, "activation");
+
+    const rendered = renderStoryScreen(state, { width: 100, height: 24 });
+    Object.assign(state, rendered.derived);
+    const tagRight = state.hitRows
+      .flatMap((row, y) => row?.overrides?.map((region) => ({ region, y })) ?? [])
+      .find(({ region }) => region.target.kind === "action"
+        && region.target.action === "take-next"
+        && region.target.composerSourceId === "fact-tag");
+    expect(tagRight).toBeDefined();
+    const tagAction = mouseToAction(
+      mouseClick(tagRight!.region.left, tagRight!.y), state
+    );
+    await dispatch(
+      tagAction!, state, source, cache, () => undefined, async () => undefined, () => undefined
+    );
+    expect(editor.tag.text).toBe("places");
+    expect(editor.focus).toBe("body");
+    setFactEditorFocus(editor, "activation");
+    const right = state.hitRows
+      .flatMap((row, y) => row?.overrides?.map((region) => ({ region, y })) ?? [])
+      .find(({ region }) => region.target.kind === "action"
+        && region.target.action === "take-next"
+        && region.target.composerSourceId === "fact-activation");
+    expect(right).toBeDefined();
+    const mouseAction = mouseToAction(
+      mouseClick(right!.region.left, right!.y), state
+    );
+    expect(mouseAction).toEqual({
+      action: "take-next",
+      composerSourceId: "fact-activation"
+    });
+    await dispatch(
+      mouseAction!, state, source, cache, () => undefined, async () => undefined, () => undefined
+    );
+    expect(editor.focus).toBe("activation");
+    expect(editor.activation).toBe("keyed");
+
+    await press(key("left"));
+    expect(editor.activation).toBe("always");
+
+    editor.chromeFocus = "view";
+    await press(key("right"));
+    expect(editor.activation).toBe("always");
+    editor.chromeFocus = "state";
+    await press(key("left"));
+    expect(editor.activation).toBe("always");
+    editor.chromeFocus = undefined;
+
+    const choiceSources = [
+      "fact-tag", "fact-activation", "fact-secondary-mode", "fact-recursion", "fact-priority"
+    ];
+    for (const sourceId of choiceSources) {
+      const arrows = state.hitRows
+        .flatMap((row) => row?.overrides ?? [])
+        .filter((region) => region.target.kind === "action"
+          && (region.target.action === "take-previous" || region.target.action === "take-next")
+          && region.target.composerSourceId === sourceId);
+      expect(arrows).toHaveLength(2);
+    }
+  });
+
+  test("each Fact option has a short explanation", async () => {
+    const { state, press } = editorHarness();
+    await press(key("f"));
+    await press(key("return"));
+    const editor = activeFactEditor(state);
+    const options: Array<[FactEditorSession["focus"], string]> = [
+      ["name", "Optional name shown in the Facts list."],
+      ["tag", "Groups similar Facts together."],
+      ["activation", "Always sends this Fact when a request is made."],
+      ["keys", "Words or phrases that activate a keyed Fact."],
+      ["secondary", "An optional second key list for the match rule below."],
+      ["match", "Needs one primary key and one secondary key."],
+      ["scan", "How many recent story parts to check."],
+      ["chain", "Let this Fact activate other keyed Facts."],
+      ["priority", "When the request is full, low priority Facts drop first."],
+      ["budget", "Optional token limit for this Fact."],
+      ["body", "Write the names, places, items, or rules"],
+    ];
+    for (const [focus, explanation] of options) {
+      setFactEditorFocus(editor, focus);
+      expect(frameText(renderStoryScreen(state, { width: 100, height: 24 }).lines))
+        .toContain(explanation);
+    }
+    editor.chromeFocus = "state";
+    expect(frameText(renderStoryScreen(state, { width: 100, height: 24 }).lines))
+      .toContain("A state keeps one Fact text at a story point.");
+
+    openFactEditor(state, null);
+    const newFact = activeFactEditor(state);
+    newFact.chromeFocus = "scope";
+    expect(frameText(renderStoryScreen(state, { width: 100, height: 24 }).lines))
+      .toContain("Choose whether this Fact applies everywhere");
+  });
+
+  test("the Fact editor adds a state at the cursor and moves one by mouse", async () => {
+    const { source, state, cache, press } = editorHarness();
+    const fact = state.payload.facts[0]!;
+    openFactEditor(state, fact);
+    const editor = activeFactEditor(state);
+    editor.chromeFocus = "state";
+    await press(key("s"));
+    expect(editor.stateCreating).toBeTrue();
+    expect(editor.stateAnchorPartId).toBe(editor.stateCursorAnchorId);
+    expect(editor.composer.text).toBe("");
+
+    openFactEditor(state, fact);
+    const movable = activeFactEditor(state);
+    movable.chromeFocus = "state";
+    const rendered = renderStoryScreen(state, { width: 100, height: 24 });
+    Object.assign(state, rendered.derived);
+    const move = state.hitRows
+      .flatMap((row, y) => row?.overrides?.map((region) => ({ region, y })) ?? [])
+      .find(({ region }) => region.target.kind === "action"
+        && region.target.action === "reanchor-state");
+    expect(move).toBeDefined();
+    const mouseAction = mouseToAction(
+      mouseClick(move!.region.left, move!.y), state
+    );
+    expect(mouseAction?.action).toBe("reanchor-state");
+    await dispatch(
+      mouseAction!, state, source, cache, () => undefined, async () => undefined, () => undefined
+    );
+    expect(movable.stateAnchorPartId).toBe(movable.stateCursorAnchorId);
+
+    openFactEditor(state, fact);
+    const dirty = activeFactEditor(state);
+    setComposerText(dirty.composer, "unsaved state edit");
+    dirty.chromeFocus = "state";
+    const dirtyFrame = renderStoryScreen(state, { width: 100, height: 24 });
+    Object.assign(state, dirtyFrame.derived);
+    const add = state.hitRows
+      .flatMap((row, y) => row?.overrides?.map((region) => ({ region, y })) ?? [])
+      .find(({ region }) => region.target.kind === "action" && region.target.action === "new-state");
+    expect(add).toBeDefined();
+    await dispatch(
+      mouseToAction(mouseClick(add!.region.left, add!.y), state)!,
+      state, source, cache, () => undefined, async () => undefined, () => undefined
+    );
+    expect(dirty.stateCreating).toBe(false);
+    expect(state.toast).toBe("save or cancel this state before adding another");
+  });
+
+  test("an older backend refuses state-only edits before changing the draft", async () => {
+    const { source, state, cache } = editorHarness();
+    const fact = state.payload.facts[0]!;
+    openFactEditor(state, fact);
+    const editor = activeFactEditor(state);
+    const initialAnchor = editor.stateAnchorPartId;
+    const initialEnd = editor.stateIsEnd;
+    source.api.patchFactState = undefined;
+
+    await dispatch(
+      { action: "reanchor-state" }, state, source, cache,
+      () => undefined, async () => undefined, () => undefined
+    );
+    expect(editor.stateAnchorPartId).toBe(initialAnchor);
+    expect(state.toast).toBe("state editing requires a newer backend");
+
+    state.toast = null;
+    await dispatch(
+      { action: "convert-state" }, state, source, cache,
+      () => undefined, async () => undefined, () => undefined
+    );
+    expect(editor.stateIsEnd).toBe(initialEnd);
+    expect(state.toast).toBe("state editing requires a newer backend");
+  });
+
+  test("an older backend cannot save a new state through the Fact PATCH", async () => {
+    const { source, state, press } = editorHarness();
+    const fact = state.payload.facts[0]!;
+    const before = structuredClone(state.payload.facts);
+    source.api.createFactState = undefined;
+
+    openFactStateEditor(state, fact, state.payload.path[0]!.id);
+    const editor = activeFactEditor(state);
+    setComposerText(editor.composer, "draft state");
+    await press(key("s", { sequence: SAVE_SEQUENCE, ctrl: true }));
+
+    expect(state.editor).toBe(editor);
+    expect(state.payload.facts).toEqual(before);
+    expect(state.toast).toBe("state creation requires a newer backend");
+  });
+
+  test("an older backend refuses changed persisted stateful Facts without state PATCH", async () => {
+    const { source, state, press } = editorHarness();
+    const fact = state.payload.facts[0]!;
+    const anchorPartId = state.payload.path[0]!.id;
+    const stateful = {
+      ...fact,
+      states: [
+        ...fact.states,
+        {
+          id: `${fact.id}-branch`,
+          anchorPartId,
+          text: "branch state body",
+          createdAt: fact.updatedAt,
+          updatedAt: fact.updatedAt
+        }
+      ]
+    };
+    state.payload = {
+      ...state.payload,
+      facts: [stateful, ...state.payload.facts.slice(1)]
+    };
+    const before = structuredClone(state.payload.facts);
+    let ordinaryPatches = 0;
+    const patchFact = source.api.patchFact;
+    source.api.patchFact = async (...args) => {
+      ordinaryPatches += 1;
+      return patchFact(...args);
+    };
+    source.api.patchFactState = undefined;
+
+    openFactEditor(state, stateful, { stateId: `${fact.id}-branch` });
+    const editor = activeFactEditor(state);
+    setComposerText(editor.composer, "changed branch body");
+    await press(key("s", { sequence: SAVE_SEQUENCE, ctrl: true }));
+
+    expect(ordinaryPatches).toBe(0);
+    expect(state.editor).toBe(editor);
+    expect(state.payload.facts).toEqual(before);
+    expect(state.toast).toBe("state editing requires a newer backend");
+  });
+
+  test("legacy Facts still save through ordinary PATCH without state PATCH", async () => {
+    const { source, state, press } = editorHarness();
+    const fact = state.payload.facts[0]!;
+    let ordinaryPatches = 0;
+    const patchFact = source.api.patchFact;
+    source.api.patchFact = async (...args) => {
+      ordinaryPatches += 1;
+      return patchFact(...args);
+    };
+    source.api.patchFactState = undefined;
+
+    openFactEditor(state, fact);
+    const editor = activeFactEditor(state);
+    setComposerText(editor.composer, "changed legacy body");
+    await press(key("s", { sequence: SAVE_SEQUENCE, ctrl: true }));
+
+    expect(ordinaryPatches).toBe(1);
+    expect(state.payload.facts[0]).toMatchObject({ id: fact.id });
+    expect(factText(state.payload.facts[0]!)).toBe("changed legacy body");
   });
 
   test("stateful recovery detects a dirty selected-state conflict and keeps remote text", async () => {
@@ -903,6 +1195,8 @@ describe("Fact editor", () => {
     expect(editor.focus).toBe("budget");
     expect(editor.budget.cutConfirmation).toEqual({ start: 0, end: 1, text: "5" });
     await press(key("down"));
+    expect(editor.chromeFocus).toBe("state");
+    await press(key("down"));
     expect(editor.focus).toBe("body");
     expect(editor.tag.anchor).toBe(null);
     expect(editor.tag.cutConfirmation).toBe(null);
@@ -914,6 +1208,8 @@ describe("Fact editor", () => {
     editor.composer.cutConfirmation = { start: 0, end: 5, text: "Maren" };
 
     // Move focus to budget. The body selection ownership clears immediately.
+    await press(key("up"));
+    expect(editor.chromeFocus).toBe("state");
     await press(key("up"));
     expect(editor.focus).toBe("budget");
     expect(editor.composer.anchor).toBe(null);
@@ -953,7 +1249,8 @@ describe("Fact editor", () => {
     // the text cursor within it.
     activeFactEditor(state).composer.anchor = null;
     activeFactEditor(state).composer.cursor = 0;
-    await press(key("up")); // body -> budget
+    await press(key("up")); // body -> states
+    await press(key("up")); // states -> budget
     await press(key("up")); // budget -> priority
     expect(activeFactEditor(state).focus).toBe("priority");
     await press(key("left")); // normal -> low
@@ -1091,6 +1388,28 @@ describe("Fact editor", () => {
 
     const rendered = renderStoryScreen(state, { width: 100, height: 24 });
     Object.assign(state, rendered.derived);
+    const scopeNext = state.hitRows
+      .flatMap((row, y) => row?.overrides?.map((region) => ({ region, y })) ?? [])
+      .find(({ region }) => region.target.kind === "action"
+        && region.target.action === "take-next"
+        && region.target.composerSourceId === "fact-scope");
+    expect(scopeNext).toBeDefined();
+    const scopeNextAction = mouseToAction(
+      mouseClick(scopeNext!.region.left, scopeNext!.y),
+      captureMouseActionState(state)
+    );
+    expect(scopeNextAction).toEqual({
+      action: "take-next",
+      composerSourceId: "fact-scope"
+    });
+    await dispatch(
+      scopeNextAction!, state, source, cache,
+      () => undefined, async () => undefined, () => undefined
+    );
+    expect(activeFactEditor(state).factAnchorPartId).toBeNull();
+
+    // The rest of the row keeps its forward-cycle shortcut too.
+    Object.assign(state, renderStoryScreen(state, { width: 100, height: 24 }).derived);
     const scopeRow = state.hitRows.findIndex((row) => row?.overrides?.some((region) =>
       region.target.kind === "action" && region.target.action === "cycle-fact-scope"));
     expect(scopeRow).toBeGreaterThan(-1);
@@ -1103,7 +1422,7 @@ describe("Fact editor", () => {
     );
     expect(mouseAction).toEqual({ action: "cycle-fact-scope" });
     await dispatch(mouseAction!, state, source, cache, () => undefined, async () => undefined, () => undefined);
-    expect(activeFactEditor(state).factAnchorPartId).toBeNull();
+    expect(activeFactEditor(state).factAnchorPartId).toBe(xAnchorPartId);
   });
 
   test("state chrome owns bracket walking and Enter lands on its anchor", async () => {

--- a/tui/test/facts-dossier.test.ts
+++ b/tui/test/facts-dossier.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import type { KeyEvent } from "@opentui/core";
+import { ActionRuntime } from "../src/action-runtime.js";
 import { dispatch, initialState } from "../src/app.js";
 import { demoAppSource } from "../src/demo.js";
 import { canonicalFactStates } from "../../shared/fact-state.js";
@@ -11,6 +12,7 @@ import { renderStoryScreen } from "../src/screens/story.js";
 import { frameText, plainLine } from "../src/screens/story/frame.js";
 import { createWrapCache } from "../src/wrap.js";
 import { createStoryViewModel, rowIndexForNode } from "../src/model.js";
+import { runPartAction } from "../src/story-actions.js";
 import type { StoryFact } from "../../shared/types.js";
 
 const STAMP = "2026-01-01T00:00:00.000Z";
@@ -109,6 +111,65 @@ describe("Facts scope chips and dossier", () => {
     expect(state.mode).toBe("EDITOR");
     expect(state.editor?.kind).toBe("fact");
     expect(state.editor?.kind === "fact" ? state.editor.name?.text : null).toBe("Named story-wide Fact");
+  });
+
+  test("overview edit still opens a legacy Fact without state PATCH", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    state.mode = "FACTS";
+    state.facts = {
+      cursor: 0,
+      query: "",
+      chip: 0,
+      selectedTag: null,
+      filtering: false,
+      deleteArmedId: null,
+      scopeFilter: "everywhere",
+      dossier: null
+    };
+    source.api.patchFactState = undefined;
+
+    await dispatch(
+      { action: "edit" }, state, source, createWrapCache(),
+      () => undefined, async () => undefined, () => undefined
+    );
+
+    expect(state.mode).toBe("EDITOR");
+    expect(state.editor?.kind).toBe("fact");
+  });
+
+  test("overview edit refuses a stateful Fact without state PATCH", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const template = state.payload.facts[0]!;
+    const fact = customFact(template, "overview-edit-old", "overview edit old", [
+      stateText("base", "Story-wide body."),
+      stateText("branch", "Branch body.", "p12")
+    ]);
+    state.payload = { ...state.payload, facts: [fact] };
+    state.mode = "FACTS";
+    state.facts = {
+      cursor: 0,
+      query: "",
+      chip: 0,
+      selectedTag: null,
+      filtering: false,
+      deleteArmedId: null,
+      scopeFilter: "everywhere",
+      dossier: null
+    };
+    const before = structuredClone(state.payload.facts);
+    source.api.patchFactState = undefined;
+
+    await dispatch(
+      { action: "edit" }, state, source, createWrapCache(),
+      () => undefined, async () => undefined, () => undefined
+    );
+
+    expect(state.mode).toBe("FACTS");
+    expect(state.editor).toBeNull();
+    expect(state.payload.facts).toEqual(before);
+    expect(state.toast).toBe("state editing requires a newer backend");
   });
 
   test("renders the resolution line, scope chips, and visible search-hit context", async () => {
@@ -308,6 +369,250 @@ describe("Facts scope chips and dossier", () => {
       .toBe(openedPartId);
   });
 
+  test("overview new state uses the story part that opened Facts", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const template = state.payload.facts[0]!;
+    const fact = customFact(template, "overview-new", "overview new", [
+      stateText("base", "Story-wide body."),
+      stateText("branch", "Branch body.", "p12")
+    ]);
+    state.payload = { ...state.payload, facts: [fact] };
+    const openedPartId = state.payload.path[0]!.id;
+    state.focusIndex = rowIndexForNode(createStoryViewModel(state.payload), openedPartId);
+    state.mode = "FACTS";
+    state.facts = {
+      cursor: 0,
+      query: "",
+      chip: 0,
+      selectedTag: null,
+      filtering: false,
+      deleteArmedId: null,
+      scopeFilter: "everywhere",
+      dossier: null
+    };
+
+    await dispatch(
+      { action: "new-state" }, state, source, createWrapCache(),
+      () => undefined, async () => undefined, () => undefined
+    );
+
+    expect(state.editor?.kind).toBe("fact");
+    expect(state.editor?.kind === "fact" ? state.editor.stateAnchorPartId : null)
+      .toBe(openedPartId);
+    expect(state.editor?.kind === "fact" ? state.editor.stateCursorAnchorId : null)
+      .toBe(openedPartId);
+  });
+
+  test("overview state creation refuses chapter summary and divider cursors", async () => {
+    for (const rowKind of ["chapter-summary", "chapter-divider"] as const) {
+      const source = demoAppSource();
+      const state = initialState(source, false);
+      const before = structuredClone(state.payload.facts);
+      const view = createStoryViewModel(state.payload);
+      state.focusIndex = view.rows.findIndex((row) => row.kind === rowKind);
+      expect(state.focusIndex).toBeGreaterThan(-1);
+      state.mode = "FACTS";
+      state.facts = {
+        cursor: 0,
+        query: "",
+        chip: 0,
+        selectedTag: null,
+        filtering: false,
+        deleteArmedId: null,
+        scopeFilter: "everywhere",
+        dossier: null
+      };
+
+      await dispatch(
+        { action: "new-state" }, state, source, createWrapCache(),
+        () => undefined, async () => undefined, () => undefined
+      );
+
+      expect(state.editor).toBeNull();
+      expect(state.payload.facts).toEqual(before);
+      expect(state.toast).toBe("select a story part before adding a state");
+    }
+  });
+
+  test("overview state creation fails closed on an older backend", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const fact = state.payload.facts[0]!;
+    const before = structuredClone(state.payload.facts);
+    source.api.createFactState = undefined;
+    state.mode = "FACTS";
+    state.facts = {
+      cursor: 0,
+      query: "",
+      chip: 0,
+      selectedTag: null,
+      filtering: false,
+      deleteArmedId: null,
+      scopeFilter: "everywhere",
+      dossier: null
+    };
+
+    await dispatch(
+      { action: "new-state" }, state, source, createWrapCache(),
+      () => undefined, async () => undefined, () => undefined
+    );
+
+    expect(state.editor).toBeNull();
+    expect(state.payload.facts).toEqual(before);
+    expect(state.toast).toBe("state creation requires a newer backend");
+    expect(state.payload.facts.find(({ id }) => id === fact.id)).toEqual(fact);
+  });
+
+  test("dossier state creation fails closed on an older backend", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const template = state.payload.facts[0]!;
+    const fact = customFact(template, "dossier-old", "dossier old", [
+      stateText("base", "Story-wide body."),
+      stateText("branch", "Branch body.", "p12")
+    ]);
+    state.payload = { ...state.payload, facts: [fact] };
+    state.mode = "FACTS";
+    state.facts = {
+      cursor: 0,
+      query: "",
+      chip: 0,
+      selectedTag: null,
+      filtering: false,
+      deleteArmedId: null,
+      scopeFilter: "everywhere",
+      dossier: { factId: fact.id, stateIndex: 0, diff: false }
+    };
+    const before = structuredClone(state.payload.facts);
+    source.api.createFactState = undefined;
+
+    await dispatch(
+      { action: "new-state" }, state, source, createWrapCache(),
+      () => undefined, async () => undefined, () => undefined
+    );
+
+    expect(state.editor).toBeNull();
+    expect(state.facts?.dossier).toEqual({ factId: fact.id, stateIndex: 0, diff: false });
+    expect(state.payload.facts).toEqual(before);
+    expect(state.toast).toBe("state creation requires a newer backend");
+  });
+
+  test("dossier edit refuses a stateful Fact without state PATCH", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const template = state.payload.facts[0]!;
+    const fact = customFact(template, "dossier-edit-old", "dossier edit old", [
+      stateText("base", "Story-wide body."),
+      stateText("branch", "Branch body.", "p12")
+    ]);
+    state.payload = { ...state.payload, facts: [fact] };
+    state.mode = "FACTS";
+    state.facts = {
+      cursor: 0,
+      query: "",
+      chip: 0,
+      selectedTag: null,
+      filtering: false,
+      deleteArmedId: null,
+      scopeFilter: "everywhere",
+      dossier: { factId: fact.id, stateIndex: 1, diff: false }
+    };
+    const before = structuredClone(state.payload.facts);
+    source.api.patchFactState = undefined;
+
+    await dispatch(
+      { action: "edit" }, state, source, createWrapCache(),
+      () => undefined, async () => undefined, () => undefined
+    );
+
+    expect(state.editor).toBeNull();
+    expect(state.facts?.dossier).toEqual({
+      factId: fact.id,
+      stateIndex: 1,
+      diff: false
+    });
+    expect(state.payload.facts).toEqual(before);
+    expect(state.toast).toBe("state editing requires a newer backend");
+  });
+
+  test("dossier state creation refuses chapter summary and divider cursors", async () => {
+    for (const rowKind of ["chapter-summary", "chapter-divider"] as const) {
+      const source = demoAppSource();
+      const state = initialState(source, false);
+      const template = state.payload.facts[0]!;
+      const fact = customFact(template, `dossier-row-${rowKind}`, "dossier row", [
+        stateText("base", "Story-wide body."),
+        stateText("branch", "Branch body.", "p12")
+      ]);
+      state.payload = { ...state.payload, facts: [fact] };
+      const view = createStoryViewModel(state.payload);
+      state.focusIndex = view.rows.findIndex((row) => row.kind === rowKind);
+      expect(state.focusIndex).toBeGreaterThan(-1);
+      state.mode = "FACTS";
+      state.facts = {
+        cursor: 0,
+        query: "",
+        chip: 0,
+        selectedTag: null,
+        filtering: false,
+        deleteArmedId: null,
+        scopeFilter: "everywhere",
+        dossier: { factId: fact.id, stateIndex: 0, diff: false }
+      };
+
+      await dispatch(
+        { action: "new-state" }, state, source, createWrapCache(),
+        () => undefined, async () => undefined, () => undefined
+      );
+
+      expect(state.editor).toBeNull();
+      expect(state.facts?.dossier).toEqual({
+        factId: fact.id,
+        stateIndex: 0,
+        diff: false
+      });
+      expect(state.toast).toBe("select a story part before adding a state");
+    }
+  });
+
+  test("a pending part state action fails closed on an older backend", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const anchorPartId = state.payload.path[0]!.id;
+    state.focusIndex = rowIndexForNode(createStoryViewModel(state.payload), anchorPartId);
+    source.api.createFactState = undefined;
+
+    await runPartAction("fact-new-state", state, source, {
+      cache: createWrapCache(),
+      repaint: () => undefined,
+      backend: new ActionRuntime(state, () => undefined),
+      renderer: null,
+      applyTheme: () => undefined,
+      previewTheme: () => undefined
+    });
+
+    expect(state.mode).toBe("FACTS");
+    expect(state.facts?.pendingFactAction).toEqual({
+      kind: "new-state",
+      anchorPartId
+    });
+    const before = structuredClone(state.payload.facts);
+    await dispatch(
+      { action: "open-selected" }, state, source, createWrapCache(),
+      () => undefined, async () => undefined, () => undefined
+    );
+
+    expect(state.editor).toBeNull();
+    expect(state.mode).toBe("FACTS");
+    expect(state.facts?.pendingFactAction).toEqual({
+      kind: "new-state",
+      anchorPartId
+    });
+    expect(state.payload.facts).toEqual(before);
+    expect(state.toast).toBe("state creation requires a newer backend");
+  });
+
   test("mouse dossier End State uses the story part that opened Facts", async () => {
     const source = demoAppSource();
     const state = initialState(source, false);
@@ -403,6 +708,7 @@ describe("Facts scope chips and dossier", () => {
       action: "cycle-state",
       index: 1
     });
+    expect(resolveKey(key("e"), "FACTS", { factDossier: true }).action).toBe("edit");
     expect(resolveKey(key("n"), "FACTS", { factDossier: true }).action).toBe("new-state");
     expect(resolveKey(key("x"), "FACTS", { factDossier: true }).action).toBe("end-state");
     expect(resolveKey(key("d"), "FACTS", { factDossier: true }).action).toBe("toggle-fact-diff");
@@ -427,6 +733,12 @@ describe("Facts scope chips and dossier", () => {
     expect(endHit).toBeDefined();
     expect(mouseToAction(click(endHit!.hit.left + 1, endHit!.y), state))
       .toEqual({ action: "end-state" });
+    const editHit = state.hitRows
+      .flatMap((row, y) => row?.overrides?.map((hit) => ({ hit, y })) ?? [])
+      .find(({ hit }) => hit.target.kind === "action" && hit.target.action === "edit");
+    expect(editHit).toBeDefined();
+    expect(mouseToAction(click(editHit!.hit.left + 1, editHit!.y), state))
+      .toEqual({ action: "edit" });
     expect(canonicalFactStates(fact)).toHaveLength(1);
   });
 

--- a/tui/test/golden-panels.test.ts
+++ b/tui/test/golden-panels.test.ts
@@ -547,7 +547,7 @@ describe("run C overlay frames", () => {
     expect(frame).toContain("72 ✓ summary");
     expect(frame).toContain("208 raw — no summary");
     expect(frame).toContain("total 884 / 32.8k");
-    expect(frame).toContain("s summarize · e rename · n break · D remove");
+    expect(frame).toContain("r summarize · e rename · n break · D remove");
   });
 
   test("80x24 library and chapters compact without clipping useful fields", async () => {

--- a/tui/test/hit-map-chrome.test.ts
+++ b/tui/test/hit-map-chrome.test.ts
@@ -1218,12 +1218,12 @@ describe("hit map clickable chrome", () => {
       { name: "library", expected: "↑↓ move · ↵ open · n new · e rename · / filter · D delete · esc",
         setup: (state, source) => { state.mode = "LIBRARY"; state.library = { stories: source.stories, cursor: 0, query: "", prompt: null }; } },
       { name: "facts", expected: (width: number) => width < 100
-        ? "↑·↓·tab·↵·/·e·n·s state·x·esc"
-        : "↑↓ · tab · ↵ open · / filter · e edit · n new · s state · x delete · esc",
+        ? "↑·↓·tab·↵·/·e·n·s new state·x·esc"
+        : "↑↓ · tab · ↵ open · / filter · e edit · n new · s new state · x delete · esc",
         setup: (state) => { state.mode = "FACTS"; state.facts = { cursor: 0, query: "", chip: 0, selectedTag: null, filtering: false, deleteArmedId: null }; } },
       { name: "facts confirm", expected: (width) => width < 100
-        ? "↑·↓·tab·↵·/·e·n·s state·x confirms·esc keeps"
-        : "↑↓ · tab · ↵ open · / filter · e edit · n new · s state · x confirms · esc keeps",
+        ? "↑·↓·tab·↵·/·e·n·s new state·x confirms·esc keeps"
+        : "↑↓ · tab · ↵ open · / filter · e edit · n new · s new state · x confirms · esc keeps",
         setup: (state) => { state.mode = "FACTS"; state.facts = { cursor: 0, query: "", chip: 0, selectedTag: null, filtering: false, deleteArmedId: "fact-1" }; } },
       { name: "commands", expected: "↑↓ move · ↵ run · esc close",
         setup: (state) => { state.mode = "COMMANDS"; state.commands = { query: "", cursor: 0, selectedId: null, view: "commands", returnMode: "NAV" }; } },
@@ -1234,8 +1234,8 @@ describe("hit map clickable chrome", () => {
       // Context status moved into the panel, so the footer is actions only and
       // no longer grows with `over`/`fix`.
       { name: "chapters", expected: (width) => width < 100
-        ? "↵ jump · s sum · e rename · n break · D rm · esc"
-        : "↵ jump · s summarize · e rename · n break · D remove · esc",
+        ? "↵ jump · r sum · e rename · n break · D rm · esc"
+        : "↵ jump · r summarize · e rename · n break · D remove · esc",
         setup: (state) => { state.mode = "CHAPTERS"; state.chapters = { cursor: 0, rename: null, deleteArmedId: null }; } },
       // A chapter list longer than the row budget: the panel must still show the
       // context status it moved inside to stop the footer from hiding.
@@ -1247,7 +1247,7 @@ describe("hit map clickable chrome", () => {
             id: `b${index}`, parentPartId: node.id, title: `ch ${index + 1}`, createdAt: "2022-10-25T09:00:00.000Z"
           })) };
         } },
-      { name: "chapters confirm", expected: "↵ jump · s sum · e rename · n break · D confirms · esc keeps",
+      { name: "chapters confirm", expected: "↵ jump · r sum · e rename · n break · D confirms · esc keeps",
         setup: (state) => { state.mode = "CHAPTERS"; state.chapters = { cursor: 0, rename: null, deleteArmedId: "chapter-break-1" }; } },
       { name: "settings",
         expected: "↑↓ move · ←→ choose · ↵ next · s save · c check · m simple · esc",

--- a/tui/test/hit-map.test.ts
+++ b/tui/test/hit-map.test.ts
@@ -81,7 +81,7 @@ const footerCases: FooterCase[] = [
     keys: [key("up"), key("down"), key("return"), key("n"), key("r"), key("/"), key("D"), key("escape")],
     setup: (state, source) => { state.mode = "LIBRARY"; state.library = { stories: source.stories, cursor: 0, query: "", prompt: null }; } },
   { name: "chapters", mode: "CHAPTERS", actions: CHAPTERS_FOOTER_ACTIONS,
-    keys: [key("return"), key("s"), key("e"), key("n"), key("D"), key("escape")],
+    keys: [key("return"), key("r"), key("e"), key("n"), key("D"), key("escape")],
     setup: (state) => { state.mode = "CHAPTERS"; state.chapters = { cursor: 0, rename: null, deleteArmedId: null }; } },
   { name: "commands", mode: "COMMANDS", actions: COMMANDS_FOOTER_ACTIONS,
     keys: [key("return"), key("up"), key("down"), key("escape")],

--- a/tui/test/keys.test.ts
+++ b/tui/test/keys.test.ts
@@ -529,7 +529,10 @@ describe("text surfaces and palette", () => {
   });
 
   test("chapters owns TOC actions and rename text", () => {
-    expect(resolveKey(key("s"), "CHAPTERS").action).toBe("summarize-chapter");
+    expect(resolveKey(key("r"), "CHAPTERS").action).toBe("regenerate");
+    // The former shortcut remains accepted for existing keyboard muscle
+    // memory, but resolves to the same canonical action as the visible `r`.
+    expect(resolveKey(key("s"), "CHAPTERS").action).toBe("regenerate");
     expect(resolveKey(key("e"), "CHAPTERS").action).toBe("rename-item");
     expect(resolveKey(key("d"), "CHAPTERS").action).toBe("none");
     expect(resolveKey(key("D"), "CHAPTERS").action).toBe("delete-item");


### PR DESCRIPTION
## Outcome\n\nMake Fact editing, state actions, and chapter summarization consistent across keyboard and mouse input.\n\n## Changes\n\n- Explain each Fact option in concise language.\n- Show state creation and movement actions for every saved Fact.\n- Use the selected story part as the new state Anchor.\n- Make Fact choice arrows work like Settings with keyboard and mouse input.\n- Block hidden text input while Fact chrome owns focus.\n- Fail closed when an older backend does not support a state mutation.\n- Preserve ordinary edits for legacy flat Facts without changing stored formats.\n- Use r for chapter summarization in both chapter surfaces.\n- Keep s as a hidden compatibility alias.\n- Remove unavailable model progress text while retaining real working and stopping status.\n- Document the state creation and movement workflow.\n\n## Verification\n\n- npm run build\n- npm test: 3,044 tests; 2,815 passed; 229 skipped; 0 failed\n- cd tui and bun run typecheck\n- cd tui and bun run test: all 16 shards passed\n- cd tui and bun run build:standalone\n- cd tui and bun bench/perf.ts: the same six existing budget misses reproduce on unchanged main\n- focused Fact integration tests: 78 passed\n- autoreview: clean, 0 actionable findings\n- thermo-nuclear maintainability review: clean, 0 actionable findings\n- git diff --check\n\n## Risk\n\nThe change touches shared TUI input dispatch and Fact mutation routing. Integration tests cover keyboard, mouse, stale input ownership, current-part anchoring, legacy Fact saves, and unsupported backend paths. Persistence schemas do not change.\n\nTracks #377