### PR TITLE
chore(release): prepare 0.10.6-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ This file records notable changes to 1667. Product terms use the definitions in
 
 ## Unreleased
 
+## 0.10.6-rc.1 - 2026-08-31
+
+- **Fact controls are easier to understand and use.** The Fact editor explains
+  each option in simple English. Choice fields use the same arrow keys and
+  clickable controls as Settings.
+- **You can add, move, and edit Fact States.** Select a story part and press
+  `s` to add a state there. Select a state and press `a` to move it to the
+  current story part. The Facts dossier can open a state for editing. Existing
+  flat Facts continue to work without a store migration.
+- **Chapter summarize now uses `r` everywhere.** The Chapters menu and inline
+  chapter controls use the same key and work with the mouse. 1667 shows model
+  progress only when progress data is available.
+
 ## 0.10.5 - 2026-08-31
 
 - **This release has no additional product changes.** It contains the same

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "1667-workspace",
-  "version": "0.10.5",
+  "version": "0.10.6-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "1667-workspace",
-      "version": "0.10.5",
+      "version": "0.10.6-rc.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@earendil-works/pi-ai": "0.84.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667-workspace",
-  "version": "0.10.5",
+  "version": "0.10.6-rc.1",
   "private": true,
   "description": "Source workspace for the 1667 terminal writing environment",
   "license": "Apache-2.0",

--- a/shared/release-notes.ts
+++ b/shared/release-notes.ts
@@ -11,6 +11,11 @@ export interface ReleaseNote {
  *  a release, and is not included. */
 export const RELEASE_NOTES: readonly ReleaseNote[] = [
   {
+    version: "0.10.6-rc.1",
+    date: "2026-08-31",
+    body: "- **Fact controls are easier to understand and use.** The Fact editor explains\n  each option in simple English. Choice fields use the same arrow keys and\n  clickable controls as Settings.\n- **You can add, move, and edit Fact States.** Select a story part and press\n  `s` to add a state there. Select a state and press `a` to move it to the\n  current story part. The Facts dossier can open a state for editing. Existing\n  flat Facts continue to work without a store migration.\n- **Chapter summarize now uses `r` everywhere.** The Chapters menu and inline\n  chapter controls use the same key and work with the mouse. 1667 shows model\n  progress only when progress data is available."
+  },
+  {
     version: "0.10.5",
     date: "2026-08-31",
     body: "- **This release has no additional product changes.** It contains the same\n  behavior as 0.10.5-rc.3."

--- a/tui/package.json
+++ b/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667",
-  "version": "0.10.5",
+  "version": "0.10.6-rc.1",
   "private": true,
   "description": "A terminal environment for writing fiction with language models",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Outcome

Prepare the first 0.10.6 beta from the merged Fact editor and chapter control changes.

## Changes

- Set the workspace and TUI versions to 0.10.6-rc.1.
- Add concise user-facing release notes.
- Regenerate embedded release notes.

## Verification

- npm run notes:check
- npm run notes:check-version -- 0.10.6-rc.1
- npm run build
- npm test: 3044 tests, 0 failures
- tui: bun run typecheck
- tui: all 16 test shards passed
- tui: bun run build:standalone
- tui: bun bench/perf.ts, all budgets passed

## Risk

Metadata-only release preparation. Product code is identical to merged PR #378.

Tracks #377