### PR TITLE
feat(tui): add global Fact commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ This file records notable changes to 1667. Product terms use the definitions in
 
 ## Unreleased
 
+- **The command palette is available from every screen.** Press `Ctrl+P` from
+  Aside, editors, menus, and full-screen panels. Close the palette to return to
+  the exact screen and input that you were using.
+- **The command palette covers all Fact controls.** Create, edit, end, move,
+  re-anchor, convert, and delete Facts and Fact States. The available commands
+  follow the selected Fact, state, story part, or map row.
+- **The Facts Budget command uses a numeric field.** Enter a token limit, clear
+  the field for no limit, and save with `Enter` or `Ctrl+S`. The field works
+  with the keyboard and mouse.
+
 ## 0.10.6 - 2026-08-31
 
 - **This release has no additional product changes.** It contains the same

--- a/README.md
+++ b/README.md
@@ -160,13 +160,21 @@ applies its subscription limits, terms, and data controls.
 | Copy the selected story part or story line | `y` or `Y` |
 | Undo an added or removed chapter break | `u` |
 | Open the map, facts, chapters, or library | `m`, `f`, `c`, or `o` |
-| Open commands | `Ctrl+P` or `:` |
+| Open commands | `Ctrl+P` from any surface or `:` |
 | Open the request viewer | `Ctrl+R` |
 | Open the token probability viewer | `l` |
 | Open settings or the key reference | `,` or `?` |
 | Quit | `q` |
 
 The `q` key also quits when Aside is open.
+
+Press `Ctrl+P` from every surface to open the command palette. Press `Escape` to
+return to the prior surface. If the command palette is already open, `Ctrl+P`
+keeps it open.
+
+The command palette provides contextual Fact workflows. It shows the Fact
+commands that apply to the current surface, such as opening Facts, adding a
+Fact State, editing a Fact, and using the Map Fact lens.
 
 The keys `h`, `j`, `k`, and `l` do not move between story parts. `l` opens
 the token probability viewer instead. In the map, `l` follows or opens the

--- a/docs/model-providers.md
+++ b/docs/model-providers.md
@@ -13,6 +13,14 @@ read_when:
 
 ## Use Facts and the context meter
 
+Press `Ctrl+P` from every surface to open the command palette. Press `Escape` to
+return to the prior surface. If the command palette is already open, `Ctrl+P`
+keeps it open.
+
+The command palette provides contextual Fact workflows. It shows the Fact
+commands that apply to the current surface, such as opening Facts, adding a
+Fact State, editing a Fact, and using the Map Fact lens.
+
 Press `e` to edit the selected Fact. Double-click a Fact to edit it. For an
 unscoped Fact with one state, `Enter` also opens the editor. For a scoped Fact
 or a Fact with multiple states, `Enter` opens the Fact dossier.
@@ -176,9 +184,14 @@ A story can hold a Facts budget: a limit on the combined estimated token
 count of every Fact in a request. When the total goes over the Facts budget,
 1667 drops the lowest-priority Facts first until the total fits.
 
-Open the command palette and select **facts budget**. Type a whole number of
-tokens, then press `Ctrl+S`. Leave the field empty and press `Ctrl+S` to
-remove the Facts budget.
+Press `Ctrl+P` and select **facts budget**. The editor shows a compact,
+Settings-style field. The field accepts digits only. Type a whole number from
+`1` to `1,000,000` tokens. Press `Enter` or `Ctrl+S` to save. An empty field
+means uncapped.
+
+Click the field to place the cursor. Click `clear` to empty the field. Click
+`enter save` or `ctrl+s save` to save. Click `esc cancel` to close without
+saving.
 
 ### See a Fact's priority
 

--- a/tui/README.md
+++ b/tui/README.md
@@ -58,8 +58,14 @@ The release publishes packages for macOS, Linux, and Windows x64. See
 ## Use the TUI
 
 Use the arrow keys to move between story parts and sibling takes. Press
-`Ctrl+P` or `:` to open the command palette. Press `?` for the complete key
-reference.
+`Ctrl+P` from every surface to open the command palette. In the story view,
+`:` also opens it. Press `Escape` to return to the prior surface. If the
+command palette is already open, `Ctrl+P` keeps it open. Press `?` for the
+complete key reference.
+
+The command palette provides contextual Fact workflows. It shows the Fact
+commands that apply to the current surface, such as opening Facts, adding a
+Fact State, editing a Fact, and using the Map Fact lens.
 
 Press `Ctrl+R` to open the request viewer. The request viewer shows the next
 request plan in provider order. It shows each message and its estimated token

--- a/tui/src/app.ts
+++ b/tui/src/app.ts
@@ -83,11 +83,13 @@ import {
   isCopyShortcut,
   isInterruptShortcut,
   mouseComposerSelectionMessage,
+  storySelectionFromRendererSelection,
   syncMouseComposerSelection
 } from "./copy-actions.js";
 import {
   capturePresentedInputSelection,
   consumePresentedSelection,
+  guardFactsStorySelectionCapture,
   hasCopyablePresentedSelection,
   reconcilePresentedSelection,
   retirePresentedSelection
@@ -98,10 +100,14 @@ import {
   openTextActions,
   textActionsMenuAction
 } from "./text-actions.js";
-import { composerRangeFromProjection } from "./selection-projection.js";
+import {
+  composerRangeFromProjection,
+  type ProjectedStorySelection
+} from "./selection-projection.js";
 import { canClaimAsideComposer, claimAsideComposer } from "./aside-surface.js";
 import { pastePlainTextFromClipboard } from "./plain-text-paste.js";
 import { applyTerminalPaste } from "./terminal-paste.js";
+import { finalizeDispatch } from "./dispatch-finalization.js";
 
 export { recoveryNotice } from "./recovery-orchestration.js";
 
@@ -411,9 +417,10 @@ export async function runInteractive(source: AppSource): Promise<void> {
   onPresentationFailure = inputs.presentationFailed;
   let latestSelectionCapture: ReturnType<typeof capturePresentedInputSelection> | null = null;
   const captureQueuedSelection = () => {
-    latestSelectionCapture = capturePresentedInputSelection(
-      renderer, presentedInteraction, latestSelectionCapture, frames.failed
-    );
+    const previous = latestSelectionCapture;
+    latestSelectionCapture = guardFactsStorySelectionCapture(capturePresentedInputSelection(
+      renderer, presentedInteraction, previous, frames.failed
+    ), previous);
     return latestSelectionCapture;
   };
 
@@ -444,6 +451,21 @@ export async function runInteractive(source: AppSource): Promise<void> {
       const native = selection.kind === "captured"
         ? selection.native ?? EMPTY_NATIVE_SELECTION
         : EMPTY_NATIVE_SELECTION;
+      // The native range is cleared before dispatch. Preserve its projected
+      // story selection for Ctrl-P while it still belongs to this frame.
+      const capturedStorySelection: ProjectedStorySelection | null =
+        selection.kind === "captured"
+          ? storySelectionFromRendererSelection(selection.native, selection.story)
+          : null;
+      // A new Facts-panel drag owns the native range. It must not revive the
+      // selection retained when Facts opened from NAV.
+      if (state.mode === "FACTS"
+        && selection.kind === "captured"
+        && selection.native !== null
+        && capturedStorySelection === null
+        && state.facts !== null) {
+        state.facts.storySelection = null;
+      }
       if (copyShortcut) {
         const copied = handleMainCopyShortcut(
           native,
@@ -503,7 +525,8 @@ export async function runInteractive(source: AppSource): Promise<void> {
         renderer,
         applyTheme,
         previewTheme,
-        withActionAdmission(backend, admit)
+        withActionAdmission(backend, admit),
+        capturedStorySelection
       ), (work) => backend.observe(work));
     }, () => {
       retirePresentedSelection(renderer, queuedSelection);
@@ -562,12 +585,17 @@ export async function runInteractive(source: AppSource): Promise<void> {
       stillPresented: (captured) => captured === presentedInteraction,
       decorate: (resolved, gesture, presented) => {
         const interaction = presented as InteractivePresentedInteraction;
-        const partAction = selectionAwarePartMenuAction(
-          gesture as never,
-          resolved,
-          renderer,
-          interaction.storySelectionProjection
-        );
+        // FACTS retains the NAV projection only for the keyboard capture that
+        // proves the same native range. A fresh mouse range belongs to the
+        // panel, so it must not be translated into an underlying story span.
+        const partAction = interaction.state.mode === "FACTS"
+          ? resolved
+          : selectionAwarePartMenuAction(
+              gesture as never,
+              resolved,
+              renderer,
+              interaction.storySelectionProjection
+            );
         return selectionAwareTextMenuAction(
           gesture as never,
           partAction,
@@ -632,7 +660,8 @@ export async function handleKey(
   renderer: ActionContext["renderer"] = null,
   applyTheme: ActionContext["applyTheme"] = () => undefined,
   previewTheme: ActionContext["previewTheme"] = () => undefined,
-  backend: ActionRunner = new ActionRuntime(state, repaint)
+  backend: ActionRunner = new ActionRuntime(state, repaint),
+  capturedStorySelection: ProjectedStorySelection | null | undefined = undefined
 ): Promise<void> {
   if (isCopyShortcut(key)
     && state.mode !== "EDITOR"
@@ -678,7 +707,7 @@ export async function handleKey(
       && state.map.factLensFactId !== null
   });
   return await dispatch(resolved, state, source, wrapCache, repaint, cancelStream, requestQuit,
-    renderer, applyTheme, previewTheme, backend);
+    renderer, applyTheme, previewTheme, backend, capturedStorySelection);
 }
 
 /** Everything after key resolution — shared by the keyboard and the mouse. */
@@ -693,9 +722,20 @@ export async function dispatch(
   renderer: ActionContext["renderer"] = null,
   applyTheme: ActionContext["applyTheme"] = () => undefined,
   previewTheme: ActionContext["previewTheme"] = () => undefined,
-  backend: ActionRunner = new ActionRuntime(state, repaint)
+  backend: ActionRunner = new ActionRuntime(state, repaint),
+  capturedStorySelection: ProjectedStorySelection | null | undefined = undefined
 ): Promise<void> {
   const previousMode = state.mode;
+  const context: ActionContext = {
+    cache: wrapCache, repaint, backend, renderer, applyTheme, previewTheme
+  };
+  // Ctrl-P is a global palette escape hatch. Route it before transient menus
+  // and confirmations so those owners remain intact for Esc restoration.
+  if (resolved.action === "open-commands") {
+    await handleOverlayAction(resolved, state, source, context, capturedStorySelection);
+    finalizeDispatch(previousMode, state, renderer, repaint);
+    return;
+  }
   if (state.chapterSummary !== null && resolved.action === "cancel"
     && state.textActions === null
     && (isPlainNavigation(state) || state.mode === "CHAPTERS")) {
@@ -735,9 +775,6 @@ export async function dispatch(
     state.toast = `Chapter ${chapterWord(state.chapterSummary.chapterNumber)} summary running · esc cancels`;
     return repaint();
   }
-  const context: ActionContext = {
-    cache: wrapCache, repaint, backend, renderer, applyTheme, previewTheme
-  };
   // Recovery belongs to the connection banner, above transient part menus
   // and confirmations. Those surfaces stay open while retry runs; otherwise
   // their reducers would swallow the banner's advertised keyboard/click action.
@@ -782,6 +819,14 @@ export async function dispatch(
       sync === "uneditable"
     );
   }
+  else if (resolved.action === "paste-clipboard"
+    && await pastePlainTextFromClipboard(state, source, context)) { /* handled */ }
+  // The palette suspends the current menu/editor, so it must own every key
+  // after opening as well as the Ctrl-P opener. Otherwise an ACTIONS, prune,
+  // or text-actions owner underneath it can swallow palette typing.
+  else if (state.mode === "COMMANDS" && state.commands !== null) {
+    await handleOverlayAction(resolved, state, source, context);
+  }
   else if (state.textActions !== null) {
     const overlay = state.textActions;
     const action = textActionsMenuAction(resolved, state);
@@ -810,9 +855,7 @@ export async function dispatch(
   }
   else if (state.prune !== null) await pruneAction(resolved, state, source, context);
   else if (state.actions !== null) await actionsMenuAction(resolved, state, source, context);
-  else if (resolved.action === "paste-clipboard"
-    && await pastePlainTextFromClipboard(state, source, context)) { /* handled */ }
-  else if (await handleOverlayAction(resolved, state, source, context)) { /* handled */ }
+  else if (await handleOverlayAction(resolved, state, source, context, capturedStorySelection)) { /* handled */ }
   else if (resolved.action === "toggle-context-meter" && (state.mode === "NAV" || state.mode === "COMPOSE")) {
     state.contextMeterExpanded = !state.contextMeterExpanded;
   }
@@ -828,19 +871,7 @@ export async function dispatch(
   else if (state.mode === "EDITOR") await inlineEditorAction(resolved, state, source, context);
   else if (state.mode === "NAV" && await directChapterRowAction(resolved, state, source, context)) { /* handled */ }
   else await navAction(resolved, state, source, context, requestQuit);
-  // Native buffer offsets must not leak between the story, Direct, and the
-  // full-screen editor when their rendered document changes.
-  const previousTextSurface = previousMode === "COMPOSE"
-    || previousMode === "EDITOR"
-    || previousMode === "ASIDE";
-  const currentTextSurface = state.mode === "COMPOSE"
-    || state.mode === "EDITOR"
-    || state.mode === "ASIDE";
-  if (state.mode !== previousMode && (previousTextSurface || currentTextSurface)) {
-    renderer?.clearSelection();
-  }
-  recordSessionNotices(state);
-  repaint();
+  finalizeDispatch(previousMode, state, renderer, repaint);
 }
 
 export function initialState(source: AppSource, renderMode: boolean): RuntimeState {

--- a/tui/src/archive-import-actions.ts
+++ b/tui/src/archive-import-actions.ts
@@ -7,6 +7,7 @@ import type { ResolvedKey } from "./keys.js";
 import { recordNotice } from "./notice-log.js";
 import { publishStories } from "./overlay-publication.js";
 import { adoptSameStoryPayload, adoptStoryState } from "./story-adoption.js";
+import { paletteSessionReturningTo, restorePaletteSession, settleModeUnderPalette } from "./palette-owner.js";
 import type { ArchiveImportPrompt, RuntimeState } from "./state.js";
 
 export function openArchiveImport(
@@ -114,7 +115,17 @@ async function applyArchiveImport(
         ? await source.api.importScenario(text)
         : await source.api.importNovelAI(text);
       if (!task.storyCurrent()) return;
+      const palette = paletteSessionReturningTo(state, "ARCHIVE");
       adoptStoryState(state, payload, context.cache);
+      if (palette !== null) {
+        // A different-story adoption clears every story-bound surface,
+        // including the palette. Keep Ctrl-P visible, with Esc returning to
+        // the settled story's NAV surface. Its captured selection names the
+        // old story and must not cross this boundary.
+        palette.selection = null;
+        palette.deleteArmedTagNodeId = null;
+        restorePaletteSession(state, palette, "NAV");
+      }
       adopted = true;
       state.toast = `new story · ${payload.nodes.length} ${countNoun(payload.nodes.length, "part")}`
         + ` · ${payload.facts.length} ${countNoun(payload.facts.length, "fact")}`;
@@ -126,8 +137,8 @@ async function applyArchiveImport(
     });
     if (ran && adopted) {
       if (state.archive === overlay) {
+        settleModeUnderPalette(state, "ARCHIVE", overlay.returnMode);
         state.archive = null;
-        state.mode = overlay.returnMode;
       }
     } else if (!ran && overlay.error === null) {
       overlay.error = "another task is running · start the import again";
@@ -147,4 +158,3 @@ function archiveRoute(value: string): "facts" | "scenario" | "story" | null {
   if (lower.endsWith(".json")) return "facts";
   return null;
 }
-

--- a/tui/src/aside-actions.ts
+++ b/tui/src/aside-actions.ts
@@ -37,6 +37,7 @@ import {
 import { noteCursorAfterHistoryScroll } from "./aside-note-scroll.js";
 import type { RuntimeState } from "./state.js";
 import { adoptSameStoryPayload } from "./story-adoption.js";
+import { retargetPaletteSession } from "./palette-owner.js";
 import { createTextPresentation, drainTextPresentation } from "./text-presentation.js";
 import { createStoryViewModel, rowPart } from "./model.js";
 import { persistablePartId } from "./reading-position.js";
@@ -552,6 +553,24 @@ export function noteAsideDisplayScroll(state: RuntimeState): void {
   }
 }
 
+/** Keep an in-flight Ask's restore fence behind palette-only interaction.
+ * The palette suspends Aside, so its typing, movement, and Escape do not edit
+ * the cleared question. A real Aside composer interaction still advances the
+ * shared epoch and remains fenced normally. */
+export function noteAsidePaletteInteraction(state: RuntimeState): void {
+  const active = state.abort?.kind === "generation" ? state.abort : null;
+  if (state.mode !== "COMMANDS"
+    || state.commands?.returnMode !== "ASIDE"
+    || state.aside?.busy !== true
+    || active?.asideAsk === undefined
+    || active.askInteractionVersion === undefined) return;
+  if (active.stopInteractionVersion !== null) {
+    active.stopInteractionVersion = state.interactionVersion;
+    return;
+  }
+  active.askInteractionVersion = state.interactionVersion;
+}
+
 export async function openAside(
   state: RuntimeState,
   api: StoryApi,
@@ -567,6 +586,9 @@ export async function openAside(
   }
   const requestedStoryId = state.payload.id;
   const requestedInteractionVersion = state.interactionVersion;
+  // Ctrl-P can open while the read is pending. Capture the palette identity
+  // now so a palette created during this load can survive the settlement.
+  const paletteSessionAtOpen = state.commands;
   // Capture before the load await so a focus change while getAside is pending
   // cannot move Placement's initial stop off the Part the writer invoked on.
   // Summary/divider NAV rows have no rowPart; persistablePartId maps them to a
@@ -653,8 +675,21 @@ export async function openAside(
       openingPartId
     );
   }
-  state.mode = "ASIDE";
-  state.commands = null;
+  // A newer Ctrl-P session may have opened while the document was loading.
+  // Keep that session visible and make Escape return to the newly opened
+  // Aside. A normal open, or the original palette with no replacement, still
+  // enters Aside directly.
+  const newerPalette = state.commands !== null
+    && state.commands !== paletteSessionAtOpen
+    ? state.commands
+    : null;
+  if (newerPalette !== null) {
+    retargetPaletteSession(state, newerPalette, "ASIDE");
+    state.mode = "COMMANDS";
+  } else {
+    state.mode = "ASIDE";
+    state.commands = null;
+  }
   return true;
 }
 
@@ -736,11 +771,11 @@ export async function sendAsideQuestion(
   api: StoryApi,
   question: string,
   options: AsideAskOptions = {}
-): Promise<void> {
+): Promise<boolean> {
   const surface = state.aside;
-  if (surface === null || surface.busy || state.abort !== null) return;
+  if (surface === null || surface.busy || state.abort !== null) return false;
   const trimmed = question.trim();
-  if (trimmed.length === 0) return;
+  if (trimmed.length === 0) return false;
   const owns = options.task?.owns ?? (() => true);
   const storyCurrent = options.task?.storyCurrent ?? (() => true);
   const interactionCurrent = options.task?.interactionCurrent ?? (() => true);
@@ -847,9 +882,9 @@ export async function sendAsideQuestion(
         controller.signal
       );
     }
-    if (!current()) return;
+    if (!current()) return false;
     if (surface.presentation !== undefined) await drainTextPresentation(surface.presentation);
-    if (!current()) return;
+    if (!current()) return false;
     if (result === null) {
       // Cancelled or stopped: return the question to the input.
       const restore = mayRestore();
@@ -858,7 +893,7 @@ export async function sendAsideQuestion(
       clearAsideStream(surface);
       if (restore && !preserveScroll) surface.scrollTop = null;
       surface.busy = false;
-      return;
+      return false;
     }
     const preserveScroll = isAsideV2(surface) && surface.scrollTop !== null;
     applyAsideResult(surface, result);
@@ -891,8 +926,9 @@ export async function sendAsideQuestion(
     if (controller.signal.aborted) {
       state.toast = "Aside stopped · answer kept";
     }
+    return true;
   } catch (error) {
-    if (!current()) return;
+    if (!current()) return false;
     const restore = mayRestore();
     const preserveScroll = isAsideV2(surface) && surface.scrollTop !== null;
     if (restore && !active.asideAsk.restored) setComposerText(surface.composer, trimmed);
@@ -900,6 +936,7 @@ export async function sendAsideQuestion(
     if (restore && !preserveScroll) surface.scrollTop = null;
     surface.busy = false;
     state.toast = error instanceof Error ? error.message : String(error);
+    return false;
   } finally {
     if (state.abort === active) state.abort = null;
     if (current()) repaint();

--- a/tui/src/aside-overlay-actions.ts
+++ b/tui/src/aside-overlay-actions.ts
@@ -212,13 +212,13 @@ export async function asideKeyAction(
       if (!isAsideV2(surface)) surface.confirmClear = true;
       return;
     }
-    context.backend.observe(context.backend.run("asking Aside", (task) =>
-      sendAsideQuestion(state, source.api, text, {
+    context.backend.observe(context.backend.run("asking Aside", async (task) => {
+      await sendAsideQuestion(state, source.api, text, {
         task,
         repaint: context.repaint,
         cache: context.cache
-      })
-    ));
+      });
+    }));
     return;
   }
   if (resolved.action === "newline") {

--- a/tui/src/aside-placement-settle.ts
+++ b/tui/src/aside-placement-settle.ts
@@ -10,6 +10,7 @@ import {
   rowPart
 } from "./model.js";
 import type { RuntimeState } from "./state.js";
+import { settleModeUnderPalette } from "./palette-owner.js";
 import { followStoryViewport } from "./viewport-intent.js";
 
 /**
@@ -22,9 +23,9 @@ export function completePlacementLanding(
   landedId: string | null,
   partNumber: number
 ): void {
+  settleModeUnderPalette(state, "PLACE", "NAV");
   state.placement = null;
   state.unresolvedPlacement = null;
-  state.mode = "NAV";
   reportPlacedPart(state, payload, landedId, partNumber, true);
 }
 
@@ -83,7 +84,9 @@ export function trySettlePlacementFromPayload(
   // Uncertain recovery: exact path text + instruction only (no stub approx).
   const landed = findSubmittedPlacementNode(payload, candidate);
   if (landed === undefined) return false;
-  const activePlacement = state.mode === "PLACE" && state.placement !== null;
+  const activePlacement = state.placement !== null
+    && (state.mode === "PLACE"
+      || state.mode === "COMMANDS" && state.commands?.returnMode === "PLACE");
   if (activePlacement) {
     completePlacementLanding(state, payload, landed.id, candidate.partNumber);
   } else {

--- a/tui/src/aside-v2-actions.ts
+++ b/tui/src/aside-v2-actions.ts
@@ -24,6 +24,7 @@ import type { ResolvedKey } from "./keys.js";
 import type { RuntimeState } from "./state.js";
 import { asideUseActions } from "./aside-use.js";
 import { adoptSameStoryPayload } from "./story-adoption.js";
+import { settleModeUnderPalette } from "./palette-owner.js";
 import { recordNotice } from "./notice-log.js";
 import { saveConfig } from "./config.js";
 import type { ReasoningDelta } from "./worker-pending.js";
@@ -776,7 +777,7 @@ export async function asideV2KeyAction(
       }
       surface.busy = false;
       state.aside = null;
-      state.mode = "NAV";
+      settleModeUnderPalette(state, "ASIDE", "NAV");
     }));
     return true;
   }

--- a/tui/src/card-import-actions.ts
+++ b/tui/src/card-import-actions.ts
@@ -7,6 +7,7 @@ import { readImportBytes } from "../../server/import-file.js";
 import type { ResolvedKey } from "./keys.js";
 import { recordNotice } from "./notice-log.js";
 import { adoptSameStoryPayload } from "./story-adoption.js";
+import { settleModeUnderPalette } from "./palette-owner.js";
 import type { CardImportPrompt, RuntimeState } from "./state.js";
 import { fidelityReport } from "../../shared/fidelity.js";
 
@@ -99,8 +100,8 @@ async function applyCardImport(
     // closure has run.
     const finishedPlan = plan as CardImportPlan | null;
     if (ran && adopted && finishedPlan !== null && state.card === overlay) {
+      settleModeUnderPalette(state, "CARD", overlay.returnMode);
       state.card = null;
-      state.mode = overlay.returnMode;
       const headline = `imported ${describeCardImport(finishedPlan)}`;
       if (finishedPlan.fidelity.length === 0) {
         state.toast = headline;
@@ -122,4 +123,3 @@ async function applyCardImport(
     overlay.error = errorMessage(error);
   }
 }
-

--- a/tui/src/command-model.ts
+++ b/tui/src/command-model.ts
@@ -3,6 +3,7 @@ import { imageInputEntryPointsOpen } from "../../shared/image-input-release.js";
 import { asideEntryPointsOpen } from "../../shared/aside-release.js";
 import { THEME_NAMES, type ThemeName } from "./config.js";
 import { fuzzyMatch } from "./fuzzy.js";
+import { FACT_COMMAND_DEFINITIONS } from "./facts-command-catalog.js";
 import {
   SETTINGS_COMMAND_DEFINITIONS,
   type SettingsCommandId,
@@ -13,7 +14,18 @@ export type CommandSectionId = "suggested" | "story" | "take" | "view" | "system
 export type CommandId =
   | "export" | "summary" | "tag-line"
   | "switch-story" | "rename-story" | "folder" | "autoname" | "import-card" | "import-archive"
-  | "authors-note" | "author-brief" | "facts-budget" | "phrase-bias" | "banned-strings"
+  | "authors-note" | "author-brief" | "facts" | "new-fact" | "new-fact-from-here"
+  | "new-fact-from-selection" | "edit-fact" | "new-fact-state" | "end-fact-here"
+  | "facts-open-selected" | "facts-filter" | "facts-cycle-tag" | "facts-clear-filter"
+  | "facts-cycle-scope" | "facts-delete"
+  | "facts-move-up" | "facts-move-down" | "facts-open-anchor" | "facts-edit-state"
+  | "facts-dossier-previous-state" | "facts-dossier-next-state" | "facts-toggle-diff"
+  | "facts-budget" | "phrase-bias" | "banned-strings"
+  | "fact-editor-toggle-view" | "fact-editor-previous-state" | "fact-editor-next-state"
+  | "fact-editor-new-state" | "fact-editor-open-anchor" | "fact-editor-reanchor-state"
+  | "fact-editor-convert-state" | "fact-editor-delete-state"
+  | "map-open-fact-lens" | "map-cycle-fact-lens" | "map-close-fact-lens"
+  | "map-open-fact-lens-anchor" | "map-edit-fact-lens"
   | "aside"
   | "direct-take" | "retake" | "rewrite-selection" | "prune" | "attach-image"
   | "tags" | "chapters" | "chapter" | "prompts"
@@ -83,6 +95,33 @@ export interface CommandPaletteContext {
   canRewriteSelection: boolean;
   /** Test seam for release-gated commands. Production uses the build switch. */
   asideEntryPointsOpen?: boolean;
+  /** A story part is focused and can be used as a Fact anchor. */
+  hasStoryPart?: boolean;
+  /** A story selection captured at palette open time can seed a new Fact. */
+  hasStorySelection?: boolean;
+  /** The suspended editor is a Fact editor. */
+  factEditor?: boolean;
+  /** The Fact editor owns a persisted state strip. */
+  factEditorStateful?: boolean;
+  /** The Fact editor currently has a selectable saved/created state. */
+  factEditorHasState?: boolean;
+  /** The Fact editor is creating a state draft. */
+  factEditorStateCreating?: boolean;
+  /** The selected Fact State has a story anchor that can be opened. */
+  factEditorCanOpenAnchor?: boolean;
+  /** The selected Fact State can be deleted through the existing reducer. */
+  factEditorCanDeleteState?: boolean;
+  /** Facts list/dossier is the suspended panel behind the palette. */
+  factsPanel?: boolean;
+  factsDossier?: boolean;
+  factsFiltering?: boolean;
+  factsHasFilter?: boolean;
+  factsSelected?: boolean;
+  factsCanMoveUp?: boolean;
+  factsCanMoveDown?: boolean;
+  /** The map owns the suspended Fact lens. */
+  mapTree?: boolean;
+  mapFactLens?: boolean;
 }
 
 const DEFAULT_CONTEXT: CommandPaletteContext = {
@@ -90,7 +129,24 @@ const DEFAULT_CONTEXT: CommandPaletteContext = {
   requestActive: false,
   hasProse: true,
   lineTagged: false,
-  canRewriteSelection: false
+  canRewriteSelection: false,
+  hasStoryPart: false,
+  hasStorySelection: false,
+  factEditor: false,
+  factEditorStateful: false,
+  factEditorHasState: false,
+  factEditorStateCreating: false,
+  factEditorCanOpenAnchor: false,
+  factEditorCanDeleteState: false,
+  factsPanel: false,
+  factsDossier: false,
+  factsFiltering: false,
+  factsHasFilter: false,
+  factsSelected: false,
+  factsCanMoveUp: false,
+  factsCanMoveDown: false,
+  mapTree: false,
+  mapFactLens: false
 };
 
 const SECTIONS: ReadonlyArray<{ id: CommandSectionId; label: string }> = [
@@ -115,7 +171,8 @@ const COMMANDS: readonly PaletteCommand[] = [
   { id: "import-card", section: "story", name: "import character card", description: "add a card's fields as Facts", mutating: true },
   { id: "authors-note", section: "story", name: "author's note", description: "steer the next passage with style, tone, or current truth", shortcut: "n", mutating: true },
   { id: "author-brief", section: "story", name: "author brief", description: "override the machine-wide author brief for this story", mutating: true },
-  { id: "facts-budget", section: "story", name: "facts budget", description: "cap the combined estimated tokens every Fact spends in a request", mutating: true },
+  ...FACT_COMMAND_DEFINITIONS,
+  { id: "facts-budget", section: "story", name: "facts budget", description: "cap the combined estimated tokens every Fact spends in a request", mutating: true, requires: (context) => context.factEditor !== true },
   { id: "phrase-bias", section: "story", name: "phrase bias", description: "bias phrases for this story only, adding to the profile's own", mutating: true },
   { id: "banned-strings", section: "story", name: "banned strings", description: "ban strings for this story only, adding to the profile's own", mutating: true },
   {
@@ -179,6 +236,23 @@ export function commandContext(
     requestActive: boolean;
     canRewriteSelection: boolean;
     asideEntryPointsOpen?: boolean;
+    hasStoryPart?: boolean;
+    hasStorySelection?: boolean;
+    factEditor?: boolean;
+    factEditorStateful?: boolean;
+    factEditorHasState?: boolean;
+    factEditorStateCreating?: boolean;
+    factEditorCanOpenAnchor?: boolean;
+    factEditorCanDeleteState?: boolean;
+    factsPanel?: boolean;
+    factsDossier?: boolean;
+    factsFiltering?: boolean;
+    factsHasFilter?: boolean;
+    factsSelected?: boolean;
+    factsCanMoveUp?: boolean;
+    factsCanMoveDown?: boolean;
+    mapTree?: boolean;
+    mapFactLens?: boolean;
   }
 ): CommandPaletteContext {
   const leafId = payload.path.at(-1)?.id ?? null;
@@ -188,7 +262,24 @@ export function commandContext(
     hasProse: payload.path.length > 0,
     lineTagged: leafId !== null && payload.tags.some((tag) => tag.nodeId === leafId),
     canRewriteSelection: context.canRewriteSelection,
-    asideEntryPointsOpen: context.asideEntryPointsOpen
+    asideEntryPointsOpen: context.asideEntryPointsOpen,
+    hasStoryPart: context.hasStoryPart ?? payload.path.length > 0,
+    hasStorySelection: context.hasStorySelection ?? false,
+    factEditor: context.factEditor ?? false,
+    factEditorStateful: context.factEditorStateful ?? false,
+    factEditorHasState: context.factEditorHasState ?? false,
+    factEditorStateCreating: context.factEditorStateCreating ?? false,
+    factEditorCanOpenAnchor: context.factEditorCanOpenAnchor ?? false,
+    factEditorCanDeleteState: context.factEditorCanDeleteState ?? false,
+    factsPanel: context.factsPanel ?? false,
+    factsDossier: context.factsDossier ?? false,
+    factsFiltering: context.factsFiltering ?? false,
+    factsHasFilter: context.factsHasFilter ?? false,
+    factsSelected: context.factsSelected ?? false,
+    factsCanMoveUp: context.factsCanMoveUp ?? false,
+    factsCanMoveDown: context.factsCanMoveDown ?? false,
+    mapTree: context.mapTree ?? false,
+    mapFactLens: context.mapFactLens ?? false
   };
 }
 

--- a/tui/src/dispatch-finalization.ts
+++ b/tui/src/dispatch-finalization.ts
@@ -1,0 +1,29 @@
+import { recordSessionNotices } from "./notice-log.js";
+import type { ActionContext } from "./story-actions.js";
+import type { RuntimeState } from "./state.js";
+
+export function finalizeDispatch(
+  previousMode: RuntimeState["mode"],
+  state: RuntimeState,
+  renderer: ActionContext["renderer"],
+  repaint: () => void
+): void {
+  if (previousMode === "FACTS" && state.mode !== "FACTS" && state.mode !== "COMMANDS"
+    && state.facts !== null
+    && "storySelection" in state.facts) {
+    state.facts.storySelection = null;
+  }
+  // Native buffer offsets must not leak between the story, Direct, and the
+  // full-screen editor when their rendered document changes.
+  const previousTextSurface = previousMode === "COMPOSE"
+    || previousMode === "EDITOR"
+    || previousMode === "ASIDE";
+  const currentTextSurface = state.mode === "COMPOSE"
+    || state.mode === "EDITOR"
+    || state.mode === "ASIDE";
+  if (state.mode !== previousMode && (previousTextSurface || currentTextSurface)) {
+    renderer?.clearSelection();
+  }
+  recordSessionNotices(state);
+  repaint();
+}

--- a/tui/src/editor-action.ts
+++ b/tui/src/editor-action.ts
@@ -39,6 +39,7 @@ import {
 import type { ResolvedKey } from "./keys.js";
 import { createStoryViewModel, rowIndexForNode } from "./model.js";
 import { rebaseSelectedState } from "./editor-reconciliation.js";
+import { settleModeUnderPalette } from "./palette-owner.js";
 import { adoptSameStoryPayload } from "./story-adoption.js";
 import { storyScalarFieldSpec } from "./story-scalar-fields.js";
 import type {
@@ -51,7 +52,7 @@ import type { ActionContext } from "./action-context.js";
 import { textHash } from "./api.js";
 import { findCreatedTake } from "./created-take.js";
 import { rememberFocus } from "./reading-position-persist.js";
-import { setComposerText } from "./composer-model.js";
+import { moveComposerTo, setComposerText } from "./composer-model.js";
 import {
   applyWritingPromptDraft,
   settingsDraftChanged
@@ -59,11 +60,13 @@ import {
 import { writingPromptFieldDefinitionForRow } from "../../shared/settings-v5-writing.js";
 import { toggleFactEditorViewMode } from "./settings-view-mode.js";
 import { canonicalFactStates, firstFactText, isFactEndState, isFactStateful } from "../../shared/fact-state.js";
+import { isFactsBudgetEditor } from "./facts-budget-editor.js";
 
 export {
   openChapterSummaryEditor,
   openFactEditor,
   openFactStateEditor,
+  factEditorCursorAnchorId,
   openFactFromSelection,
   openAuthorsNoteEditor,
   openAuthorBriefEditor,
@@ -94,6 +97,13 @@ export async function inlineEditorAction(
     // action continues through the Fact reducer.
     if (source === null && resolved.action !== "take-previous" && resolved.action !== "take-next") return;
     if (resolved.action === "compose") return;
+  }
+
+  if (isFactsBudgetEditor(editor)
+    && resolved.action === "compose"
+    && resolved.composerCursor !== undefined) {
+    moveComposerTo(editor.composer, resolved.composerCursor);
+    return;
   }
 
   // Author's Note grammar owns the depth control, the same way the Fact
@@ -168,6 +178,12 @@ export async function inlineEditorAction(
     && handleFactEditorHistory(resolved, state, editor)) {
     return;
   }
+  // Facts Budget is a one-line scalar. Enter commits it, matching the Settings
+  // field behavior; every other document editor keeps Enter as a newline.
+  if (isFactsBudgetEditor(editor) && resolved.action === "newline") {
+    await saveInlineEditor(state, source, context, editor, "default");
+    return;
+  }
   const motion = composerMotion(
     state.config.wordWrap === "on",
     () => Math.max(1, (context.renderer?.width ?? 80) - 4)
@@ -227,25 +243,27 @@ function closeInlineEditor(
   toast?: string
 ): void {
   if (state.editor !== editor) return;
+  const nextMode = editor.returnMode === "FACTS" && state.facts !== null
+    ? "FACTS"
+    : editor.returnMode === "MAP" && state.map !== null
+    ? "MAP"
+    : editor.returnMode === "SETTINGS"
+    && editor.kind === "document"
+    && editor.target.kind === "settings-prompt"
+    && state.settings === editor.target.owner
+    ? "SETTINGS"
+    : "NAV";
+  if (nextMode === "SETTINGS"
+    && editor.kind === "document"
+    && editor.target.kind === "settings-prompt"
+    && !settingsDraftChanged(editor.target.owner)) {
+    editor.target.owner.conflict = null;
+  }
   state.textActions = null;
   state.editor = null;
   state.editorScrollTop = 0;
   state.editorScrollDetached = false;
-  if (editor.returnMode === "FACTS" && state.facts !== null) {
-    state.mode = "FACTS";
-  } else if (editor.returnMode === "MAP" && state.map !== null) {
-    state.mode = "MAP";
-  } else if (editor.returnMode === "SETTINGS"
-    && editor.kind === "document"
-    && editor.target.kind === "settings-prompt"
-    && state.settings === editor.target.owner) {
-    if (!settingsDraftChanged(editor.target.owner)) {
-      editor.target.owner.conflict = null;
-    }
-    state.mode = "SETTINGS";
-  } else {
-    state.mode = "NAV";
-  }
+  settleModeUnderPalette(state, "EDITOR", nextMode);
   if (toast !== undefined) state.toast = toast;
 }
 

--- a/tui/src/editor-open.ts
+++ b/tui/src/editor-open.ts
@@ -74,7 +74,7 @@ export interface FactEditorOpenOptions {
  * Facts keep that story-row focus while their overlay is open; the Map lens
  * owns its own selected tree node. Pending and summary rows are not valid
  * Fact anchors, so they fail closed instead of leaking a non-persisted id. */
-function factEditorCursorAnchorId(
+export function factEditorCursorAnchorId(
   state: RuntimeState,
   returnMode: FactEditorOpenOptions["returnMode"]
 ): string | null {
@@ -137,7 +137,13 @@ export function openFactEditor(
       stateAnchorPartId: stateCreating
         ? options.anchorPartId ?? null
         : selectedState?.anchorPartId ?? null,
-      stateCursorAnchorId: factEditorCursorAnchorId(state, returnMode),
+      // A newly-created state already has an explicit anchor supplied by its
+      // entry point. Keep that same anchor for later re-anchor actions; the
+      // Map may have been released while Facts was selecting the Fact.
+      stateCursorAnchorId: stateCreating && options.anchorPartId !== null
+        && options.anchorPartId !== undefined
+        ? options.anchorPartId
+        : factEditorCursorAnchorId(state, returnMode),
       stateInitialId: stateCreating ? null : selectedState?.id ?? null,
       stateInitialAnchorPartId: stateCreating
         ? options.anchorPartId ?? null
@@ -189,7 +195,11 @@ export function openFactStateEditor(
   });
 }
 
-export function openFactFromSelection(state: RuntimeState, text: string): void {
+export function openFactFromSelection(
+  state: RuntimeState,
+  text: string,
+  options: Pick<FactEditorOpenOptions, "returnMode"> = {}
+): void {
   const composer = createComposer(text);
   if (text.length > 0) composer.anchor = 0;
   const editor: Omit<FactEditorSession, "kind"> = {
@@ -213,7 +223,7 @@ export function openFactFromSelection(state: RuntimeState, text: string): void {
     initialFact: EMPTY_FACT_DRAFT,
     title: "new fact from selection",
     placeholder: "fact text…",
-    returnMode: "NAV",
+    returnMode: options.returnMode ?? "NAV",
     conflict: null
   };
   initializeFactEditorHistory(editor);
@@ -258,6 +268,17 @@ export function openAuthorBriefEditor(state: RuntimeState): void {
 /** The story's total Facts budget. Its text field follows the same "empty
  *  means unset" convention as the per-Fact budget field. */
 export function openFactsBudgetEditor(state: RuntimeState): void {
+  // The command palette is global, including while an editor is open. Keep
+  // that draft intact rather than replacing the only editor slot with a
+  // story scalar session. `runCommand` has already returned to NAV by the
+  // time this guard runs, so restore the editor route for the refusal.
+  if (state.editor !== null) {
+    state.mode = "EDITOR";
+    state.toast = state.editor.kind === "fact"
+      ? "save or cancel this Fact before opening facts budget"
+      : "save or cancel this editor before opening facts budget";
+    return;
+  }
   openStoryScalarEditor(state, "facts-budget");
 }
 
@@ -278,9 +299,13 @@ export function openBannedStringsEditor(state: RuntimeState): void {
 function openStoryScalarEditor(state: RuntimeState, field: StoryScalarField): void {
   const spec = storyScalarFieldSpec(field);
   const expected = spec.read(state.payload);
+  const composer = createComposer(expected);
+  // Numeric Settings fields select their current value when they open, so a
+  // first digit replaces it instead of silently appending to the old cap.
+  if (field === "facts-budget" && expected.length > 0) composer.anchor = 0;
   openInlineEditor(state, {
     target: { kind: "story-scalar", field, expected },
-    composer: createComposer(expected),
+    composer,
     initial: expected,
     title: spec.title,
     placeholder: spec.placeholder,

--- a/tui/src/editor-text-insertion.ts
+++ b/tui/src/editor-text-insertion.ts
@@ -1,5 +1,6 @@
 import { insertComposerText, type ComposerState } from "./composer-model.js";
 import { factEditorInsert } from "./fact-editor-policy.js";
+import { factsBudgetInsert, isFactsBudgetEditor } from "./facts-budget-editor.js";
 import type { DocumentEditorSession } from "./state.js";
 
 export interface EditorTextBuffer {
@@ -38,6 +39,8 @@ export function editorInsertionPolicy(
     insert: (raw, source) =>
       editor.kind === "fact"
         ? factEditorInsert(editor, raw, source)
+        : isFactsBudgetEditor(editor)
+          ? factsBudgetInsert(raw)
         : { text: raw }
   };
 }

--- a/tui/src/fact-editor-draft.ts
+++ b/tui/src/fact-editor-draft.ts
@@ -329,7 +329,7 @@ export function parseBudgetText(
 ): { ok: true; budgetTokens: number | undefined } | { ok: false; toast: string } {
   const trimmed = raw.trim();
   if (trimmed.length === 0) return { ok: true, budgetTokens: undefined };
-  if (!/^[0-9]+$/.test(trimmed)) {
+  if (!budgetTextIsDigitsOrEmpty(trimmed)) {
     return { ok: false, toast: `${label} must be a whole number of tokens, or empty` };
   }
   const parsed = Number(trimmed);
@@ -337,4 +337,11 @@ export function parseBudgetText(
     return { ok: false, toast: `${label} must be between 1 and ${max.toLocaleString()}` };
   }
   return { ok: true, budgetTokens: parsed };
+}
+
+/** The budget fields accept only ASCII digits while they are being edited.
+ * Keep this syntax check beside the commit parser so keyboard and paste
+ * admission cannot drift from the value that the save path accepts. */
+export function budgetTextIsDigitsOrEmpty(raw: string): boolean {
+  return raw.length === 0 || /^[0-9]+$/.test(raw);
 }

--- a/tui/src/facts-budget-editor.ts
+++ b/tui/src/facts-budget-editor.ts
@@ -1,0 +1,113 @@
+import { MAX_STORY_FACTS_BUDGET_TOKENS } from "../../shared/fact-budget.js";
+import { graphemeCells } from "./cell-width.js";
+import { budgetTextIsDigitsOrEmpty } from "./fact-editor-draft.js";
+import { addHit, type HitRows } from "./hit.js";
+import type { DocumentEditorSession, InlineEditorTarget } from "./state.js";
+import {
+  hintItem,
+  segment,
+  visibleWidth,
+  type FrameLine,
+  type HintItem
+} from "./screens/story/frame.js";
+import type { KeyAction } from "./keys.js";
+
+/** The one story scalar that is a bounded numeric field rather than a
+ * document. Keep the target check in one place for the editor reducer,
+ * renderer, and insertion policy. */
+export type FactsBudgetEditor = Extract<DocumentEditorSession, { kind: "document" }> & {
+  target: Extract<InlineEditorTarget, { kind: "story-scalar" }> & { field: "facts-budget" };
+};
+
+export function isFactsBudgetEditor(
+  editor: DocumentEditorSession | null | undefined
+): editor is FactsBudgetEditor {
+  return editor?.kind === "document"
+    && editor.target.kind === "story-scalar"
+    && editor.target.field === "facts-budget";
+}
+
+/** Map each rendered composer cell to its raw grapheme offset. The compact
+ * field keeps the broad row fallback for clicks outside the input chip. */
+export function addFactsBudgetComposerHits(
+  line: FrameLine | undefined,
+  row: number,
+  hits: HitRows
+): void {
+  let left = 0;
+  let endpoint: { cursor: number; left: number } | null = null;
+  for (const part of line ?? []) {
+    if (part.composerStart === undefined) {
+      left += visibleWidth(part.text);
+      continue;
+    }
+    for (const [offset, cell] of graphemeCells(part.text).entries()) {
+      const right = left + cell.width;
+      if (right > left) {
+        addHit(hits, row, {
+          target: {
+            kind: "composer",
+            composerCursor: part.composerStart + offset
+          },
+          left,
+          right
+        });
+      }
+      endpoint = {
+        cursor: part.composerStart + offset + 1,
+        left: right
+      };
+      left = right;
+    }
+  }
+  if (endpoint !== null) {
+    addHit(hits, row, {
+      target: { kind: "composer", composerCursor: endpoint.cursor },
+      left: endpoint.left,
+      right: endpoint.left + 1
+    });
+  }
+}
+
+/** Admission for the live field. Range and safe-integer checks stay in
+ * `parseBudgetText`, which runs once on save for both budget editors. */
+export function factsBudgetInsert(
+  raw: string
+): { text: string } | { blocked: string } {
+  return budgetTextIsDigitsOrEmpty(raw)
+    ? { text: raw }
+    : { blocked: "facts budget accepts digits only" };
+}
+
+/** The bound is visible before the writer types, while the empty sentinel has
+ * an explicit meaning instead of relying on a long prose placeholder. */
+export const FACTS_BUDGET_STATUS =
+  `1–${MAX_STORY_FACTS_BUDGET_TOKENS.toLocaleString("en-US")} tokens · empty = uncapped`;
+
+function budgetFooterAction(
+  token: string,
+  action: KeyAction,
+  rank = 0
+): HintItem {
+  return hintItem([segment(token, "chrome", { kind: "action", action })], rank);
+}
+
+/** Semantic footer controls use the same reducer as their keyboard names.
+ * Ranks keep save and cancel visible on narrow terminals. */
+export const FACTS_BUDGET_FOOTER_ACTIONS: readonly HintItem[] = [
+  budgetFooterAction("enter save", "save-edit"),
+  budgetFooterAction("ctrl+s save", "save-edit", 1),
+  budgetFooterAction("clear", "delete-line", 2),
+  budgetFooterAction("esc cancel", "cancel", 3)
+];
+
+/** Keep all core controls discoverable when the footer has only a narrow
+ * budget. The full labels remain on ordinary terminals. */
+export function factsBudgetFooterActions(width: number): readonly HintItem[] {
+  if (width >= 48) return FACTS_BUDGET_FOOTER_ACTIONS;
+  return [
+    budgetFooterAction("↵/⌃s", "save-edit"),
+    budgetFooterAction("clear", "delete-line", 1),
+    budgetFooterAction("esc", "cancel")
+  ];
+}

--- a/tui/src/facts-command-catalog.ts
+++ b/tui/src/facts-command-catalog.ts
@@ -1,0 +1,235 @@
+import type { CommandPaletteContext, PaletteCommand } from "./command-model.js";
+import type { FactEditorSession } from "./state.js";
+
+/** Fact entry points and Fact-editor actions. The command model owns grouping
+ * and search; this catalog owns the Fact vocabulary and context gates. */
+export const FACT_COMMAND_DEFINITIONS: readonly PaletteCommand[] = [
+  {
+    id: "facts", section: "story", name: "facts overview", description: "open the Facts manager and inspect story memory",
+    requires: (context) => context.factEditor !== true,
+    searchTerms: ["facts", "fact manager", "manage facts", "fact overview"]
+  },
+  {
+    id: "new-fact", section: "story", name: "new unscoped fact", description: "create a story-wide Fact",
+    requires: (context) => context.factEditor !== true,
+    searchTerms: ["new fact", "unscoped fact", "fact-new"]
+  },
+  {
+    id: "new-fact-from-here", section: "story", name: "new Fact from here",
+    description: "create a Fact scoped to the focused story part",
+    requires: (context) => context.hasStoryPart === true && context.factEditor !== true,
+    searchTerms: ["fact from here", "scoped fact"]
+  },
+  {
+    id: "new-fact-from-selection", section: "story", name: "new Fact from selection",
+    description: "create a Fact from highlighted story text",
+    requires: (context) => context.hasStorySelection === true && context.factEditor !== true,
+    searchTerms: ["fact from selection", "selection fact"]
+  },
+  {
+    id: "edit-fact", section: "story", name: "edit selected Fact",
+    description: "open a Fact in the editor, or choose one in Facts",
+    requires: (context) => context.factEditor !== true,
+    searchTerms: [
+      "edit fact", "manage fact", "Fact name", "Fact tag", "Fact scope",
+      "Fact activation", "Fact keys", "Fact priority", "per-Fact budget"
+    ]
+  },
+  {
+    id: "new-fact-state", section: "story", name: "new Fact State",
+    description: "add a Fact State at the focused story part",
+    requires: (context) => context.hasStoryPart === true && context.factEditor !== true,
+    searchTerms: ["add fact state", "fact state", "state from here"]
+  },
+  {
+    id: "end-fact-here", section: "story", name: "end Fact here",
+    description: "add an End State at the focused story part",
+    requires: (context) => context.hasStoryPart === true && context.factEditor !== true,
+    searchTerms: ["end fact", "fact end state", "end state"]
+  },
+  {
+    id: "facts-open-selected", section: "story", name: "open selected Fact",
+    description: "open the selected Fact or its state dossier",
+    requires: (context) => context.factsPanel === true && context.factsDossier !== true
+      && context.factsFiltering !== true && context.factsSelected === true,
+    searchTerms: ["open fact", "fact dossier", "selected fact"]
+  },
+  {
+    id: "facts-filter", section: "story", name: "filter Facts",
+    description: "search the Facts manager",
+    requires: (context) => context.factsPanel === true && context.factsDossier !== true
+      && context.factsFiltering !== true,
+    searchTerms: ["filter facts", "search facts", "fact filter"]
+  },
+  {
+    id: "facts-cycle-tag", section: "story", name: "cycle Fact tag",
+    description: "move through the saved Fact tag filters",
+    requires: (context) => context.factsPanel === true && context.factsDossier !== true
+      && context.factsFiltering !== true,
+    searchTerms: ["fact tag", "next fact tag", "tag filter"]
+  },
+  {
+    id: "facts-clear-filter", section: "story", name: "clear Facts filter",
+    description: "leave the active Facts search or tag filter",
+    requires: (context) => context.factsPanel === true && context.factsDossier !== true
+      && (context.factsFiltering === true || context.factsHasFilter === true),
+    searchTerms: ["clear facts", "reset facts", "close fact filter"]
+  },
+  {
+    id: "facts-cycle-scope", section: "story", name: "cycle Fact scope",
+    description: "show Facts everywhere, on this line, elsewhere, or ended",
+    requires: (context) => context.factsPanel === true && context.factsDossier !== true
+      && context.factsFiltering !== true,
+    searchTerms: ["fact scope", "scope filter", "everywhere this line"]
+  },
+  {
+    id: "facts-delete", section: "story", name: "delete selected Fact", mutating: true,
+    description: "arm the existing Fact delete confirmation",
+    requires: (context) => context.factsPanel === true && context.factsDossier !== true
+      && context.factsFiltering !== true && context.factsSelected === true,
+    searchTerms: ["delete fact", "remove fact"]
+  },
+  {
+    id: "facts-move-up", section: "story", name: "move Fact earlier", mutating: true,
+    description: "move the selected Fact earlier in the Facts list",
+    requires: (context) => context.factsPanel === true && context.factsDossier !== true
+      && context.factsFiltering !== true && context.factsCanMoveUp === true,
+    searchTerms: ["move fact up", "reorder fact", "fact earlier"]
+  },
+  {
+    id: "facts-move-down", section: "story", name: "move Fact later", mutating: true,
+    description: "move the selected Fact later in the Facts list",
+    requires: (context) => context.factsPanel === true && context.factsDossier !== true
+      && context.factsFiltering !== true && context.factsCanMoveDown === true,
+    searchTerms: ["move fact down", "reorder fact", "fact later"]
+  },
+  {
+    id: "facts-open-anchor", section: "story", name: "open Fact State Anchor",
+    description: "jump from the Fact dossier to its selected story anchor",
+    requires: (context) => context.factsPanel === true && context.factsDossier === true,
+    searchTerms: ["open fact anchor", "dossier anchor", "state anchor"]
+  },
+  {
+    id: "facts-edit-state", section: "story", name: "edit Fact State",
+    description: "edit the selected state in the Fact editor",
+    requires: (context) => context.factsPanel === true && context.factsDossier === true,
+    searchTerms: ["edit state", "edit fact state", "dossier edit"]
+  },
+  {
+    id: "facts-dossier-previous-state", section: "story", name: "previous dossier Fact State",
+    description: "select the previous state in the Fact dossier",
+    requires: (context) => context.factsPanel === true && context.factsDossier === true,
+    searchTerms: ["previous dossier state", "previous fact state"]
+  },
+  {
+    id: "facts-dossier-next-state", section: "story", name: "next dossier Fact State",
+    description: "select the next state in the Fact dossier",
+    requires: (context) => context.factsPanel === true && context.factsDossier === true,
+    searchTerms: ["next dossier state", "next fact state"]
+  },
+  {
+    id: "facts-toggle-diff", section: "story", name: "compare Fact States",
+    description: "show or hide the selected Fact State diff",
+    requires: (context) => context.factsPanel === true && context.factsDossier === true,
+    searchTerms: ["Fact diff", "compare states", "state diff"]
+  },
+  {
+    id: "fact-editor-toggle-view", section: "story", name: "toggle Fact editor view",
+    description: "show or hide advanced Fact fields",
+    requires: (context) => context.factEditor === true,
+    searchTerms: ["fact editor basic advanced", "advanced Fact fields", "fact view"]
+  },
+  {
+    id: "fact-editor-previous-state", section: "story", name: "previous Fact State",
+    description: "select the previous Fact State",
+    requires: (context) => context.factEditorStateful === true && context.factEditorHasState === true,
+    searchTerms: ["previous state", "previous fact state", "fact state back"]
+  },
+  {
+    id: "fact-editor-next-state", section: "story", name: "next Fact State",
+    description: "select the next Fact State",
+    requires: (context) => context.factEditorStateful === true && context.factEditorHasState === true,
+    searchTerms: ["next state", "next fact state", "fact state forward"]
+  },
+  {
+    id: "fact-editor-new-state", section: "story", name: "add Fact State",
+    description: "start a new Fact State draft",
+    requires: (context) => context.factEditorStateful === true && context.factEditorStateCreating !== true,
+    searchTerms: ["new state", "add state", "fact editor state"]
+  },
+  {
+    id: "fact-editor-open-anchor", section: "story", name: "open Fact State Anchor",
+    description: "jump to the selected Fact State Anchor",
+    requires: (context) => context.factEditorCanOpenAnchor === true,
+    searchTerms: ["open anchor", "fact anchor", "state anchor"]
+  },
+  {
+    id: "fact-editor-reanchor-state", section: "story", name: "re-anchor Fact State",
+    description: "move the selected Fact State to the story cursor",
+    requires: (context) => context.factEditorStateful === true
+      && (context.factEditorHasState === true || context.factEditorStateCreating === true),
+    searchTerms: ["reanchor state", "re-anchor", "move fact state"]
+  },
+  {
+    id: "fact-editor-convert-state", section: "story", name: "convert Fact State",
+    description: "toggle the selected state between text and End State",
+    requires: (context) => context.factEditorStateful === true && context.factEditorHasState === true,
+    searchTerms: ["convert state", "text state", "end state"]
+  },
+  {
+    id: "fact-editor-delete-state", section: "story", name: "delete Fact State",
+    description: "arm the existing Fact State delete confirmation",
+    requires: (context) => context.factEditorCanDeleteState === true,
+    searchTerms: ["delete state", "remove fact state"]
+  },
+  {
+    id: "map-open-fact-lens", section: "view", name: "open Fact lens",
+    description: "show Fact anchors in the tree map",
+    requires: (context) => context.mapTree === true && context.mapFactLens !== true,
+    searchTerms: ["fact lens", "map facts", "lens facts"]
+  },
+  {
+    id: "map-cycle-fact-lens", section: "view", name: "next Fact in lens",
+    description: "select the next Fact in the tree map lens",
+    requires: (context) => context.mapFactLens === true,
+    searchTerms: ["next lensed fact", "cycle fact lens", "lens next"]
+  },
+  {
+    id: "map-close-fact-lens", section: "view", name: "close Fact lens",
+    description: "close the Fact lens and keep the tree map open",
+    requires: (context) => context.mapFactLens === true,
+    searchTerms: ["close lens", "hide fact lens", "map lens close"]
+  },
+  {
+    id: "map-open-fact-lens-anchor", section: "view", name: "open lensed Fact Anchor",
+    description: "jump from the map lens to its selected anchor",
+    requires: (context) => context.mapFactLens === true,
+    searchTerms: ["open lens anchor", "map fact anchor"]
+  },
+  {
+    id: "map-edit-fact-lens", section: "view", name: "edit lensed Fact State",
+    description: "edit the Fact State at the map cursor",
+    requires: (context) => context.mapFactLens === true,
+    searchTerms: ["edit lensed fact", "map fact state", "lens edit"]
+  }
+];
+
+/** Derive only the Fact-editor state needed by contextual palette commands.
+ *  The editor reducer remains the authority for whether an action is valid. */
+export function factEditorPaletteContext(
+  editor: FactEditorSession | null | undefined
+): Pick<CommandPaletteContext,
+  "factEditor" | "factEditorStateful" | "factEditorHasState"
+  | "factEditorStateCreating" | "factEditorCanOpenAnchor" | "factEditorCanDeleteState"> {
+  const factEditor = editor?.kind === "fact";
+  const stateful = factEditor && (editor.target.factId !== null || editor.stateCreating === true);
+  const hasState = stateful && editor.stateId !== undefined && editor.stateId !== null;
+  return {
+    factEditor,
+    factEditorStateful: stateful,
+    factEditorHasState: hasState,
+    factEditorStateCreating: factEditor && editor.stateCreating === true,
+    factEditorCanOpenAnchor: hasState && editor.stateAnchorPartId != null,
+    factEditorCanDeleteState: hasState && editor.stateCreating !== true && editor.target.factId !== null
+  };
+}

--- a/tui/src/facts-command-context.ts
+++ b/tui/src/facts-command-context.ts
@@ -1,0 +1,117 @@
+import { factRows } from "./facts-model.js";
+import { mapCursorNodeId } from "./map-actions.js";
+import { createStoryViewModel, rowPart } from "./model.js";
+import type { RuntimeState } from "./state.js";
+
+type FactsAnchorState = Pick<RuntimeState, "payload" | "stream" | "mode" | "commands" | "focusIndex" | "now">
+  & {
+    map?: RuntimeState["map"];
+    probs?: { nodeId: string } | null;
+    record?: { nodeId: string } | null;
+  };
+
+/** Resolve the story part that an anchored Fact command would use.
+ *
+ * The command palette, its renderer, mouse reconciliation, and the command
+ * runner all call this function. MAP, PROBS, and RECORD own cursors that are
+ * different from NAV focus, so resolve their displayed node first. Non-MAP
+ * structural rows (chapter summaries and dividers) are not valid Fact anchors
+ * and fail closed. */
+export function factsOpeningPartId(state: FactsAnchorState): string | null {
+  const owner = state.mode === "COMMANDS"
+    ? state.commands?.returnMode
+    : state.mode;
+  const candidateId = owner === "MAP"
+    ? mapCursorNodeId(state)
+    : owner === "PROBS"
+      ? state.probs?.nodeId ?? null
+      : owner === "RECORD"
+        ? state.record?.nodeId ?? null
+        : focusedStoryPartId(state);
+  if (candidateId === null) return null;
+  const node = state.payload.nodes.find(({ id }) => id === candidateId);
+  return node === undefined || node.role === "summary" ? null : node.id;
+}
+
+function focusedStoryPartId(state: FactsAnchorState): string | null {
+  const view = createStoryViewModel(state.payload, state.stream);
+  const row = view.rows[state.focusIndex];
+  if (row !== undefined) return rowPart(view, state.focusIndex)?.node.id ?? null;
+  return state.payload.path.at(-1)?.id ?? null;
+}
+
+/** Context for commands that operate the already-open Facts or Map surface.
+ *  The command only selects the canonical reducer; it never creates a second
+ *  target picker or a parallel mutation path. */
+export function factsPaletteContext(state: {
+  facts: RuntimeState["facts"];
+  payload: RuntimeState["payload"];
+  map?: RuntimeState["map"];
+  mode: RuntimeState["mode"];
+  commands?: RuntimeState["commands"];
+}): {
+  factsPanel: boolean;
+  factsDossier: boolean;
+  factsFiltering: boolean;
+  factsHasFilter: boolean;
+  factsSelected: boolean;
+  factsCanMoveUp: boolean;
+  factsCanMoveDown: boolean;
+  mapTree: boolean;
+  mapFactLens: boolean;
+} {
+  const owner = state.commands?.returnMode ?? state.mode;
+  const mapTree = owner === "MAP" && state.map?.view === "tree";
+  const mapFactLens = mapTree && state.map?.factLensFactId != null;
+  const overlay = owner === "FACTS" ? state.facts : null;
+  if (overlay === null) {
+    return {
+      factsPanel: false,
+      factsDossier: false,
+      factsFiltering: false,
+      factsHasFilter: false,
+      factsSelected: false,
+      factsCanMoveUp: false,
+      factsCanMoveDown: false,
+      mapTree,
+      mapFactLens
+    };
+  }
+  const factsDossier = overlay.dossier != null;
+  if (factsDossier) {
+    return {
+      factsPanel: true,
+      factsDossier: true,
+      factsFiltering: false,
+      factsHasFilter: false,
+      factsSelected: state.payload.facts.some(({ id }) => id === overlay.dossier?.factId),
+      factsCanMoveUp: false,
+      factsCanMoveDown: false,
+      mapTree,
+      mapFactLens
+    };
+  }
+  const rows = factRows(
+    state.payload.facts,
+    overlay.selectedTag,
+    overlay.query,
+    state.payload.path.map(({ id }) => id),
+    overlay.scopeFilter ?? "everywhere"
+  );
+  const selected = rows[overlay.cursor];
+  const selectedIndex = selected === undefined
+    ? -1
+    : state.payload.facts.findIndex(({ id }) => id === selected.id);
+  const canReorder = !overlay.filtering && overlay.query.length === 0 && overlay.selectedTag === null;
+  return {
+    factsPanel: true,
+    factsDossier: false,
+    factsFiltering: overlay.filtering,
+    factsHasFilter: overlay.query.length > 0 || overlay.selectedTag !== null,
+    factsSelected: selected !== undefined,
+    factsCanMoveUp: canReorder && selectedIndex > 0,
+    factsCanMoveDown: canReorder && selectedIndex >= 0 && selectedIndex < state.payload.facts.length - 1,
+    mapTree,
+    mapFactLens
+  };
+}

--- a/tui/src/hit.ts
+++ b/tui/src/hit.ts
@@ -50,6 +50,8 @@ export type HitTarget =
       /** Exact field identity for multi-buffer editors. */
       composerSourceId?: string;
       composerEditable?: boolean;
+      /** Absolute grapheme offset selected by a click in the field. */
+      composerCursor?: number;
     }
   /** Page behind an open panel: a click there dismisses the panel. */
   /** A saved Aside answer row. Right-click uses the terminal selection when

--- a/tui/src/image-attach-actions.ts
+++ b/tui/src/image-attach-actions.ts
@@ -12,6 +12,7 @@ import { MAX_SOURCE_IMAGE_BYTES, imageAttachmentLabel } from "../../shared/image
 import { imageInputEntryPointsOpen } from "../../shared/image-input-release.js";
 import { readImportBytes } from "../../server/import-file.js";
 import { attachDraftImage, draftImagesFor, MAX_DRAFT_IMAGES } from "./draft-image.js";
+import { settleModeUnderPalette } from "./palette-owner.js";
 import {
   currentImageInputCapability,
   imageInputRefusalMessage,
@@ -144,8 +145,8 @@ async function applyImageAttach(
       if (!task.storyCurrent() || state.composer !== composer) return;
       const images = attachDraftImage(composer, { leaseId: staged.leaseId, attachment: staged.attachment });
       if (state.image === overlay) {
+        settleModeUnderPalette(state, "IMAGE", overlay.returnMode);
         state.image = null;
-        state.mode = overlay.returnMode;
         state.toast = `attached ${imageAttachmentLabel(images.length - 1)}`;
       }
     });

--- a/tui/src/keys.ts
+++ b/tui/src/keys.ts
@@ -68,7 +68,8 @@ export type KeyAction =
   | "complete" | "open-log" | "clear-log" | "row-action"
   | "open-probs" | "next-part" | "open-text-actions" | "import-profile" | "open-records"
   | "toggle-view-mode" | "cycle-state" | "cycle-fact-scope" | "convert-state" | "reanchor-state"
-  | "delete-state" | "open-state-anchor" | "new-state" | "end-state" | "toggle-fact-diff";
+  | "delete-state" | "open-state-anchor" | "new-state" | "end-state" | "clear-filter"
+  | "toggle-fact-diff";
 
 export type AppMode = "NAV" | "COMPOSE" | "EDITOR" | "MAP" | "KEYS" | "TAG"
   | "LIBRARY" | "FACTS" | "COMMANDS" | "SUMMARY" | "SETTINGS" | "ACTIONS" | "CHAPTERS"
@@ -94,6 +95,8 @@ export interface ResolvedKey {
   /** Exact field under a context-menu click in a multi-buffer editor. */
   composerSourceId?: string;
   composerEditable?: boolean;
+  /** Absolute grapheme offset selected by a click in the field. */
+  composerCursor?: number;
   /** Extend an editor/composer selection instead of only moving its caret. */
   extendSelection?: boolean;
   /** Absolute cursor placement (mouse clicks). */
@@ -413,9 +416,8 @@ export function resolveKey(key: KeyEvent, mode: AppMode, options: ResolveOptions
     libraryRenaming = false,
     mapView = "path", mapFactLens = false } = options;
   const globalReference = resolveReferenceBinding("global", key, mode, mapView);
-  if (globalReference !== null || key.name === "escape") {
-    return { action: "cancel" };
-  }
+  if (globalReference !== null) return { action: globalReference.action };
+  if (key.name === "escape") return { action: "cancel" };
   if (mode === "ASIDE"
     && !key.ctrl && !key.meta && !key.option && !key.super
     && key.name === "q") {
@@ -423,7 +425,10 @@ export function resolveKey(key: KeyEvent, mode: AppMode, options: ResolveOptions
     // is open. The menu is an interaction aid, not a separate application.
     return { action: "quit" };
   }
-  if (textActionsOpen) {
+  // Ctrl-P suspends transient menus by changing the visible mode to
+  // COMMANDS. Let the palette own its query and Enter even while the captured
+  // text-actions menu remains available for Escape restoration.
+  if (textActionsOpen && mode !== "COMMANDS") {
     if (key.name === "down") return { action: "focus-next" };
     if (key.name === "up") return { action: "focus-previous" };
     if (key.name === "return") return { action: "apply" };
@@ -453,7 +458,9 @@ export function resolveKey(key: KeyEvent, mode: AppMode, options: ResolveOptions
     if (key.name === "return") return { action: "apply" };
     return { action: "none" };
   }
-  if (confirmingPrune) {
+  // The global palette has priority over a captured prune confirmation. Its
+  // cleanup is identity-fenced when the selected command returns to the owner.
+  if (confirmingPrune && mode !== "COMMANDS") {
     return { action: plainShiftedLetter(key, "d") ? "prune" : "none" };
   }
   if (mode === "REQUEST") return resolveRequestViewerKey(key);

--- a/tui/src/library-actions.ts
+++ b/tui/src/library-actions.ts
@@ -17,6 +17,7 @@ import {
   forgetStoryReadingPosition
 } from "./reading-position-persist.js";
 import { adoptReconciliationSnapshot, adoptSameStoryPayload, adoptStoryState } from "./story-adoption.js";
+import { paletteSessionReturningTo, restorePaletteSession } from "./palette-owner.js";
 import type { RuntimeState, TextPrompt } from "./state.js";
 
 export interface OpenLibraryOptions {
@@ -132,7 +133,19 @@ export async function libraryAction(
       const payload = await source.api.loadStory(selected.id);
       if (task.interactionCurrent() && state.library === overlay) {
         flushReadingPositionPersist();
+        const palette = paletteSessionReturningTo(state, "LIBRARY");
+        const differentStory = payload.id !== state.payload.id;
         adoptStory(state, payload, context);
+        if (palette !== null) {
+          // A different-story adoption clears every story-bound surface,
+          // including the palette. Keep Ctrl-P visible, with Esc returning to
+          // the settled story's NAV surface.
+          if (differentStory) {
+            palette.selection = null;
+            palette.deleteArmedTagNodeId = null;
+          }
+          restorePaletteSession(state, palette, "NAV");
+        }
       }
     });
   }
@@ -158,7 +171,16 @@ export async function createNewStory(
       adoptReconciliationSnapshot(state, payload, context.cache);
       adopted = true;
     } else if (overlay !== null && task.interactionCurrent() && state.library === overlay) {
+      const palette = paletteSessionReturningTo(state, "LIBRARY");
       adoptStory(state, payload, context);
+      if (palette !== null) {
+        // A new story clears every story-bound surface, including the
+        // library. Keep Ctrl-P visible, with Esc returning to the settled
+        // story's NAV surface. Its captured selection names the old story.
+        palette.selection = null;
+        palette.deleteArmedTagNodeId = null;
+        restorePaletteSession(state, palette, "NAV");
+      }
       adopted = true;
     }
     if (adopted) {
@@ -271,12 +293,21 @@ async function deleteStory(
         if (!task.owns()) return;
       }
       publishStories(state, source, stories);
-      if (task.interactionCurrent()) adoptStoryState(state, next, context.cache);
+      const palette = paletteSessionReturningTo(state, "LIBRARY");
+      if (task.interactionCurrent() && palette === null) adoptStoryState(state, next, context.cache);
       else {
         adoptReconciliationSnapshot(state, next, context.cache,
           state.library === overlay && overlay.prompt === prompt
             ? { discardedLibrary: overlay }
             : {});
+      }
+      if (palette !== null) {
+        // Deleting the open story changes stories. Keep Ctrl-P visible, with
+        // Esc returning to the fallback story's NAV surface. Its captured
+        // selection names the deleted story and must not cross this boundary.
+        palette.selection = null;
+        palette.deleteArmedTagNodeId = null;
+        restorePaletteSession(state, palette, "NAV");
       }
       state.toast = `deleted ${target.title}`;
       return;

--- a/tui/src/map-actions.ts
+++ b/tui/src/map-actions.ts
@@ -305,9 +305,11 @@ async function massAction(
  *  the cursor row's node in Tree/Mass — a folded "cold" row names a whole
  *  subtree, not one take, so it names nothing. Map logic, so it lives here
  *  rather than in `generation-record-actions.ts`, which just calls it. */
-export function mapCursorNodeId(state: RuntimeState): string | null {
+export function mapCursorNodeId(
+  state: Pick<RuntimeState, "payload" | "stream" | "now"> & { map?: RuntimeState["map"] }
+): string | null {
   const map = state.map;
-  if (map === null) return null;
+  if (map == null) return null;
   if (map.view === "path") return map.pathCursorId;
   const payload = mapPayload(state);
   if (map.view === "tree") {

--- a/tui/src/mouse-actions.ts
+++ b/tui/src/mouse-actions.ts
@@ -17,13 +17,18 @@ export type MouseGesture = Pick<
  *  under an open menu or list are derived from the story, and reconciliation
  *  has to compare the row, not its index. */
 export type MouseActionState = Pick<RuntimeState,
-  | "mode" | "focusIndex" | "hitRows" | "map" | "payload" | "stream" | "demo" | "lineClipboard"
+  | "mode" | "focusIndex" | "hitRows" | "map" | "payload" | "stream" | "now" | "demo" | "lineClipboard"
   | "connection" | "composer" | "editor"
   | "actions" | "textActions" | "library" | "facts" | "commands" | "chapters" | "settings"
   | "search"
   | "request"
   | "aside"
 > & {
+  /** The displayed take identity for viewers that can sit beneath the
+   *  command palette. A queued command row only needs this one field to
+   *  rebuild its contextual availability. */
+  probs: { nodeId: string } | null;
+  record: { nodeId: string } | null;
   /** Derived exactly as the panel renderer derives it, since the palette's
    *  rows — and therefore their indexes — depend on it. Optional so live
    *  `RuntimeState` still satisfies this type; a captured snapshot always
@@ -96,10 +101,14 @@ export function createFactDoubleClickGate(
       }
       if (event.type === "drag" || event.type === "scroll") previous = null;
       if (event.type !== "down") return resolved;
-      const target = event.button === 0 && state.facts !== null
+      if (state.mode !== "FACTS" || state.facts === null) {
+        previous = null;
+        return resolved;
+      }
+      const target = event.button === 0
         ? hitAt(state.hitRows, event.x, event.y)
         : null;
-      if (state.facts?.dossier !== null && state.facts?.dossier !== undefined) {
+      if (state.facts.dossier !== null && state.facts.dossier !== undefined) {
         return resolved;
       }
       if (target?.kind !== "list") {
@@ -193,6 +202,7 @@ export function captureMouseActionState(state: RuntimeState): MouseActionState {
     // snapshot.
     payload: state.payload,
     stream: state.stream,
+    now: state.now,
     lineClipboard: state.lineClipboard === null ? null : { ...state.lineClipboard },
     demo: state.demo,
     composer: state.composer,
@@ -201,6 +211,8 @@ export function captureMouseActionState(state: RuntimeState): MouseActionState {
     // the frame that drew it saw.
     connection: state.connection,
     requestActive: generationBusy(state) || state.summary !== null || state.chapterSummary != null,
+    probs: state.probs === null ? null : { nodeId: state.probs.nodeId },
+    record: state.record === null ? null : { nodeId: state.record.nodeId },
     map: state.map === null ? null : {
       ...state.map,
       rowIds: [...state.map.rowIds],
@@ -434,10 +446,18 @@ export function mouseToAction(
       && target.composerSourceId !== undefined) {
       return {
         action: "compose",
-        composerSourceId: target.composerSourceId
+        composerSourceId: target.composerSourceId,
+        ...(target.composerCursor === undefined
+          ? {}
+          : { composerCursor: target.composerCursor })
       };
     }
-    return { action: "compose" };
+    return {
+      action: "compose",
+      ...(target.composerCursor === undefined
+        ? {}
+        : { composerCursor: target.composerCursor })
+    };
   }
   if (target.kind === "part") {
     // Carry the row identity its neighbours carry: an index alone cannot
@@ -476,6 +496,7 @@ export function mouseToAction(
 
 /** Where the open overlay's cursor sits, for click-again-to-run. */
 function listCursor(state: MouseActionState): number | null {
+  if (state.mode === "COMMANDS" && state.commands !== null) return state.commands.cursor;
   if (state.textActions !== null) return state.textActions.cursor;
   if (state.request !== null) return state.request.cursor;
   if (state.actions !== null) return state.actions.cursor;

--- a/tui/src/overlay-actions.ts
+++ b/tui/src/overlay-actions.ts
@@ -3,14 +3,11 @@ import {
   commandMatches,
   commandQueryCursor,
   retainCommandSelection,
-  type CommandMatch,
-  type PaletteCommand
+  type CommandMatch
 } from "./command-model.js";
+import { factEditorPaletteContext } from "./facts-command-catalog.js";
 import { connectionFailed, connectionSucceeded } from "./connection.js";
 import { createComposer, setComposerText } from "./composer-model.js";
-import { writeExportFile, writeStoryExport } from "./export-file.js";
-import { exportGenerationProfile } from "../../server/import-profile-export.js";
-import { selectSettingsRoute } from "../../shared/settings-route.js";
 import {
   boundedFactCursor,
   boundedFactSelection,
@@ -35,17 +32,13 @@ import {
   landOnNode,
   openTag,
   rerouteToNode,
-  runPartAction,
-  streamLive
 } from "./story-actions.js";
 import { openDirectComposer } from "./composer-ownership.js";
-import { createUnusedTakesPrunePlan } from "./prune-model.js";
 import { chaptersAction, createBreakAtFocus, openChapters } from "./chapter-actions.js";
 import { createStoryViewModel, lastPartRowIndex, rowPart } from "./model.js";
-import { rememberFocus } from "./reading-position-persist.js";
 import { adoptSameStoryPayload } from "./story-adoption.js";
-import { cancelSummary, startSummary } from "./summary-action.js";
-import { openAside } from "./aside-actions.js";
+import { cancelSummary } from "./summary-action.js";
+import { noteAsidePaletteInteraction, openAside } from "./aside-actions.js";
 import { openAsideUseMenuFromMouse } from "./aside-use.js";
 import {
   cancelPlacement,
@@ -68,6 +61,8 @@ import { openSearch } from "./search-actions.js";
 import { cardImportAction, openCardImport } from "./card-import-actions.js";
 import { archiveImportAction, openArchiveImport } from "./archive-import-actions.js";
 import { imageAttachAction, openImageAttach } from "./image-attach-actions.js";
+import { factsOpeningPartId, factsPaletteContext } from "./facts-command-context.js";
+import { runPaletteCommand } from "./palette-command-runner.js";
 import { publishStories } from "./overlay-publication.js";
 import { retryBackendState } from "./recovery-orchestration.js";
 import {
@@ -115,11 +110,48 @@ export async function handleOverlayAction(
   resolved: ResolvedKey,
   state: RuntimeState,
   source: AppSource,
-  context: OverlayActionContext
+  context: OverlayActionContext,
+  capturedStorySelection: ProjectedStorySelection | null | undefined = undefined
 ): Promise<boolean> {
   // Top-level navigation owns quit even while an overlay is open. Let the
   // dispatch tail call `navAction`, which invokes the app's quit callback.
   if (resolved.action === "quit") return false;
+  if (resolved.action === "open-commands") {
+    // Ctrl-P is a global escape hatch. Do not nest a second palette, and do
+    // not clear any transient menu/editor that must be restored on Esc.
+    if (state.mode === "COMMANDS" && state.commands !== null) return true;
+    // The NAV projection this reads is only built for that one frame, so the
+    // selection has to be captured now — a later keystroke cannot rebuild it.
+    const factsSelection = state.mode === "FACTS"
+      ? state.facts?.storySelection
+      : undefined;
+    const retainedFactsSelection = factsSelection ?? null;
+    const selection = state.mode === "FACTS"
+      ? capturedStorySelection !== undefined
+        ? capturedStorySelection ?? retainedFactsSelection
+        : factsSelection !== undefined
+          ? retainedFactsSelection
+          : context.renderer === null
+            ? null
+            : storySelectionFromRendererSelection(context.renderer, state.storySelectionProjection)
+      : capturedStorySelection !== undefined
+        ? capturedStorySelection
+        : context.renderer === null
+          ? null
+          : storySelectionFromRendererSelection(context.renderer, state.storySelectionProjection);
+    state.commands = {
+      query: "",
+      view: "commands",
+      deleteArmedTagNodeId: null,
+      returnMode: state.mode === "COMMANDS" ? "NAV" : state.mode,
+      selection,
+      ...retainCommandSelection(liveCommandMatches(
+        state, "", selection, context.asideEntryPointsOpen
+      ), null, 0)
+    };
+    state.mode = "COMMANDS";
+    return true;
+  }
   if (resolved.action === "retry") { await reconnect(state, source, context); return true; }
   if (resolved.action === "open-aside") {
     await openAside(state, source.api, {
@@ -194,31 +226,15 @@ export async function handleOverlayAction(
   }
   if (resolved.action === "open-library") { await openLibrary(state, source, context); return true; }
   if (resolved.action === "open-facts") {
-    state.facts = initialFacts();
+    state.facts = {
+      ...initialFacts(),
+      storySelection: capturedStorySelection === undefined ? null : capturedStorySelection
+    };
     if (resolved.index !== undefined) {
       const cursor = Math.max(0, Math.min(state.payload.facts.length - 1, resolved.index));
       state.facts.cursor = cursor;
     }
     state.mode = "FACTS";
-    return true;
-  }
-  if (resolved.action === "open-commands") {
-    // The NAV projection this reads is only built for that one frame, so the
-    // selection has to be captured now — a later keystroke cannot rebuild it.
-    const selection = context.renderer === null
-      ? null
-      : storySelectionFromRendererSelection(context.renderer, state.storySelectionProjection);
-    state.commands = {
-      query: "",
-      view: "commands",
-      deleteArmedTagNodeId: null,
-      returnMode: state.mode === "COMPOSE" ? "COMPOSE" : "NAV",
-      selection,
-      ...retainCommandSelection(liveCommandMatches(
-        state, "", selection, context.asideEntryPointsOpen
-      ), null, 0)
-    };
-    state.mode = "COMMANDS";
     return true;
   }
   if (resolved.action === "open-settings") {
@@ -399,23 +415,6 @@ function initialFacts() {
   };
 }
 
-/** Facts stays over the story row that opened it. The focus index is not
- * changed by the overlay, so state creation can use that persisted part
- * instead of silently falling back to the active path leaf. */
-function factsOpeningPartId(state: RuntimeState): string | null {
-  const view = createStoryViewModel(state.payload);
-  const persistedPartId = (candidateId: string | undefined): string | null => {
-    if (candidateId === undefined) return null;
-    const node = state.payload.nodes.find(({ id }) => id === candidateId);
-    return node === undefined || node.role === "summary" ? null : node.id;
-  };
-  if (view.rows[state.focusIndex] === undefined) {
-    return persistedPartId(state.payload.path.at(-1)?.id);
-  }
-  const part = rowPart(view, state.focusIndex);
-  return persistedPartId(part?.node.id);
-}
-
 async function factsAction(
   resolved: ResolvedKey,
   state: RuntimeState,
@@ -452,6 +451,17 @@ async function factsAction(
   else if (resolved.action === "focus-index") overlay.cursor = boundedFactCursor(resolved.index ?? overlay.cursor, rows.length);
   else if (resolved.action === "focus-previous") overlay.cursor = boundedFactCursor(overlay.cursor - 1, rows.length);
   else if (resolved.action === "filter") overlay.filtering = true;
+  else if (resolved.action === "clear-filter") {
+    overlay.query = "";
+    overlay.selectedTag = null;
+    overlay.filtering = false;
+    overlay.chip = 0;
+    overlay.selectedStateId = undefined;
+    Object.assign(
+      overlay,
+      boundedFactSelection(state.payload.facts, overlay, "", pathIds, scopeFilter)
+    );
+  }
   else if (resolved.action === "cycle") {
     overlay.chip = resolved.index === undefined
       ? (overlay.chip + 1) % tags.length
@@ -483,25 +493,49 @@ async function factsAction(
       )
     );
   }
+  else if (resolved.action === "end-state") {
+    overlay.pendingFactAction = {
+      kind: "end",
+      anchorPartId: factsOpeningPartId(state)
+    };
+    overlay.filtering = false;
+    state.toast = "select a Fact · enter opens an end state";
+  }
+  else if (resolved.action === "new-state" && overlay.filtering) {
+    overlay.pendingFactAction = {
+      kind: "new-state",
+      anchorPartId: factsOpeningPartId(state)
+    };
+    overlay.filtering = false;
+    state.toast = "select a Fact · enter opens a new state";
+  }
   else if ((resolved.action === "new-state"
     || resolved.action === "open-selected" && overlay.pendingFactAction !== null
       && overlay.pendingFactAction !== undefined)
     && !overlay.filtering && selected !== undefined) {
-    if (source.api.createFactState === undefined) {
-      state.toast = "state creation requires a newer backend";
-      return true;
-    }
     const pending = overlay.pendingFactAction;
-    const anchorPartId = pending?.anchorPartId
-      ?? factsOpeningPartId(state);
-    if (anchorPartId === null) {
-      state.toast = "select a story part before adding a state";
-      return true;
-    }
-    openFactStateEditor(state, selected, anchorPartId);
-    if (pending?.kind === "end" && state.editor?.kind === "fact") {
-      state.editor.stateIsEnd = true;
-      setComposerText(state.editor.composer, "");
+    if (pending?.kind === "edit") {
+      if (isFactStateful(selected) && source.api.patchFactState === undefined) {
+        state.toast = "state editing requires a newer backend";
+        return true;
+      }
+      openFactEditor(state, selected);
+    } else {
+      if (source.api.createFactState === undefined) {
+        state.toast = "state creation requires a newer backend";
+        return true;
+      }
+      const anchorPartId = pending?.anchorPartId
+        ?? factsOpeningPartId(state);
+      if (anchorPartId === null) {
+        state.toast = "select a story part before adding a state";
+        return true;
+      }
+      openFactStateEditor(state, selected, anchorPartId);
+      if (pending?.kind === "end" && state.editor?.kind === "fact") {
+        state.editor.stateIsEnd = true;
+        setComposerText(state.editor.composer, "");
+      }
     }
     overlay.pendingFactAction = null;
   }
@@ -638,12 +672,33 @@ async function factsDossierAction(
       landOnNode(state, source, targetId);
       return true;
     }
+    // Ctrl-P can suspend the dossier while its switchLine request is in
+    // flight. Keep that exact palette session visible after landing, with
+    // Escape returning to the settled story instead of the stale dossier.
+    let palette: RuntimeState["commands"] = null;
     await rerouteToNode(state, source, context, targetId, {
-      owns: (currentState) => currentState.mode === "FACTS"
-        && currentState.facts === overlay
-        && currentState.facts.dossier === dossier,
-      release: (currentState) => { currentState.facts = null; }
+      owns: (currentState) => {
+        if (palette !== null) {
+          return currentState.mode === "COMMANDS" && currentState.commands === palette;
+        }
+        if (currentState.mode === "COMMANDS"
+          && currentState.commands?.returnMode === "FACTS"
+          && currentState.facts === overlay) {
+          palette = currentState.commands;
+          return true;
+        }
+        return currentState.mode === "FACTS"
+          && currentState.facts === overlay
+          && currentState.facts.dossier === dossier;
+      },
+      release: (currentState) => {
+        if (currentState.facts === overlay) currentState.facts = null;
+        if (palette !== null && currentState.commands === palette) {
+          palette.returnMode = "NAV";
+        }
+      }
     });
+    if (palette !== null && state.commands === palette) state.mode = "COMMANDS";
   } else if (resolved.action === "edit") {
     if (isFactStateful(fact) && source.api.patchFactState === undefined) {
       state.toast = "state editing requires a newer backend";
@@ -700,6 +755,7 @@ async function moveFact(
 
 async function commandsAction(resolved: ResolvedKey, state: RuntimeState, source: AppSource, context: OverlayActionContext): Promise<boolean> {
   const overlay = state.commands!;
+  noteAsidePaletteInteraction(state);
   if (overlay.view === "tags") {
     if (resolved.action === "cancel") {
       if (overlay.deleteArmedTagNodeId != null) {
@@ -770,7 +826,12 @@ async function commandsAction(resolved: ResolvedKey, state: RuntimeState, source
   }
   else if (resolved.action === "open-selected") {
     const command = matches[overlay.cursor]?.command;
-    if (command !== undefined) await runCommand(command, state, source, context);
+    if (command !== undefined) await runPaletteCommand(command, state, source, context, {
+      factsAction,
+      initialFacts,
+      reconnect,
+      rewriteRequestNotProjectedToast: REWRITE_REQUEST_NOT_PROJECTED_TOAST
+    });
   }
   // Live theme preview: highlighting a theme command shows it immediately;
   // leaving the highlight (or the palette) reverts to the saved theme.
@@ -789,154 +850,7 @@ async function commandsAction(resolved: ResolvedKey, state: RuntimeState, source
   return true;
 }
 
-async function runCommand(command: PaletteCommand, state: RuntimeState, source: AppSource, context: OverlayActionContext): Promise<void> {
-  // Both refusals belong here, ahead of the `state.mode = "NAV"` below: a
-  // command that refuses after that commit strands whatever surface the
-  // palette was opened from, the trap the next-request branch documents.
-  if ((command.mutating === true && generationBusy(state))
-    || (command.blockedByLiveStream === true && streamLive(state))) {
-    state.toast = "stream running · esc stops it first";
-    return;
-  }
-  if (command.id === "tags") { state.commands!.view = "tags"; state.commands!.cursor = 0; return; }
-  const returnMode = state.commands!.returnMode;
-  const selection = state.commands!.selection ?? null;
-  state.commands = null;
-  state.mode = "NAV";
-  if (command.id === "next-request") {
-    if (state.retakePrompt?.intent.kind === "rewrite") {
-      // The unconditional `state.mode = "NAV"` above assumed every command
-      // either runs or falls through to a toast in NAV; this one refuses
-      // instead, so it has to put the writer back where the palette found
-      // them — otherwise the rewrite composer is still open in `retakePrompt`
-      // but no longer visible, stranded behind a NAV screen.
-      state.mode = returnMode;
-      state.toast = REWRITE_REQUEST_NOT_PROJECTED_TOAST;
-    } else {
-      openRequestViewer(state, returnMode);
-    }
-  }
-  else if (command.id === "token-probabilities") await openTokenProbabilities(state, source, context);
-  else if (command.id === "generation-records") await openGenerationRecordViewer(state, source, context);
-  else if (command.id === "tag-line") openTag(state);
-  else if (command.id === "authors-note") openAuthorsNoteEditor(state);
-  else if (command.id === "author-brief") openAuthorBriefEditor(state);
-  else if (command.id === "facts-budget") openFactsBudgetEditor(state);
-  else if (command.id === "phrase-bias") openPhraseBiasEditor(state);
-  else if (command.id === "banned-strings") openBannedStringsEditor(state);
-  else if (command.id === "aside") await openAside(state, source.api, {
-    entryPointsOpen: context.asideEntryPointsOpen
-  });
-  else if (command.id === "switch-story") await openLibrary(state, source, context);
-  else if (command.id === "rename-story") {
-    const targetId = state.payload.id;
-    const title = state.payload.title;
-    await openLibrary(state, source, context, {
-      selectedStoryId: targetId,
-      prompt: { kind: "rename", composer: createComposer(title), targetId }
-    });
-  }
-  else if (command.id === "direct-take") openDirectComposer(state);
-  else if (command.id === "retake") await runPartAction("retake", state, source, context);
-  else if (command.id === "rewrite-selection") {
-    // The palette's own filtering already requires a captured selection, but
-    // that only means one existed at open time — re-resolve it against the
-    // live story exactly as the part-actions menu does.
-    if (selection === null) {
-      state.toast = "highlight story text before rewriting it";
-    } else if (state.connection.down) {
-      state.toast = "offline · reading still works";
-    } else {
-      const partId = partIdFromTextSelection(selection.spans);
-      const resolved = partId === null
-        ? { error: "highlight story text before rewriting it" }
-        : resolveRewriteTarget(state.payload, partId, selection.spans);
-      if ("error" in resolved) state.toast = resolved.error;
-      else openRewriteComposer(state, resolved);
-    }
-  }
-  else if (command.id === "export") {
-    const title = state.payload.title;
-    await context.backend.run("exporting story", async (task) => {
-      const exported = await source.api.exportMarkdown(task.storyId);
-      if (!task.owns()) return;
-      const file = await writeStoryExport({
-        directory: source.exportDirectory,
-        title,
-        markdown: exported.markdown
-      });
-      if (task.interactionCurrent()) {
-        state.toast = exported.fidelity.length === 0
-          ? `exported ${file}`
-          : `exported ${file} · ${exported.fidelity.join("; ")}`;
-      }
-    });
-  } else if (command.id === "export-profile") {
-    if (!source.settingsView.editable) {
-      state.toast = "Generation Profiles require settings format 2";
-      return;
-    }
-    const document = source.settingsView.document;
-    const profileId = selectSettingsRoute(document, "prose").profileId;
-    await context.backend.run("exporting Generation Profile", async (task) => {
-      try {
-        const archive = exportGenerationProfile(document as never, profileId);
-        const file = await writeExportFile({
-          directory: source.exportDirectory,
-          title: document.profiles[profileId]!.name,
-          extension: archive.extension,
-          content: archive.text
-        });
-        if (!task.interactionCurrent()) return;
-        state.toast = `exported ${file} · connection data omitted`;
-        recordNotice(state.notices, "toast", `exported Generation Profile · ${archive.fidelity.join("; ")}`);
-      } catch (error) {
-        if (task.interactionCurrent()) {
-          state.toast = `could not export Generation Profile · ${error instanceof Error ? error.message : String(error)}`;
-        }
-      }
-    });
-  } else if (command.id === "summary") await startSummary(state, source, context);
-  else if (command.id === "chapters") openChapters(state);
-  else if (command.id === "chapter") {
-    state.focusIndex = lastPartRowIndex(createStoryViewModel(state.payload));
-    rememberFocus(state, source);
-    await createBreakAtFocus(state, source, context);
-  }
-  else if (command.id === "autoname") {
-    await context.backend.run("naming story", async (task) => {
-      const payload = await source.api.autonameStory(task.storyId);
-      if (!task.storyCurrent()) return;
-      adoptSameStoryPayload(state, payload, context.cache);
-      if (!task.owns()) return;
-      const stories = await source.api.listStories();
-      if (!task.owns()) return;
-      publishStories(state, source, stories);
-      if (task.interactionCurrent()) state.toast = `story named ${payload.title}`;
-    });
-  } else if (command.id === "prune") {
-    const plan = createUnusedTakesPrunePlan(state.payload);
-    if (plan === null) state.toast = "nothing to prune · every leaf is protected";
-    else state.prune = plan;
-  } else if (command.id === "prompts") { state.showInstructions = !state.showInstructions; state.toast = `directions ${state.showInstructions ? "shown" : "hidden"}`; }
-  else if (command.settingsTarget !== undefined || command.id === "settings") {
-    await openSettingsOverlay(state, source, context, command.settingsTarget);
-    await synchronizeSettingsModelDiscovery(state, source, context);
-  }
-  else if (command.id === "theme" && command.theme !== undefined) {
-    context.applyTheme(command.theme);
-    state.toast = `theme · ${command.theme}`;
-  }
-  else if (command.id === "reconnect") await reconnect(state, source, context);
-  else if (command.id === "folder") state.toast = source.storyFolder;
-  else if (command.id === "import-card") openCardImport(state, returnMode);
-  else if (command.id === "import-archive") openArchiveImport(state, returnMode);
-  else if (command.id === "attach-image") openImageAttach(state, source, returnMode);
-  else if (command.id === "disconnect" && state.demo) {
-    state.connection = connectionFailed(connectionSucceeded(), new Error("demo disconnect"), state.now);
-    state.toast = "simulated connection loss";
-  }
-}
+
 
 function liveCommandMatches(
   state: RuntimeState,
@@ -951,7 +865,11 @@ function liveCommandMatches(
       connectionDown: state.connection.down,
       requestActive: generationBusy(state) || state.summary !== null || state.chapterSummary != null,
       canRewriteSelection: canRewriteSelection(selection?.spans ?? []),
-      asideEntryPointsOpen: asideOpen
+      asideEntryPointsOpen: asideOpen,
+      hasStoryPart: factsOpeningPartId(state) !== null,
+      hasStorySelection: selection !== null && selection.text.trim().length > 0,
+      ...factEditorPaletteContext(state.editor?.kind === "fact" ? state.editor : null),
+      ...factsPaletteContext(state)
     })
   );
 }

--- a/tui/src/palette-command-runner.ts
+++ b/tui/src/palette-command-runner.ts
@@ -1,0 +1,483 @@
+import { type CommandId, type PaletteCommand } from "./command-model.js";
+import { connectionFailed, connectionSucceeded } from "./connection.js";
+import { createComposer } from "./composer-model.js";
+import { writeExportFile, writeStoryExport } from "./export-file.js";
+import { exportGenerationProfile } from "../../server/import-profile-export.js";
+import { selectSettingsRoute } from "../../shared/settings-route.js";
+import {
+  openAuthorBriefEditor,
+  openAuthorsNoteEditor,
+  openBannedStringsEditor,
+  openFactEditor,
+  openFactFromSelection,
+  openFactsBudgetEditor,
+  openPhraseBiasEditor,
+  inlineEditorAction
+} from "./editor-action.js";
+import {
+  armPrune,
+  generationBusy,
+  openTag,
+  runPartAction,
+  rerouteToNode,
+  streamLive
+} from "./story-actions.js";
+import { openDirectComposer } from "./composer-ownership.js";
+import { createUnusedTakesPrunePlan } from "./prune-model.js";
+import { openChapters, createBreakAtFocus } from "./chapter-actions.js";
+import { createStoryViewModel, lastPartRowIndex } from "./model.js";
+import { rememberFocus } from "./reading-position-persist.js";
+import { adoptSameStoryPayload } from "./story-adoption.js";
+import { startSummary } from "./summary-action.js";
+import { openAside } from "./aside-actions.js";
+import { openRewriteComposer, partIdFromTextSelection, resolveRewriteTarget } from "./rewrite-action.js";
+import { openLibrary } from "./library-actions.js";
+import { openCardImport } from "./card-import-actions.js";
+import { openArchiveImport } from "./archive-import-actions.js";
+import { openImageAttach } from "./image-attach-actions.js";
+import { publishStories } from "./overlay-publication.js";
+import {
+  openSettingsOverlay
+} from "./settings-overlay-actions.js";
+import { synchronizeSettingsModelDiscovery } from "./settings-model-discovery.js";
+import { recordNotice } from "./notice-log.js";
+import { openTokenProbabilities } from "./token-probabilities-actions.js";
+import { openGenerationRecordViewer } from "./generation-record-actions.js";
+import { openRequestViewer } from "./request-viewer-actions.js";
+import { mapAction } from "./map-actions.js";
+import { factsOpeningPartId } from "./facts-command-context.js";
+import { runPaletteMapRetake } from "./palette-map-retake.js";
+import {
+  capturePaletteOwner,
+  clearPaletteOwnerTransients,
+  editorHasUnsavedInput,
+  paletteOwnerHasUnsavedInput,
+  releasePaletteOwner,
+  settingsPaletteHasUnsavedWork
+} from "./palette-owner.js";
+import type { AppSource } from "./app.js";
+import type { ResolvedKey } from "./keys.js";
+import type { FactsOverlayState, RuntimeState } from "./state.js";
+import type { ActionContext } from "./action-context.js";
+
+export interface PaletteCommandRunnerDeps {
+  factsAction: (
+    resolved: ResolvedKey,
+    state: RuntimeState,
+    source: AppSource,
+    context: ActionContext
+  ) => Promise<boolean>;
+  initialFacts: () => FactsOverlayState;
+  reconnect: (state: RuntimeState, source: AppSource, context: ActionContext) => Promise<void>;
+  rewriteRequestNotProjectedToast: string;
+}
+
+const FACT_EDITOR_COMMAND_ACTIONS: Partial<Record<CommandId, ResolvedKey["action"]>> = {
+  "fact-editor-toggle-view": "toggle-view-mode",
+  "fact-editor-previous-state": "cycle-state",
+  "fact-editor-next-state": "cycle-state",
+  "fact-editor-new-state": "new-state",
+  "fact-editor-open-anchor": "open-state-anchor",
+  "fact-editor-reanchor-state": "reanchor-state",
+  "fact-editor-convert-state": "convert-state",
+  "fact-editor-delete-state": "delete-state"
+};
+
+const FACTS_COMMAND_ACTIONS: Partial<Record<CommandId, ResolvedKey["action"]>> = {
+  "facts-open-selected": "open-selected",
+  "facts-filter": "filter",
+  "facts-cycle-tag": "cycle",
+  "facts-clear-filter": "clear-filter",
+  "facts-cycle-scope": "cycle-fact-scope",
+  "facts-delete": "delete-item",
+  "facts-move-up": "move-item-up",
+  "facts-move-down": "move-item-down",
+  "facts-open-anchor": "open-selected",
+  "facts-edit-state": "edit",
+  "facts-dossier-previous-state": "cycle-state",
+  "facts-dossier-next-state": "cycle-state",
+  "facts-toggle-diff": "toggle-fact-diff"
+};
+
+const MAP_COMMAND_ACTIONS: Partial<Record<CommandId, ResolvedKey["action"]>> = {
+  "map-open-fact-lens": "open-fact-lens",
+  "map-cycle-fact-lens": "cycle-fact-lens",
+  "map-close-fact-lens": "cancel",
+  "map-open-fact-lens-anchor": "open-fact-lens-anchor",
+  "map-edit-fact-lens": "edit-fact-lens"
+};
+
+/** Commands that replace the surface which opened the global palette. */
+const PALETTE_DESTINATION_COMMANDS: ReadonlySet<CommandId> = new Set([
+  "facts", "new-fact", "new-fact-from-here", "new-fact-from-selection", "edit-fact",
+  "new-fact-state", "end-fact-here", "token-probabilities",
+  "generation-records", "tag-line", "authors-note", "author-brief", "facts-budget",
+  "phrase-bias", "banned-strings", "aside", "switch-story", "rename-story",
+  "direct-take", "retake", "rewrite-selection", "summary", "chapters", "chapter",
+  "import-card", "import-archive", "attach-image", "settings", "reconnect", "prune"
+]);
+
+export async function runPaletteCommand(
+  command: PaletteCommand,
+  state: RuntimeState,
+  source: AppSource,
+  context: ActionContext,
+  deps: PaletteCommandRunnerDeps
+): Promise<void> {
+  // Both refusals belong here, ahead of any mode change. A refused command
+  // leaves the invoking surface and its draft untouched.
+  if ((command.mutating === true && generationBusy(state))
+    || (command.blockedByLiveStream === true && streamLive(state))) {
+    state.toast = "stream running · esc stops it first";
+    return;
+  }
+  if (command.id === "tags") {
+    state.commands!.view = "tags";
+    state.commands!.cursor = 0;
+    return;
+  }
+  const paletteSession = state.commands!;
+  const returnMode = state.commands!.returnMode;
+  const dormantOwner = capturePaletteOwner(state, returnMode);
+  if (returnMode === "SETTINGS"
+    && settingsPaletteHasUnsavedWork(state)
+    && (command.settingsTarget !== undefined || PALETTE_DESTINATION_COMMANDS.has(command.id))) {
+    state.commands = null;
+    state.mode = "SETTINGS";
+    state.toast = "save or cancel Settings changes first";
+    return;
+  }
+  if ((command.settingsTarget !== undefined || PALETTE_DESTINATION_COMMANDS.has(command.id))
+    // Direct resumes the retained composer and retires only a suspended
+    // retake. It is safe even when that Direct composer has text.
+    && !(command.id === "direct-take" && returnMode === "COMPOSE")
+    && paletteOwnerHasUnsavedInput(state, returnMode)) {
+    state.commands = null;
+    state.mode = returnMode;
+    state.toast = "finish or cancel current input first";
+    return;
+  }
+  // A dirty editor can target an abandoned leaf; pruning that leaf would
+  // invalidate the draft before Escape can restore it.
+  if (command.id === "prune"
+    && returnMode === "EDITOR"
+    && editorHasUnsavedInput(state)) {
+    state.commands = null;
+    state.mode = "EDITOR";
+    state.toast = "finish or cancel current input first";
+    return;
+  }
+  const selection = state.commands!.selection ?? null;
+  // MAP has its own cursor in each view. Capture it while the palette still
+  // owns the suspended Map; the normal NAV retake path otherwise falls back
+  // to the stale story focus index.
+  const mapRetakeTarget = command.id === "retake" && returnMode === "MAP"
+    ? factsOpeningPartId(state)
+    : undefined;
+  // PROBS keeps its own displayed take identity. Its Tab cursor does not
+  // move NAV's focusIndex, so never let Retake fall back to that stale row.
+  const probsRetakeTarget = command.id === "retake" && returnMode === "PROBS"
+    ? state.probs?.nodeId ?? null
+    : undefined;
+  // RECORD keeps its own displayed take identity. Its viewer can be opened
+  // from MAP while NAV's focus remains on a different story part.
+  const recordRetakeTarget = command.id === "retake" && returnMode === "RECORD"
+    ? state.record?.nodeId ?? null
+    : undefined;
+  // A Record opened from MAP keeps that exact Map parent alive for its close
+  // route. Retake exits to NAV, so retain the identity for the final cascade
+  // release after the Record owner settles.
+  const recordParentMap = command.id === "retake" && returnMode === "RECORD"
+    && state.record?.returnMode === "MAP"
+    ? capturePaletteOwner(state, "MAP")
+    : null;
+
+  // Summary and an in-flight Aside answer own their surface until they settle.
+  // Keep the palette escapable, but do not let a destination command strand the
+  // live operation or let its completion overwrite the requested destination.
+  if (returnMode === "SUMMARY" && state.summary !== null
+    || returnMode === "ASIDE" && state.aside?.busy === true) {
+    state.commands = null;
+    state.mode = returnMode;
+    state.toast = returnMode === "SUMMARY"
+      ? "summary running · esc cancels"
+      : "Aside is answering · esc stops it first";
+    return;
+  }
+
+  // The palette may suspend a dirty editor, but a second command must not
+  // replace its draft. Fact-editor commands use the existing reducer below.
+  if (returnMode === "EDITOR"
+    && !command.id.startsWith("fact-editor-")
+    && (command.settingsTarget !== undefined || PALETTE_DESTINATION_COMMANDS.has(command.id))) {
+    state.commands = null;
+    state.mode = "EDITOR";
+    state.toast = "close the current editor before running this command";
+    return;
+  }
+
+  const factEditorAction = FACT_EDITOR_COMMAND_ACTIONS[command.id];
+  if (factEditorAction !== undefined) {
+    state.commands = null;
+    if (returnMode !== "EDITOR" || state.editor?.kind !== "fact") {
+      state.mode = returnMode;
+      state.toast = "Fact editor is no longer open";
+      clearPaletteOwnerTransients(state, returnMode, dormantOwner, paletteSession);
+      return;
+    }
+    state.mode = "EDITOR";
+    await inlineEditorAction({
+      action: factEditorAction,
+      ...(command.id === "fact-editor-previous-state" ? { index: -1 } : {}),
+      ...(command.id === "fact-editor-next-state" ? { index: 1 } : {})
+    }, state, source, context);
+    clearPaletteOwnerTransients(state, returnMode, dormantOwner, paletteSession);
+    return;
+  }
+
+  const factsActionName = FACTS_COMMAND_ACTIONS[command.id]
+    ?? (command.id === "new-fact-state" ? "new-state"
+      : command.id === "end-fact-here" ? "end-state"
+        : command.id === "edit-fact" ? "edit"
+          : undefined);
+  if (factsActionName !== undefined && returnMode === "FACTS" && state.facts !== null) {
+    state.commands = null;
+    state.mode = "FACTS";
+    await deps.factsAction({
+      action: factsActionName,
+      ...(command.id === "facts-dossier-previous-state" ? { index: -1 } : {}),
+      ...(command.id === "facts-dossier-next-state" ? { index: 1 } : {})
+    }, state, source, context);
+    clearPaletteOwnerTransients(state, returnMode, dormantOwner, paletteSession);
+    return;
+  }
+
+  const mapActionName = MAP_COMMAND_ACTIONS[command.id];
+  if (mapActionName !== undefined && returnMode === "MAP" && state.map !== null) {
+    state.commands = null;
+    state.mode = "MAP";
+    await mapAction({ action: mapActionName }, state, source, {
+      ...context,
+      reroute: (currentState, currentSource, currentContext, nodeId) => rerouteToNode(
+        currentState,
+        currentSource,
+        currentContext,
+        nodeId,
+        {
+          owns: (ownedState) => ownedState.mode === "MAP" && ownedState.map === state.map,
+          release: (ownedState) => { ownedState.map = null; }
+        }
+      ),
+      armPrune,
+      openTag
+    });
+    clearPaletteOwnerTransients(state, returnMode, dormantOwner, paletteSession);
+    return;
+  }
+
+  state.commands = null;
+  // A command that does not open another surface returns to its exact owner.
+  // Surface-changing commands below select their own mode as needed.
+  state.mode = returnMode;
+  if (command.id === "facts") {
+    state.facts ??= deps.initialFacts();
+    state.mode = "FACTS";
+  }
+  else if (command.id === "new-fact") openFactEditor(state, null);
+  else if (command.id === "new-fact-from-selection") {
+    if (selection === null || selection.text.trim().length === 0) {
+      state.toast = "highlight story text before creating a Fact";
+    } else {
+      openFactFromSelection(
+        state,
+        selection.text,
+        returnMode === "FACTS" ? { returnMode: "FACTS" } : {}
+      );
+    }
+  }
+  else if (command.id === "new-fact-from-here") {
+    const anchorPartId = factsOpeningPartId(state);
+    if (anchorPartId === null) state.toast = "select a story part before creating a Fact";
+    else openFactEditor(state, null, { anchorPartId });
+  }
+  else if (command.id === "edit-fact") {
+    state.facts = deps.initialFacts();
+    state.facts.pendingFactAction = { kind: "edit", anchorPartId: null };
+    state.mode = "FACTS";
+  }
+  else if (command.id === "new-fact-state" || command.id === "end-fact-here") {
+    state.facts = deps.initialFacts();
+    state.facts.pendingFactAction = {
+      kind: command.id === "new-fact-state" ? "new-state" : "end",
+      anchorPartId: factsOpeningPartId(state)
+    };
+    state.mode = "FACTS";
+  }
+  else if (command.id === "next-request") {
+    if (state.retakePrompt?.intent.kind === "rewrite") {
+      state.mode = returnMode;
+      state.toast = deps.rewriteRequestNotProjectedToast;
+    } else if (!(returnMode === "REQUEST" && state.request !== null)) {
+      openRequestViewer(state, returnMode === "COMMANDS" ? "NAV" : returnMode);
+    }
+  }
+  else if (command.id === "token-probabilities") {
+    if (state.mode !== "NAV") state.mode = "NAV";
+    await openTokenProbabilities(state, source, context);
+  }
+  else if (command.id === "generation-records") {
+    if (state.mode !== "NAV" && state.mode !== "MAP") state.mode = "NAV";
+    await openGenerationRecordViewer(state, source, context);
+  }
+  else if (command.id === "tag-line") {
+    const anchorPartId = factsOpeningPartId(state);
+    if (anchorPartId === null) state.toast = "select a story part before tagging it";
+    else openTag(state, anchorPartId);
+  }
+  else if (command.id === "authors-note") openAuthorsNoteEditor(state);
+  else if (command.id === "author-brief") openAuthorBriefEditor(state);
+  else if (command.id === "facts-budget") openFactsBudgetEditor(state);
+  else if (command.id === "phrase-bias") openPhraseBiasEditor(state);
+  else if (command.id === "banned-strings") openBannedStringsEditor(state);
+  else if (command.id === "aside") await openAside(state, source.api, {
+    entryPointsOpen: context.asideEntryPointsOpen
+  });
+  else if (command.id === "switch-story") await openLibrary(state, source, context);
+  else if (command.id === "rename-story") {
+    const targetId = state.payload.id;
+    const title = state.payload.title;
+    await openLibrary(state, source, context, {
+      selectedStoryId: targetId,
+      prompt: { kind: "rename", composer: createComposer(title), targetId }
+    });
+  }
+  else if (command.id === "direct-take") openDirectComposer(state);
+  else if (command.id === "retake") {
+    if (returnMode === "PROBS" || returnMode === "RECORD") {
+      state.mode = "NAV";
+      const target = returnMode === "PROBS" ? probsRetakeTarget : recordRetakeTarget;
+      if (target === null) {
+        state.toast = "select a visible story part before retaking it";
+      } else {
+        await runPartAction("retake", state, source, context, target);
+      }
+    } else {
+      await runPaletteMapRetake(
+        state,
+        source,
+        context,
+        returnMode === "MAP" ? mapRetakeTarget : undefined,
+        paletteSession
+      );
+    }
+  }
+  else if (command.id === "rewrite-selection") {
+    if (selection === null) {
+      state.toast = "highlight story text before rewriting it";
+    } else if (state.connection.down) {
+      state.toast = "offline · reading still works";
+    } else {
+      const partId = partIdFromTextSelection(selection.spans);
+      const resolved = partId === null
+        ? { error: "highlight story text before rewriting it" }
+        : resolveRewriteTarget(state.payload, partId, selection.spans);
+      if ("error" in resolved) state.toast = resolved.error;
+      else openRewriteComposer(state, resolved);
+    }
+  }
+  else if (command.id === "export") {
+    const title = state.payload.title;
+    await context.backend.run("exporting story", async (task) => {
+      const exported = await source.api.exportMarkdown(task.storyId);
+      if (!task.owns()) return;
+      const file = await writeStoryExport({
+        directory: source.exportDirectory,
+        title,
+        markdown: exported.markdown
+      });
+      if (task.interactionCurrent()) {
+        state.toast = exported.fidelity.length === 0
+          ? `exported ${file}`
+          : `exported ${file} · ${exported.fidelity.join("; ")}`;
+      }
+    });
+  } else if (command.id === "export-profile") {
+    if (!source.settingsView.editable) {
+      state.toast = "Generation Profiles require settings format 2";
+      return;
+    }
+    const document = source.settingsView.document;
+    const profileId = selectSettingsRoute(document, "prose").profileId;
+    await context.backend.run("exporting Generation Profile", async (task) => {
+      try {
+        const archive = exportGenerationProfile(document as never, profileId);
+        const file = await writeExportFile({
+          directory: source.exportDirectory,
+          title: document.profiles[profileId]!.name,
+          extension: archive.extension,
+          content: archive.text
+        });
+        if (!task.interactionCurrent()) return;
+        state.toast = `exported ${file} · connection data omitted`;
+        recordNotice(state.notices, "toast", `exported Generation Profile · ${archive.fidelity.join("; ")}`);
+      } catch (error) {
+        if (task.interactionCurrent()) {
+          state.toast = `could not export Generation Profile · ${error instanceof Error ? error.message : String(error)}`;
+        }
+      }
+    });
+  } else if (command.id === "summary") await startSummary(state, source, context);
+  else if (command.id === "chapters") openChapters(state);
+  else if (command.id === "chapter") {
+    state.mode = "NAV";
+    state.focusIndex = lastPartRowIndex(createStoryViewModel(state.payload));
+    rememberFocus(state, source);
+    await createBreakAtFocus(state, source, context);
+  }
+  else if (command.id === "autoname") {
+    await context.backend.run("naming story", async (task) => {
+      const payload = await source.api.autonameStory(task.storyId);
+      if (!task.storyCurrent()) return;
+      adoptSameStoryPayload(state, payload, context.cache);
+      if (!task.owns()) return;
+      const stories = await source.api.listStories();
+      if (!task.owns()) return;
+      publishStories(state, source, stories);
+      if (task.interactionCurrent()) state.toast = `story named ${payload.title}`;
+    });
+  } else if (command.id === "prune") {
+    const plan = createUnusedTakesPrunePlan(state.payload);
+    if (plan === null) state.toast = "nothing to prune · every leaf is protected";
+    else {
+      state.prune = plan;
+      // Only NAV and MAP render the destructive confirmation as their active
+      // surface. Keep MAP because its breadcrumb owns the same confirmation;
+      // release every other suspended owner before confirmation is accepted.
+      if (returnMode !== "MAP") state.mode = "NAV";
+    }
+  } else if (command.id === "prompts") {
+    state.showInstructions = !state.showInstructions;
+    state.toast = `directions ${state.showInstructions ? "shown" : "hidden"}`;
+  }
+  else if (command.settingsTarget !== undefined || command.id === "settings") {
+    await openSettingsOverlay(state, source, context, command.settingsTarget);
+    await synchronizeSettingsModelDiscovery(state, source, context);
+  }
+  else if (command.id === "theme" && command.theme !== undefined) {
+    context.applyTheme(command.theme);
+    state.toast = `theme · ${command.theme}`;
+  }
+  else if (command.id === "reconnect") await deps.reconnect(state, source, context);
+  else if (command.id === "folder") state.toast = source.storyFolder;
+  else if (command.id === "import-card") openCardImport(state, returnMode === "COMPOSE" ? "COMPOSE" : "NAV");
+  else if (command.id === "import-archive") openArchiveImport(state, returnMode === "COMPOSE" ? "COMPOSE" : "NAV");
+  else if (command.id === "attach-image") openImageAttach(state, source, returnMode === "COMPOSE" ? "COMPOSE" : "NAV");
+  else if (command.id === "disconnect" && state.demo) {
+    state.connection = connectionFailed(connectionSucceeded(), new Error("demo disconnect"), state.now);
+    state.toast = "simulated connection loss";
+  }
+  releasePaletteOwner(state, returnMode, dormantOwner, paletteSession);
+  if (recordParentMap !== null && state.mode === "NAV") {
+    releasePaletteOwner(state, "MAP", recordParentMap, paletteSession);
+  }
+}

--- a/tui/src/palette-map-retake.ts
+++ b/tui/src/palette-map-retake.ts
@@ -1,0 +1,69 @@
+import { rerouteToNode, runPartAction } from "./story-actions.js";
+import type { ActionContext } from "./action-context.js";
+import type { AppSource } from "./app.js";
+import type { PaletteSession } from "./palette-owner.js";
+import type { RuntimeState } from "./state.js";
+
+/** Run Retake for the row selected in a suspended Map palette. */
+export async function runPaletteMapRetake(
+  state: RuntimeState,
+  source: AppSource,
+  context: ActionContext,
+  target: string | null | undefined,
+  paletteSession: PaletteSession
+): Promise<void> {
+  if (target === null) {
+    state.mode = "MAP";
+    state.toast = "select a visible story part before retaking it";
+    return;
+  }
+  if (target === undefined) {
+    state.mode = "NAV";
+    await runPartAction("retake", state, source, context);
+    return;
+  }
+
+  // Map rows outside the active path expose stubs. Land the selected row
+  // first so the canonical retake reducer receives the full StoryNode.
+  const map = state.map;
+  if (map === null) {
+    state.mode = "MAP";
+    state.toast = "select a visible story part before retaking it";
+    return;
+  }
+
+  // Keep the exact Map/palette operation that selected this row. A reroute may
+  // adopt its payload after Escape or a newer Ctrl-P has taken ownership.
+  const interactionVersion = state.interactionVersion;
+  const view = map.view;
+  const cursorId = view === "path" ? map.pathCursorId : map.treeCursorId;
+  let ownsLanding = state.payload.path.some(({ id }) => id === target);
+  if (!ownsLanding) {
+    await rerouteToNode(state, source, context, target, {
+      owns: (ownedState) => ownedState.mode === "MAP"
+        && ownedState.map !== null
+        && ownedState.map.view === view
+        && (ownedState.map.view === "path"
+          ? ownedState.map.pathCursorId
+          : ownedState.map.treeCursorId) === cursorId
+        && ownedState.interactionVersion === interactionVersion
+        && (ownedState.commands === null || ownedState.commands === paletteSession),
+      release: (ownedState) => {
+        ownsLanding = true;
+        if (ownedState.map !== null
+          && ownedState.map.view === view
+          && (ownedState.map.view === "path"
+            ? ownedState.map.pathCursorId
+            : ownedState.map.treeCursorId) === cursorId) {
+          ownedState.map = null;
+        }
+      }
+    });
+  }
+  if (ownsLanding && state.payload.path.some(({ id }) => id === target)) {
+    state.mode = "NAV";
+    await runPartAction("retake", state, source, context, target);
+  } else if (state.mode === "MAP") {
+    state.toast ??= "select a visible story part before retaking it";
+  }
+}

--- a/tui/src/palette-owner.ts
+++ b/tui/src/palette-owner.ts
@@ -1,0 +1,281 @@
+import { factEditorChanged } from "./fact-editor-draft.js";
+import { draftImagesFor } from "./draft-image.js";
+import { activeSettingsEdit } from "./settings-edit-state.js";
+import { settingsDraftChanged } from "./settings-overlay-reconciliation.js";
+import { TAG_STATUSES } from "../../shared/types.js";
+import type { RuntimeState } from "./state.js";
+
+/** The exact palette object that owns one suspended interaction. */
+export type PaletteSession = NonNullable<RuntimeState["commands"]>;
+export type PaletteOwnerMode = Exclude<RuntimeState["mode"], "COMMANDS">;
+
+type PaletteSurface = object;
+
+export interface PaletteOwnerSnapshot {
+  actions: RuntimeState["actions"];
+  textActions: RuntimeState["textActions"];
+  prune: RuntimeState["prune"];
+  surface: PaletteSurface | null;
+}
+
+/** Capture the identity-bearing state that Escape must restore or release. */
+export function capturePaletteOwner(
+  state: RuntimeState,
+  returnMode: RuntimeState["mode"]
+): PaletteOwnerSnapshot {
+  return {
+    actions: state.actions,
+    textActions: state.textActions,
+    prune: state.prune,
+    surface: paletteOwnerSurface(state, returnMode)
+  };
+}
+
+/** Settings has more than one draft owner, so check all of them together. */
+export function settingsPaletteHasUnsavedWork(state: RuntimeState): boolean {
+  const overlay = state.settings;
+  if (overlay === null) return false;
+  const editMode = state.editor?.kind === "document"
+    && state.editor.target.kind === "settings-prompt"
+    && state.editor.target.owner === overlay
+    ? "EDITOR"
+    : "SETTINGS";
+  const edit = activeSettingsEdit(
+    { mode: editMode, editor: state.editor, settings: overlay },
+    overlay
+  );
+  return settingsDraftChanged(overlay)
+    || overlay.view.pendingRevision !== null
+    || overlay.saveIntent !== undefined
+    || overlay.profileTransfer !== null
+    || overlay.modelPicker !== null
+    || edit !== null && edit.composer.text !== edit.initialText();
+}
+
+/** A destination cannot discard unsent input in its suspended owner. */
+export function paletteOwnerHasUnsavedInput(
+  state: RuntimeState,
+  returnMode: RuntimeState["mode"]
+): boolean {
+  switch (returnMode) {
+    case "COMPOSE":
+      return state.retakePrompt !== null
+        || state.composer.text.length > 0
+        || draftImagesFor(state.composer).length > 0;
+    case "ASIDE":
+      return state.aside?.busy !== true
+        && (state.aside?.composer.text.length ?? 0) > 0;
+    case "CARD":
+      return (state.card?.path.length ?? 0) > 0;
+    case "ARCHIVE":
+      return (state.archive?.path.length ?? 0) > 0;
+    case "IMAGE":
+      return (state.image?.path.length ?? 0) > 0;
+    case "LIBRARY": {
+      const prompt = state.library?.prompt;
+      if (prompt?.kind !== "rename") return false;
+      const target = state.library?.stories.find((story) => story.id === prompt.targetId);
+      return target === undefined
+        ? prompt.composer.text.length > 0
+        : prompt.composer.text !== target.title;
+    }
+    case "CHAPTERS": {
+      const rename = state.chapters?.rename;
+      if (rename === null || rename === undefined) return false;
+      const expected = rename.breakId === null
+        ? state.payload.firstChapterTitle ?? ""
+        : state.payload.chapterBreaks.find(({ id }) => id === rename.breakId)?.title;
+      return expected === undefined
+        ? rename.composer.text.length > 0
+        : rename.composer.text !== expected;
+    }
+    case "TAG": {
+      const prompt = state.tag;
+      if (prompt === null) return false;
+      // Status selection and delete confirmation are live prompt state, even
+      // when the selected value still matches the saved tag.
+      if (prompt.choosingStatus || prompt.deleteArmed) return true;
+      const existing = state.payload.tags.find(({ nodeId }) => nodeId === prompt.nodeId);
+      if (prompt.existing !== (existing !== undefined)) return true;
+      if (existing === undefined) {
+        return prompt.name.length > 0 || prompt.statusIndex !== 0;
+      }
+      return prompt.name !== existing.name
+        || prompt.statusIndex !== TAG_STATUSES.indexOf(existing.status);
+    }
+    case "PLACE":
+      // Placement keeps the exact Aside surface aside while it owns the
+      // screen. Do not release that surface while it has an unsent question.
+      return (state.placement?.returnAside.composer.text.length ?? 0) > 0;
+    default:
+      return false;
+  }
+}
+
+export function editorHasUnsavedInput(state: RuntimeState): boolean {
+  const editor = state.editor;
+  if (editor === null) return false;
+  if (editor.kind === "fact") return factEditorChanged(editor);
+  if (editor.composer.text !== editor.initial) return true;
+  return editor.target.kind === "authors-note"
+    && editor.target.depth !== editor.target.expectedDepth;
+}
+
+/** Clear the transient menus captured by one palette invocation. */
+export function clearPaletteOwnerTransients(
+  state: RuntimeState,
+  returnMode: RuntimeState["mode"],
+  owner: PaletteOwnerSnapshot,
+  paletteSession: PaletteSession
+): boolean {
+  // An awaited command may settle after the user opens a new palette over the
+  // same owner. The old transition no longer owns cleanup in that session.
+  if (state.commands !== null
+    && state.commands !== paletteSession
+    && state.commands.returnMode === returnMode) return false;
+  // ACTIONS is itself the return surface. Read-only commands that leave the
+  // mode unchanged must keep its exact owner so Escape can close it normally.
+  if (state.actions === owner.actions
+    && !(returnMode === "ACTIONS"
+      && state.mode === returnMode
+      && state.prune === owner.prune)) state.actions = null;
+  if (state.textActions === owner.textActions) state.textActions = null;
+  if (state.prune === owner.prune) state.prune = null;
+  return true;
+}
+
+/** Release the suspended owner after a palette destination takes over. */
+export function releasePaletteOwner(
+  state: RuntimeState,
+  returnMode: RuntimeState["mode"],
+  owner: PaletteOwnerSnapshot,
+  paletteSession: PaletteSession
+): void {
+  // The request viewer is a read-only child of the exact surface that opened
+  // the palette. Keep that owner and all of its transient state until the
+  // viewer closes and restores its return mode.
+  if (state.mode === "REQUEST" && state.request?.returnMode === returnMode) return;
+  if (!clearPaletteOwnerTransients(state, returnMode, owner, paletteSession)) return;
+  if (state.mode === returnMode) return;
+  // A new Fact opened from the Facts palette is still owned by the same
+  // overlay. Keep that exact object so cancel and save return to its context.
+  if (returnMode === "FACTS"
+    && owner.surface !== null
+    && state.facts === owner.surface
+    && state.editor?.kind === "fact"
+    && state.editor.returnMode === "FACTS") return;
+  // Record and Tag are children of MAP. Keep its exact owner while their
+  // close action still needs to return to MAP.
+  if (returnMode === "MAP"
+    && owner.surface !== null
+    && state.map === owner.surface
+    && ((state.record?.returnMode === "MAP")
+      || (state.tag?.returnMode === "MAP")
+      || (state.editor?.returnMode === "MAP"))) return;
+  // A Settings prompt editor is a child of the captured Settings overlay.
+  // Keep that exact owner so the prompt can still save its draft.
+  if (returnMode === "SETTINGS"
+    && owner.surface !== null
+    && state.settings === owner.surface
+    && state.editor?.kind === "document"
+    && state.editor.target.kind === "settings-prompt"
+    && state.editor.target.owner === owner.surface) return;
+  switch (returnMode) {
+    case "ARCHIVE": if (state.archive === owner.surface) state.archive = null; break;
+    case "ASIDE": if (state.aside === owner.surface) state.aside = null; break;
+    case "CARD": if (state.card === owner.surface) state.card = null; break;
+    case "CHAPTERS": if (state.chapters === owner.surface) state.chapters = null; break;
+    case "FACTS": if (state.facts === owner.surface) state.facts = null; break;
+    case "IMAGE": if (state.image === owner.surface) state.image = null; break;
+    case "LIBRARY": if (state.library === owner.surface) state.library = null; break;
+    case "MAP": if (state.map === owner.surface) state.map = null; break;
+    case "PROBS": if (state.probs === owner.surface) state.probs = null; break;
+    case "RECORD": if (state.record === owner.surface) state.record = null; break;
+    case "REQUEST": if (state.request === owner.surface) state.request = null; break;
+    case "SEARCH": if (state.search === owner.surface) state.search = null; break;
+    case "SETTINGS": if (state.settings === owner.surface) state.settings = null; break;
+    case "TAG": if (state.tag === owner.surface) state.tag = null; break;
+    case "PLACE": if (state.placement === owner.surface) state.placement = null; break;
+    default: break;
+  }
+}
+
+/** Retarget an exact live palette session without claiming a newer one. */
+export function retargetPaletteSession(
+  state: Pick<RuntimeState, "commands">,
+  paletteSession: PaletteSession,
+  returnMode: RuntimeState["mode"]
+): boolean {
+  if (state.commands !== paletteSession) return false;
+  paletteSession.returnMode = returnMode;
+  return true;
+}
+
+/** Restore one exact palette session after a story replacement. */
+export function restorePaletteSession(
+  state: Pick<RuntimeState, "commands" | "mode">,
+  paletteSession: PaletteSession,
+  returnMode: RuntimeState["mode"]
+): void {
+  paletteSession.returnMode = returnMode;
+  state.commands = paletteSession;
+  state.mode = "COMMANDS";
+}
+
+/** Return the exact live palette that is waiting for one owner to settle. */
+export function paletteSessionReturningTo(
+  state: Pick<RuntimeState, "mode" | "commands">,
+  ownerMode: PaletteOwnerMode
+): PaletteSession | null {
+  return state.mode === "COMMANDS"
+    && state.commands?.returnMode === ownerMode
+    ? state.commands
+    : null;
+}
+
+/** Settle an owner without replacing a matching palette session. */
+export function settleModeUnderPalette(
+  state: Pick<RuntimeState, "mode" | "commands" | "request">,
+  ownerMode: PaletteOwnerMode,
+  nextMode: PaletteOwnerMode
+): PaletteSession | null {
+  const palette = paletteSessionReturningTo(state, ownerMode);
+  if (palette !== null) {
+    palette.returnMode = nextMode;
+    state.mode = "COMMANDS";
+    return palette;
+  }
+  // A request viewer is a read-only child of the same owner, but it removes
+  // the palette before the owner can settle. Retarget the viewer instead of
+  // sending its visible route to a hidden or already-released owner.
+  if (state.mode === "REQUEST" && state.request?.returnMode === ownerMode) {
+    state.request.returnMode = nextMode;
+    return null;
+  }
+  state.mode = nextMode;
+  return null;
+}
+
+function paletteOwnerSurface(
+  state: RuntimeState,
+  returnMode: RuntimeState["mode"]
+): PaletteSurface | null {
+  switch (returnMode) {
+    case "ARCHIVE": return state.archive;
+    case "ASIDE": return state.aside;
+    case "CARD": return state.card;
+    case "CHAPTERS": return state.chapters;
+    case "FACTS": return state.facts;
+    case "IMAGE": return state.image ?? null;
+    case "LIBRARY": return state.library;
+    case "MAP": return state.map;
+    case "PROBS": return state.probs;
+    case "RECORD": return state.record;
+    case "REQUEST": return state.request;
+    case "SEARCH": return state.search;
+    case "SETTINGS": return state.settings;
+    case "TAG": return state.tag;
+    case "PLACE": return state.placement;
+    default: return null;
+  }
+}

--- a/tui/src/plain-text-paste.ts
+++ b/tui/src/plain-text-paste.ts
@@ -1,5 +1,6 @@
 import type { AppSource } from "./app.js";
 import type { ActionContext } from "./action-context.js";
+import { noteAsidePaletteInteraction } from "./aside-actions.js";
 import { readFromClipboard } from "./clipboard.js";
 import { sanitizePastedText } from "./keys.js";
 import { handleOverlayAction } from "./overlay-actions.js";
@@ -161,6 +162,10 @@ export async function pastePlainTextFromClipboard(
 ): Promise<boolean> {
   const target = plainTextPasteTarget(state, source, context);
   if (target === null) return false;
+  // A palette paste can wait on the host clipboard while a suspended Aside
+  // Ask settles. Advance its restore fence before that await, so a null or
+  // failed response still returns the question to the Aside composer.
+  noteAsidePaletteInteraction(state);
   const interactionVersion = state.interactionVersion;
   const text = await readFromClipboard();
   if (state.interactionVersion !== interactionVersion || !target.isCurrent()) return true;

--- a/tui/src/presented-mouse-action.ts
+++ b/tui/src/presented-mouse-action.ts
@@ -3,7 +3,14 @@ import { hitAt } from "./hit.js";
 import type { ResolvedKey } from "./keys.js";
 import { factRows } from "./facts-model.js";
 import { canonicalFactStates } from "../../shared/fact-state.js";
-import { commandContext, commandMatches, commandSelectionId } from "./command-model.js";
+import {
+  commandContext,
+  commandMatches,
+  commandSelectionId,
+  retainCommandSelection
+} from "./command-model.js";
+import { factEditorPaletteContext } from "./facts-command-catalog.js";
+import { factsOpeningPartId, factsPaletteContext } from "./facts-command-context.js";
 import { libraryRows } from "./library-model.js";
 import { searchRows, selectedSearchRow } from "./search-model.js";
 import { canRewriteSelection } from "./selection-projection.js";
@@ -255,7 +262,8 @@ function sameMouseTarget(
     && before.settingsRow === after.settingsRow
     && before.text === after.text
     && before.composerSourceId === after.composerSourceId
-    && before.composerEditable === after.composerEditable;
+    && before.composerEditable === after.composerEditable
+    && before.composerCursor === after.composerCursor;
 }
 
 function mapRowAt(
@@ -290,7 +298,10 @@ function mapRowId(state: MouseActionState, index: number | undefined): string | 
  *  Null means the row cannot be named, which reconciliation refuses. */
 function listRowIdentity(state: MouseActionState, index: number | undefined): string | null {
   if (index === undefined) return null;
-  if (state.textActions !== null) return availableTextActions(state.textActions)[index]?.id ?? null;
+  const commandsOwnRows = state.mode === "COMMANDS" && state.commands !== null;
+  if (!commandsOwnRows && state.textActions !== null) {
+    return availableTextActions(state.textActions)[index]?.id ?? null;
+  }
   if (state.mode === "ASIDE" && state.aside?.useMenu !== null
     && state.aside?.useMenu !== undefined) {
     const entry = asideUseActions(state.aside.useMenu.selectionText)[index];
@@ -298,13 +309,15 @@ function listRowIdentity(state: MouseActionState, index: number | undefined): st
       ? null
       : asideUseRowId(state.aside.useMenu.sessionId, entry.id);
   }
-  if (state.request !== null) return requestRowIdentity(state, index);
+  if (!commandsOwnRows && state.request !== null) return requestRowIdentity(state, index);
   if (state.mode === "MAP" && state.map !== null) return mapRowId(state, index);
-  if (state.search !== null) {
+  if (!commandsOwnRows && state.search !== null) {
     return searchRowIdentity(state, index);
   }
-  if (state.actions !== null) return currentPartActions(state)[index]?.id ?? null;
-  if (state.library !== null) {
+  if (!commandsOwnRows && state.actions !== null) {
+    return currentPartActions(state)[index]?.id ?? null;
+  }
+  if (!commandsOwnRows && state.library !== null) {
     return libraryRows(
       state.library.stories,
       state.library.query
@@ -320,7 +333,11 @@ function listRowIdentity(state: MouseActionState, index: number | undefined): st
       commandContext(state.payload, {
         connectionDown: state.connection.down,
         requestActive: state.requestActive ?? false,
-        canRewriteSelection: canRewriteSelection(state.commands.selection?.spans ?? [])
+        canRewriteSelection: canRewriteSelection(state.commands.selection?.spans ?? []),
+        hasStoryPart: factsOpeningPartId(state) !== null,
+        hasStorySelection: Boolean(state.commands.selection?.text?.trim()),
+        ...factEditorPaletteContext(state.editor?.kind === "fact" ? state.editor : null),
+        ...factsPaletteContext(state)
       })
     )[index];
     return match === undefined ? null : commandSelectionId(match.command);
@@ -390,7 +407,8 @@ function selectableRowsOpen(state: MouseActionState): boolean {
 }
 
 function selectedListIdentity(state: MouseActionState): string | null {
-  if (state.textActions !== null) {
+  const commandsOwnRows = state.mode === "COMMANDS" && state.commands !== null;
+  if (!commandsOwnRows && state.textActions !== null) {
     const entry = availableTextActions(state.textActions)[state.textActions.cursor];
     return entry === undefined ? null : `text-actions:${entry.id}`;
   }
@@ -401,8 +419,10 @@ function selectedListIdentity(state: MouseActionState): string | null {
       ? null
       : asideUseRowId(state.aside.useMenu.sessionId, entry.id);
   }
-  if (state.request !== null) return requestRowIdentity(state, state.request.cursor);
-  if (state.search !== null) {
+  if (!commandsOwnRows && state.request !== null) {
+    return requestRowIdentity(state, state.request.cursor);
+  }
+  if (!commandsOwnRows && state.search !== null) {
     return searchRowIdentity(state, state.search.cursor);
   }
   if (state.mode === "MAP" && state.map !== null) {
@@ -412,11 +432,11 @@ function selectedListIdentity(state: MouseActionState): string | null {
   // Name the verb, not its position: the menu's entries change composition
   // while a generation lands, so the row under an unmoved cursor can become a
   // different — and destructive — action.
-  if (state.actions !== null) {
+  if (!commandsOwnRows && state.actions !== null) {
     const entry = currentPartActions(state)[state.actions.cursor];
     return entry === undefined ? null : `actions:${state.actions.partId}:${entry.id}`;
   }
-  if (state.library !== null) {
+  if (!commandsOwnRows && state.library !== null) {
     const story = libraryRows(
       state.library.stories,
       state.library.query
@@ -431,7 +451,33 @@ function selectedListIdentity(state: MouseActionState): string | null {
       const tag = state.payload.tags[state.commands.cursor];
       return tag === undefined ? null : `tags:${tag.nodeId}`;
     }
-    return `commands:${state.commands.view}:${state.commands.selectedId ?? state.commands.cursor}`;
+    if (state.commands.view === "commands") {
+      const matches = commandMatches(
+        state.commands.query,
+        state.demo,
+        commandContext(state.payload, {
+          connectionDown: state.connection.down,
+          requestActive: state.requestActive ?? false,
+          canRewriteSelection: canRewriteSelection(state.commands.selection?.spans ?? []),
+          hasStoryPart: factsOpeningPartId(state) !== null,
+          hasStorySelection: Boolean(state.commands.selection?.text?.trim()),
+          ...factEditorPaletteContext(state.editor?.kind === "fact" ? state.editor : null),
+          ...factsPaletteContext(state)
+        })
+      );
+      // Rendering retains the command by id, then falls back to the cursor.
+      // Use that same effective selection here; selectedId can be stale until
+      // the next keyboard reducer runs after a contextual repaint.
+      const retained = retainCommandSelection(
+        matches,
+        state.commands.selectedId,
+        state.commands.cursor
+      );
+      return retained.selectedId === null
+        ? null
+        : `commands:${state.commands.view}:${retained.selectedId}`;
+    }
+    return `commands:${state.commands.view}:${state.commands.cursor}`;
   }
   if (state.facts !== null) {
     if (state.facts.dossier !== null && state.facts.dossier !== undefined) {

--- a/tui/src/presented-selection.ts
+++ b/tui/src/presented-selection.ts
@@ -68,6 +68,31 @@ export function capturePresentedInputSelection(
   return capturePresentedSelection(renderer, frame, previous);
 }
 
+/** Facts keeps the last NAV story projection under its panel so the original
+ * native range can still open a palette command. A new or changed range on
+ * the Facts frame must not map panel cells onto unrelated prose underneath. */
+export function guardFactsStorySelectionCapture(
+  captured: CapturedPresentedSelection,
+  previous: CapturedPresentedSelection | null
+): CapturedPresentedSelection {
+  const frame = captured.frame;
+  if (captured === previous || frame?.state.mode !== "FACTS"
+    || frame.storySelectionProjection === null || captured.native === null) {
+    return captured;
+  }
+  const priorNavNative = previous?.frame?.state.mode === "NAV"
+    ? previous.native
+    : null;
+  if (priorNavNative !== null && priorNavNative !== undefined
+    && sameNativeSelection(priorNavNative, captured.native)) {
+    return captured;
+  }
+  return {
+    ...captured,
+    frame: { ...frame, storySelectionProjection: null }
+  };
+}
+
 export function consumePresentedSelection(captured: CapturedPresentedSelection): void {
   if (captured.disposition === "active") captured.disposition = "consumed";
 }

--- a/tui/src/reference-bindings.ts
+++ b/tui/src/reference-bindings.ts
@@ -11,6 +11,9 @@ export interface ReferenceBinding {
   sequence?: string;
   shift?: boolean;
   ctrl?: boolean;
+  /** Match in every application mode. Keep the binding's mode as its
+   *  reference owner so the keys screen and contract tests stay stable. */
+  global?: boolean;
   mapView?: MapView;
 }
 
@@ -25,7 +28,7 @@ export type ReferenceBindingLane =
 
 type BindingOptions = Partial<Pick<
   ReferenceBinding,
-  "sequence" | "shift" | "ctrl" | "mapView"
+  "sequence" | "shift" | "ctrl" | "global" | "mapView"
 >>;
 
 type BindingDefinition = Omit<ReferenceBinding, "display">;
@@ -96,7 +99,7 @@ const DEFINITIONS = {
   navOpenFacts: route("nav", "f", "NAV", "open-facts"),
   navOpenLibrary: route("nav", "o", "NAV", "open-library"),
   navOpenCommandsColon: route("nav", ":", "NAV", "open-commands"),
-  navOpenCommandsCtrlP: route("nav-chord", "p", "NAV", "open-commands", { ctrl: true }),
+  navOpenCommandsCtrlP: route("global", "p", "NAV", "open-commands", { ctrl: true, global: true }),
   navOpenSettings: route("nav", ",", "NAV", "open-settings"),
   navToggleContext: route("nav-chord", "g", "NAV", "toggle-context-meter", { ctrl: true }),
   composeToggleContext: route("compose-chord", "g", "COMPOSE", "toggle-context-meter", { ctrl: true }),
@@ -204,7 +207,7 @@ function matches(
   mode: AppMode,
   mapView: MapView
 ): boolean {
-  if (binding.mode !== mode || key.meta) return false;
+  if ((!binding.global && binding.mode !== mode) || key.meta) return false;
   if ((binding.ctrl ?? false) !== Boolean(key.ctrl)) return false;
   if (binding.mapView !== undefined && binding.mapView !== mapView) return false;
   if (binding.sequence !== undefined && binding.sequence !== key.sequence) return false;

--- a/tui/src/request-viewer-actions.ts
+++ b/tui/src/request-viewer-actions.ts
@@ -1,11 +1,13 @@
 import type { KeyEvent } from "@opentui/core";
 import type { ResolvedKey } from "./keys.js";
-import type { RuntimeState } from "./state.js";
+import type { RequestViewerState, RuntimeState } from "./state.js";
+
+type RequestViewerReturnMode = RequestViewerState["returnMode"];
 
 /** Open the read-only request document without moving its owner. */
 export function openRequestViewer(
   state: RuntimeState,
-  returnMode: "NAV" | "COMPOSE" = state.mode === "COMPOSE" ? "COMPOSE" : "NAV"
+  returnMode: RequestViewerReturnMode = state.mode === "COMPOSE" ? "COMPOSE" : "NAV"
 ): void {
   state.request = { cursor: 0, scrollTop: -1, returnMode };
   state.mode = "REQUEST";

--- a/tui/src/screens/panels.ts
+++ b/tui/src/screens/panels.ts
@@ -8,6 +8,8 @@ import {
   commandPaletteWindow,
   retainCommandSelection
 } from "../command-model.js";
+import { factEditorPaletteContext } from "../facts-command-catalog.js";
+import { factsOpeningPartId, factsPaletteContext } from "../facts-command-context.js";
 import {
   libraryAge,
   libraryRows,
@@ -113,6 +115,8 @@ type PanelState = Omit<OverlayState, "hitRows"> & {
   now: number;
   contextWindow?: number | null;
   stream: StreamView | null;
+  editor?: StoryScreenState["editor"];
+  map?: StoryScreenState["map"];
   abort: StoryScreenState["abort"];
 };
 
@@ -133,12 +137,17 @@ export function renderPanels(
     requestActive: generationBusy(state) || state.summary !== null || state.chapterSummary != null
   };
   let composition: FrameComposition = { lines: base, selectable: null };
-  if (state.archive !== null) {
+  // The command palette can suspend any panel without clearing its state.
+  // Route by its active mode before testing dormant panel state.
+  if (state.mode === "COMMANDS" && state.commands !== null) {
+    composition = renderCommands(dimPage(base), local, width, height);
+  }
+  else if (state.mode === "ARCHIVE" && state.archive !== null) {
     composition = renderArchiveImportPanel(
       dimPage(base), local, width, height, ARCHIVE_IMPORT_FOOTER_ACTIONS
     );
   }
-  else if (local.settings !== null && local.settings.profileTransfer !== null) {
+  else if (state.mode === "SETTINGS" && local.settings !== null && local.settings.profileTransfer !== null) {
     composition = renderProfileTransferPanel(
       dimPage(base),
       local.settings.profileTransfer,
@@ -147,29 +156,28 @@ export function renderPanels(
       height
     );
   }
-  else if (state.card !== null) {
+  else if (state.mode === "CARD" && state.card !== null) {
     composition = renderCardImportPanel(
       dimPage(base), local, width, height, CARD_IMPORT_FOOTER_ACTIONS
     );
   }
-  else if (state.image != null) {
+  else if (state.mode === "IMAGE" && state.image != null) {
     composition = renderImageAttachPanel(
       dimPage(base), local, width, height, IMAGE_ATTACH_FOOTER_ACTIONS
     );
   }
-  else if (state.actions != null) composition = renderActions(dimPage(base), local, width, height);
-  else if (state.library !== null) composition = renderLibrary(dimPage(base), local, width, height, deadlines);
-  else if (state.facts !== null) {
+  else if (state.mode === "ACTIONS" && state.actions != null) composition = renderActions(dimPage(base), local, width, height);
+  else if (state.mode === "LIBRARY" && state.library !== null) composition = renderLibrary(dimPage(base), local, width, height, deadlines);
+  else if (state.mode === "FACTS" && state.facts !== null) {
     composition = renderFactsPanel(dimPage(base), local, width, height, estimate);
   }
-  else if (state.commands !== null) composition = renderCommands(dimPage(base), local, width, height);
-  else if (state.chapters !== null) composition = renderChapters(dimPage(base), local, width, height, estimate);
-  else if (state.settings?.sampling !== null && state.settings !== null) {
+  else if (state.mode === "CHAPTERS" && state.chapters !== null) composition = renderChapters(dimPage(base), local, width, height, estimate);
+  else if (state.mode === "SETTINGS" && state.settings?.sampling !== null && state.settings !== null) {
     composition = renderSamplingPanel(base, local, width, height);
   }
-  else if (state.settings !== null) composition = renderSettingsPanel(base, local, width, height);
-  else if (state.summary !== null) composition = renderSummary(dimPage(base), local, width, height);
-  if (state.textActions !== null) {
+  else if (state.mode === "SETTINGS" && state.settings !== null) composition = renderSettingsPanel(base, local, width, height);
+  else if (state.mode === "SUMMARY" && state.summary !== null) composition = renderSummary(dimPage(base), local, width, height);
+  if (state.mode !== "COMMANDS" && state.textActions !== null) {
     composition = renderTextActionsPanel(dimPage(composition.lines), local, width, height);
   }
   if (state.connection.down) {
@@ -486,7 +494,11 @@ function renderCommands(
     commandContext(state.payload, {
       connectionDown: state.connection.down,
       requestActive: state.requestActive,
-      canRewriteSelection: canRewriteSelection(overlay.selection?.spans ?? [])
+      canRewriteSelection: canRewriteSelection(overlay.selection?.spans ?? []),
+      hasStoryPart: factsOpeningPartId(state) !== null,
+      hasStorySelection: Boolean(overlay.selection?.text?.trim()),
+      ...factEditorPaletteContext(state.editor?.kind === "fact" ? state.editor : null),
+      ...factsPaletteContext(state)
     })
   );
   const cursor = retainCommandSelection(model.selectable, overlay.selectedId, overlay.cursor).cursor;

--- a/tui/src/screens/story.ts
+++ b/tui/src/screens/story.ts
@@ -1,10 +1,4 @@
 import { STARTER_LOGO_TEXT } from "../../../shared/starter-vault.js";
-import {
-  authorsNoteWarning,
-  MAX_AUTHORS_NOTE_CHARS,
-  MAX_AUTHORS_NOTE_DEPTH
-} from "../../../shared/authors-note.js";
-import { unicodeScalarLength } from "../../../shared/unicode.js";
 import { TAG_STATUSES } from "../../../shared/types.js";
 import type { FrameDeadlineCollector } from "../animation-deadline.js";
 import { tagStatusChoice } from "../tag-presentation.js";
@@ -78,8 +72,11 @@ import {
   renderComposerLayout,
   type ComposerLayout
 } from "./story/composer.js";
+import {
+  addFactsBudgetComposerHits,
+  isFactsBudgetEditor,
+} from "../facts-budget-editor.js";
 import { storyProseMeasure, STORY_GUTTER } from "../composer-geometry.js";
-import type { ComposerStatus as ComposerChromeStatus } from "./story/composer-chrome.js";
 import { renderStatus as renderCanonicalStatus } from "./story/status.js";
 import { viewportLines, type ViewportBlock } from "./story/viewport.js";
 import {
@@ -99,6 +96,12 @@ import {
   type ComposerSelectionProjection,
   type StorySelectionProjection
 } from "../selection-projection.js";
+import {
+  authorNoteStatus,
+  composerHitTarget,
+  editorFooterHints,
+  renderFactsBudgetLayout
+} from "./story/editor-chrome.js";
 
 export interface StoryScreenOptions {
   width: number;
@@ -413,9 +416,18 @@ export function renderStoryScreen(state: StoryScreenState, options: StoryScreenO
         : state.mode === "COMPOSE"
           ? buildComposerSelectionProjection(pageSelectionLines, frameLayout.pageWidth)
           : null,
+      // FACTS is a panel over the story page. Keep the last NAV projection so
+      // a native range captured on the page still resolves when Ctrl-P opens
+      // from the rendered Facts frame. Input admission rejects a new or
+      // changed Facts range before it can use this retained coordinate map.
+      // Other full-screen owners replace the page buffer and must not inherit
+      // its coordinate map.
       storySelectionProjection: state.mode === "NAV"
         ? buildStorySelectionProjection(pageSelectionLines, frameLayout.pageWidth)
-        : null,
+        : state.mode === "FACTS"
+          || state.mode === "COMMANDS" && state.commands?.returnMode === "FACTS"
+          ? state.storySelectionProjection
+          : null,
       map: state.map,
       request: state.request,
       record: state.record
@@ -805,21 +817,6 @@ function renderFullscreenComposer(
   };
 }
 
-function editorFooterHints(editor: DocumentEditorSession): string {
-  if (editor.kind === "document"
-    && editor.target.kind === "settings-prompt") {
-    return "shift+arrows select · ctrl+c/x/v · ctrl+s keep draft · esc cancel";
-  }
-  // Part editors offer dual save; other targets and incomplete fixtures keep
-  // the single-save footer (tests may stub a minimal session without target).
-  if (editor.kind === "document" && editor.target.kind === "part") {
-    // ctrl+o is the portable same-take chord; ctrl+shift+s is an alias where
-    // the terminal reports modified keys.
-    return "shift+arrows select · ctrl+c/x/v · ctrl+s new take · ctrl+o same take · esc cancel";
-  }
-  return "shift+arrows select · ctrl+c/x/v · ctrl+s save · esc cancel";
-}
-
 function renderInlineEditor(
   state: StoryScreenState,
   view: StoryViewModel,
@@ -846,6 +843,8 @@ function renderInlineEditor(
         softWrap: state.config.wordWrap === "on",
         viewMode: state.config.factsViewMode ?? "simple"
       })
+    : isFactsBudgetEditor(host)
+      ? renderFactsBudgetLayout(host, width, height, footerNotice)
     : renderComposerLayout({
         composer: host.composer,
         fullscreen: true,
@@ -864,46 +863,6 @@ function renderInlineEditor(
   return renderEditorLayoutFrame(state, view, width, height, estimate, layout, deadlines);
 }
 
-function composerHitTarget(line: FrameLine | undefined): HitTarget {
-  const sources = new Map<string, boolean>();
-  for (const part of line ?? []) {
-    if (part.composerHitSource !== undefined) {
-      sources.set(part.composerHitSource.id, part.composerHitSource.editable);
-    }
-  }
-  if (sources.size !== 1) return { kind: "composer" };
-  const source = sources.entries().next().value;
-  if (source === undefined) return { kind: "composer" };
-  return {
-    kind: "composer",
-    composerSourceId: source[0],
-    composerEditable: source[1]
-  };
-}
-
-function authorNoteStatus(
-  host: DocumentEditorSession,
-  width: number
-): ComposerChromeStatus | undefined {
-  if (host.kind !== "document" || host.target.kind !== "authors-note") return undefined;
-  const maxWidth = Math.max(1, width - visibleWidth(`┏━ ${host.title} `) - 1);
-  if (unicodeScalarLength(host.composer.text, MAX_AUTHORS_NOTE_CHARS) > MAX_AUTHORS_NOTE_CHARS) {
-    const text = [
-      `· max is ${MAX_AUTHORS_NOTE_CHARS.toLocaleString("en-US")} Unicode scalar values`,
-      `· max is ${MAX_AUTHORS_NOTE_CHARS.toLocaleString("en-US")} scalar values`,
-      `· max is ${MAX_AUTHORS_NOTE_CHARS.toLocaleString("en-US")}`
-    ].find((candidate) => [...candidate].length <= maxWidth)
-      ?? `· max is ${MAX_AUTHORS_NOTE_CHARS.toLocaleString("en-US")}`;
-    return { text, role: "danger text" };
-  }
-  const warning = authorsNoteWarning(host.composer.text, maxWidth);
-  if (warning !== null) return { text: warning, role: "context warning" };
-  const depthShort = `depth ${host.target.depth}/${MAX_AUTHORS_NOTE_DEPTH}`;
-  const depthHint = `${depthShort} · ⌥-/= change`;
-  const text = [depthHint, depthShort].find((candidate) => [...candidate].length <= maxWidth) ?? depthShort;
-  return { text, role: "context note" };
-}
-
 function renderEditorLayoutFrame(
   state: StoryScreenState,
   view: StoryViewModel,
@@ -913,7 +872,20 @@ function renderEditorLayoutFrame(
   layout: ComposerLayout,
   deadlines?: FrameDeadlineCollector
 ): StoryScreenFrame {
-  const base = [...layout.lines, renderStoryStatus(
+  // Inline scalar editors own only a few rows. Keep the app status at the
+  // bottom of the viewport while the compact field stays at the top; full
+  // screen editors already provide their complete surface height.
+  const surfaceRows = Math.max(0, height - 1);
+  const surface = layout.fullscreen
+    ? layout.lines
+    : [
+        ...layout.lines,
+        ...Array.from(
+          { length: Math.max(0, surfaceRows - layout.lines.length) },
+          (): FrameLine => []
+        )
+      ];
+  const base = [...surface, renderStoryStatus(
     state, view, width, width < 100, estimate, deadlines
   )]
     .slice(0, height)
@@ -921,6 +893,9 @@ function renderEditorLayoutFrame(
   const hitRows: HitRows = Array.from({ length: height }, (_, row): HitRow | null => row < height - 1
     ? { target: composerHitTarget(base[row]), left: 0, right: width }
     : null);
+  if (isFactsBudgetEditor(state.editor)) {
+    for (const [row, line] of base.entries()) addFactsBudgetComposerHits(line, row, hitRows);
+  }
   // Fact editor headers and the semantic footer carry explicit controls. Add
   // their narrow targets over the broad composer rows so mouse and keyboard
   // actions share the same reducer.

--- a/tui/src/screens/story/editor-chrome.ts
+++ b/tui/src/screens/story/editor-chrome.ts
@@ -1,0 +1,141 @@
+import {
+  authorsNoteWarning,
+  MAX_AUTHORS_NOTE_CHARS,
+  MAX_AUTHORS_NOTE_DEPTH
+} from "../../../../shared/authors-note.js";
+import { unicodeScalarLength } from "../../../../shared/unicode.js";
+import { composerPosition } from "../../composer-model.js";
+import type { HitTarget } from "../../hit.js";
+import type { DocumentEditorSession } from "../../state.js";
+import {
+  FACTS_BUDGET_STATUS,
+  factsBudgetFooterActions,
+  type FactsBudgetEditor
+} from "../../facts-budget-editor.js";
+import {
+  renderComposerInput,
+  renderComposerLayout,
+  type ComposerLayout
+} from "./composer.js";
+import {
+  composerFieldLine,
+  type ComposerStatus as ComposerChromeStatus
+} from "./composer-chrome.js";
+import {
+  segment,
+  visibleWidth,
+  type FrameLine
+} from "./frame.js";
+
+export function editorFooterHints(editor: DocumentEditorSession): string {
+  if (editor.kind === "document"
+    && editor.target.kind === "settings-prompt") {
+    return "shift+arrows select · ctrl+c/x/v · ctrl+s keep draft · esc cancel";
+  }
+  // Part editors offer dual save; other targets and incomplete fixtures keep
+  // the single-save footer (tests may stub a minimal session without target).
+  if (editor.kind === "document" && editor.target.kind === "part") {
+    // ctrl+o is the portable same-take chord; ctrl+shift+s is an alias where
+    // the terminal reports modified keys.
+    return "shift+arrows select · ctrl+c/x/v · ctrl+s new take · ctrl+o same take · esc cancel";
+  }
+  return "shift+arrows select · ctrl+c/x/v · ctrl+s save · esc cancel";
+}
+
+/** Facts Budget is a bounded scalar, so keep its editor to one Settings-style
+ * field instead of opening the multiline document surface. The shared
+ * composer renderer still owns caret, selection, clipping, and history. */
+export function renderFactsBudgetLayout(
+  editor: FactsBudgetEditor,
+  width: number,
+  height: number,
+  footerNotice: string | null
+): ComposerLayout {
+  const layout = renderComposerLayout({
+    composer: editor.composer,
+    fullscreen: false,
+    terminalWidth: width,
+    terminalHeight: height,
+    measure: width,
+    composeMaxHeight: 1,
+    title: editor.title,
+    status: { text: FACTS_BUDGET_STATUS },
+    footerActions: factsBudgetFooterActions(width),
+    placeholder: "uncapped",
+    footerNotice,
+    narrow: width < 100,
+    softWrap: false,
+    caret: "focused"
+  });
+  const body = layout.lines[1];
+  if (body === undefined) return layout;
+
+  const position = composerPosition(editor.composer);
+  const prefix = "┃ › facts budget ";
+  const suffix = " tokens";
+  // Keep the input chip at the same compact width as a Settings scalar. The
+  // shared input renderer clips long drafts and keeps the caret visible.
+  const chipWidth = Math.min(
+    13,
+    Math.max(3, layout.fieldWidth - visibleWidth(prefix) - visibleWidth(suffix))
+  );
+  const input = renderComposerInput(
+    editor.composer,
+    position.line,
+    position.column,
+    Math.max(1, chipWidth - 2),
+    "focused",
+    editor.composer.text.length === 0,
+    "uncapped"
+  );
+  layout.lines[1] = composerFieldLine("", layout.fieldWidth, [
+    segment("┃ ", "compose accent"),
+    segment("› ", "compose accent"),
+    segment("facts budget ", "prose"),
+    segment("[", "chrome"),
+    ...input,
+    segment("]", "chrome"),
+    segment(" tokens", "chrome")
+  ]);
+  return layout;
+}
+
+export function composerHitTarget(line: FrameLine | undefined): HitTarget {
+  const sources = new Map<string, boolean>();
+  for (const part of line ?? []) {
+    if (part.composerHitSource !== undefined) {
+      sources.set(part.composerHitSource.id, part.composerHitSource.editable);
+    }
+  }
+  if (sources.size !== 1) return { kind: "composer" };
+  const source = sources.entries().next().value;
+  if (source === undefined) return { kind: "composer" };
+  return {
+    kind: "composer",
+    composerSourceId: source[0],
+    composerEditable: source[1]
+  };
+}
+
+export function authorNoteStatus(
+  host: DocumentEditorSession,
+  width: number
+): ComposerChromeStatus | undefined {
+  if (host.kind !== "document" || host.target.kind !== "authors-note") return undefined;
+  const maxWidth = Math.max(1, width - visibleWidth(`┏━ ${host.title} `) - 1);
+  if (unicodeScalarLength(host.composer.text, MAX_AUTHORS_NOTE_CHARS) > MAX_AUTHORS_NOTE_CHARS) {
+    const text = [
+      `· max is ${MAX_AUTHORS_NOTE_CHARS.toLocaleString("en-US")} Unicode scalar values`,
+      `· max is ${MAX_AUTHORS_NOTE_CHARS.toLocaleString("en-US")} scalar values`,
+      `· max is ${MAX_AUTHORS_NOTE_CHARS.toLocaleString("en-US")}`
+    ].find((candidate) => [...candidate].length <= maxWidth)
+      ?? `· max is ${MAX_AUTHORS_NOTE_CHARS.toLocaleString("en-US")}`;
+    return { text, role: "danger text" };
+  }
+  const warning = authorsNoteWarning(host.composer.text, maxWidth);
+  if (warning !== null) return { text: warning, role: "context warning" };
+  const depthShort = `depth ${host.target.depth}/${MAX_AUTHORS_NOTE_DEPTH}`;
+  const depthHint = `${depthShort} · ⌥-/= change`;
+  const text = [depthHint, depthShort].find((candidate) => [...candidate].length <= maxWidth) ?? depthShort;
+  return { text, role: "context note" };
+}

--- a/tui/src/search-actions.ts
+++ b/tui/src/search-actions.ts
@@ -19,6 +19,7 @@ import {
   type SearchState
 } from "./search-model.js";
 import { adoptStoryState } from "./story-adoption.js";
+import { paletteSessionReturningTo, restorePaletteSession } from "./palette-owner.js";
 import {
   generationBusy,
   landOnNode,
@@ -155,7 +156,16 @@ async function openSearchHit(
     return;
   }
   if (hit.kind === "fact") {
-    openHitFact(hit, state, search);
+    // A vault hit can adopt a different story while Ctrl-P is suspended over
+    // Search. Adoption clears the Search object, so the normal identity fence
+    // in `openHitFact` no longer matches. Keep that palette session alive and
+    // retarget its return surface to the Facts overlay we are about to open.
+    const palette = state.mode === "COMMANDS"
+      && state.commands?.returnMode === "NAV"
+      && state.search !== search
+      ? state.commands
+      : null;
+    openHitFact(hit, state, search, palette);
     return;
   }
   const target = resolveRerouteTarget(state.payload, hit.targetId);
@@ -163,12 +173,44 @@ async function openSearchHit(
     state.toast = "that part is no longer in this story";
     return;
   }
-  if (landOnOwnLine(target, state, search, source)) return;
+  let palette = state.mode === "COMMANDS"
+    && state.commands?.returnMode === "NAV"
+    ? state.commands
+    : null;
+  if (landOnOwnLine(target, state, search, source)) {
+    if (palette !== null) {
+      // Landing normally closes Search. A palette opened while the story was
+      // loading is still the visible owner, so restore it after landing.
+      state.commands = palette;
+      state.mode = "COMMANDS";
+    }
+    return;
+  }
   const searchOrigin: RerouteOrigin = {
-    owns: (current) => current.mode === "SEARCH" && current.search === search,
-    release: (current) => { current.search = null; }
+    owns: (current) => {
+      if (palette !== null) {
+        return current.mode === "COMMANDS" && current.commands === palette;
+      }
+      // Ctrl-P can open while switchLine is settling. Capture only a palette
+      // that still returns to this exact Search; a later palette is fenced by
+      // the task's interaction epoch before this predicate is reached.
+      if (current.mode === "COMMANDS"
+        && current.commands?.returnMode === "SEARCH"
+        && current.search === search) {
+        palette = current.commands;
+        return true;
+      }
+      return current.mode === "SEARCH" && current.search === search;
+    },
+    release: (current) => {
+      if (current.search === search) current.search = null;
+      if (palette !== null && current.commands === palette) {
+        palette.returnMode = "NAV";
+      }
+    }
   };
   await rerouteToNode(state, source, context, target, searchOrigin);
+  if (palette !== null && state.commands === palette) state.mode = "COMMANDS";
 }
 
 /** Load and adopt the story a vault hit belongs to. Search keeps the screen
@@ -192,12 +234,23 @@ async function openHitStory(
       state.toast = "that part is no longer in that story";
       return;
     }
+    const palette = paletteSessionReturningTo(state, "SEARCH");
     flushReadingPositionPersist();
     adoptStoryState(state, payload, context.cache);
-    // adoptStoryState returns the app to NAV; search still owns the screen
-    // until the part it is travelling to is on the page.
-    state.mode = "SEARCH";
-    state.search = search;
+    if (palette !== null) {
+      // A different-story adoption clears every story-bound surface,
+      // including the search navigator. Keep Ctrl-P visible, with Esc
+      // returning to the settled story's NAV surface. Its captured
+      // selection names the old story and must not cross this boundary.
+      palette.selection = null;
+      palette.deleteArmedTagNodeId = null;
+      restorePaletteSession(state, palette, "NAV");
+    } else {
+      // adoptStoryState returns the app to NAV; search still owns the screen
+      // until the part it is travelling to is on the page.
+      state.mode = "SEARCH";
+      state.search = search;
+    }
     adopted = true;
   });
   return adopted;
@@ -233,8 +286,13 @@ function landOnOwnLine(
 
 /** A fact has no place on the page, so its hit opens the facts overlay with
  *  that note selected. */
-function openHitFact(hit: SearchHit, state: RuntimeState, search: SearchState): void {
-  if (state.search !== search) return;
+function openHitFact(
+  hit: SearchHit,
+  state: RuntimeState,
+  search: SearchState,
+  palette: RuntimeState["commands"] = null
+): void {
+  if (state.search !== search && palette === null) return;
   const rows = factRows(state.payload.facts, null, "");
   const cursor = rows.findIndex((fact) => fact.id === hit.targetId);
   if (cursor < 0) {
@@ -253,5 +311,12 @@ function openHitFact(hit: SearchHit, state: RuntimeState, search: SearchState): 
     dossier: null,
     ...(hit.stateId === undefined ? {} : { selectedStateId: hit.stateId })
   };
-  state.mode = "FACTS";
+  if (palette !== null) {
+    palette.returnMode = "FACTS";
+    palette.selection = null;
+    state.commands = palette;
+    state.mode = "COMMANDS";
+  } else {
+    state.mode = "FACTS";
+  }
 }

--- a/tui/src/state.ts
+++ b/tui/src/state.ts
@@ -202,10 +202,12 @@ export interface FactsOverlayState {
   scopeFilter?: "everywhere" | "this-line" | "elsewhere" | "ended";
   /** One Fact's history, rendered inside this overlay. */
   dossier?: FactsDossierState | null;
+  /** Story prose selected immediately before this Facts overlay opened. */
+  storySelection?: ProjectedStorySelection | null;
   /** Pending action from the NAV `x` menu; the next Enter chooses its Fact. */
   pendingFactAction?: {
-    kind: "new-state" | "end";
-    anchorPartId: string;
+    kind: "new-state" | "end" | "edit";
+    anchorPartId: string | null;
   } | null;
 }
 export interface CommandsOverlayState {
@@ -217,7 +219,7 @@ export interface CommandsOverlayState {
   /** Omitted predecessor/test states are unarmed. */
   deleteArmedTagNodeId?: string | null;
   /** Surface that owns the composer while the palette is open. */
-  returnMode: "NAV" | "COMPOSE";
+  returnMode: AppMode;
   /** Story selection captured at open time — the NAV projection it reads
    *  only exists for that one frame, so a later keystroke cannot rebuild it. */
   selection?: ProjectedStorySelection | null;
@@ -435,7 +437,8 @@ export interface RequestViewerState {
   cursor: number;
   /** Negative means reveal the focused message on the next render. */
   scrollTop: number;
-  returnMode: "NAV" | "COMPOSE";
+  /** Surface to restore when the read-only request document closes. */
+  returnMode: Exclude<AppMode, "COMMANDS">;
 }
 
 /** The token probability viewer (issue #291 phase 4), open on one take.

--- a/tui/src/story-actions.ts
+++ b/tui/src/story-actions.ts
@@ -59,6 +59,7 @@ import { canRewriteSelection, type StorySelectionSpan } from "./selection-projec
 import type { ActionContext } from "./action-context.js";
 import { adoptSameStoryPayload } from "./story-adoption.js";
 import { openRewriteComposer, resolveRewriteTarget, submitRewriteComposer } from "./rewrite-action.js";
+import { retargetPaletteSession } from "./palette-owner.js";
 import {
   advanceOrSaveTag,
   confirmPrune,
@@ -321,10 +322,11 @@ export async function runPartAction(
   id: PartActionId,
   state: RuntimeState,
   source: AppSource,
-  context: ActionContext
+  context: ActionContext,
+  targetPartId?: string
 ): Promise<void> {
   const view = createStoryViewModel(state.payload, state.stream);
-  const partId = state.actions?.partId ?? rowPart(view, state.focusIndex)?.id ?? null;
+  const partId = targetPartId ?? state.actions?.partId ?? rowPart(view, state.focusIndex)?.id ?? null;
   const selectionText = state.actions?.selectionText ?? null;
   const selectionSpans = state.actions?.selectionSpans ?? [];
   closeActions(state);
@@ -673,8 +675,20 @@ export async function composeAction(
         }
         // Keep the Direct draft until the load succeeds. A failed Aside read
         // must leave the writer in COMPOSE with the exact text they entered.
+        const paletteAtStart = state.commands;
+        const restoreDirectDraft = () => {
+          const newerPalette = state.mode === "COMMANDS"
+            && state.commands !== null
+            && state.commands !== paletteAtStart
+            ? state.commands
+            : null;
+          if (newerPalette === null) state.mode = "COMPOSE";
+          else retargetPaletteSession(state, newerPalette, "COMPOSE");
+          setComposerText(state.composer, instruction);
+        };
         try {
           let opened = false;
+          let initialAskCompleted = asideParse.kind !== "open-and-ask";
           const admitted = await context.backend.run(
             asideParse.kind === "open" ? "opening Aside" : "asking Aside",
             async (task) => {
@@ -684,7 +698,7 @@ export async function composeAction(
                 task
               });
               if (opened && asideParse.kind === "open-and-ask" && state.aside !== null) {
-                await sendAsideQuestion(state, source.api, asideParse.question, {
+                initialAskCompleted = await sendAsideQuestion(state, source.api, asideParse.question, {
                   task,
                   repaint: context.repaint,
                   cache: context.cache
@@ -692,12 +706,15 @@ export async function composeAction(
               }
             }
           );
-          if (admitted && opened && state.mode === "ASIDE" && state.aside !== null) {
-            setComposerText(state.composer, "");
+          // Aside can finish loading underneath the global palette. `opened`
+          // is the ownership-fenced success signal; the visible mode may be
+          // COMMANDS with ASIDE as its return mode in that case.
+          if (admitted && opened && state.aside !== null) {
+            if (initialAskCompleted) setComposerText(state.composer, "");
+            else restoreDirectDraft();
           }
         } catch (error) {
-          state.mode = "COMPOSE";
-          setComposerText(state.composer, instruction);
+          restoreDirectDraft();
           state.toast = error instanceof Error ? error.message : String(error);
         }
         return;
@@ -806,10 +823,33 @@ export async function rerouteFromMap(
   context: ActionContext,
   nodeId = state.map?.pathCursorId ?? null
 ): Promise<void> {
+  // Ctrl-P can suspend the Map while its switchLine request is in flight. The
+  // palette does not start a new interaction, so the request still owns the
+  // landing; retarget that exact suspended surface to NAV when it settles.
+  let palette: RuntimeState["commands"] = null;
   await rerouteToNode(state, source, context, nodeId, {
-    owns: (current) => current.mode === "MAP" && current.map !== null,
-    release: (current) => { current.map = null; }
+    owns: (current) => {
+      if (palette !== null) {
+        return current.mode === "COMMANDS" && current.commands === palette;
+      }
+      if (current.mode === "COMMANDS"
+        && current.commands?.returnMode === "MAP"
+        && current.map !== null) {
+        palette = current.commands;
+        return true;
+      }
+      return current.mode === "MAP" && current.map !== null;
+    },
+    release: (current) => {
+      if (current.mode === "MAP" || palette !== null && current.commands === palette) {
+        current.map = null;
+      }
+      if (palette !== null && current.commands === palette) {
+        palette.returnMode = "NAV";
+      }
+    }
   });
+  if (palette !== null && state.commands === palette) state.mode = "COMMANDS";
 }
 
 /** Route the line through a node and land on it.

--- a/tui/src/story-adoption.ts
+++ b/tui/src/story-adoption.ts
@@ -19,6 +19,11 @@ import {
   rememberFocus
 } from "./reading-position-persist.js";
 import { abortPendingSearch, retireSearch } from "./search-request.js";
+import {
+  paletteSessionReturningTo,
+  restorePaletteSession,
+  retargetPaletteSession
+} from "./palette-owner.js";
 import type { RuntimeState } from "./state.js";
 import { followStoryViewport } from "./viewport-intent.js";
 import { reconcileWrapCache } from "./wrap-invalidation.js";
@@ -100,12 +105,17 @@ export function adoptSameStoryPayload(
   const retainedAside = state.aside?.storyId === payload.id
     ? state.aside
     : state.placement?.returnAside.storyId === payload.id
-      ? state.placement.returnAside
+    ? state.placement.returnAside
       : null;
   if (retainedAside !== null) {
     retainedAside.storyTitle = payload.title;
   }
   state.payload = payload;
+  // The page-cell map belongs to the revision that was just replaced. Clear
+  // it before the next frame so a Facts panel cannot reuse coordinates from
+  // edited prose as if they were the current story selection.
+  state.storySelectionProjection = null;
+  clearAdoptedStorySelection(state);
   const view = restoreStoryFocus(state, focus);
   reconcilePlacementStops(state, view);
 
@@ -189,6 +199,8 @@ export function reconcileStoryActions(
   if (actions === null) return;
   if (rowIndexForNode(view, actions.partId) >= 0) return;
   state.actions = null;
+  const palette = paletteSessionReturningTo(state, "ACTIONS");
+  if (palette !== null) retargetPaletteSession(state, palette, "NAV");
   if (state.mode === "ACTIONS") state.mode = "NAV";
 }
 
@@ -235,6 +247,8 @@ export function reconcileMapNavigation(state: RuntimeState, payload = state.payl
   const fallbackId = payload.path.at(-1)?.id ?? null;
   if (fallbackId === null) {
     state.map = null;
+    const palette = paletteSessionReturningTo(state, "MAP");
+    if (palette !== null) retargetPaletteSession(state, palette, "NAV");
     if (state.mode === "MAP") state.mode = "NAV";
     return;
   }
@@ -285,20 +299,39 @@ export function adoptReconciliationSnapshot(
     text !== null && text.length > 0 && text !== composer.text && drafts.indexOf(text) === index);
   const mode = state.mode;
   const quitArmed = state.quitArmed;
-  const library = mode === "LIBRARY"
+  const paletteReturnMode = mode === "COMMANDS"
+    ? state.commands?.returnMode ?? null
+    : null;
+  const library = (mode === "LIBRARY" || paletteReturnMode === "LIBRARY")
     && state.library !== null
     && state.library !== options.discardedLibrary
+    // A suspended palette has no Library owner to restore unless the user
+    // left an active prompt/filter behind. This also lets an intentional
+    // delete/fallback, whose prompt was cleared by catalog publication, fall
+    // back to NAV instead of reviving an empty Library shell.
+    && (mode !== "COMMANDS" || state.library.prompt !== null)
     ? state.library
     : null;
-  const retainedGlobalEditor = globalEditor(state);
+  const retainedGlobalEditor = globalEditor(state)
+    ?? (paletteReturnMode === "EDITOR"
+      && state.editor?.kind === "document"
+      && state.editor.target.kind === "settings-prompt"
+      && state.settings === state.editor.target.owner
+      ? state.editor
+      : null);
   const retainedSettings = state.settings?.profileTransfer === null
-    && (mode === "SETTINGS" || retainedGlobalEditor !== null)
+    && (mode === "SETTINGS"
+      || paletteReturnMode === "SETTINGS"
+      || retainedGlobalEditor !== null)
     ? state.settings
     : null;
   const editorScrollTop = state.editorScrollTop;
-  const commands = mode === "COMMANDS" && state.commands?.view === "commands"
+  const commands = mode === "COMMANDS"
     ? state.commands
     : null;
+  // A tag-manager delete arm names a node in the previous story. Preserve the
+  // palette context, but always require a fresh confirmation after adoption.
+  if (commands !== null) commands.deleteArmedTagNodeId = null;
 
   adoptStoryState(state, payload, cache);
   // Destination story keeps its stored opening focus from adoptStoryState.
@@ -315,30 +348,74 @@ export function adoptReconciliationSnapshot(
   }
   state.quitArmed = quitArmed;
 
-  if (mode === "COMPOSE") state.mode = "COMPOSE";
-  else if (retainedGlobalEditor !== null && retainedSettings !== null) {
+  if (mode === "COMPOSE") {
+    state.mode = "COMPOSE";
+  } else {
+    // Restore the underlying owner once. A palette then layers its exact
+    // session on top when that owner still has a valid return route.
+    const restoredOwner = paletteReturnMode === "COMPOSE"
+      ? "COMPOSE"
+      : restoreStoryOwner(
+        state,
+        retainedSettings,
+        retainedGlobalEditor,
+        editorScrollTop,
+        library,
+        commands !== null && paletteReturnMode === "LIBRARY"
+      );
+    if (commands !== null && restoredOwner !== null && restoredOwner === paletteReturnMode) {
+      if (restoredOwner === "COMPOSE") commands.selection = null;
+      restorePaletteSession(state, commands, restoredOwner);
+    } else if (restoredOwner !== null) {
+      state.mode = restoredOwner;
+    } else if (commands !== null) {
+      // A different-story adoption clears every story-bound surface. Keep the
+      // exact palette session visible, but never let it return to an owner that
+      // belonged to the replaced story or carry its captured selection across
+      // the boundary.
+      commands.selection = null;
+      restorePaletteSession(state, commands, "NAV");
+    } else if (mode === "KEYS") {
+      state.mode = "KEYS";
+    }
+  }
+}
+
+type RetainedStoryOwner = "COMPOSE" | "EDITOR" | "LIBRARY" | "SETTINGS";
+
+/** Restore the one story-independent or catalog owner that survived adoption. */
+function restoreStoryOwner(
+  state: RuntimeState,
+  retainedSettings: NonNullable<RuntimeState["settings"]> | null,
+  retainedGlobalEditor: RuntimeState["editor"],
+  editorScrollTop: number,
+  library: NonNullable<RuntimeState["library"]> | null,
+  discardInvalidLibrary: boolean
+): RetainedStoryOwner | null {
+  if (retainedGlobalEditor !== null && retainedSettings !== null) {
     state.settings = retainedSettings;
     state.editor = retainedGlobalEditor;
     state.editorScrollTop = editorScrollTop;
-    state.mode = "EDITOR";
+    return "EDITOR";
   }
-  else if (library !== null) {
+  if (library !== null) {
     const targetId = library.prompt?.kind === "filter"
       ? undefined
       : library.prompt?.targetId;
-    if (targetId !== undefined
-      && !library.stories.some((story) => story.id === targetId)) {
+    const targetValid = targetId === undefined
+      || library.stories.some((story) => story.id === targetId);
+    if (!targetValid) {
       library.prompt = null;
+      if (discardInvalidLibrary) return null;
     }
     state.library = library;
-    state.mode = "LIBRARY";
-  } else if (retainedSettings !== null) {
+    return "LIBRARY";
+  }
+  if (retainedSettings !== null) {
     state.settings = retainedSettings;
-    state.mode = "SETTINGS";
-  } else if (commands !== null) {
-    state.commands = commands;
-    state.mode = "COMMANDS";
-  } else if (mode === "KEYS") state.mode = "KEYS";
+    return "SETTINGS";
+  }
+  return null;
 }
 
 /** An authoritative call may settle while local input keeps moving. Revalidate
@@ -378,8 +455,11 @@ function reconcileStoryBoundIntent(
   } else {
     const returnMode = tag?.returnMode ?? "NAV";
     state.tag = null;
+    const fallbackMode = returnMode === "MAP" && state.map !== null ? "MAP" : "NAV";
+    const palette = paletteSessionReturningTo(state, "TAG");
+    if (palette !== null) retargetPaletteSession(state, palette, fallbackMode);
     if (state.mode === "TAG") {
-      state.mode = returnMode === "MAP" && state.map !== null ? "MAP" : "NAV";
+      state.mode = fallbackMode;
     }
   }
 
@@ -429,10 +509,13 @@ function reconcileStoryBoundIntent(
       state.editor = null;
       state.editorScrollTop = 0;
       state.editorScrollDetached = false;
+      const fallbackMode = editor.returnMode === "FACTS" && state.facts !== null
+        ? "FACTS"
+        : editor.returnMode === "MAP" && state.map !== null ? "MAP" : "NAV";
+      const palette = paletteSessionReturningTo(state, "EDITOR");
+      if (palette !== null) retargetPaletteSession(state, palette, fallbackMode);
       if (state.mode === "EDITOR") {
-        state.mode = editor.returnMode === "FACTS" && state.facts !== null
-          ? "FACTS"
-          : editor.returnMode === "MAP" && state.map !== null ? "MAP" : "NAV";
+        state.mode = fallbackMode;
       }
     }
   }
@@ -448,6 +531,10 @@ export function adoptStoryState(state: RuntimeState, payload: StoryPayload, cach
   flushReadingPositionPersist();
   reconcileWrapCache(cache, state.payload, payload);
   state.payload = payload;
+  // A story switch replaces the page buffer and its semantic cell map. The
+  // next NAV frame must build a fresh projection for the new story.
+  state.storySelectionProjection = null;
+  clearAdoptedStorySelection(state);
   state.uncertainFirstTakeStoryId = null;
   state.focusIndex = applyOpeningFocus(payload, state.readingPositions);
   state.mode = "NAV";
@@ -505,4 +592,16 @@ export function adoptStoryState(state: RuntimeState, payload: StoryPayload, cach
   state.quitArmed = false;
   // Returning to the guarded story with an authoritative payload may settle it.
   trySettlePlacementFromPayload(state, payload);
+}
+
+/** Invalidate every copy of a story selection at the payload boundary.
+ *  Facts keeps one copy for the panel, and the command palette keeps another
+ *  while it is open over that panel. Both describe the replaced revision. */
+function clearAdoptedStorySelection(state: RuntimeState): void {
+  if (state.facts !== null && "storySelection" in state.facts) {
+    state.facts.storySelection = null;
+  }
+  if (state.mode === "COMMANDS" && state.commands?.returnMode === "FACTS") {
+    state.commands.selection = null;
+  }
 }

--- a/tui/src/story-mutations.ts
+++ b/tui/src/story-mutations.ts
@@ -16,6 +16,7 @@ import {
 import { rememberFocus } from "./reading-position-persist.js";
 import type { RuntimeState } from "./state.js";
 import { adoptSameStoryPayload } from "./story-adoption.js";
+import { settleModeUnderPalette } from "./palette-owner.js";
 import { followStoryViewport } from "./viewport-intent.js";
 
 export async function switchTake(
@@ -158,9 +159,9 @@ export async function advanceOrSaveTag(
     if (state.tag === prompt
       && prompt.name.trim() === name
       && TAG_STATUSES[prompt.statusIndex] === label) {
-      state.mode = prompt.returnMode;
       state.tag = null;
       state.toast = `${tagGlyph(label)} ${name} saved`;
+      settleModeUnderPalette(state, "TAG", prompt.returnMode);
     }
   });
 }
@@ -183,9 +184,9 @@ export async function removeTag(
       && prompt.name === submittedName
       && prompt.statusIndex === submittedStatusIndex
       && prompt.choosingStatus === submittedChoosingStatus) {
-      state.mode = prompt.returnMode;
       state.tag = null;
       state.toast = "tag deleted";
+      settleModeUnderPalette(state, "TAG", prompt.returnMode);
     }
   });
 }

--- a/tui/src/summary-action.ts
+++ b/tui/src/summary-action.ts
@@ -9,6 +9,7 @@ import type { ActionContext } from "./action-context.js";
 import { rememberFocus } from "./reading-position-persist.js";
 import { adoptSameStoryPayload } from "./story-adoption.js";
 import { createTextPresentation, drainTextPresentation } from "./text-presentation.js";
+import { settleModeUnderPalette } from "./palette-owner.js";
 
 type SummaryActionContext = Pick<ActionContext, "backend" | "cache" | "repaint">;
 
@@ -102,8 +103,7 @@ export async function startSummary(
         state.toast = narrowedTo === null ? "◈ summary take saved" : narrowedSummaryToast(requestedPath, stretch, narrowedTo);
       }
       rememberFocus(state, source);
-      state.summary = null;
-      state.mode = "NAV";
+      settleSummarySurface(state, summary);
     } catch (error) {
       if (controller.signal.aborted) {
         await reloadAfterStop(state, source, task.storyId, task.storyCurrent, context.cache);
@@ -117,8 +117,7 @@ export async function startSummary(
       }
       summary.presentation?.dispose();
       if (state.summary === summary) {
-        state.summary = null;
-        if (state.mode === "SUMMARY") state.mode = "NAV";
+        settleSummarySurface(state, summary);
       }
       context.repaint();
     }
@@ -132,8 +131,18 @@ export function cancelSummary(state: RuntimeState): void {
   summary.controller.abort();
   summary.presentation?.dispose();
   state.summary = null;
-  state.mode = "NAV";
+  // A palette opened over Summary remains visible while the request settles.
+  // Release its Summary owner now so a command chosen during cancellation
+  // returns to a real post-summary surface.
+  settleModeUnderPalette(state, "SUMMARY", "NAV");
   state.toast = SUMMARY_STOPPING_TOAST;
+}
+
+/** Release Summary ownership without stranding a palette opened over it. */
+function settleSummarySurface(state: RuntimeState, summary: SummaryOverlayState): void {
+  if (state.summary !== summary) return;
+  state.summary = null;
+  settleModeUnderPalette(state, "SUMMARY", "NAV");
 }
 
 async function reloadAfterStop(

--- a/tui/test/aside-open-race.test.ts
+++ b/tui/test/aside-open-race.test.ts
@@ -102,6 +102,47 @@ describe("Aside open ownership", () => {
     expect(state.aside?.openingPartId).not.toBe(otherPart.id);
   });
 
+  test("consumes a Direct /aside draft when loading finishes under the palette", async () => {
+    for (const draft of ["/aside", "/aside ask about the open story"]) {
+      const source = demoAppSource();
+      const state = initialState(source, false);
+      expect(openDirectComposer(state)).toBeTrue();
+      setComposerText(state.composer, draft);
+
+      let resolveAside!: (document: { notes: readonly { question: string; answer: string }[] }) => void;
+      const pendingAside = new Promise<{ notes: readonly { question: string; answer: string }[] }>(
+        (resolve) => { resolveAside = resolve; }
+      );
+      const api: StoryApi = {
+        ...source.api,
+        getAside: async () => pendingAside
+      };
+      const actionContext = context(state);
+      const opening = composeAction(
+        { action: "send" },
+        state,
+        { ...source, api },
+        actionContext,
+        { asideEntryPointsOpen: true }
+      );
+      await Promise.resolve();
+
+      // Ctrl-P does not replace the submitted Direct owner. It only paints
+      // the palette over the load, so the Aside settlement can retain it.
+      await handleOverlayAction({ action: "open-commands" }, state, source, actionContext);
+      expect(state.mode).toBe("COMMANDS");
+
+      resolveAside({ notes: [] });
+      await opening;
+
+      expect(state.aside).not.toBeNull();
+      expect(state.mode).toBe("COMMANDS");
+      expect(state.commands?.returnMode).toBe("ASIDE");
+      expect(state.composer.text).toBe("");
+      actionContext.backend.dispose();
+    }
+  });
+
   test("discards an A response after recovery adopts B and keeps the Direct draft", async () => {
     const source = demoAppSource();
     const state = initialState(source, false);

--- a/tui/test/aside-v2.test.ts
+++ b/tui/test/aside-v2.test.ts
@@ -2283,6 +2283,95 @@ describe("Aside v2 surface", () => {
     expect(state.aside).toBeNull();
   });
 
+  test("keeps Ctrl-P open when g's Aside take switch settles", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const target = state.payload.path.at(-1)!;
+    const anchor = { partId: target.id, takeId: target.id };
+    const surface = createAsideSurface(
+      state.payload.id,
+      state.payload.title,
+      [{ id: "s", title: "session", anchor, turns: [] }],
+      null,
+      null,
+      {
+        v2: true,
+        anchor,
+        anchors: [{ ...anchor, partNumber: 13, sessionCount: 1 }]
+      }
+    );
+    if (!isAsideV2(surface)) throw new Error("expected an Aside session surface");
+    state.aside = surface;
+    state.mode = "ASIDE";
+
+    let release!: () => void;
+    const switchPending = new Promise<void>((resolve) => { release = resolve; });
+    const api = {
+      ...source.api,
+      switchLine: async () => {
+        await switchPending;
+        return state.payload;
+      }
+    } as StoryApi;
+    const sourceWithApi = { ...source, api };
+    const backend = new ActionRuntime(state, () => undefined);
+    const cache = createWrapCache<ProseStyle>();
+    const key = (name: string, options: Record<string, unknown> = {}) => ({
+      name,
+      sequence: name,
+      shift: false,
+      ctrl: false,
+      meta: false,
+      ...options
+    }) as Parameters<typeof handleKey>[0];
+    const context = {
+      source: { api, config: state.config },
+      backend,
+      cache
+    };
+
+    await asideV2KeyAction({ action: "aside-go-anchor" }, state, surface, context);
+    expect(state.backendTask?.label).toBe("switching to Aside take");
+
+    await handleKey(
+      key("p", { sequence: "\u0010", ctrl: true }),
+      state,
+      sourceWithApi,
+      cache,
+      () => undefined,
+      async () => undefined,
+      () => undefined,
+      null,
+      () => undefined,
+      () => undefined,
+      backend
+    );
+    expect(state.mode).toBe("COMMANDS");
+    expect(state.commands?.returnMode).toBe("ASIDE");
+
+    release();
+    await backend.settle();
+
+    expect(state.aside).toBeNull();
+    expect(state.mode).toBe("COMMANDS");
+    expect(state.commands?.returnMode).toBe("NAV");
+    await handleKey(
+      key("escape", { sequence: "\u001b" }),
+      state,
+      sourceWithApi,
+      cache,
+      () => undefined,
+      async () => undefined,
+      () => undefined,
+      null,
+      () => undefined,
+      () => undefined,
+      backend
+    );
+    expect(state.mode).toBe("NAV");
+    expect(state.commands).toBeNull();
+  });
+
   test("session cycling preserves an explicit unanchored target", () => {
     const { surface } = surfaceWithTurns([]);
     surface.anchor = { partId: "part-1", takeId: "take-1" };

--- a/tui/test/aside.test.ts
+++ b/tui/test/aside.test.ts
@@ -396,6 +396,153 @@ describe("Aside TUI contract", () => {
     expect(state.composer.text).toBe("");
   });
 
+  test("failed /aside load keeps a newer Ctrl-P palette over the Direct draft", async () => {
+    const source = demoAppSource();
+    let startLoad!: () => void;
+    let rejectLoad!: (error: Error) => void;
+    const loading = new Promise<void>((resolve) => { startLoad = resolve; });
+    const pendingLoad = new Promise<never>((_, reject) => { rejectLoad = reject; });
+    const failingSource = {
+      ...source,
+      api: {
+        ...source.api,
+        getAside: async () => {
+          startLoad();
+          return await pendingLoad;
+        }
+      }
+    };
+    const state = initialState(failingSource, false);
+    expect(openDirectComposer(state)).toBeTrue();
+    setComposerText(state.composer, "/aside keep this draft");
+    const context = overlayContext(state);
+    const opening = composeAction(
+      { action: "send" },
+      state,
+      failingSource,
+      context,
+      { asideEntryPointsOpen: true }
+    );
+
+    await loading;
+    await handleKey(
+      key("p", { ctrl: true }),
+      state,
+      failingSource,
+      context.cache,
+      () => undefined,
+      async () => undefined,
+      () => undefined
+    );
+    const palette = state.commands;
+    expect(palette).not.toBeNull();
+    expect(state.mode).toBe("COMMANDS");
+    expect(palette?.returnMode).toBe("COMPOSE");
+
+    rejectLoad(new Error("Aside load failed"));
+    await opening;
+
+    expect(state.mode).toBe("COMMANDS");
+    expect(state.commands).toBe(palette);
+    expect(state.commands?.returnMode).toBe("COMPOSE");
+    expect(state.composer.text).toBe("/aside keep this draft");
+    await handleKey(
+      key("escape"),
+      state,
+      failingSource,
+      context.cache,
+      () => undefined,
+      async () => undefined,
+      () => undefined
+    );
+    expect(state.mode).toBe("COMPOSE");
+    expect(state.commands).toBeNull();
+    expect(state.composer.text).toBe("/aside keep this draft");
+  });
+
+  test("failed initial Direct /aside Ask restores its draft under a newer palette", async () => {
+    for (const outcome of ["null", "rejected"] as const) {
+      const source = demoAppSource();
+      let startLoad!: () => void;
+      let resolveLoad!: () => void;
+      let resolveAsk!: () => void;
+      let rejectAsk!: (error: Error) => void;
+      let markAskStarted!: () => void;
+      const loading = new Promise<void>((resolve) => { startLoad = resolve; });
+      const pendingLoad = new Promise<{ notes: never[] }>((resolve) => { resolveLoad = () => resolve({ notes: [] }); });
+      const askStarted = new Promise<void>((resolve) => { markAskStarted = resolve; });
+      const asking = new Promise<null>((resolve, reject) => {
+        resolveAsk = () => resolve(null);
+        rejectAsk = reject;
+      });
+      const sourceWithApi = {
+        ...source,
+        api: {
+          ...source.api,
+          getAside: async () => {
+            startLoad();
+            return await pendingLoad;
+          },
+          askAside: async () => {
+            markAskStarted();
+            return await asking;
+          }
+        }
+      };
+      const state = initialState(sourceWithApi, false);
+      expect(openDirectComposer(state)).toBeTrue();
+      setComposerText(state.composer, "/aside ask from Direct");
+      const context = overlayContext(state);
+      const opening = composeAction(
+        { action: "send" },
+        state,
+        sourceWithApi,
+        context,
+        { asideEntryPointsOpen: true }
+      );
+
+      await loading;
+      await handleKey(
+        key("p", { ctrl: true }),
+        state,
+        sourceWithApi,
+        context.cache,
+        () => undefined,
+        async () => undefined,
+        () => undefined
+      );
+      const palette = state.commands;
+      expect(palette).not.toBeNull();
+      expect(palette?.returnMode).toBe("COMPOSE");
+
+      resolveLoad();
+      await askStarted;
+      expect(state.mode).toBe("COMMANDS");
+      expect(palette?.returnMode).toBe("ASIDE");
+      if (outcome === "null") resolveAsk();
+      else rejectAsk(new Error("Aside ask failed"));
+      await opening;
+
+      expect(state.mode).toBe("COMMANDS");
+      expect(state.commands).toBe(palette);
+      expect(palette?.returnMode).toBe("COMPOSE");
+      expect(state.composer.text).toBe("/aside ask from Direct");
+
+      await handleKey(
+        key("escape"),
+        state,
+        sourceWithApi,
+        context.cache,
+        () => undefined,
+        async () => undefined,
+        () => undefined
+      );
+      expect(state.mode).toBe("COMPOSE");
+      expect(state.commands).toBeNull();
+      expect(state.composer.text).toBe("/aside ask from Direct");
+    }
+  });
+
   test("Aside input uses composer caret, selection projection, and copy ownership", () => {
     const source = demoAppSource();
     const state = initialState(source, false);

--- a/tui/test/fact-double-click-input.test.ts
+++ b/tui/test/fact-double-click-input.test.ts
@@ -110,6 +110,94 @@ function factsPanelState(): RuntimeState {
 }
 
 describe("Fact double-click through interactive input admission", () => {
+  test("a first command-row click runs while dormant Facts owns the return surface", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const cache = createWrapCache<ProseStyle>();
+    state.facts = {
+      cursor: 0,
+      query: "",
+      chip: 0,
+      selectedTag: null,
+      filtering: false,
+      deleteArmedId: null,
+      scopeFilter: "everywhere",
+      dossier: null
+    };
+    state.mode = "COMMANDS";
+    state.commands = {
+      query: "filter facts",
+      cursor: 0,
+      selectedId: "facts-filter",
+      view: "commands",
+      returnMode: "FACTS"
+    };
+    Object.assign(state, renderStoryScreen(state, {
+      width: 120,
+      height: 30,
+      wrapCache: cache
+    }).derived);
+
+    const selected = state.hitRows
+      .flatMap((hit, y) => [
+        ...(hit?.target.kind === "list" && hit.target.selected === true
+          ? [{ left: hit.left, y }]
+          : []),
+        ...(hit?.overrides ?? [])
+          .filter((region) => region.target.kind === "list" && region.target.selected === true)
+          .map((region) => ({ left: region.left, y }))
+      ])
+      .at(0);
+    expect(selected).toBeDefined();
+    const event: FactClick = {
+      type: "down",
+      button: 0,
+      x: selected!.left + 2,
+      y: selected!.y,
+      modifiers: { shift: false, alt: false, ctrl: false }
+    };
+    const presented: PresentedInteraction = {
+      version: 1,
+      frameToken: 1,
+      interactive: true,
+      storyId: state.payload.id,
+      state: captureMouseActionState(state)
+    };
+    const queue = createPresentedInputQueue({ flush() {}, ready: () => true });
+    const admission = createInteractiveInputAdmission();
+    const actions: string[] = [];
+    admission.enqueueMouse(queue, event, {
+      presented,
+      frameFailed: false,
+      requestInputRecovery() {},
+      run: (action, queuedEvent, captured) => {
+        const reconciled = reconcilePresentedMouseAction({
+          action,
+          event: queuedEvent,
+          captured,
+          presented,
+          state
+        });
+        if (reconciled === null) return;
+        actions.push(reconciled.action);
+        return dispatch(
+          reconciled,
+          state,
+          source,
+          cache,
+          () => undefined,
+          async () => undefined,
+          () => undefined
+        );
+      }
+    });
+    await drainMicrotasks();
+
+    expect(actions).toEqual(["open-selected"]);
+    expect(state.mode).toBe("FACTS");
+    expect(state.facts?.filtering).toBeTrue();
+  });
+
   test("uninterrupted double-click opens the exact Fact editor", async () => {
     let now = 1_000;
     const { source, state, enqueueMouse } = createFactsAdmission({ now: () => now });

--- a/tui/test/facts-budget-editor.test.ts
+++ b/tui/test/facts-budget-editor.test.ts
@@ -1,0 +1,224 @@
+import { describe, expect, test } from "bun:test";
+import { dispatch } from "../src/app.js";
+import { createComposer, setComposerText } from "../src/composer-model.js";
+import {
+  FACTS_BUDGET_STATUS,
+  isFactsBudgetEditor
+} from "../src/facts-budget-editor.js";
+import { openFactsBudgetEditor } from "../src/editor-open.js";
+import { frameText, plainLine, visibleWidth } from "../src/screens/story/frame.js";
+import { renderStoryScreen } from "../src/screens/story.js";
+import { pasteInto } from "../src/keys.js";
+import { mouseToAction } from "../src/mouse-actions.js";
+import type { RuntimeState } from "../src/state.js";
+import { createWrapCache } from "../src/wrap.js";
+import { editorHarness, key } from "./editor-harness.js";
+
+function budgetEditor(state: RuntimeState) {
+  if (!isFactsBudgetEditor(state.editor)) throw new Error("Facts Budget editor did not open");
+  return state.editor;
+}
+
+async function openBudget(
+  state: RuntimeState,
+  press: (event: ReturnType<typeof key>) => Promise<void>
+): Promise<void> {
+  await press(key("p", { ctrl: true }));
+  expect(state.mode).toBe("COMMANDS");
+  state.commands = {
+    query: "facts budget",
+    cursor: 0,
+    selectedId: "facts-budget",
+    view: "commands",
+    returnMode: state.commands?.returnMode ?? "NAV"
+  };
+  await press(key("return"));
+  expect(state.mode).toBe("EDITOR");
+  expect(isFactsBudgetEditor(state.editor)).toBeTrue();
+}
+
+function render(state: RuntimeState, width = 100, height = 24) {
+  const frame = renderStoryScreen(state, {
+    width,
+    height,
+    wrapCache: createWrapCache()
+  });
+  Object.assign(state, frame.derived);
+  return frame;
+}
+
+function clickToken(
+  state: RuntimeState,
+  frame: ReturnType<typeof render>,
+  token: string
+) {
+  const row = frame.lines.findIndex((line) => plainLine(line).includes(token));
+  expect(row).toBeGreaterThan(-1);
+  const line = plainLine(frame.lines[row]!);
+  const start = line.indexOf(token);
+  return mouseToAction({
+    type: "down",
+    button: 0,
+    x: visibleWidth(line.slice(0, start)) + Math.floor(visibleWidth(token) / 2),
+    y: row,
+    modifiers: { shift: false, alt: false, ctrl: false }
+  } as never, state);
+}
+
+describe("story Facts Budget editor", () => {
+  test("renders a compact bounded field and admits digits only", async () => {
+    const { state, press } = editorHarness();
+    await openBudget(state, press);
+
+    const frame = render(state);
+    const drawn = frameText(frame.lines);
+    expect(drawn).toContain("facts budget [");
+    expect(drawn).toContain(FACTS_BUDGET_STATUS);
+    expect(drawn).toContain("uncapped");
+    expect(drawn).not.toContain("Cap the combined estimated tokens");
+    expect(frame.lines.length).toBe(24);
+
+    const editor = budgetEditor(state);
+    await press(key("x"));
+    expect(editor.composer.text).toBe("");
+    expect(state.toast).toBe("facts budget accepts digits only");
+    await press(key("7"));
+    expect(editor.composer.text).toBe("7");
+    expect(pasteInto(state, "8x")).toBeTrue();
+    expect(editor.composer.text).toBe("7");
+    expect(pasteInto(state, "8")).toBeTrue();
+    expect(editor.composer.text).toBe("78");
+
+    setComposerText(editor.composer, "1000001");
+    await press(key("s", { sequence: "\u0013", ctrl: true }));
+    expect(state.mode).toBe("EDITOR");
+    expect(state.payload.factsBudgetTokens).toBe(undefined);
+    expect(state.toast).toBe("facts budget must be between 1 and 1,000,000");
+  });
+
+  test("Enter and Ctrl+S save the number, while Escape cancels and empty clears", async () => {
+    const { state, press } = editorHarness();
+    await openBudget(state, press);
+    const editor = budgetEditor(state);
+    await press(key("4"));
+    await press(key("2"));
+    await press(key("return", { sequence: "\r" }));
+    expect(state.mode).toBe("NAV");
+    expect(state.payload.factsBudgetTokens).toBe(42);
+
+    await openBudget(state, press);
+    await press(key("9"));
+    expect(budgetEditor(state).composer.text).toBe("9");
+    setComposerText(budgetEditor(state).composer, "");
+    await press(key("s", { sequence: "\u0013", ctrl: true }));
+    expect(state.mode).toBe("NAV");
+    expect(state.payload.factsBudgetTokens).toBe(undefined);
+
+    await openBudget(state, press);
+    setComposerText(budgetEditor(state).composer, "19");
+    await press(key("escape", { sequence: "\u001b" }));
+    expect(state.mode).toBe("NAV");
+    expect(state.payload.factsBudgetTokens).toBe(undefined);
+  });
+
+  test("the field, clear control, and save control respond to mouse input", async () => {
+    const { source, state, press } = editorHarness();
+    await openBudget(state, press);
+    setComposerText(budgetEditor(state).composer, "314");
+    let frame = render(state);
+
+    const fieldRow = state.hitRows.findIndex((row) => row?.target.kind === "composer");
+    expect(fieldRow).toBeGreaterThan(-1);
+    expect(mouseToAction({
+      type: "down",
+      button: 0,
+      x: 30,
+      y: fieldRow,
+      modifiers: { shift: false, alt: false, ctrl: false }
+    } as never, state)).toEqual({ action: "compose" });
+
+    const clear = clickToken(state, frame, "clear");
+    expect(clear).toEqual({ action: "delete-line" });
+    await dispatch(clear!, state, source, createWrapCache(), () => {}, async () => {}, () => {});
+    expect(budgetEditor(state).composer.text).toBe("");
+
+    setComposerText(budgetEditor(state).composer, "314");
+    frame = render(state);
+    const save = clickToken(state, frame, "ctrl+s save");
+    expect(save).toEqual({ action: "save-edit" });
+    await dispatch(save!, state, source, createWrapCache(), () => {}, async () => {}, () => {});
+    expect(state.mode).toBe("NAV");
+    expect(state.payload.factsBudgetTokens).toBe(314);
+  });
+
+  test("clicking between budget digits places the insertion caret", async () => {
+    const { source, state, press } = editorHarness();
+    state.payload = { ...state.payload, factsBudgetTokens: 314 };
+    await openBudget(state, press);
+    const editor = budgetEditor(state);
+    expect(editor.composer.anchor).toBe(0);
+
+    const frame = render(state);
+    const row = frame.lines.findIndex((line) => plainLine(line).includes("314"));
+    expect(row).toBeGreaterThan(-1);
+    const line = plainLine(frame.lines[row]!);
+    const digits = line.indexOf("314");
+    const action = mouseToAction({
+      type: "down",
+      button: 0,
+      // The second digit cell represents the boundary before that digit.
+      x: visibleWidth(line.slice(0, digits + 1)),
+      y: row,
+      modifiers: { shift: false, alt: false, ctrl: false }
+    } as never, state);
+    expect(action).toEqual({ action: "compose", composerCursor: 1 });
+
+    await dispatch(action!, state, source, createWrapCache(), () => {}, async () => {}, () => {});
+    expect(editor.composer.cursor).toBe(1);
+    expect(editor.composer.anchor).toBe(null);
+    await press(key("9"));
+    expect(editor.composer.text).toBe("3914");
+  });
+
+  test("clicking after the final budget digit appends after the open selection", async () => {
+    const { source, state, press } = editorHarness();
+    state.payload = { ...state.payload, factsBudgetTokens: 314 };
+    await openBudget(state, press);
+    const editor = budgetEditor(state);
+    const frame = render(state);
+    const row = frame.lines.findIndex((line) => plainLine(line).includes("314"));
+    expect(row).toBeGreaterThan(-1);
+    const line = plainLine(frame.lines[row]!);
+    const digits = line.indexOf("314");
+    const action = mouseToAction({
+      type: "down",
+      button: 0,
+      x: visibleWidth(line.slice(0, digits + 3)),
+      y: row,
+      modifiers: { shift: false, alt: false, ctrl: false }
+    } as never, state);
+    expect(action).toEqual({ action: "compose", composerCursor: 3 });
+
+    await dispatch(action!, state, source, createWrapCache(), () => {}, async () => {}, () => {});
+    expect(editor.composer.cursor).toBe(3);
+    expect(editor.composer.anchor).toBe(null);
+    await press(key("9"));
+    expect(editor.composer.text).toBe("3149");
+  });
+
+  test("does not replace a suspended Fact draft when the global palette selects Facts Budget", async () => {
+    const { state, press } = editorHarness();
+    await press(key("f"));
+    await press(key("return"));
+    if (state.editor?.kind !== "fact") throw new Error("Fact editor did not open");
+    const factEditor = state.editor;
+    const draft = `${factEditor.composer.text} unsaved`;
+    setComposerText(factEditor.composer, draft);
+
+    openFactsBudgetEditor(state);
+    expect(state.mode).toBe("EDITOR");
+    expect(state.editor).toBe(factEditor);
+    expect(state.editor?.kind === "fact" ? state.editor.composer.text : null).toBe(draft);
+    expect(state.toast).toBe("save or cancel this Fact before opening facts budget");
+  });
+});

--- a/tui/test/facts-command-palette.test.ts
+++ b/tui/test/facts-command-palette.test.ts
@@ -1,0 +1,653 @@
+import { describe, expect, test } from "bun:test";
+import type { KeyEvent } from "@opentui/core";
+import { dispatch, handleKey, initialState } from "../src/app.js";
+import { createAsideSurface } from "../src/aside-surface.js";
+import { commandContext, commandMatches, type CommandId } from "../src/command-model.js";
+import { createComposer, setComposerText } from "../src/composer-model.js";
+import { attachDraftImage, draftImagesFor } from "../src/draft-image.js";
+import { demoAppSource } from "../src/demo.js";
+import { factsOpeningPartId, factsPaletteContext } from "../src/facts-command-context.js";
+import { mapCursorNodeId, openMap } from "../src/map-actions.js";
+import { mouseToAction } from "../src/mouse-actions.js";
+import { createStoryViewModel, rowIndexForNode } from "../src/model.js";
+import { adoptSameStoryPayload } from "../src/story-adoption.js";
+import { rememberedLeafId } from "../../shared/story-model.js";
+import { unusedTakePruneSelection } from "../../shared/story-tree.js";
+import { renderStoryScreen } from "../src/screens/story.js";
+import { frameText } from "../src/screens/story/frame.js";
+import type { AppMode } from "../src/keys.js";
+import { publishCurrentSettingsModelDiscovery } from "../src/settings-model-discovery.js";
+import { createWrapCache, type ProseStyle } from "../src/wrap.js";
+import { editorHarness, key } from "./editor-harness.js";
+import { openTextActions } from "../src/text-actions.js";
+import { openActions } from "../src/story-actions.js";
+import {
+  deferred,
+  openSettings as openSettingsForm,
+  selectRow,
+  settingsHarness
+} from "./settings-test-harness.js";
+import { ActionRuntime } from "../src/action-runtime.js";
+import { openRetakeComposer } from "../src/composer-ownership.js";
+import { cancelSummary } from "../src/summary-action.js";
+import { openAsideUseMenu } from "../src/aside-use.js";
+import { openPlacementFromAside } from "../src/aside-placement.js";
+
+const APP_MODES = Object.keys({
+  NAV: true,
+  COMPOSE: true,
+  EDITOR: true,
+  MAP: true,
+  KEYS: true,
+  TAG: true,
+  LIBRARY: true,
+  FACTS: true,
+  COMMANDS: true,
+  SUMMARY: true,
+  SETTINGS: true,
+  ACTIONS: true,
+  CHAPTERS: true,
+  SEARCH: true,
+  REQUEST: true,
+  CARD: true,
+  ARCHIVE: true,
+  IMAGE: true,
+  LOG: true,
+  PROBS: true,
+  RECORD: true,
+  ASIDE: true,
+  PLACE: true
+} satisfies Record<AppMode, true>) as AppMode[];
+
+function ctrlP(): KeyEvent {
+  return {
+    name: "p",
+    sequence: "\u0010",
+    shift: false,
+    ctrl: true,
+    meta: false,
+    option: false,
+    super: false
+  } as KeyEvent;
+}
+
+async function typeQuery(
+  press: (event: ReturnType<typeof key>) => Promise<void>,
+  query: string
+): Promise<void> {
+  for (const character of query) await press(key(character));
+}
+
+describe("global command palette", () => {
+  test("a mouse click runs a contextual Facts command through the existing reducer", async () => {
+    const { source, state, cache, press } = editorHarness();
+    await press(key("f"));
+    await press(ctrlP());
+    await typeQuery(press, "filter facts");
+    expect(state.commands?.selectedId).toBe("facts-filter");
+
+    const frame = renderStoryScreen(state, { width: 100, height: 24, wrapCache: cache });
+    Object.assign(state, frame.derived);
+    const selected = state.hitRows
+      .flatMap((hit, y) => [
+        ...(hit?.target.kind === "list" && hit.target.selected === true
+          ? [{ left: hit.left, y }]
+          : []),
+        ...(hit?.overrides ?? [])
+          .filter((region) => region.target.kind === "list" && region.target.selected === true)
+          .map((region) => ({ left: region.left, y }))
+      ])
+      .at(0);
+    expect(selected).toBeDefined();
+    const action = mouseToAction({
+      type: "down",
+      button: 0,
+      x: selected!.left + 2,
+      y: selected!.y,
+      modifiers: { shift: false, alt: false, ctrl: false }
+    } as never, state);
+    expect(action).toEqual({ action: "open-selected" });
+    await dispatch(
+      action!, state, source, cache,
+      () => undefined, async () => undefined, () => undefined
+    );
+    expect(state.mode).toBe("FACTS");
+    expect(state.facts?.filtering).toBeTrue();
+  });
+
+  test("the re-anchor command operates the suspended Fact editor without replacing its draft", async () => {
+    const { state, press } = editorHarness();
+    await press(key("f"));
+    await press(key("return"));
+    if (state.editor?.kind !== "fact") throw new Error("Fact editor did not open");
+    const editor = state.editor;
+    editor.stateAnchorPartId = null;
+    editor.stateCursorAnchorId = state.payload.path.at(-1)?.id ?? null;
+
+    await press(ctrlP());
+    await typeQuery(press, "reanchor state");
+    expect(state.commands?.selectedId).toBe("fact-editor-reanchor-state");
+    await press(key("return", { sequence: "\r" }));
+
+    expect(state.mode).toBe("EDITOR");
+    expect(state.editor).toBe(editor);
+    expect(editor.stateAnchorPartId).toBe(editor.stateCursorAnchorId);
+  });
+
+  test("the re-anchor command operates a newly creating Fact State", async () => {
+    const { state, press } = editorHarness();
+    await press(key("f"));
+    await press(key("return"));
+    if (state.editor?.kind !== "fact") throw new Error("Fact editor did not open");
+    const editor = state.editor;
+    editor.chromeFocus = "state";
+    await press(key("s"));
+    expect(editor.stateCreating).toBeTrue();
+    expect(editor.stateId).toBeNull();
+    const cursorAnchor = editor.stateCursorAnchorId;
+    expect(cursorAnchor).not.toBeNull();
+    editor.stateAnchorPartId = null;
+
+    await press(ctrlP());
+    await typeQuery(press, "reanchor state");
+    expect(state.commands?.selectedId).toBe("fact-editor-reanchor-state");
+    await press(key("return", { sequence: "\r" }));
+
+    expect(state.mode).toBe("EDITOR");
+    expect(state.editor).toBe(editor);
+    expect(editor.stateCreating).toBeTrue();
+    expect(editor.stateId).toBeNull();
+    expect(editor.stateAnchorPartId).toBe(cursorAnchor);
+  });
+
+  test("contextual Fact editor commands release a captured text menu", async () => {
+    const { state, press } = editorHarness();
+    await press(key("f"));
+    await press(key("return"));
+    if (state.editor?.kind !== "fact") throw new Error("Fact editor did not open");
+    const editor = state.editor;
+    openTextActions(state);
+    expect(state.textActions).not.toBeNull();
+
+    await press(ctrlP());
+    await typeQuery(press, "toggle Fact editor view");
+    expect(state.commands?.selectedId).toBe("fact-editor-toggle-view");
+    await press(key("return", { sequence: "\r" }));
+
+    expect(state.mode).toBe("EDITOR");
+    expect(state.editor).toBe(editor);
+    expect(state.textActions).toBeNull();
+    // Tab now reaches the Fact editor's view-controlled fields. Before the
+    // cleanup, the captured text menu swallowed this key as a no-op.
+    await press(key("tab"));
+    expect(editor.focus).toBe("name");
+  });
+
+  test("contextual Facts and Map commands release captured text menus", async () => {
+    {
+      const { state, press } = editorHarness();
+      await press(key("f"));
+      openTextActions(state, undefined, null, undefined, true);
+      expect(state.textActions).not.toBeNull();
+
+      await press(ctrlP());
+      await typeQuery(press, "filter Facts");
+      expect(state.commands?.selectedId).toBe("facts-filter");
+      await press(key("return", { sequence: "\r" }));
+
+      expect(state.mode).toBe("FACTS");
+      expect(state.facts?.filtering).toBeTrue();
+      expect(state.textActions).toBeNull();
+      await press(key("m"));
+      expect(state.facts?.query).toBe("m");
+    }
+
+    {
+      const source = demoAppSource();
+      const state = initialState(source, false);
+      const cache = createWrapCache<ProseStyle>();
+      const press = (event: KeyEvent) => handleKey(
+        event,
+        state,
+        source,
+        cache,
+        () => undefined,
+        async () => undefined,
+        () => undefined
+      );
+      openMap(state);
+      if (state.map === null) throw new Error("Map did not open");
+      state.map.view = "tree";
+      openTextActions(state, undefined, null, undefined, true);
+      expect(state.textActions).not.toBeNull();
+
+      await press(ctrlP());
+      await typeQuery(press, "open Fact lens");
+      expect(state.commands?.selectedId).toBe("map-open-fact-lens");
+      await press(key("return", { sequence: "\r" }));
+
+      expect(state.mode).toBe("MAP");
+      expect(state.map?.factLensFactId).not.toBeNull();
+      expect(state.textActions).toBeNull();
+    }
+  });
+
+  test("dirty Settings refuse a palette destination and keep the draft owner", async () => {
+    const { state, press } = settingsHarness();
+    await openSettingsForm(press);
+    await selectRow(press, state, "model");
+    await press(key("return"));
+    await press(key("x"));
+    const settings = state.settings;
+
+    await press(ctrlP());
+    await typeQuery(press, "facts overview");
+    await press(key("return", { sequence: "\r" }));
+
+    expect(state.mode).toBe("SETTINGS");
+    expect(state.settings).toBe(settings);
+    expect(state.settings?.edit?.composer.text).toBe("x");
+    expect(state.toast).toBe("save or cancel Settings changes first");
+  });
+
+  test("dirty non-Settings palette owners refuse destinations and preserve their input", async () => {
+    const cases = [
+      {
+        name: "Aside question",
+        mode: "ASIDE" as const,
+        setup: (state: ReturnType<typeof initialState>) => {
+          state.aside = createAsideSurface(state.payload.id, state.payload.title);
+          setComposerText(state.aside.composer, "keep this question");
+          state.mode = "ASIDE";
+          return {
+            owner: state.aside,
+            input: () => state.aside?.composer.text
+          };
+        }
+      },
+      {
+        name: "Card path",
+        mode: "CARD" as const,
+        setup: (state: ReturnType<typeof initialState>) => {
+          state.card = {
+            path: "/tmp/character-card.json",
+            storyId: state.payload.id,
+            candidates: [],
+            error: null,
+            returnMode: "NAV"
+          };
+          state.mode = "CARD";
+          return {
+            owner: state.card,
+            input: () => state.card?.path
+          };
+        }
+      },
+      {
+        name: "Archive path",
+        mode: "ARCHIVE" as const,
+        setup: (state: ReturnType<typeof initialState>) => {
+          state.archive = {
+            path: "/tmp/story.story",
+            storyId: state.payload.id,
+            candidates: [],
+            error: null,
+            returnMode: "NAV"
+          };
+          state.mode = "ARCHIVE";
+          return {
+            owner: state.archive,
+            input: () => state.archive?.path
+          };
+        }
+      },
+      {
+        name: "Image path",
+        mode: "IMAGE" as const,
+        setup: (state: ReturnType<typeof initialState>) => {
+          state.image = {
+            path: "/tmp/reference.png",
+            storyId: state.payload.id,
+            candidates: [],
+            error: null,
+            returnMode: "NAV"
+          };
+          state.mode = "IMAGE";
+          return {
+            owner: state.image,
+            input: () => state.image?.path
+          };
+        }
+      },
+      {
+        name: "Library rename",
+        mode: "LIBRARY" as const,
+        setup: (state: ReturnType<typeof initialState>) => {
+          const target = state.payload;
+          state.library = {
+            stories: [{
+              id: target.id,
+              title: target.title,
+              updatedAt: target.updatedAt,
+              partCount: target.nodes.length,
+              words: target.path.reduce((total, node) => total + node.text.length, 0),
+              forked: false,
+              lineCount: 1
+            }],
+            cursor: 0,
+            query: "",
+            prompt: {
+              kind: "rename",
+              composer: createComposer(`${target.title} draft`),
+              targetId: target.id
+            }
+          };
+          state.mode = "LIBRARY";
+          return {
+            owner: state.library,
+            input: () => state.library?.prompt?.kind === "rename"
+              ? state.library.prompt.composer.text
+              : undefined
+          };
+        }
+      }
+    ];
+
+    for (const scenario of cases) {
+      const source = demoAppSource();
+      const state = initialState(source, false);
+      const cache = createWrapCache<ProseStyle>();
+      const retained = scenario.setup(state);
+      await handleKey(
+        ctrlP(), state, source, cache,
+        () => undefined, async () => undefined, () => undefined
+      );
+      await typeQuery(
+        (event) => handleKey(
+          event, state, source, cache,
+          () => undefined, async () => undefined, () => undefined
+        ),
+        "chapters"
+      );
+      await handleKey(
+        key("return", { sequence: "\r" }), state, source, cache,
+        () => undefined, async () => undefined, () => undefined
+      );
+
+      expect(state.mode).toBe(scenario.mode);
+      expect(state.commands).toBeNull();
+      expect(state.library ?? state.aside ?? state.card ?? state.archive ?? state.image)
+        .toBe(retained.owner);
+      expect(retained.input()).not.toBe("");
+      expect(state.toast).toBe("finish or cancel current input first");
+    }
+  });
+
+  test("dirty COMPOSE drafts refuse palette destinations and preserve their owner", async () => {
+    const cases = [
+      {
+        setup: (state: ReturnType<typeof initialState>) => {
+          state.mode = "COMPOSE";
+          setComposerText(state.composer, "keep this Direct draft");
+          return {
+            composer: state.composer,
+            retake: null,
+            text: state.composer.text,
+            images: draftImagesFor(state.composer).length
+          };
+        }
+      },
+      {
+        setup: (state: ReturnType<typeof initialState>) => {
+          const target = state.payload.path.find((node) => node.id === "p12");
+          if (target === undefined) throw new Error("demo target did not load");
+          const prompt = openRetakeComposer(
+            state, target.id, target.instruction, { kind: "retake" }
+          );
+          // Keep this case about the retake owner itself, not its seeded text.
+          setComposerText(state.composer, "");
+          return {
+            composer: state.composer,
+            retake: prompt,
+            text: state.composer.text,
+            images: draftImagesFor(state.composer).length
+          };
+        }
+      },
+      {
+        setup: (state: ReturnType<typeof initialState>) => {
+          state.mode = "COMPOSE";
+          attachDraftImage(state.composer, {
+            leaseId: "a".repeat(64),
+            attachment: {
+              objectId: "b".repeat(64),
+              mediaType: "image/png",
+              width: 64,
+              height: 48,
+              byteLength: 4_096
+            }
+          });
+          return {
+            composer: state.composer,
+            retake: null,
+            text: state.composer.text,
+            images: draftImagesFor(state.composer).length
+          };
+        }
+      }
+    ];
+
+    for (const scenario of cases) {
+      for (const destination of ["switch story", "import archive"] as const) {
+        const source = demoAppSource();
+        const state = initialState(source, false);
+        const cache = createWrapCache<ProseStyle>();
+        const retained = scenario.setup(state);
+        const press = (event: KeyEvent) => handleKey(
+          event, state, source, cache,
+          () => undefined, async () => undefined, () => undefined
+        );
+
+        await press(ctrlP());
+        await typeQuery(press, destination);
+        await press(key("return", { sequence: "\r" }));
+
+        expect(state.mode).toBe("COMPOSE");
+        expect(state.commands).toBeNull();
+        expect(state.composer).toBe(retained.composer);
+        expect(state.retakePrompt).toBe(retained.retake);
+        expect(state.composer.text).toBe(retained.text);
+        expect(draftImagesFor(state.composer)).toHaveLength(retained.images);
+        expect(state.toast).toBe("finish or cancel current input first");
+      }
+    }
+  });
+
+  test("a dirty CHAPTERS rename refuses a palette destination and preserves its draft", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const cache = createWrapCache<ProseStyle>();
+    const chapterBreak = state.payload.chapterBreaks[0]!;
+    const rename = {
+      breakId: chapterBreak.id,
+      composer: createComposer(`${chapterBreak.title} draft`)
+    };
+    state.chapters = { cursor: 0, rename, deleteArmedId: null };
+    state.mode = "CHAPTERS";
+
+    await handleKey(
+      ctrlP(), state, source, cache,
+      () => undefined, async () => undefined, () => undefined
+    );
+    await typeQuery(
+      (event) => handleKey(
+        event, state, source, cache,
+        () => undefined, async () => undefined, () => undefined
+      ),
+      "facts overview"
+    );
+    await handleKey(
+      key("return", { sequence: "\r" }), state, source, cache,
+      () => undefined, async () => undefined, () => undefined
+    );
+
+    expect(state.mode).toBe("CHAPTERS");
+    expect(state.chapters?.rename).toBe(rename);
+    expect(state.chapters?.rename?.composer.text).toBe(`${chapterBreak.title} draft`);
+    expect(state.toast).toBe("finish or cancel current input first");
+  });
+
+  test("dirty non-Settings input still allows a non-destination read-only command", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const cache = createWrapCache<ProseStyle>();
+    state.aside = createAsideSurface(state.payload.id, state.payload.title);
+    setComposerText(state.aside.composer, "keep this question");
+    state.mode = "ASIDE";
+    const aside = state.aside;
+
+    await handleKey(
+      ctrlP(), state, source, cache,
+      () => undefined, async () => undefined, () => undefined
+    );
+    await typeQuery(
+      (event) => handleKey(
+        event, state, source, cache,
+        () => undefined, async () => undefined, () => undefined
+      ),
+      "open story folder"
+    );
+    await handleKey(
+      key("return", { sequence: "\r" }), state, source, cache,
+      () => undefined, async () => undefined, () => undefined
+    );
+
+    expect(state.mode).toBe("ASIDE");
+    expect(state.aside).toBe(aside);
+    expect(state.aside?.composer.text).toBe("keep this question");
+    expect(state.toast).toBe(source.storyFolder);
+  });
+
+  test("read-only palette commands keep a suspended EDITOR draft", async () => {
+    for (const query of ["open story folder", "theme: graphite", "export markdown"]) {
+      const { source, state, press } = editorHarness();
+      await press(key("f"));
+      await press(key("return"));
+      if (state.editor?.kind !== "fact") throw new Error("Fact editor did not open");
+      const editor = state.editor;
+      setComposerText(editor.composer, "keep this Fact draft");
+      if (query === "export markdown") source.exportDirectory = "/tmp";
+
+      await press(ctrlP());
+      await typeQuery(press, query);
+      await press(key("return", { sequence: "\r" }));
+
+      expect(state.mode).toBe("EDITOR");
+      expect(state.editor).toBe(editor);
+      expect(editor.composer.text).toBe("keep this Fact draft");
+    }
+  });
+
+  test("a dirty editor blocks prune when its abandoned leaf is prunable", async () => {
+    const { source, state, cache, press } = editorHarness();
+    state.focusIndex = rowIndexForNode(createStoryViewModel(state.payload), "p12");
+    // Move to an abandoned leaf, open its editor, then make another take
+    // active. The open editor now owns a real target that prune would remove.
+    await press(key("left"));
+    expect(state.payload.path.at(-1)?.id).toBe("p12-t2");
+    await press(key("e"));
+    if (state.editor?.kind !== "document") throw new Error("part editor did not open");
+    const editor = state.editor;
+    setComposerText(editor.composer, "keep this abandoned draft");
+    const targetId = editor.target.kind === "part" ? editor.target.node.id : null;
+    expect(targetId).toBe("p12-t2");
+
+    const activePayload = await source.api.switchLine(
+      state.payload.id,
+      "p12",
+      { stopAtNode: true }
+    );
+    adoptSameStoryPayload(state, activePayload, cache);
+    expect(unusedTakePruneSelection(state.payload).takeIds).toContain(targetId);
+
+    await press(ctrlP());
+    await typeQuery(press, "prune");
+    expect(state.commands?.selectedId).toBe("prune");
+    await press(key("return", { sequence: "\r" }));
+
+    expect(state.mode).toBe("EDITOR");
+    expect(state.editor).toBe(editor);
+    expect(editor.composer.text).toBe("keep this abandoned draft");
+    expect(state.prune).toBeNull();
+    expect(state.toast).toBe("finish or cancel current input first");
+
+    await press(key("escape", { sequence: "\u001b" }));
+    expect(state.mode).toBe("NAV");
+    expect(state.editor).toBeNull();
+  });
+
+  test("payload adoption clears a story selection retained by Facts and its palette", async () => {
+    const { source, state, cache, press } = editorHarness();
+    const selection = {
+      text: "selected prose",
+      spans: [{ key: "p1:text", text: "selected prose", start: 0, end: 8 }]
+    };
+    const facts = {
+      cursor: 0,
+      query: "",
+      chip: 0,
+      selectedTag: null,
+      filtering: false,
+      deleteArmedId: null,
+      scopeFilter: "everywhere" as const,
+      dossier: null,
+      storySelection: selection
+    };
+    state.facts = facts;
+    state.mode = "FACTS";
+    await press(ctrlP());
+    const palette = state.commands;
+    expect(palette?.returnMode).toBe("FACTS");
+    expect(palette?.selection).toBe(selection);
+
+    adoptSameStoryPayload(
+      state,
+      { ...state.payload, title: "updated story" },
+      cache
+    );
+
+    expect(state.facts).toBe(facts);
+    expect(state.facts?.storySelection).toBeNull();
+    expect(palette?.selection).toBeNull();
+
+    await typeQuery(press, "new Fact from selection");
+    expect(state.commands?.selectedId).not.toBe("new-fact-from-selection");
+  });
+
+  test("same-story adoption preserves selection for a non-Facts palette owner", () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const selection = {
+      text: "selected prose",
+      spans: [{ key: "p1:text", text: "selected prose", start: 0, end: 8 }]
+    };
+    state.mode = "COMMANDS";
+    state.commands = {
+      query: "",
+      cursor: 0,
+      selectedId: null,
+      view: "commands",
+      returnMode: "NAV",
+      selection
+    };
+
+    adoptSameStoryPayload(
+      state,
+      { ...state.payload, title: "updated story" },
+      createWrapCache<ProseStyle>()
+    );
+
+    expect(state.commands?.selection).toBe(selection);
+  });
+
+});

--- a/tui/test/facts-map-command-palette.test.ts
+++ b/tui/test/facts-map-command-palette.test.ts
@@ -1,0 +1,638 @@
+import { describe, expect, test } from "bun:test";
+import type { KeyEvent } from "@opentui/core";
+import { dispatch, handleKey, initialState } from "../src/app.js";
+import { createAsideSurface } from "../src/aside-surface.js";
+import { commandContext, commandMatches, type CommandId } from "../src/command-model.js";
+import { createComposer, setComposerText } from "../src/composer-model.js";
+import { attachDraftImage, draftImagesFor } from "../src/draft-image.js";
+import { demoAppSource } from "../src/demo.js";
+import { factsOpeningPartId, factsPaletteContext } from "../src/facts-command-context.js";
+import { mapCursorNodeId, openMap } from "../src/map-actions.js";
+import { mouseToAction } from "../src/mouse-actions.js";
+import { createStoryViewModel, rowIndexForNode } from "../src/model.js";
+import { createGenerationRecordDetailCache } from "../src/generation-record-detail-cache.js";
+import { adoptSameStoryPayload } from "../src/story-adoption.js";
+import { rememberedLeafId } from "../../shared/story-model.js";
+import { unusedTakePruneSelection } from "../../shared/story-tree.js";
+import { renderStoryScreen } from "../src/screens/story.js";
+import { frameText } from "../src/screens/story/frame.js";
+import type { AppMode } from "../src/keys.js";
+import { publishCurrentSettingsModelDiscovery } from "../src/settings-model-discovery.js";
+import { createWrapCache, type ProseStyle } from "../src/wrap.js";
+import { editorHarness, key } from "./editor-harness.js";
+import { openTextActions } from "../src/text-actions.js";
+import { openActions } from "../src/story-actions.js";
+import {
+  deferred,
+  openSettings as openSettingsForm,
+  selectRow,
+  settingsHarness
+} from "./settings-test-harness.js";
+import { ActionRuntime } from "../src/action-runtime.js";
+import { openRetakeComposer } from "../src/composer-ownership.js";
+import { cancelSummary } from "../src/summary-action.js";
+import { openAsideUseMenu } from "../src/aside-use.js";
+import { openPlacementFromAside } from "../src/aside-placement.js";
+
+const APP_MODES = Object.keys({
+  NAV: true,
+  COMPOSE: true,
+  EDITOR: true,
+  MAP: true,
+  KEYS: true,
+  TAG: true,
+  LIBRARY: true,
+  FACTS: true,
+  COMMANDS: true,
+  SUMMARY: true,
+  SETTINGS: true,
+  ACTIONS: true,
+  CHAPTERS: true,
+  SEARCH: true,
+  REQUEST: true,
+  CARD: true,
+  ARCHIVE: true,
+  IMAGE: true,
+  LOG: true,
+  PROBS: true,
+  RECORD: true,
+  ASIDE: true,
+  PLACE: true
+} satisfies Record<AppMode, true>) as AppMode[];
+
+function ctrlP(): KeyEvent {
+  return {
+    name: "p",
+    sequence: "\u0010",
+    shift: false,
+    ctrl: true,
+    meta: false,
+    option: false,
+    super: false
+  } as KeyEvent;
+}
+
+async function typeQuery(
+  press: (event: ReturnType<typeof key>) => Promise<void>,
+  query: string
+): Promise<void> {
+  for (const character of query) await press(key(character));
+}
+
+describe("global command palette", () => {
+  for (const mode of ["PROBS", "RECORD"] as const) {
+    test(`Fact palette entry points from ${mode} use the displayed take`, async () => {
+      for (const query of ["new Fact from here", "new Fact State", "end Fact here"] as const) {
+        const source = demoAppSource();
+        const state = initialState(source, false);
+        const cache = createWrapCache<ProseStyle>();
+        const view = createStoryViewModel(state.payload);
+        const stale = view.parts.at(-1);
+        const displayed = view.parts[1];
+        if (stale === undefined || displayed === undefined) throw new Error("demo story needs two parts");
+        state.focusIndex = rowIndexForNode(view, stale.id);
+        if (mode === "PROBS") {
+          state.probs = {
+            nodeId: displayed.id,
+            tokenIndex: 0,
+            altIndex: 0,
+            expanded: false,
+            record: null,
+            loading: false,
+            empty: null
+          };
+        } else {
+          state.record = {
+            nodeId: displayed.id,
+            returnMode: "NAV",
+            list: { status: "ready", summaries: [] },
+            eventIndex: 0,
+            entryIndex: 0,
+            scrollTop: -1,
+            detail: { status: "idle" },
+            cache: createGenerationRecordDetailCache()
+          };
+        }
+        state.mode = mode;
+
+        expect(factsOpeningPartId(state)).toBe(displayed.id);
+        await handleKey(
+          ctrlP(), state, source, cache,
+          () => undefined, async () => undefined, () => undefined
+        );
+        await typeQuery(
+          (event) => handleKey(
+            event, state, source, cache,
+            () => undefined, async () => undefined, () => undefined
+          ),
+          query
+        );
+        await handleKey(
+          key("return", { sequence: "\r" }), state, source, cache,
+          () => undefined, async () => undefined, () => undefined
+        );
+
+        if (query === "new Fact from here") {
+          expect(state.mode).toBe("EDITOR");
+          expect(state.editor?.kind).toBe("fact");
+          if (state.editor?.kind !== "fact") throw new Error("Fact editor did not open");
+          expect(state.editor.factAnchorPartId).toBe(displayed.id);
+        } else {
+          expect(state.mode).toBe("FACTS");
+          expect(state.facts?.pendingFactAction).toEqual({
+            kind: query === "new Fact State" ? "new-state" : "end",
+            anchorPartId: displayed.id
+          });
+        }
+      }
+    });
+  }
+
+  test("Fact palette entry points from MAP use the visible tree cursor", async () => {
+    for (const [query, kind] of [
+      ["new Fact from here", "new"],
+      ["new Fact State", "state"],
+      ["end Fact here", "end"]
+    ] as const) {
+      const source = demoAppSource();
+      const state = initialState(source, false);
+      const cache = createWrapCache<ProseStyle>();
+      state.focusIndex = rowIndexForNode(
+        createStoryViewModel(state.payload),
+        state.payload.path.at(-1)!.id
+      );
+      openMap(state);
+      if (state.map === null) throw new Error("Map did not open");
+      state.map.view = "tree";
+      const mapCursorId = state.payload.path[0]!.id;
+      state.map.treeCursorId = mapCursorId;
+
+      await handleKey(
+        ctrlP(), state, source, cache,
+        () => undefined, async () => undefined, () => undefined
+      );
+      await typeQuery(
+        (event) => handleKey(
+          event, state, source, cache,
+          () => undefined, async () => undefined, () => undefined
+        ),
+        query
+      );
+      await handleKey(
+        key("return", { sequence: "\r" }), state, source, cache,
+        () => undefined, async () => undefined, () => undefined
+      );
+
+      if (kind === "new") {
+        expect(state.mode).toBe("EDITOR");
+        expect(state.editor?.kind).toBe("fact");
+        if (state.editor?.kind !== "fact") throw new Error("Fact editor did not open");
+        expect(state.editor.factAnchorPartId).toBe(mapCursorId);
+        expect(state.editor.factScopeAnchorPartId).toBe(mapCursorId);
+      } else {
+        expect(state.mode).toBe("FACTS");
+        await handleKey(
+          key("return", { sequence: "\r" }), state, source, cache,
+          () => undefined, async () => undefined, () => undefined
+        );
+        expect(state.mode).toBe("EDITOR");
+        if (state.editor?.kind !== "fact") throw new Error("Fact State editor did not open");
+        expect(state.editor.stateAnchorPartId).toBe(mapCursorId);
+        expect(state.editor.stateCursorAnchorId).toBe(mapCursorId);
+        expect(state.editor.stateIsEnd).toBe(kind === "end");
+      }
+    }
+  });
+
+  test("Fact palette entry points from MAP use path and mass visible cursors", async () => {
+    for (const view of ["path", "mass"] as const) {
+      const source = demoAppSource();
+      const state = initialState(source, false);
+      const cache = createWrapCache<ProseStyle>();
+      openMap(state);
+      if (state.map === null) throw new Error("Map did not open");
+      state.map.view = view;
+      state.map.pathCursorId = state.payload.path[0]!.id;
+      // Mass compresses a contiguous line into its visible endpoint row. The
+      // stale tree cursor deliberately differs so this catches a direct
+      // `treeCursorId` read in palette entry points.
+      state.map.treeCursorId = state.payload.path[0]!.id;
+      const anchor = mapCursorNodeId(state);
+      expect(anchor).not.toBeNull();
+      expect(factsOpeningPartId(state)).toBe(anchor);
+
+      await handleKey(
+        ctrlP(), state, source, cache,
+        () => undefined, async () => undefined, () => undefined
+      );
+      await typeQuery(
+        (event) => handleKey(
+          event, state, source, cache,
+          () => undefined, async () => undefined, () => undefined
+        ),
+        "new Fact from here"
+      );
+      await handleKey(
+        key("return", { sequence: "\r" }), state, source, cache,
+        () => undefined, async () => undefined, () => undefined
+      );
+
+      expect(state.mode).toBe("EDITOR");
+      if (state.editor?.kind !== "fact") throw new Error("Fact editor did not open");
+      expect(state.editor.factAnchorPartId).toBe(anchor);
+      expect(state.editor.factScopeAnchorPartId).toBe(anchor);
+    }
+  });
+
+  test("MAP retake uses the visible cursor instead of stale story focus", async () => {
+    const cases = [
+      { view: "path", target: "p1" },
+      { view: "tree", target: "p1" },
+      { view: "mass", target: "p5-alt" }
+    ] as const;
+
+    for (const { view, target } of cases) {
+      const source = demoAppSource();
+      const state = initialState(source, false);
+      const cache = createWrapCache<ProseStyle>();
+      const storyView = createStoryViewModel(state.payload);
+      state.focusIndex = rowIndexForNode(storyView, "p13");
+      openMap(state);
+      if (state.map === null) throw new Error("Map did not open");
+      state.map.view = view;
+      if (view === "path") state.map.pathCursorId = target;
+      else state.map.treeCursorId = target;
+      expect(mapCursorNodeId(state)).toBe(target);
+      expect(storyView.rows[state.focusIndex]?.id).toBe("p13");
+
+      const targets: unknown[] = [];
+      source.api.continueStory = async (_storyId, _instruction, _genId, requestTarget) => {
+        targets.push(requestTarget);
+        return { payload: state.payload, droppedFacts: [] };
+      };
+      const press = (event: KeyEvent) => handleKey(
+        event, state, source, cache,
+        () => undefined, async () => undefined, () => undefined
+      );
+      await press(ctrlP());
+      await typeQuery(press, "retake");
+      await press(key("return", { sequence: "\r" }));
+      for (let waited = 0; (state.stream !== null || state.abort !== null) && waited < 100; waited += 1) {
+        await new Promise((resolve) => setTimeout(resolve, 20));
+      }
+
+      const targetParentId = source.payload.nodes.find(({ id }) => id === target)?.parentId;
+      expect(targets).toEqual([{ parentId: targetParentId }]);
+    }
+  });
+
+  test("MAP retake refuses a folded cold row without a paid call", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const cache = createWrapCache<ProseStyle>();
+    state.focusIndex = rowIndexForNode(createStoryViewModel(state.payload), "p13");
+    openMap(state);
+    if (state.map === null) throw new Error("Map did not open");
+    state.map.view = "tree";
+    state.map.treeCursorId = "p5-alt";
+    expect(mapCursorNodeId(state)).toBeNull();
+
+    let calls = 0;
+    const continueStory = source.api.continueStory.bind(source.api);
+    source.api.continueStory = async (...args) => {
+      calls += 1;
+      return continueStory(...args);
+    };
+    const press = (event: KeyEvent) => handleKey(
+      event, state, source, cache,
+      () => undefined, async () => undefined, () => undefined
+    );
+    await press(ctrlP());
+    await typeQuery(press, "retake");
+    await press(key("return", { sequence: "\r" }));
+
+    expect(calls).toBe(0);
+    expect(state.mode).toBe("MAP");
+    expect(state.map?.treeCursorId).toBe("p5-alt");
+    expect(state.toast).toBe("select a visible story part before retaking it");
+  });
+
+  test("MAP tag-line palette command opens the visible Tree and Mass cursor", async () => {
+    for (const view of ["tree", "mass"] as const) {
+      const source = demoAppSource();
+      const state = initialState(source, false);
+      const cache = createWrapCache<ProseStyle>();
+      openMap(state);
+      if (state.map === null) throw new Error("Map did not open");
+      state.map.view = view;
+      state.map.pathCursorId = state.payload.path.at(-2)!.id;
+      state.map.treeCursorId = state.payload.path[0]!.id;
+      const visibleId = mapCursorNodeId(state);
+      expect(visibleId).not.toBeNull();
+      expect(visibleId).not.toBe(state.map.pathCursorId);
+      const expectedNodeId = rememberedLeafId(state.payload, visibleId!);
+
+      const press = (event: KeyEvent) => handleKey(
+        event, state, source, cache,
+        () => undefined, async () => undefined, () => undefined
+      );
+      await press(ctrlP());
+      await typeQuery(press, "tag this line");
+      await press(key("return", { sequence: "\r" }));
+
+      expect(state.mode).toBe("TAG");
+      expect(state.tag?.nodeId).toBe(expectedNodeId);
+      expect(state.tag?.returnMode).toBe("MAP");
+    }
+  });
+
+  test("MAP tag-line refuses a folded cold row without falling back to Path", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const cache = createWrapCache<ProseStyle>();
+    openMap(state);
+    if (state.map === null) throw new Error("Map did not open");
+    state.map.view = "tree";
+    const pathCursorId = state.payload.path.at(-1)!.id;
+    state.map.pathCursorId = pathCursorId;
+    // The demo's old alternate is a visible cold fold in Tree. It has no
+    // single addressable take while folded, so do not tag the Path cursor.
+    state.map.treeCursorId = "p5-alt";
+    expect(mapCursorNodeId(state)).toBeNull();
+
+    const press = (event: KeyEvent) => handleKey(
+      event, state, source, cache,
+      () => undefined, async () => undefined, () => undefined
+    );
+    await press(ctrlP());
+    await typeQuery(press, "tag this line");
+    await press(key("return", { sequence: "\r" }));
+
+    expect(state.mode).toBe("MAP");
+    expect(state.tag).toBeNull();
+    expect(state.map?.pathCursorId).toBe(pathCursorId);
+    expect(state.toast).toBe("select a story part before tagging it");
+  });
+
+  test("new Fact palette commands from FACTS return to the same Facts context after cancel", async () => {
+    for (const query of ["new unscoped fact", "new Fact from here", "new Fact from selection"] as const) {
+      const source = demoAppSource();
+      const state = initialState(source, false);
+      const cache = createWrapCache<ProseStyle>();
+      const facts = {
+        cursor: 0,
+        query: "Maren",
+        chip: 2,
+        selectedTag: "people",
+        filtering: false,
+        deleteArmedId: null,
+        scopeFilter: "everywhere" as const,
+        dossier: { factId: "fact-1", stateIndex: 0, diff: true }
+      };
+      state.facts = facts;
+      state.mode = "FACTS";
+      if (query === "new Fact from selection") {
+        const node = state.payload.path.find(({ id }) => id === "p1")!;
+        const text = node.text.slice(0, 5);
+        state.storySelectionProjection = [...text].map((_, index) => ({
+          key: "p1:text",
+          text: node.text,
+          start: index,
+          end: index + 1
+        }));
+      }
+
+      const renderer = query === "new Fact from selection"
+        ? { identity: {}, text: "Maren", range: { start: 0, end: 5 }, backward: false }
+        : null;
+      await handleKey(
+        ctrlP(), state, source, cache,
+        () => undefined, async () => undefined, () => undefined,
+        renderer as never
+      );
+      await typeQuery(
+        (event) => handleKey(
+          event, state, source, cache,
+          () => undefined, async () => undefined, () => undefined
+        ),
+        query
+      );
+      await handleKey(
+        key("return", { sequence: "\r" }), state, source, cache,
+        () => undefined, async () => undefined, () => undefined
+      );
+
+      expect(state.mode).toBe("EDITOR");
+      expect(state.facts).toBe(facts);
+      expect(state.editor?.kind).toBe("fact");
+      expect(state.editor?.returnMode).toBe("FACTS");
+      await handleKey(
+        key("escape", { sequence: "\u001b" }), state, source, cache,
+        () => undefined, async () => undefined, () => undefined
+      );
+      expect(state.mode).toBe("FACTS");
+      expect(state.facts).toBe(facts);
+      expect(state.facts).toEqual({
+        cursor: 0,
+        query: "Maren",
+        chip: 2,
+        selectedTag: "people",
+        filtering: false,
+        deleteArmedId: null,
+        scopeFilter: "everywhere",
+        dossier: { factId: "fact-1", stateIndex: 0, diff: true }
+      });
+    }
+  });
+
+  test("new Fact palette commands from FACTS return to the same Facts context after save", async () => {
+    for (const query of ["new unscoped fact", "new Fact from here", "new Fact from selection"] as const) {
+      const source = demoAppSource();
+      const state = initialState(source, false);
+      const cache = createWrapCache<ProseStyle>();
+      const facts = {
+        cursor: 0,
+        query: "Maren",
+        chip: 2,
+        selectedTag: "people",
+        filtering: false,
+        deleteArmedId: null,
+        scopeFilter: "everywhere" as const,
+        dossier: { factId: "fact-1", stateIndex: 0, diff: true }
+      };
+      state.facts = facts;
+      state.mode = "FACTS";
+      if (query === "new Fact from selection") {
+        const node = state.payload.path.find(({ id }) => id === "p1")!;
+        const text = node.text.slice(0, 5);
+        state.storySelectionProjection = [...text].map((_, index) => ({
+          key: "p1:text",
+          text: node.text,
+          start: index,
+          end: index + 1
+        }));
+      }
+
+      const renderer = query === "new Fact from selection"
+        ? { identity: {}, text: "Maren", range: { start: 0, end: 5 }, backward: false }
+        : null;
+      await handleKey(
+        ctrlP(), state, source, cache,
+        () => undefined, async () => undefined, () => undefined,
+        renderer as never
+      );
+      await typeQuery(
+        (event) => handleKey(
+          event, state, source, cache,
+          () => undefined, async () => undefined, () => undefined
+        ),
+        query
+      );
+      await handleKey(
+        key("return", { sequence: "\r" }), state, source, cache,
+        () => undefined, async () => undefined, () => undefined
+      );
+
+      if (state.editor?.kind !== "fact") throw new Error("Fact editor did not open");
+      if (query !== "new Fact from selection") setComposerText(state.editor.composer, "created from Facts");
+      await handleKey(
+        key("s", { sequence: String.fromCharCode(0x13), ctrl: true }),
+        state, source, cache,
+        () => undefined, async () => undefined, () => undefined
+      );
+
+      expect(state.mode).toBe("FACTS");
+      expect(state.facts).toBe(facts);
+      expect(state.facts).toEqual({
+        cursor: 0,
+        query: "Maren",
+        chip: 2,
+        selectedTag: "people",
+        filtering: false,
+        deleteArmedId: null,
+        scopeFilter: "everywhere",
+        dossier: { factId: "fact-1", stateIndex: 0, diff: true }
+      });
+    }
+  });
+
+  test("selection-based Fact commands survive a rendered Facts frame", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const cache = createWrapCache<ProseStyle>();
+    const width = 100;
+    const height = 24;
+
+    // Build the real NAV projection first. This is the lifecycle path that a
+    // mouse selection takes before the user opens Facts.
+    const navFrame = renderStoryScreen(state, { width, height, wrapCache: cache });
+    Object.assign(state, navFrame.derived);
+    const projection = state.storySelectionProjection;
+    const displayStart = projection?.findIndex((cell) => cell?.key.endsWith(":text")) ?? -1;
+    const sourceCell = displayStart < 0 ? undefined : projection?.[displayStart];
+    expect(sourceCell).toBeDefined();
+    if (sourceCell == null) throw new Error("rendered story selection has no source cell");
+    const selectedText = sourceCell.text.slice(sourceCell.start, sourceCell.start + 5);
+    expect(displayStart).toBeGreaterThan(-1);
+
+    const nativeSelection = {
+      identity: {},
+      text: selectedText,
+      range: { start: displayStart, end: displayStart + selectedText.length },
+      backward: false
+    };
+    const renderer = {
+      getSelection: () => ({
+        getSelectedText: () => nativeSelection.text,
+        selectedRenderables: [{ getSelection: () => nativeSelection.range }]
+      }),
+      clearSelection: () => undefined
+    };
+
+    state.facts = {
+      cursor: 0,
+      query: "",
+      chip: 0,
+      selectedTag: null,
+      filtering: false,
+      deleteArmedId: null
+    };
+    state.mode = "FACTS";
+    const factsFrame = renderStoryScreen(state, { width, height, wrapCache: cache });
+    Object.assign(state, factsFrame.derived);
+    expect(state.storySelectionProjection).not.toBeNull();
+
+    const press = (event: KeyEvent) => handleKey(
+      event,
+      state,
+      source,
+      cache,
+      () => undefined,
+      async () => undefined,
+      () => undefined,
+      renderer as never
+    );
+    await press(ctrlP());
+    expect(state.commands?.selection?.text).toBe(selectedText);
+
+    // A palette frame replaces the visible page. Keep the Facts projection
+    // through cancel so a second Ctrl-P can capture the same native range.
+    Object.assign(state, renderStoryScreen(state, { width, height, wrapCache: cache }).derived);
+    expect(state.storySelectionProjection).not.toBeNull();
+    await press(key("escape", { sequence: "\u001b" }));
+    expect(state.mode).toBe("FACTS");
+    Object.assign(state, renderStoryScreen(state, { width, height, wrapCache: cache }).derived);
+    expect(state.storySelectionProjection).not.toBeNull();
+    await press(ctrlP());
+    expect(state.commands?.selection?.text).toBe(selectedText);
+
+    await typeQuery(press, "new Fact from selection");
+    expect(state.commands?.selectedId).toBe("new-fact-from-selection");
+    await press(key("return", { sequence: "\r" }));
+
+    expect(state.mode).toBe("EDITOR");
+    expect(state.editor?.kind).toBe("fact");
+    expect(state.editor?.composer.text).toBe(selectedText);
+  });
+
+  test("summary rows hide anchored Fact commands for matching, rendering, keyboard, and mouse", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const cache = createWrapCache<ProseStyle>();
+    const summaryIndex = createStoryViewModel(state.payload).rows
+      .findIndex((row) => row.kind === "chapter-summary");
+    expect(summaryIndex).toBeGreaterThan(-1);
+    state.focusIndex = summaryIndex;
+    expect(factsOpeningPartId(state)).toBeNull();
+
+    const press = (event: KeyEvent) => handleKey(
+      event,
+      state,
+      source,
+      cache,
+      () => undefined,
+      async () => undefined,
+      () => undefined
+    );
+    await press(ctrlP());
+    await typeQuery(press, "new Fact from here");
+    expect(state.commands?.selectedId).not.toBe("new-fact-from-here");
+
+    const frame = renderStoryScreen(state, { width: 100, height: 24, wrapCache: cache });
+    Object.assign(state, frame.derived);
+    expect(frameText(frame.lines)).not.toContain("create a Fact scoped to the focused story part");
+    expect(state.hitRows.some((hit) => hit?.target.kind === "list")).toBeFalse();
+    expect(mouseToAction({
+      type: "down",
+      button: 0,
+      x: 50,
+      y: 10,
+      modifiers: { shift: false, alt: false, ctrl: false }
+    } as never, state)).toBeNull();
+
+    await press(key("return", { sequence: "\r" }));
+    expect(state.mode).toBe("COMMANDS");
+    expect(state.editor).toBeNull();
+  });
+
+});

--- a/tui/test/generation-draft-restoration.test.ts
+++ b/tui/test/generation-draft-restoration.test.ts
@@ -44,8 +44,7 @@ function context(state: RuntimeState) {
   };
 }
 
-/** NAV is the only mode that binds `open-commands` (reference-bindings.ts),
- *  so a palette session can only ever return to NAV. */
+/** These draft-restoration cases open their palette from NAV. */
 function openCommandPalette(state: RuntimeState): void {
   state.mode = "COMMANDS";
   state.commands = {

--- a/tui/test/global-command-palette.test.ts
+++ b/tui/test/global-command-palette.test.ts
@@ -1,0 +1,552 @@
+import { describe, expect, test } from "bun:test";
+import type { KeyEvent } from "@opentui/core";
+import { dispatch, handleKey, initialState } from "../src/app.js";
+import { createAsideSurface } from "../src/aside-surface.js";
+import { commandContext, commandMatches, type CommandId } from "../src/command-model.js";
+import { createComposer, setComposerText } from "../src/composer-model.js";
+import { attachDraftImage, draftImagesFor } from "../src/draft-image.js";
+import { demoAppSource } from "../src/demo.js";
+import { factsOpeningPartId, factsPaletteContext } from "../src/facts-command-context.js";
+import { mapCursorNodeId, openMap } from "../src/map-actions.js";
+import { mouseToAction } from "../src/mouse-actions.js";
+import { createStoryViewModel, rowIndexForNode } from "../src/model.js";
+import { adoptSameStoryPayload } from "../src/story-adoption.js";
+import { rememberedLeafId } from "../../shared/story-model.js";
+import { unusedTakePruneSelection } from "../../shared/story-tree.js";
+import { renderStoryScreen } from "../src/screens/story.js";
+import { frameText } from "../src/screens/story/frame.js";
+import type { AppMode } from "../src/keys.js";
+import { publishCurrentSettingsModelDiscovery } from "../src/settings-model-discovery.js";
+import { createWrapCache, type ProseStyle } from "../src/wrap.js";
+import { editorHarness, key } from "./editor-harness.js";
+import { openTextActions } from "../src/text-actions.js";
+import { openActions } from "../src/story-actions.js";
+import {
+  deferred,
+  openSettings as openSettingsForm,
+  selectRow,
+  settingsHarness
+} from "./settings-test-harness.js";
+import { ActionRuntime } from "../src/action-runtime.js";
+import { openRetakeComposer } from "../src/composer-ownership.js";
+import { cancelSummary } from "../src/summary-action.js";
+import { openAsideUseMenu } from "../src/aside-use.js";
+import { openPlacementFromAside } from "../src/aside-placement.js";
+
+const APP_MODES = Object.keys({
+  NAV: true,
+  COMPOSE: true,
+  EDITOR: true,
+  MAP: true,
+  KEYS: true,
+  TAG: true,
+  LIBRARY: true,
+  FACTS: true,
+  COMMANDS: true,
+  SUMMARY: true,
+  SETTINGS: true,
+  ACTIONS: true,
+  CHAPTERS: true,
+  SEARCH: true,
+  REQUEST: true,
+  CARD: true,
+  ARCHIVE: true,
+  IMAGE: true,
+  LOG: true,
+  PROBS: true,
+  RECORD: true,
+  ASIDE: true,
+  PLACE: true
+} satisfies Record<AppMode, true>) as AppMode[];
+
+function ctrlP(): KeyEvent {
+  return {
+    name: "p",
+    sequence: "\u0010",
+    shift: false,
+    ctrl: true,
+    meta: false,
+    option: false,
+    super: false
+  } as KeyEvent;
+}
+
+async function typeQuery(
+  press: (event: ReturnType<typeof key>) => Promise<void>,
+  query: string
+): Promise<void> {
+  for (const character of query) await press(key(character));
+}
+
+describe("global command palette", () => {
+  test("Ctrl+P opens from every app mode, remains idempotent, and Escape restores the owner", async () => {
+    for (const mode of APP_MODES) {
+      const source = demoAppSource();
+      const state = initialState(source, false);
+      const cache = createWrapCache<ProseStyle>();
+      const press = (event: KeyEvent) => handleKey(
+        event,
+        state,
+        source,
+        cache,
+        () => undefined,
+        async () => undefined,
+        () => undefined
+      );
+
+      if (mode === "COMMANDS") {
+        state.mode = "COMMANDS";
+        state.commands = {
+          query: "facts",
+          cursor: 2,
+          selectedId: "facts",
+          view: "commands",
+          returnMode: "ASIDE"
+        };
+        const existing = state.commands;
+        await press(ctrlP());
+        expect(state.commands).toBe(existing);
+        expect(state.commands.query).toBe("facts");
+        expect(state.commands.returnMode).toBe("ASIDE");
+        continue;
+      }
+
+      state.mode = mode;
+      await press(ctrlP());
+      expect(state.mode).toBe("COMMANDS");
+      expect(state.commands?.returnMode).toBe(mode);
+      await press(ctrlP());
+      expect(state.commands?.returnMode).toBe(mode);
+      await press(key("escape", { sequence: "\u001b" }));
+      expect(state.mode).toBe(mode);
+      expect(state.commands).toBeNull();
+    }
+  });
+
+  test("every Fact workflow has a contextual command", () => {
+    const state = initialState(demoAppSource(), false);
+    const base = {
+      connectionDown: false,
+      requestActive: false,
+      canRewriteSelection: false,
+      hasStoryPart: true,
+      hasStorySelection: true
+    };
+    const contexts = [
+      base,
+      { ...base, factsPanel: true, factsSelected: true, factsCanMoveUp: true, factsCanMoveDown: true },
+      { ...base, factsPanel: true, factsFiltering: true },
+      { ...base, factsPanel: true, factsDossier: true, factsSelected: true },
+      {
+        ...base,
+        factEditor: true,
+        factEditorStateful: true,
+        factEditorHasState: true,
+        factEditorStateCreating: false,
+        factEditorCanOpenAnchor: true,
+        factEditorCanDeleteState: true
+      },
+      { ...base, mapTree: true, mapFactLens: false },
+      { ...base, mapTree: true, mapFactLens: true }
+    ];
+    const available = new Set<CommandId>();
+    for (const context of contexts) {
+      for (const { command } of commandMatches("", false, commandContext(state.payload, context))) {
+        available.add(command.id);
+      }
+    }
+
+    const factCommands: CommandId[] = [
+      "facts",
+      "new-fact",
+      "new-fact-from-here",
+      "new-fact-from-selection",
+      "edit-fact",
+      "new-fact-state",
+      "end-fact-here",
+      "facts-open-selected",
+      "facts-filter",
+      "facts-cycle-tag",
+      "facts-clear-filter",
+      "facts-cycle-scope",
+      "facts-delete",
+      "facts-move-up",
+      "facts-move-down",
+      "facts-open-anchor",
+      "facts-edit-state",
+      "facts-dossier-previous-state",
+      "facts-dossier-next-state",
+      "facts-toggle-diff",
+      "fact-editor-toggle-view",
+      "fact-editor-previous-state",
+      "fact-editor-next-state",
+      "fact-editor-new-state",
+      "fact-editor-open-anchor",
+      "fact-editor-reanchor-state",
+      "fact-editor-convert-state",
+      "fact-editor-delete-state",
+      "map-open-fact-lens",
+      "map-cycle-fact-lens",
+      "map-close-fact-lens",
+      "map-open-fact-lens-anchor",
+      "map-edit-fact-lens",
+      "facts-budget"
+    ];
+    expect(factCommands.filter((id) => !available.has(id))).toEqual([]);
+  });
+
+  test("palette destinations release the suspended transient owner", async () => {
+    const first = editorHarness();
+    await first.press(key("x"));
+    await first.press(ctrlP());
+    await typeQuery(first.press, "facts overview");
+    await first.press(key("return", { sequence: "\r" }));
+    expect(first.state.mode).toBe("FACTS");
+    expect(first.state.actions).toBeNull();
+
+    const second = editorHarness();
+    await second.press(key("f"));
+    await second.press(ctrlP());
+    await typeQuery(second.press, "chapters");
+    await second.press(key("return", { sequence: "\r" }));
+    expect(second.state.mode).toBe("CHAPTERS");
+    expect(second.state.facts).toBeNull();
+    expect(second.state.chapters).not.toBeNull();
+  });
+
+  test("same-mode palette destinations clear an open text-actions menu", async () => {
+    const { source, state, cache, press } = editorHarness();
+    state.mode = "COMPOSE";
+    const composer = state.composer;
+    openTextActions(state);
+    expect(state.textActions).not.toBeNull();
+
+    await press(ctrlP());
+    // The transient menu stays captured for Escape restoration. Select the
+    // destination through the palette's normal dispatch path.
+    if (state.commands === null) throw new Error("palette did not open");
+    state.commands.query = "direct take";
+    state.commands.cursor = 0;
+    await dispatch(
+      { action: "open-selected" }, state, source, cache,
+      () => undefined, async () => undefined, () => undefined
+    );
+
+    expect(state.mode).toBe("COMPOSE");
+    expect(state.composer).toBe(composer);
+    expect(state.textActions).toBeNull();
+  });
+
+  test("read-only palette commands preserve an ACTIONS owner for Escape", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const cache = createWrapCache<ProseStyle>();
+    openActions(state, state.focusIndex);
+    const actions = state.actions;
+    if (actions === null) throw new Error("Actions menu did not open");
+    const press = (event: KeyEvent) => handleKey(
+      event, state, source, cache,
+      () => undefined, async () => undefined, () => undefined
+    );
+
+    await press(ctrlP());
+    await typeQuery(press, "open story folder");
+    await press(key("return", { sequence: "\r" }));
+
+    expect(state.mode).toBe("ACTIONS");
+    expect(state.actions).toBe(actions);
+    expect(state.toast).toBe(source.storyFolder);
+
+    await press(key("escape", { sequence: "\u001b" }));
+    expect(state.mode).toBe("NAV");
+    expect(state.actions).toBeNull();
+  });
+
+  test("MAP palette destinations keep the exact Map owner for child return routes", async () => {
+    for (const destination of ["generation records", "tag this line"] as const) {
+      const source = demoAppSource();
+      const state = initialState(source, false);
+      const cache = createWrapCache<ProseStyle>();
+      openMap(state);
+      if (state.map === null) throw new Error("Map did not open");
+      const map = state.map;
+
+      const press = (event: KeyEvent) => handleKey(
+        event, state, source, cache,
+        () => undefined, async () => undefined, () => undefined
+      );
+      await press(ctrlP());
+      await typeQuery(press, destination);
+      await press(key("return", { sequence: "\r" }));
+
+      expect(state.map).toBe(map);
+      expect(state.mode).toBe(destination === "generation records" ? "RECORD" : "TAG");
+      if (destination === "generation records") expect(state.record?.returnMode).toBe("MAP");
+      else expect(state.tag?.returnMode).toBe("MAP");
+
+      await press(key("escape", { sequence: "\u001b" }));
+      expect(state.mode).toBe("MAP");
+      expect(state.map).toBe(map);
+    }
+  });
+
+  test("a Placement-held Aside draft blocks palette destinations and survives cancel", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const cache = createWrapCache<ProseStyle>();
+    const surface = createAsideSurface(
+      state.payload.id,
+      state.payload.title,
+      [{ question: "Q?", answer: "answer to place" }],
+      null,
+      state.payload.path.at(-1)?.id ?? null
+    );
+    setComposerText(surface.composer, "keep this unsent question");
+    state.aside = surface;
+    state.mode = "ASIDE";
+    expect(openAsideUseMenu(surface, 0, 0)).toBeTrue();
+    expect(openPlacementFromAside(state)).toBeTrue();
+    const placement = state.placement;
+    expect(placement?.returnAside).toBe(surface);
+
+    const press = (event: KeyEvent) => handleKey(
+      event, state, source, cache,
+      () => undefined, async () => undefined, () => undefined
+    );
+    await press(ctrlP());
+    await typeQuery(press, "facts overview");
+    await press(key("return", { sequence: "\r" }));
+
+    expect(state.mode).toBe("PLACE");
+    expect(state.commands).toBeNull();
+    expect(state.placement).toBe(placement);
+    expect(state.placement?.returnAside.composer.text).toBe("keep this unsent question");
+    expect(state.toast).toBe("finish or cancel current input first");
+
+    await press(key("escape", { sequence: "\u001b" }));
+    expect(state.mode).toBe("ASIDE");
+    expect(state.aside).toBe(surface);
+    expect(state.aside?.composer.text).toBe("keep this unsent question");
+  });
+
+  test("Summary paints above a dormant Facts panel during provider streaming", async () => {
+    const { source, state, press } = editorHarness();
+    await press(key("f"));
+    await press(ctrlP());
+    await typeQuery(press, "summary take");
+
+    let entered!: () => void;
+    const providerEntered = new Promise<void>((resolve) => { entered = resolve; });
+    let release!: () => void;
+    const providerGate = new Promise<void>((resolve) => { release = resolve; });
+    source.api.createSummaryTake = async () => {
+      entered();
+      await providerGate;
+      return null;
+    };
+
+    const pending = press(key("return", { sequence: "\r" }));
+    await providerEntered;
+    expect(state.mode).toBe("SUMMARY");
+    expect(state.summary).not.toBeNull();
+    const frame = renderStoryScreen(state, { width: 100, height: 24 });
+    expect(frameText(frame.lines)).toContain("summary take");
+    expect(frameText(frame.lines)).not.toContain("Facts manager");
+    release();
+    await pending;
+  });
+
+  test("Summary settlement keeps the palette open and releases its owner", async () => {
+    for (const outcome of ["success", "failure", "cancel"] as const) {
+      const source = demoAppSource();
+      const state = initialState(source, false);
+      const cache = createWrapCache<ProseStyle>();
+      const backend = new ActionRuntime(state, () => undefined);
+      const press = (event: KeyEvent) => handleKey(
+        event,
+        state,
+        source,
+        cache,
+        () => undefined,
+        async () => undefined,
+        () => undefined,
+        null,
+        () => undefined,
+        () => undefined,
+        backend
+      );
+      let entered!: () => void;
+      const providerEntered = new Promise<void>((resolve) => { entered = resolve; });
+      let release!: () => void;
+      const providerGate = new Promise<void>((resolve) => { release = resolve; });
+      const leafId = state.payload.path.at(-1)!.id;
+      source.api = {
+        ...source.api,
+        createSummaryTake: async () => {
+          entered();
+          await providerGate;
+          if (outcome === "failure") throw new Error("summary failed");
+          return outcome === "cancel" ? null : { nodeId: leafId, narrowedTo: null };
+        }
+      };
+
+      await press(ctrlP());
+      await typeQuery(press, "summary take");
+      const running = press(key("return", { sequence: "\r" }));
+      await providerEntered;
+      expect(state.mode).toBe("SUMMARY");
+      expect(state.summary).not.toBeNull();
+
+      await press(ctrlP());
+      expect(state.mode).toBe("COMMANDS");
+      expect(state.commands?.returnMode).toBe("SUMMARY");
+      if (outcome === "cancel") {
+        cancelSummary(state);
+        expect(state.mode).toBe("COMMANDS");
+        expect(state.commands?.returnMode).toBe("NAV");
+      }
+
+      release();
+      await running;
+      expect(state.mode).toBe("COMMANDS");
+      expect(state.commands?.returnMode).toBe("NAV");
+      expect(state.summary).toBeNull();
+
+      await press(key("escape", { sequence: "\u001b" }));
+      expect(state.mode).toBe("NAV");
+      expect(state.commands).toBeNull();
+    }
+  });
+
+  test("Aside palette interaction preserves question restoration after null or failed Ask", async () => {
+    for (const outcome of ["null", "failure"] as const) {
+      const source = demoAppSource();
+      const state = initialState(source, false);
+      const cache = createWrapCache<ProseStyle>();
+      const backend = new ActionRuntime(state, () => undefined);
+      const aside = createAsideSurface(state.payload.id, state.payload.title);
+      state.aside = aside;
+      state.mode = "ASIDE";
+      setComposerText(aside.composer, "restore this question");
+      let finish!: (outcome: "null" | "failure") => void;
+      const pendingAsk = new Promise<null>((resolve, reject) => {
+        finish = (outcome) => outcome === "null"
+          ? resolve(null)
+          : reject(new Error("Aside failed"));
+      });
+      source.api = {
+        ...source.api,
+        askAside: async () => await pendingAsk
+      };
+      const press = (event: KeyEvent) => handleKey(
+        event,
+        state,
+        source,
+        cache,
+        () => undefined,
+        async () => undefined,
+        () => undefined,
+        null,
+        () => undefined,
+        () => undefined,
+        backend
+      );
+
+      await press(key("return", { sequence: "\r" }));
+      expect(aside.busy).toBeTrue();
+      await press(ctrlP());
+      expect(state.mode).toBe("COMMANDS");
+      expect(state.commands?.returnMode).toBe("ASIDE");
+      await press(key("x"));
+      await press(key("down"));
+      await press(key("escape", { sequence: "\u001b" }));
+      expect(state.mode).toBe("ASIDE");
+      expect(aside.composer.text).toBe("");
+
+      finish(outcome);
+      await backend.whenIdle();
+      expect(aside.composer.text).toBe("restore this question");
+      expect(aside.busy).toBeFalse();
+    }
+  });
+
+  test("the palette paints over Aside and restores its draft", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const cache = createWrapCache<ProseStyle>();
+    state.mode = "ASIDE";
+    state.aside = createAsideSurface(state.payload.id, state.payload.title);
+    setComposerText(state.aside.composer, "Keep this question");
+    const aside = state.aside;
+
+    await handleKey(
+      ctrlP(), state, source, cache,
+      () => undefined, async () => undefined, () => undefined
+    );
+    const frame = renderStoryScreen(state, { width: 100, height: 24, wrapCache: cache });
+    Object.assign(state, frame.derived);
+    expect(frameText(frame.lines)).toContain("Search");
+    expect(frameText(frame.lines)).toContain("COMMANDS");
+
+    await handleKey(
+      key("escape", { sequence: "\u001b" }), state, source, cache,
+      () => undefined, async () => undefined, () => undefined
+    );
+    expect(state.mode).toBe("ASIDE");
+    expect(state.aside).toBe(aside);
+    expect(state.aside.composer.text).toBe("Keep this question");
+  });
+
+  test("contextual commands belong only to the surface behind the palette", () => {
+    const state = initialState(demoAppSource(), false);
+    state.facts = {
+      cursor: 0,
+      query: "",
+      chip: 0,
+      selectedTag: null,
+      filtering: false,
+      deleteArmedId: null,
+      scopeFilter: "everywhere",
+      dossier: null
+    };
+    state.mode = "COMMANDS";
+    state.commands = {
+      query: "",
+      cursor: 0,
+      selectedId: null,
+      view: "commands",
+      returnMode: "ASIDE"
+    };
+
+    expect(factsPaletteContext(state)).toEqual({
+      factsPanel: false,
+      factsDossier: false,
+      factsFiltering: false,
+      factsHasFilter: false,
+      factsSelected: false,
+      factsCanMoveUp: false,
+      factsCanMoveDown: false,
+      mapTree: false,
+      mapFactLens: false
+    });
+  });
+
+  test("a new Fact State context exposes the re-anchor command", () => {
+    const state = initialState(demoAppSource(), false);
+    const context = commandContext(state.payload, {
+      connectionDown: false,
+      requestActive: false,
+      canRewriteSelection: false,
+      factEditor: true,
+      factEditorStateful: true,
+      factEditorHasState: false,
+      factEditorStateCreating: true
+    });
+
+    expect(commandMatches("reanchor state", false, context)
+      .map(({ command }) => command.id))
+      .toEqual(["fact-editor-reanchor-state"]);
+  });
+
+});
+

--- a/tui/test/global-palette-guards.test.ts
+++ b/tui/test/global-palette-guards.test.ts
@@ -1,0 +1,519 @@
+import { describe, expect, test } from "bun:test";
+import type { KeyEvent } from "@opentui/core";
+import { dispatch, handleKey, initialState } from "../src/app.js";
+import { createAsideSurface } from "../src/aside-surface.js";
+import { commandContext, commandMatches, type CommandId } from "../src/command-model.js";
+import { createComposer, setComposerText } from "../src/composer-model.js";
+import { attachDraftImage, draftImagesFor } from "../src/draft-image.js";
+import { demoAppSource } from "../src/demo.js";
+import { factsOpeningPartId, factsPaletteContext } from "../src/facts-command-context.js";
+import { mapCursorNodeId, openMap } from "../src/map-actions.js";
+import { mouseToAction } from "../src/mouse-actions.js";
+import { createStoryViewModel, rowIndexForNode } from "../src/model.js";
+import { adoptSameStoryPayload } from "../src/story-adoption.js";
+import { rememberedLeafId } from "../../shared/story-model.js";
+import { unusedTakePruneSelection } from "../../shared/story-tree.js";
+import { renderStoryScreen } from "../src/screens/story.js";
+import { frameText } from "../src/screens/story/frame.js";
+import type { AppMode } from "../src/keys.js";
+import { publishCurrentSettingsModelDiscovery } from "../src/settings-model-discovery.js";
+import { createWrapCache, type ProseStyle } from "../src/wrap.js";
+import { editorHarness, key } from "./editor-harness.js";
+import { openTextActions } from "../src/text-actions.js";
+import { openActions } from "../src/story-actions.js";
+import {
+  deferred,
+  openSettings as openSettingsForm,
+  selectRow,
+  settingsHarness
+} from "./settings-test-harness.js";
+import { ActionRuntime } from "../src/action-runtime.js";
+import { openRetakeComposer } from "../src/composer-ownership.js";
+import { cancelSummary } from "../src/summary-action.js";
+import { openAsideUseMenu } from "../src/aside-use.js";
+import { openPlacementFromAside } from "../src/aside-placement.js";
+
+const APP_MODES = Object.keys({
+  NAV: true,
+  COMPOSE: true,
+  EDITOR: true,
+  MAP: true,
+  KEYS: true,
+  TAG: true,
+  LIBRARY: true,
+  FACTS: true,
+  COMMANDS: true,
+  SUMMARY: true,
+  SETTINGS: true,
+  ACTIONS: true,
+  CHAPTERS: true,
+  SEARCH: true,
+  REQUEST: true,
+  CARD: true,
+  ARCHIVE: true,
+  IMAGE: true,
+  LOG: true,
+  PROBS: true,
+  RECORD: true,
+  ASIDE: true,
+  PLACE: true
+} satisfies Record<AppMode, true>) as AppMode[];
+
+function ctrlP(): KeyEvent {
+  return {
+    name: "p",
+    sequence: "\u0010",
+    shift: false,
+    ctrl: true,
+    meta: false,
+    option: false,
+    super: false
+  } as KeyEvent;
+}
+
+async function typeQuery(
+  press: (event: ReturnType<typeof key>) => Promise<void>,
+  query: string
+): Promise<void> {
+  for (const character of query) await press(key(character));
+}
+
+describe("global command palette", () => {
+  test("palette prune returns from Facts to a visible confirmation before D can remove takes", async () => {
+    const { state, cache, press } = editorHarness();
+    await press(key("f"));
+    const facts = state.facts;
+    if (facts === null) throw new Error("Facts did not open");
+
+    await press(ctrlP());
+    await typeQuery(press, "prune");
+    expect(state.commands?.selectedId).toBe("prune");
+    await press(key("return", { sequence: "\r" }));
+
+    expect(state.mode).toBe("NAV");
+    expect(state.facts).toBeNull();
+    expect(state.prune).not.toBeNull();
+    const frame = frameText(renderStoryScreen(state, {
+      width: 100,
+      height: 24,
+      wrapCache: cache
+    }).lines);
+    expect(frame).toContain("PRUNE");
+    expect(frame).toContain("D confirms · esc keeps");
+
+    await press(key("d", { sequence: "D", shift: true }));
+    expect(state.prune).toBeNull();
+    expect(state.toast).toContain("pruned");
+  });
+
+  test("clean file prompts still allow a palette destination", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const cache = createWrapCache<ProseStyle>();
+    state.card = {
+      path: "",
+      storyId: state.payload.id,
+      candidates: [],
+      error: null,
+      returnMode: "NAV"
+    };
+    state.mode = "CARD";
+    const card = state.card;
+
+    await handleKey(
+      ctrlP(), state, source, cache,
+      () => undefined, async () => undefined, () => undefined
+    );
+    await typeQuery(
+      (event) => handleKey(
+        event, state, source, cache,
+        () => undefined, async () => undefined, () => undefined
+      ),
+      "chapters"
+    );
+    await handleKey(
+      key("return", { sequence: "\r" }), state, source, cache,
+      () => undefined, async () => undefined, () => undefined
+    );
+
+    expect(state.mode).toBe("CHAPTERS");
+    expect(state.card).toBeNull();
+    expect(state.chapters).not.toBeNull();
+    expect(card).not.toBe(state.card);
+  });
+
+  test("Direct can resume a dirty Direct composer", async () => {
+    const { source, state, press } = editorHarness();
+    state.mode = "COMPOSE";
+    setComposerText(state.composer, "keep this Direct draft");
+
+    await press(ctrlP());
+    await typeQuery(press, "direct");
+    await press(key("return", { sequence: "\r" }));
+
+    expect(state.mode).toBe("COMPOSE");
+    expect(state.commands).toBeNull();
+    expect(state.composer.text).toBe("keep this Direct draft");
+    expect(state.toast).toBe("");
+  });
+
+  test("staged Settings refuse a palette destination and restore Settings", async () => {
+    const { state, press } = settingsHarness();
+    await openSettingsForm(press);
+    if (state.settings === null) throw new Error("Settings did not open");
+    const settings = state.settings;
+    if (!settings.view.editable) throw new Error("Settings are not editable");
+    settings.view = { ...settings.view, pendingRevision: settings.view.activeRevision + 1 };
+
+    await press(ctrlP());
+    await typeQuery(press, "chapters");
+    await press(key("return", { sequence: "\r" }));
+
+    expect(state.mode).toBe("SETTINGS");
+    expect(state.settings).toBe(settings);
+    expect(state.toast).toBe("save or cancel Settings changes first");
+  });
+
+  test("active Generation Profile file transfer refuses a palette destination and keeps its path", async () => {
+    const { state, press } = settingsHarness();
+    await openSettingsForm(press);
+    await selectRow(press, state, "profile");
+    await press(key("i"));
+    await press(key("down"));
+    await press(key("down"));
+    await press(key("down"));
+    await press(key("return", { sequence: "\r" }));
+
+    const settings = state.settings;
+    if (settings === null || settings.profileTransfer?.phase !== "file") {
+      throw new Error("Generation Profile file transfer did not open");
+    }
+    const transfer = settings.profileTransfer;
+    const path = "/tmp/profile-export.json";
+    for (const character of path) await press(key(character));
+
+    await press(ctrlP());
+    await typeQuery(press, "facts overview");
+    await press(key("return", { sequence: "\r" }));
+
+    expect(state.mode).toBe("SETTINGS");
+    expect(state.settings).toBe(settings);
+    expect(state.settings?.profileTransfer).toBe(transfer);
+    expect(transfer.path).toBe(path);
+    expect(state.toast).toBe("save or cancel Settings changes first");
+  });
+
+  test("active Settings model picker refuses a palette destination and keeps its query", async () => {
+    const { state, press } = settingsHarness();
+    await openSettingsForm(press);
+    if (state.settings === null) throw new Error("Settings did not open");
+    const settings = state.settings;
+    settings.draft = {
+      ...settings.draft,
+      generation: { ...settings.draft.generation, model: "model-01" }
+    };
+    publishCurrentSettingsModelDiscovery(settings, {
+      observedAt: "2026-01-01T00:00:00.000Z",
+      models: Array.from({ length: 9 }, (_, index) => ({
+        remoteId: `model-${String(index + 1).padStart(2, "0")}`,
+        name: `Model ${String(index + 1).padStart(2, "0")}`,
+        contextWindow: 32_768,
+        maxOutputTokens: null,
+        source: "openai-models" as const
+      }))
+    });
+
+    await selectRow(press, state, "model");
+    await press(key("return"));
+    const picker = settings.modelPicker;
+    if (picker === null) throw new Error("Settings model picker did not open");
+    await typeQuery(press, "private-preview-model");
+    expect(picker.query).toBe("private-preview-model");
+
+    await press(ctrlP());
+    await typeQuery(press, "chapters");
+    await press(key("return", { sequence: "\r" }));
+
+    expect(state.mode).toBe("SETTINGS");
+    expect(state.settings).toBe(settings);
+    expect(state.settings?.modelPicker).toBe(picker);
+    expect(picker.query).toBe("private-preview-model");
+    expect(state.toast).toBe("save or cancel Settings changes first");
+  });
+
+  test("settled export cleanup keeps Settings and a newer palette session", async () => {
+    const { source, state, press } = settingsHarness();
+    await openSettingsForm(press);
+    if (state.settings === null) throw new Error("Settings did not open");
+    const settings = state.settings;
+    if (!settings.view.editable) throw new Error("Settings are not editable");
+    settings.view = { ...settings.view, pendingRevision: settings.view.activeRevision + 1 };
+    source.exportDirectory = "/tmp";
+
+    const entered = deferred<void>();
+    const release = deferred<void>();
+    source.api.exportMarkdown = async () => {
+      entered.resolve();
+      await release.promise;
+      return { markdown: "# exported", fidelity: [] };
+    };
+
+    await press(ctrlP());
+    await typeQuery(press, "export markdown");
+    const exporting = press(key("return", { sequence: "\r" }));
+    await entered.promise;
+
+    await press(ctrlP());
+    const newerPalette = state.commands;
+    expect(state.mode).toBe("COMMANDS");
+    expect(newerPalette?.returnMode).toBe("SETTINGS");
+
+    release.resolve();
+    await exporting;
+
+    expect(state.settings).toBe(settings);
+    expect(state.commands).toBe(newerPalette);
+    await press(key("escape", { sequence: "\u001b" }));
+    expect(state.mode).toBe("SETTINGS");
+    expect(state.settings).toBe(settings);
+  });
+
+  test("settled export keeps a Settings prompt editor owned by Settings", async () => {
+    const { source, state, press } = settingsHarness();
+    await openSettingsForm(press);
+    if (state.settings === null) throw new Error("Settings did not open");
+    const settings = state.settings;
+    source.exportDirectory = "/tmp";
+
+    const entered = deferred<void>();
+    const release = deferred<void>();
+    source.api.exportMarkdown = async () => {
+      entered.resolve();
+      await release.promise;
+      return { markdown: "# exported", fidelity: [] };
+    };
+
+    await press(ctrlP());
+    await typeQuery(press, "export markdown");
+    const exporting = press(key("return", { sequence: "\r" }));
+    await entered.promise;
+
+    // The old palette command has returned control to Settings while its
+    // export request is pending. Opening a prompt now makes the Settings
+    // overlay the live owner of a document editor.
+    await selectRow(press, state, "default-author-brief");
+    await press(key("return", { sequence: "\r" }));
+    const editor = state.editor;
+    if (editor?.kind !== "document" || editor.target.kind !== "settings-prompt") {
+      throw new Error("global Settings prompt did not open");
+    }
+    setComposerText(editor.composer, "preserved Settings prompt");
+
+    release.resolve();
+    await exporting;
+
+    expect(state.settings).toBe(settings);
+    expect(state.editor).toBe(editor);
+    expect(editor.target.owner).toBe(settings);
+
+    // Ctrl+S commits the document editor into Settings. Plain s then saves
+    // the Settings draft through the normal Settings mutation.
+    await press(key("s", { sequence: "\u0013", ctrl: true }));
+    expect(state.mode).toBe("SETTINGS");
+    expect(state.settings).toBe(settings);
+    expect(state.settings?.draft.document?.writing.defaultAuthorBrief)
+      .toBe("preserved Settings prompt");
+    await press(key("s"));
+    const savedDocument = source.settingsView.document;
+    if (savedDocument === null) throw new Error("saved Settings document is missing");
+    expect(savedDocument.writing.defaultAuthorBrief)
+      .toBe("preserved Settings prompt");
+  });
+
+  test("dirty TAG input and status block palette destinations", async () => {
+    for (const dirty of ["name", "status"] as const) {
+      const { state, press } = editorHarness();
+      await press(key("t"));
+      const prompt = state.tag;
+      if (prompt === null) throw new Error("Tag prompt did not open");
+      const baselineName = prompt.name;
+      await press(key("l"));
+      if (dirty === "status") {
+        await press(key("return", { sequence: "\r" }));
+        await press(key("right"));
+      }
+
+      await press(ctrlP());
+      await typeQuery(press, "chapters");
+      await press(key("return", { sequence: "\r" }));
+
+      expect(state.mode).toBe("TAG");
+      expect(state.tag).toBe(prompt);
+      expect(state.tag?.name).toBe(`${baselineName}l`);
+      if (dirty === "status") expect(state.tag?.choosingStatus).toBeTrue();
+      expect(state.toast).toBe("finish or cancel current input first");
+    }
+  });
+
+  test("palette cleanup does not clear a replacement owner created while awaiting", async () => {
+    const { source, state, press } = editorHarness();
+    await press(key("f"));
+    const originalFacts = state.facts;
+    if (originalFacts === null) throw new Error("Facts did not open");
+
+    const entered = deferred<void>();
+    const release = deferred<void>();
+    source.api.listStories = async () => {
+      entered.resolve();
+      await release.promise;
+      return source.stories;
+    };
+
+    await press(ctrlP());
+    await typeQuery(press, "switch story");
+    const pending = press(key("return", { sequence: "\r" }));
+    await entered.promise;
+    const replacementFacts = { ...originalFacts };
+    state.facts = replacementFacts;
+    release.resolve();
+    await pending;
+
+    expect(state.mode).toBe("LIBRARY");
+    expect(state.facts).toBe(replacementFacts);
+  });
+
+  test("End Fact here from the Facts list arms and opens the pending End State picker", async () => {
+    const { state, press } = editorHarness();
+    await press(key("f"));
+    const facts = state.facts;
+    if (facts === null) throw new Error("Facts did not open");
+
+    await press(ctrlP());
+    await typeQuery(press, "end Fact here");
+    expect(state.commands?.selectedId).toBe("end-fact-here");
+    await press(key("return", { sequence: "\r" }));
+
+    expect(state.mode).toBe("FACTS");
+    expect(state.facts).toBe(facts);
+    expect(state.facts?.pendingFactAction?.kind).toBe("end");
+    await press(key("return", { sequence: "\r" }));
+    expect(state.mode).toBe("EDITOR");
+    if (state.editor?.kind !== "fact") throw new Error("Fact editor did not open");
+    expect(state.editor.stateIsEnd).toBeTrue();
+    expect(state.editor.composer.text).toBe("");
+  });
+
+  test("new Fact State from an active Facts filter arms the pending state picker", async () => {
+    const { state, press } = editorHarness();
+    await press(key("f"));
+    const facts = state.facts;
+    if (facts === null) throw new Error("Facts did not open");
+
+    await press(key("/"));
+    await typeQuery(press, "Maren");
+    expect(facts.filtering).toBeTrue();
+    expect(facts.query).toBe("Maren");
+
+    await press(ctrlP());
+    await typeQuery(press, "new Fact State");
+    expect(state.commands?.selectedId).toBe("new-fact-state");
+    await press(key("return", { sequence: "\r" }));
+
+    expect(state.mode).toBe("FACTS");
+    expect(state.facts).toBe(facts);
+    expect(facts.filtering).toBeFalse();
+    expect(facts.query).toBe("Maren");
+    expect(facts.pendingFactAction?.kind).toBe("new-state");
+
+    await press(key("return", { sequence: "\r" }));
+    expect(state.mode).toBe("EDITOR");
+    expect(state.editor?.kind).toBe("fact");
+    expect(facts.query).toBe("Maren");
+  });
+
+  test("clear Facts filter clears query and tag through the canonical reducer", async () => {
+    const { state, press } = editorHarness();
+    await press(key("f"));
+    if (state.facts === null) throw new Error("Facts did not open");
+    state.facts.query = "Maren";
+    state.facts.selectedTag = "people";
+    state.facts.filtering = false;
+
+    await press(ctrlP());
+    await typeQuery(press, "clear Facts filter");
+    expect(state.commands?.selectedId).toBe("facts-clear-filter");
+    await press(key("return", { sequence: "\r" }));
+
+    expect(state.mode).toBe("FACTS");
+    expect(state.facts?.query).toBe("");
+    expect(state.facts?.selectedTag).toBeNull();
+    expect(state.facts?.filtering).toBeFalse();
+  });
+
+  test("reconnect refuses a dirty Fact editor and preserves its draft", async () => {
+    const { state, press } = editorHarness();
+    await press(key("f"));
+    await press(key("return"));
+    if (state.editor?.kind !== "fact") throw new Error("Fact editor did not open");
+    const editor = state.editor;
+    setComposerText(editor.composer, "keep this unsaved Fact");
+
+    await press(ctrlP());
+    await typeQuery(press, "reconnect");
+    expect(state.commands?.selectedId).toBe("reconnect");
+    await press(key("return", { sequence: "\r" }));
+
+    expect(state.mode).toBe("EDITOR");
+    expect(state.editor).toBe(editor);
+    expect(editor.composer.text).toBe("keep this unsaved Fact");
+    expect(state.toast).toBe("close the current editor before running this command");
+  });
+
+  test("reconnect refuses dirty Settings changes and preserves the Settings owner", async () => {
+    const { state, press } = settingsHarness();
+    await openSettingsForm(press);
+    if (state.settings === null) throw new Error("Settings did not open");
+    const settings = state.settings;
+    if (!settings.view.editable) throw new Error("Settings are not editable");
+    settings.view = { ...settings.view, pendingRevision: settings.view.activeRevision + 1 };
+
+    await press(ctrlP());
+    await typeQuery(press, "reconnect");
+    expect(state.commands?.selectedId).toBe("reconnect");
+    await press(key("return", { sequence: "\r" }));
+
+    expect(state.mode).toBe("SETTINGS");
+    expect(state.settings).toBe(settings);
+    expect(state.toast).toBe("save or cancel Settings changes first");
+  });
+
+  test("reconnect remains available from a clean owner", async () => {
+    const { state, press } = editorHarness();
+    state.mode = "COMPOSE";
+
+    await press(ctrlP());
+    await typeQuery(press, "reconnect");
+    expect(state.commands?.selectedId).toBe("reconnect");
+    await press(key("return", { sequence: "\r" }));
+
+    expect(state.mode).toBe("COMPOSE");
+    expect(state.commands).toBeNull();
+    expect(state.composer.text).toBe("");
+    expect(state.toast).toBe("reconnected · demo fixture");
+  });
+
+  test("contextual Fact mutations carry the generation guard metadata", () => {
+    const state = initialState(demoAppSource(), false);
+    const matches = commandMatches("", false, commandContext(state.payload, {
+      connectionDown: false,
+      requestActive: false,
+      canRewriteSelection: false,
+      factsPanel: true,
+      factsSelected: true,
+      factsCanMoveUp: true,
+      factsCanMoveDown: true
+    }));
+    for (const id of ["facts-delete", "facts-move-up", "facts-move-down"] as const) {
+      expect(matches.find(({ command }) => command.id === id)?.command.mutating).toBeTrue();
+    }
+  });});

--- a/tui/test/golden-panels.test.ts
+++ b/tui/test/golden-panels.test.ts
@@ -241,8 +241,11 @@ describe("run C overlay frames", () => {
     expect(grouped).toContain("direct take");
     expect(grouped).toContain("generation settings");
     expect(grouped).not.toContain("acknowledge unknown");
-    expect(grouped).toContain(`theme: ${NEW_INSTALL_THEME}`);
     expect(grouped).toContain("↑↓ move · ↵ run · esc close");
+
+    const themed = await renderOnce(demoAppSource(), 120, 36, ":theme");
+    expect(themed).toContain("System");
+    expect(themed).toContain(`theme: ${NEW_INSTALL_THEME}`);
 
     const filtered = await renderOnce(demoAppSource(), 120, 36, ":sum");
     expect(filtered).toContain("Search  sum");

--- a/tui/test/library-filter.test.ts
+++ b/tui/test/library-filter.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import type { KeyEvent } from "@opentui/core";
+import type { StoryPayload } from "../../shared/types.js";
+import { ActionRuntime } from "../src/action-runtime.js";
 import { handleKey, initialState, type AppSource } from "../src/app.js";
 import { createComposer } from "../src/composer-model.js";
 import { demoAppSource } from "../src/demo.js";
@@ -7,7 +9,7 @@ import { pasteInto } from "../src/keys.js";
 import { publishStories } from "../src/overlay-publication.js";
 import { renderStoryScreen } from "../src/screens/story.js";
 import { frameText } from "../src/screens/story/frame.js";
-import { createWrapCache } from "../src/wrap.js";
+import { createWrapCache, type ProseStyle } from "../src/wrap.js";
 
 const key = (name: string, sequence = name): KeyEvent => ({
   name,
@@ -27,6 +29,14 @@ const modifiedKey = (
   ctrl: options.ctrl ?? false,
   meta: options.meta ?? false
 }) as KeyEvent;
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
 
 function harness() {
   const source: AppSource = demoAppSource();
@@ -225,6 +235,63 @@ describe("live Library filter", () => {
     expect(renames).toBe(0);
     expect(state.library?.prompt).toBe(null);
     expect(state.toast).toBe("story changed · action cancelled");
+  });
+
+  test("cross-story library adoption clears an armed tag confirmation", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const cache = createWrapCache<ProseStyle>();
+    const backend = new ActionRuntime(state, () => undefined);
+    const pressKey = (event: KeyEvent) => handleKey(
+      event,
+      state,
+      source,
+      cache,
+      () => undefined,
+      async () => undefined,
+      () => undefined,
+      null,
+      () => undefined,
+      () => undefined,
+      backend
+    );
+
+    await pressKey(key("o"));
+    const target = source.stories.find((story) => story.id !== source.payload.id);
+    if (target === undefined) throw new Error("library fixture needs another story");
+    const targetIndex = state.library!.stories.findIndex((story) => story.id === target.id);
+    state.library!.cursor = targetIndex;
+    const entered = deferred<void>();
+    const gate = deferred<StoryPayload>();
+    const targetPayload = { ...source.payload, id: target.id, title: target.title };
+    source.api.loadStory = async () => {
+      entered.resolve();
+      return gate.promise;
+    };
+
+    const opening = pressKey(key("return", "\r"));
+    await entered.promise;
+    await pressKey(modifiedKey("p", { sequence: "\u0010", ctrl: true }));
+    const palette = state.commands;
+    if (palette === null) throw new Error("palette did not open");
+    palette.query = "tag manager";
+    palette.view = "tags";
+    const collidingTagNodeId = source.payload.tags[0]?.nodeId;
+    if (collidingTagNodeId === undefined) throw new Error("library fixture needs a tag");
+    palette.deleteArmedTagNodeId = collidingTagNodeId;
+
+    gate.resolve(targetPayload);
+    await opening;
+
+    expect(state.payload.id).toBe(target.id);
+    expect(state.commands).toBe(palette);
+    expect(state.commands?.returnMode).toBe("NAV");
+    expect(state.commands?.query).toBe("tag manager");
+    expect(state.commands?.view).toBe("tags");
+    expect(state.commands?.deleteArmedTagNodeId).toBe(null);
+
+    await pressKey(key("D"));
+    expect(state.commands?.deleteArmedTagNodeId).toBe(collidingTagNodeId);
   });
 });
 

--- a/tui/test/palette-async-settlement.test.ts
+++ b/tui/test/palette-async-settlement.test.ts
@@ -1,0 +1,733 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import type { KeyEvent } from "@opentui/core";
+import { ActionRuntime } from "../src/action-runtime.js";
+import { openArchiveImport } from "../src/archive-import-actions.js";
+import { openCardImport } from "../src/card-import-actions.js";
+import { dispatch, handleKey, initialState } from "../src/app.js";
+import type { ActionContext } from "../src/action-context.js";
+import { createAsideSurface } from "../src/aside-surface.js";
+import { demoAppSource } from "../src/demo.js";
+import {
+  FROM_ASIDE_INSTRUCTION,
+  openPlacementFromAside
+} from "../src/aside-placement.js";
+import { openAsideUseMenu } from "../src/aside-use.js";
+import { createStoryViewModel, rowIndexForNode } from "../src/model.js";
+import { setComposerText } from "../src/composer-model.js";
+import { draftImagesFor } from "../src/draft-image.js";
+import { searchRows } from "../src/search-model.js";
+import { openTag } from "../src/story-actions.js";
+import { PNG_SIGNATURE } from "../../shared/png-text-chunk.js";
+import type { ProseStyle } from "../src/wrap.js";
+import { createWrapCache } from "../src/wrap.js";
+import { openLibrary } from "../src/library-actions.js";
+import { renderStoryScreen } from "../src/screens/story.js";
+
+const created: string[] = [];
+
+afterEach(async () => {
+  for (const directory of created.splice(0)) {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+function ctrlP(): KeyEvent {
+  return key("p", { sequence: "\u0010", ctrl: true });
+}
+
+function key(
+  name: string,
+  options: { sequence?: string; ctrl?: boolean; shift?: boolean } = {}
+): KeyEvent {
+  return {
+    name,
+    sequence: options.sequence ?? name,
+    shift: options.shift ?? false,
+    ctrl: options.ctrl ?? false,
+    meta: false,
+    option: false,
+    super: false
+  } as KeyEvent;
+}
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((next) => { resolve = next; });
+  return { promise, resolve };
+}
+
+async function typeQuery(
+  press: (event: KeyEvent) => Promise<void>,
+  query: string
+): Promise<void> {
+  for (const character of query) await press(key(character));
+}
+
+function minimalPng(width = 64, height = 48): Uint8Array {
+  const bytes = new Uint8Array(29);
+  bytes.set(PNG_SIGNATURE, 0);
+  const view = new DataView(bytes.buffer);
+  view.setUint32(8, 13, false);
+  bytes.set(new TextEncoder().encode("IHDR"), 12);
+  view.setUint32(16, width, false);
+  view.setUint32(20, height, false);
+  bytes[24] = 8;
+  bytes[25] = 6;
+  return bytes;
+}
+
+function testHarness(renderer: ActionContext["renderer"] = null) {
+  const source = demoAppSource();
+  const state = initialState(source, false);
+  const cache = createWrapCache<ProseStyle>();
+  const backend = new ActionRuntime(state, () => undefined);
+  const press = (event: KeyEvent) => handleKey(
+    event,
+    state,
+    source,
+    cache,
+    () => undefined,
+    async () => undefined,
+    () => undefined,
+    renderer,
+    () => undefined,
+    () => undefined,
+    backend
+  );
+  const context = {
+    backend,
+    cache,
+    repaint: () => undefined,
+    renderer,
+    applyTheme: () => undefined,
+    previewTheme: () => undefined
+  };
+  return { source, state, press, context };
+}
+
+/** A NativeSelectionSnapshot in CliRenderer's clothing. The selection reader
+ * treats this plain object as the captured renderer state. */
+function stubSelectionRenderer(text: string): ActionContext["renderer"] {
+  return { identity: {}, text, range: { start: 0, end: text.length }, backward: false } as never;
+}
+
+describe("palette async settlement", () => {
+  test("keeps a newer palette visible when deferred Aside opens", async () => {
+    const { source, state, press } = testHarness();
+    const entered = deferred<void>();
+    const release = deferred<{ notes: readonly { question: string; answer: string }[] }>();
+    source.api.getAside = async () => {
+      entered.resolve();
+      return await release.promise;
+    };
+
+    await press(ctrlP());
+    await typeQuery(press, "aside");
+    const opening = press(key("return", { sequence: "\r" }));
+    await entered.promise;
+
+    await press(ctrlP());
+    const newerPalette = state.commands;
+    expect(state.mode).toBe("COMMANDS");
+    expect(newerPalette?.returnMode).toBe("NAV");
+
+    release.resolve({ notes: [] });
+    await opening;
+
+    expect(state.aside).not.toBeNull();
+    expect(state.mode).toBe("COMMANDS");
+    expect(state.commands).toBe(newerPalette);
+    expect(state.commands?.returnMode).toBe("ASIDE");
+
+    await press(key("escape", { sequence: "\u001b" }));
+    expect(state.mode).toBe("ASIDE");
+    expect(state.commands).toBeNull();
+  });
+
+  test("keeps a newer palette visible when direct Aside opens slowly", async () => {
+    const { source, state, press } = testHarness();
+    const entered = deferred<void>();
+    const release = deferred<{ notes: readonly { question: string; answer: string }[] }>();
+    source.api.getAside = async () => {
+      entered.resolve();
+      return await release.promise;
+    };
+
+    const opening = press(key("a"));
+    await entered.promise;
+
+    await press(ctrlP());
+    const newerPalette = state.commands;
+    expect(state.mode).toBe("COMMANDS");
+    expect(newerPalette?.returnMode).toBe("NAV");
+
+    release.resolve({ notes: [] });
+    await opening;
+
+    expect(state.aside).not.toBeNull();
+    expect(state.mode).toBe("COMMANDS");
+    expect(state.commands).toBe(newerPalette);
+    expect(state.commands?.returnMode).toBe("ASIDE");
+
+    await press(key("escape", { sequence: "\u001b" }));
+    expect(state.mode).toBe("ASIDE");
+    expect(state.commands).toBeNull();
+  });
+
+  test("keeps the palette visible after a Card import settles", async () => {
+    const directory = await mkdtemp(path.join(tmpdir(), "1667-card-palette-"));
+    created.push(directory);
+    const file = path.join(directory, "mira.json");
+    await writeFile(file, JSON.stringify({
+      spec: "chara_card_v2",
+      spec_version: "2.0",
+      data: { name: "Mira", description: "A cartographer." }
+    }));
+
+    const { source, state, press } = testHarness();
+    const entered = deferred<void>();
+    const release = deferred<void>();
+    const importCard = source.api.importCard;
+    source.api.importCard = async (...args) => {
+      entered.resolve();
+      await release.promise;
+      return importCard(...args);
+    };
+    openCardImport(state);
+    state.card!.path = file;
+
+    const importing = press(key("return", { sequence: "\r" }));
+    await entered.promise;
+    await press(ctrlP());
+    expect(state.mode).toBe("COMMANDS");
+    expect(state.commands?.returnMode).toBe("CARD");
+
+    release.resolve();
+    await importing;
+    expect(state.mode).toBe("COMMANDS");
+    expect(state.commands).not.toBeNull();
+    expect(state.commands?.returnMode).toBe("NAV");
+    expect(state.card).toBeNull();
+
+    await press(key("escape", { sequence: "\u001b" }));
+    expect(state.mode).toBe("NAV");
+    expect(state.commands).toBeNull();
+  });
+
+  test("keeps the palette visible after a same-story archive import settles", async () => {
+    const directory = await mkdtemp(path.join(tmpdir(), "1667-archive-palette-"));
+    created.push(directory);
+    const file = path.join(directory, "world.lorebook");
+    await writeFile(file, JSON.stringify({ lorebookVersion: 6, entries: [] }));
+
+    const { source, state, press } = testHarness();
+    const entered = deferred<void>();
+    const release = deferred<void>();
+    source.api.importLorebook = async () => {
+      entered.resolve();
+      await release.promise;
+      return {
+        payload: source.payload,
+        importResult: { facts: [], fidelity: [] }
+      };
+    };
+    openArchiveImport(state);
+    state.archive!.path = file;
+
+    const importing = press(key("return", { sequence: "\r" }));
+    await entered.promise;
+    await press(ctrlP());
+    expect(state.mode).toBe("COMMANDS");
+    expect(state.commands?.returnMode).toBe("ARCHIVE");
+
+    release.resolve();
+    await importing;
+    expect(state.mode).toBe("COMMANDS");
+    expect(state.commands).not.toBeNull();
+    expect(state.commands?.returnMode).toBe("NAV");
+    expect(state.archive).toBeNull();
+
+    await press(key("escape", { sequence: "\u001b" }));
+    expect(state.mode).toBe("NAV");
+    expect(state.commands).toBeNull();
+  });
+
+  test("keeps the palette visible after a cross-story archive import and clears its selection", async () => {
+    const directory = await mkdtemp(path.join(tmpdir(), "1667-cross-story-palette-"));
+    created.push(directory);
+    const file = path.join(directory, "new.story");
+    await writeFile(file, "{}");
+
+    const { source, state, press } = testHarness(stubSelectionRenderer("old"));
+    const imported = structuredClone(source.payload);
+    imported.id = "imported-story";
+    imported.title = "Imported story";
+
+    const entered = deferred<void>();
+    const release = deferred<void>();
+    source.api.importNovelAI = async () => {
+      entered.resolve();
+      await release.promise;
+      return { payload: imported, fidelity: [] };
+    };
+    state.storySelectionProjection = [
+      { key: "old:text", text: "old", start: 0, end: 1 },
+      { key: "old:text", text: "old", start: 1, end: 2 },
+      { key: "old:text", text: "old", start: 2, end: 3 }
+    ];
+    openArchiveImport(state);
+    state.archive!.path = file;
+
+    const importing = press(key("return", { sequence: "\r" }));
+    await entered.promise;
+    await press(ctrlP());
+    expect(state.mode).toBe("COMMANDS");
+    expect(state.commands?.returnMode).toBe("ARCHIVE");
+    expect(state.commands?.selection?.text).toBe("old");
+
+    release.resolve();
+    await importing;
+    expect(state.payload.id).toBe(imported.id);
+    expect(state.mode).toBe("COMMANDS");
+    expect(state.commands).not.toBeNull();
+    expect(state.commands?.returnMode).toBe("NAV");
+    expect(state.commands?.selection ?? null).toBeNull();
+    expect(state.archive).toBeNull();
+
+    await press(key("escape", { sequence: "\u001b" }));
+    expect(state.mode).toBe("NAV");
+    expect(state.commands).toBeNull();
+    expect(state.payload.id).toBe(imported.id);
+  });
+
+  test("keeps the palette visible after image staging settles", async () => {
+    const directory = await mkdtemp(path.join(tmpdir(), "1667-image-palette-"));
+    created.push(directory);
+    const file = path.join(directory, "art.png");
+    await writeFile(file, minimalPng());
+
+    const { source, state, press } = testHarness();
+    const entered = deferred<void>();
+    const release = deferred<void>();
+    source.api.stageStoryImage = async () => {
+      entered.resolve();
+      await release.promise;
+      return {
+        leaseId: "a".repeat(64),
+        attachment: {
+          objectId: "b".repeat(64),
+          mediaType: "image/png",
+          width: 64,
+          height: 48,
+          byteLength: 4_096
+        }
+      };
+    };
+    state.mode = "IMAGE";
+    state.image = {
+      path: file,
+      storyId: state.payload.id,
+      candidates: [],
+      error: null,
+      returnMode: "COMPOSE"
+    };
+
+    const staging = press(key("return", { sequence: "\r" }));
+    await entered.promise;
+    await press(ctrlP());
+    expect(state.mode).toBe("COMMANDS");
+    expect(state.commands?.returnMode).toBe("IMAGE");
+
+    release.resolve();
+    await staging;
+    expect(state.mode).toBe("COMMANDS");
+    expect(state.commands).not.toBeNull();
+    expect(state.commands?.returnMode).toBe("COMPOSE");
+    expect(state.image).toBeNull();
+    expect(draftImagesFor(state.composer)).toHaveLength(1);
+
+    await press(key("escape", { sequence: "\u001b" }));
+    expect(state.mode).toBe("COMPOSE");
+    expect(state.commands).toBeNull();
+  });
+
+  test("keeps the palette visible after a Library story load settles", async () => {
+    const { source, state, press, context } = testHarness();
+    await openLibrary(state, source, context);
+    const target = source.stories.find(({ id }) => id !== source.payload.id)!;
+    state.library!.cursor = state.library!.stories.findIndex(({ id }) => id === target.id);
+
+    const entered = deferred<void>();
+    const release = deferred<typeof state.payload>();
+    source.api.loadStory = async (storyId) => {
+      expect(storyId).toBe(target.id);
+      entered.resolve();
+      return await release.promise;
+    };
+
+    const loading = press(key("return", { sequence: "\r" }));
+    await entered.promise;
+    await press(ctrlP());
+    expect(state.mode).toBe("COMMANDS");
+    expect(state.commands?.returnMode).toBe("LIBRARY");
+
+    release.resolve({
+      ...source.payload,
+      id: target.id,
+      title: target.title
+    });
+    await loading;
+    expect(state.payload.id).toBe(target.id);
+    expect(state.mode).toBe("COMMANDS");
+    expect(state.commands).not.toBeNull();
+    expect(state.commands?.returnMode).toBe("NAV");
+    expect(state.library).toBeNull();
+
+    await press(key("escape", { sequence: "\u001b" }));
+    expect(state.mode).toBe("NAV");
+    expect(state.commands).toBeNull();
+    expect(state.payload.id).toBe(target.id);
+  });
+
+  test("cross-story Library load clears the palette selection before Fact creation", async () => {
+    const { source, state, press, context } = testHarness();
+    await openLibrary(state, source, context);
+    const target = source.stories.find(({ id }) => id !== source.payload.id)!;
+    state.library!.cursor = state.library!.stories.findIndex(({ id }) => id === target.id);
+
+    const entered = deferred<void>();
+    const release = deferred<typeof state.payload>();
+    source.api.loadStory = async (storyId) => {
+      expect(storyId).toBe(target.id);
+      entered.resolve();
+      return await release.promise;
+    };
+
+    const loading = press(key("return", { sequence: "\r" }));
+    await entered.promise;
+    await press(ctrlP());
+    state.commands!.selection = {
+      text: "old story text",
+      spans: [{ key: "p12:text", text: "old story text", start: 0, end: 15 }]
+    };
+
+    release.resolve({
+      ...source.payload,
+      id: target.id,
+      title: target.title
+    });
+    await loading;
+
+    expect(state.payload.id).toBe(target.id);
+    expect(state.mode).toBe("COMMANDS");
+    expect(state.commands?.selection ?? null).toBeNull();
+
+    await typeQuery(press, "new fact from selection");
+    await press(key("return", { sequence: "\r" }));
+    expect(state.editor).toBeNull();
+    expect(state.mode).toBe("COMMANDS");
+  });
+
+  test("keeps the palette visible after an inline editor save settles", async () => {
+    const { source, state, press } = testHarness();
+    state.focusIndex = rowIndexForNode(createStoryViewModel(state.payload), "p12");
+    await press(key("e"));
+    if (state.editor?.kind !== "document" || state.editor.target.kind !== "part") {
+      throw new Error("part editor did not open");
+    }
+    const editor = state.editor;
+    setComposerText(editor.composer, "saved direction\n---\nsaved prose");
+
+    const entered = deferred<void>();
+    const release = deferred<void>();
+    const editNode = source.api.editNode;
+    source.api.editNode = async (...args) => {
+      entered.resolve();
+      await release.promise;
+      return editNode(...args);
+    };
+
+    const saving = press(key("o", { sequence: "\u000f", ctrl: true }));
+    await entered.promise;
+    await press(ctrlP());
+    expect(state.mode).toBe("COMMANDS");
+    expect(state.commands?.returnMode).toBe("EDITOR");
+
+    release.resolve();
+    await saving;
+    expect(state.mode).toBe("COMMANDS");
+    expect(state.commands).not.toBeNull();
+    expect(state.commands?.returnMode).toBe("NAV");
+    expect(state.editor).toBeNull();
+
+    await press(key("escape", { sequence: "\u001b" }));
+    expect(state.mode).toBe("NAV");
+    expect(state.commands).toBeNull();
+  });
+
+  test("keeps Next Request visible while an editor save settles", async () => {
+    const { source, state, press } = testHarness();
+    state.focusIndex = rowIndexForNode(createStoryViewModel(state.payload), "p12");
+    await press(key("e"));
+    if (state.editor?.kind !== "document" || state.editor.target.kind !== "part") {
+      throw new Error("part editor did not open");
+    }
+    const editor = state.editor;
+    setComposerText(editor.composer, "saved direction\n---\nsaved prose");
+
+    const entered = deferred<void>();
+    const release = deferred<void>();
+    const editNode = source.api.editNode;
+    source.api.editNode = async (...args) => {
+      entered.resolve();
+      await release.promise;
+      return editNode(...args);
+    };
+
+    const saving = press(key("o", { sequence: "\u000f", ctrl: true }));
+    await entered.promise;
+    await press(ctrlP());
+    await typeQuery(press, "next request");
+    await press(key("return", { sequence: "\r" }));
+
+    expect(state.mode).toBe("REQUEST");
+    expect(state.request?.returnMode).toBe("EDITOR");
+    expect(state.editor).toBe(editor);
+
+    release.resolve();
+    await saving;
+
+    expect(state.mode).toBe("REQUEST");
+    expect(state.request?.returnMode).toBe("NAV");
+    expect(state.editor).toBeNull();
+
+    await press(key("escape", { sequence: "\u001b" }));
+    expect(state.mode).toBe("NAV");
+    expect(state.request).toBeNull();
+  });
+
+  test("keeps the palette visible after Placement settles", async () => {
+    const { source, state, press, context } = testHarness();
+    const answer = "placed below the palette";
+    const surface = createAsideSurface(
+      state.payload.id,
+      state.payload.title,
+      [{ question: "Where?", answer }],
+      null,
+      state.payload.path.at(-1)!.id
+    );
+    state.aside = surface;
+    state.mode = "ASIDE";
+    expect(openAsideUseMenu(surface, 0, 0)).toBeTrue();
+    expect(openPlacementFromAside(state)).toBeTrue();
+    expect(state.mode).toBe("PLACE");
+
+    const entered = deferred<void>();
+    const release = deferred<void>();
+    const createNode = source.api.createNode;
+    source.api.createNode = async (...args) => {
+      entered.resolve();
+      await release.promise;
+      return createNode(...args);
+    };
+
+    const placing = dispatch(
+      { action: "apply" },
+      state,
+      source,
+      context.cache,
+      () => undefined,
+      async () => undefined,
+      () => undefined,
+      null,
+      () => undefined,
+      () => undefined,
+      context.backend
+    );
+    await entered.promise;
+    await press(ctrlP());
+    expect(state.mode).toBe("COMMANDS");
+    expect(state.commands?.returnMode).toBe("PLACE");
+
+    release.resolve();
+    await placing;
+    expect(state.mode).toBe("COMMANDS");
+    expect(state.commands).not.toBeNull();
+    expect(state.commands?.returnMode).toBe("NAV");
+    expect(state.placement).toBeNull();
+    expect(state.payload.path.at(-1)?.instruction).toBe(FROM_ASIDE_INSTRUCTION);
+
+    await press(key("escape", { sequence: "\u001b" }));
+    expect(state.mode).toBe("NAV");
+    expect(state.commands).toBeNull();
+  });
+
+  test("keeps the palette visible after a tag save settles", async () => {
+    const { source, state, press } = testHarness();
+    openTag(state, "p13");
+    if (state.tag === null) throw new Error("tag prompt did not open");
+    state.tag.name = "saved tag";
+    await press(key("return", { sequence: "\r" }));
+
+    const entered = deferred<void>();
+    const release = deferred<void>();
+    const putBookmark = source.api.putBookmark;
+    source.api.putBookmark = async (...args) => {
+      entered.resolve();
+      await release.promise;
+      return putBookmark(...args);
+    };
+
+    const saving = press(key("return", { sequence: "\r" }));
+    await entered.promise;
+    await press(ctrlP());
+    expect(state.mode).toBe("COMMANDS");
+    expect(state.commands?.returnMode).toBe("TAG");
+
+    release.resolve();
+    await saving;
+    expect(state.mode).toBe("COMMANDS");
+    expect(state.commands?.returnMode).toBe("NAV");
+    expect(state.tag).toBeNull();
+
+    await press(key("escape", { sequence: "\u001b" }));
+    expect(state.mode).toBe("NAV");
+    expect(state.commands).toBeNull();
+  });
+
+  test("keeps the palette visible after a tag delete settles", async () => {
+    const { source, state, press } = testHarness();
+    openTag(state, "p13");
+    if (state.tag === null) throw new Error("tag prompt did not open");
+    state.tag.choosingStatus = true;
+
+    const entered = deferred<void>();
+    const release = deferred<void>();
+    const deleteBookmark = source.api.deleteBookmark;
+    source.api.deleteBookmark = async (...args) => {
+      entered.resolve();
+      await release.promise;
+      return deleteBookmark(...args);
+    };
+
+    await press(key("d", { sequence: "D", shift: true }));
+    const deleting = press(key("d", { sequence: "D", shift: true }));
+    await entered.promise;
+    await press(ctrlP());
+    expect(state.mode).toBe("COMMANDS");
+    expect(state.commands?.returnMode).toBe("TAG");
+
+    release.resolve();
+    await deleting;
+    expect(state.mode).toBe("COMMANDS");
+    expect(state.commands?.returnMode).toBe("NAV");
+    expect(state.tag).toBeNull();
+    expect(state.payload.tags.some(({ nodeId }) => nodeId === "p13")).toBeFalse();
+
+    await press(key("escape", { sequence: "\u001b" }));
+    expect(state.mode).toBe("NAV");
+    expect(state.commands).toBeNull();
+  });
+
+  test("keeps the palette visible after a cross-story Search hit settles", async () => {
+    const { source, state, press } = testHarness();
+    source.searchDebounceMs = 0;
+    await press(key("/"));
+    await typeQuery(press, "road");
+    await press(key("tab", { sequence: "\t" }));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const search = state.search;
+    if (search === null || search.response === null) throw new Error("search did not settle");
+    const foreign = search.response.hits.find((hit) => hit.storyId !== state.payload.id);
+    if (foreign === undefined) throw new Error("foreign Search hit did not appear");
+    const hitRow = searchRows(search, state.payload).rows.find(
+      (row): row is Extract<typeof row, { kind: "hit" }> => row.kind === "hit" && row.hit === foreign
+    );
+    if (hitRow === undefined) throw new Error("foreign Search hit row did not appear");
+    search.cursor = hitRow.select;
+
+    const entered = deferred<void>();
+    const release = deferred<void>();
+    const loadStory = source.api.loadStory;
+    source.api.loadStory = async (...args) => {
+      entered.resolve();
+      await release.promise;
+      return loadStory(...args);
+    };
+    const opening = press(key("return", { sequence: "\r" }));
+    await entered.promise;
+    await press(ctrlP());
+    expect(state.mode).toBe("COMMANDS");
+    expect(state.commands?.returnMode).toBe("SEARCH");
+    state.commands!.selection = {
+      text: "old story text",
+      spans: [{ key: "p12:text", text: "old story text", start: 0, end: 15 }]
+    };
+
+    release.resolve();
+    await opening;
+    expect(state.payload.id).toBe(foreign.storyId);
+    expect(state.mode).toBe("COMMANDS");
+    expect(state.commands?.returnMode).toBe("NAV");
+    expect(state.commands?.selection ?? null).toBeNull();
+    expect(state.search).toBeNull();
+
+    await press(key("escape", { sequence: "\u001b" }));
+    expect(state.mode).toBe("NAV");
+    expect(state.commands).toBeNull();
+    expect(state.payload.id).toBe(foreign.storyId);
+  });
+
+  test("opens a cross-story Fact Search hit beneath the palette", async () => {
+    const { source, state, press } = testHarness();
+    source.searchDebounceMs = 0;
+    await press(key("/"));
+    await typeQuery(press, "lantern-house");
+    await press(key("tab", { sequence: "\t" }));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const search = state.search;
+    if (search === null || search.response === null) throw new Error("search did not settle");
+    const foreign = search.response.hits.find(
+      (hit) => hit.storyId !== state.payload.id && hit.kind === "fact"
+    );
+    if (foreign === undefined) throw new Error("foreign Fact Search hit did not appear");
+    const hitRow = searchRows(search, state.payload).rows.find(
+      (row): row is Extract<typeof row, { kind: "hit" }> => row.kind === "hit" && row.hit === foreign
+    );
+    if (hitRow === undefined) throw new Error("foreign Fact Search hit row did not appear");
+    search.cursor = hitRow.select;
+
+    const entered = deferred<void>();
+    const release = deferred<void>();
+    const loadStory = source.api.loadStory;
+    source.api.loadStory = async (...args) => {
+      entered.resolve();
+      await release.promise;
+      return loadStory(...args);
+    };
+    const opening = press(key("return", { sequence: "\r" }));
+    await entered.promise;
+    await press(ctrlP());
+    expect(state.mode).toBe("COMMANDS");
+    expect(state.commands?.returnMode).toBe("SEARCH");
+
+    release.resolve();
+    await opening;
+    expect(state.payload.id).toBe(foreign.storyId);
+    expect(state.search).toBeNull();
+    expect(state.facts).not.toBeNull();
+    expect(state.facts?.cursor).toBe(0);
+    expect(state.payload.facts[state.facts?.cursor ?? -1]?.id).toBe(foreign.targetId);
+    expect(state.mode).toBe("COMMANDS");
+    expect(state.commands?.returnMode).toBe("FACTS");
+    expect(state.commands?.selection ?? null).toBeNull();
+
+    await press(key("escape", { sequence: "\u001b" }));
+    expect(state.mode).toBe("FACTS");
+    expect(state.commands).toBeNull();
+  });
+
+});

--- a/tui/test/palette-reroute-settlement.test.ts
+++ b/tui/test/palette-reroute-settlement.test.ts
@@ -1,0 +1,568 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import type { KeyEvent } from "@opentui/core";
+import { ActionRuntime } from "../src/action-runtime.js";
+import { openArchiveImport } from "../src/archive-import-actions.js";
+import { openCardImport } from "../src/card-import-actions.js";
+import { dispatch, handleKey, initialState } from "../src/app.js";
+import type { ActionContext } from "../src/action-context.js";
+import { createAsideSurface } from "../src/aside-surface.js";
+import { demoAppSource } from "../src/demo.js";
+import {
+  FROM_ASIDE_INSTRUCTION,
+  openPlacementFromAside
+} from "../src/aside-placement.js";
+import { openAsideUseMenu } from "../src/aside-use.js";
+import { createStoryViewModel, rowIndexForNode } from "../src/model.js";
+import { setComposerText } from "../src/composer-model.js";
+import { draftImagesFor } from "../src/draft-image.js";
+import { searchRows } from "../src/search-model.js";
+import { openTag } from "../src/story-actions.js";
+import { PNG_SIGNATURE } from "../../shared/png-text-chunk.js";
+import type { ProseStyle } from "../src/wrap.js";
+import { createWrapCache } from "../src/wrap.js";
+import { openLibrary } from "../src/library-actions.js";
+import { openGenerationRecordViewer } from "../src/generation-record-actions.js";
+import { renderStoryScreen } from "../src/screens/story.js";
+
+const created: string[] = [];
+
+afterEach(async () => {
+  for (const directory of created.splice(0)) {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+function ctrlP(): KeyEvent {
+  return key("p", { sequence: "\u0010", ctrl: true });
+}
+
+function key(
+  name: string,
+  options: { sequence?: string; ctrl?: boolean; shift?: boolean } = {}
+): KeyEvent {
+  return {
+    name,
+    sequence: options.sequence ?? name,
+    shift: options.shift ?? false,
+    ctrl: options.ctrl ?? false,
+    meta: false,
+    option: false,
+    super: false
+  } as KeyEvent;
+}
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((next) => { resolve = next; });
+  return { promise, resolve };
+}
+
+async function typeQuery(
+  press: (event: KeyEvent) => Promise<void>,
+  query: string
+): Promise<void> {
+  for (const character of query) await press(key(character));
+}
+
+function minimalPng(width = 64, height = 48): Uint8Array {
+  const bytes = new Uint8Array(29);
+  bytes.set(PNG_SIGNATURE, 0);
+  const view = new DataView(bytes.buffer);
+  view.setUint32(8, 13, false);
+  bytes.set(new TextEncoder().encode("IHDR"), 12);
+  view.setUint32(16, width, false);
+  view.setUint32(20, height, false);
+  bytes[24] = 8;
+  bytes[25] = 6;
+  return bytes;
+}
+
+function testHarness(renderer: ActionContext["renderer"] = null) {
+  const source = demoAppSource();
+  const state = initialState(source, false);
+  const cache = createWrapCache<ProseStyle>();
+  const backend = new ActionRuntime(state, () => undefined);
+  const press = (event: KeyEvent) => handleKey(
+    event,
+    state,
+    source,
+    cache,
+    () => undefined,
+    async () => undefined,
+    () => undefined,
+    renderer,
+    () => undefined,
+    () => undefined,
+    backend
+  );
+  const context = {
+    backend,
+    cache,
+    repaint: () => undefined,
+    renderer,
+    applyTheme: () => undefined,
+    previewTheme: () => undefined
+  };
+  return { source, state, press, context };
+}
+
+/** A NativeSelectionSnapshot in CliRenderer's clothing. The selection reader
+ * treats this plain object as the captured renderer state. */
+function stubSelectionRenderer(text: string): ActionContext["renderer"] {
+  return { identity: {}, text, range: { start: 0, end: text.length }, backward: false } as never;
+}
+
+describe("palette async settlement", () => {
+  test("keeps a palette opened during a same-story Search reroute", async () => {
+    const { source, state, press } = testHarness();
+    source.searchDebounceMs = 0;
+    await press(key("/"));
+    await typeQuery(press, "pantry");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const search = state.search;
+    if (search === null || search.response === null) throw new Error("search did not settle");
+    const hitRow = searchRows(search, state.payload).rows.find(
+      (row) => row.kind === "hit"
+        && !state.payload.path.some((node) => node.id === row.hit.targetId)
+    );
+    if (hitRow?.kind !== "hit") throw new Error("off-line Search hit did not appear");
+    search.cursor = hitRow.select;
+
+    const entered = deferred<void>();
+    const release = deferred<void>();
+    const switchLine = source.api.switchLine;
+    source.api.switchLine = async (...args) => {
+      entered.resolve();
+      await release.promise;
+      return switchLine(...args);
+    };
+
+    const opening = press(key("return", { sequence: "\r" }));
+    await entered.promise;
+    await press(ctrlP());
+    const palette = state.commands;
+    expect(state.mode).toBe("COMMANDS");
+    expect(palette?.returnMode).toBe("SEARCH");
+
+    release.resolve();
+    await opening;
+
+    expect(state.mode).toBe("COMMANDS");
+    expect(state.commands).toBe(palette);
+    expect(state.commands?.returnMode).toBe("NAV");
+    expect(state.search).toBeNull();
+    expect(state.focusIndex).toBe(rowIndexForNode(createStoryViewModel(state.payload), hitRow.hit.targetId));
+
+    await press(key("escape", { sequence: "\u001b" }));
+    expect(state.mode).toBe("NAV");
+    expect(state.commands).toBeNull();
+  });
+
+  test("keeps a palette opened during a same-story Map reroute", async () => {
+    const { source, state, press } = testHarness();
+    state.map = {
+      view: "path",
+      pathCursorId: "p5-alt",
+      pathShowAllTakes: true,
+      treeCursorId: state.payload.path.at(-1)?.id ?? "p13",
+      rowIds: [],
+      showSketches: true,
+      openedColdFolds: new Set<string>(),
+      massSort: "size"
+    };
+    state.mode = "MAP";
+
+    const entered = deferred<void>();
+    const release = deferred<void>();
+    const switchLine = source.api.switchLine;
+    source.api.switchLine = async (...args) => {
+      entered.resolve();
+      await release.promise;
+      return switchLine(...args);
+    };
+
+    const opening = press(key("return", { sequence: "\r" }));
+    await entered.promise;
+    await press(ctrlP());
+    const palette = state.commands;
+    expect(state.mode).toBe("COMMANDS");
+    expect(palette?.returnMode).toBe("MAP");
+
+    release.resolve();
+    await opening;
+
+    expect(state.mode).toBe("COMMANDS");
+    expect(state.commands).toBe(palette);
+    expect(state.commands?.returnMode).toBe("NAV");
+    expect(state.map).toBeNull();
+    expect(state.payload.path.at(-1)?.id).toBe("p5-alt");
+    expect(state.focusIndex).toBe(rowIndexForNode(createStoryViewModel(state.payload), "p5-alt"));
+
+    await press(key("escape", { sequence: "\u001b" }));
+    expect(state.mode).toBe("NAV");
+    expect(state.commands).toBeNull();
+  });
+
+  test("retake from PROBS uses the displayed take, not stale NAV focus", async () => {
+    const { source, state, press } = testHarness();
+    const view = createStoryViewModel(state.payload);
+    const first = view.parts[0];
+    const displayed = view.parts[1];
+    if (first === undefined || displayed === undefined) throw new Error("demo story needs two parts");
+    state.focusIndex = rowIndexForNode(view, first.id);
+    let retakeTarget: unknown = null;
+    source.api.continueStory = async (_storyId, _instruction, _genId, target) => {
+      retakeTarget = target;
+      return { payload: state.payload, droppedFacts: [] };
+    };
+
+    await press(key("l"));
+    expect(state.mode).toBe("PROBS");
+    await press(key("tab"));
+    expect(state.probs?.nodeId).toBe(displayed.id);
+    expect(state.focusIndex).toBe(rowIndexForNode(view, first.id));
+
+    await press(ctrlP());
+    await typeQuery(press, "retake");
+    expect(state.commands?.selectedId).toBe("retake");
+    await press(key("return", { sequence: "\r" }));
+
+    expect(retakeTarget).toEqual({ parentId: displayed.node.parentId });
+    expect(state.mode).toBe("NAV");
+    expect(state.probs).toBeNull();
+  });
+
+  test("retake from RECORD uses the displayed take, not stale NAV focus", async () => {
+    const { source, state, press, context } = testHarness();
+    const view = createStoryViewModel(state.payload);
+    const stale = view.parts.at(-1);
+    const displayed = view.parts[1];
+    if (stale === undefined || displayed === undefined) throw new Error("demo story needs two parts");
+    state.focusIndex = rowIndexForNode(view, stale.id);
+    state.map = {
+      view: "path",
+      pathCursorId: displayed.id,
+      pathShowAllTakes: true,
+      treeCursorId: stale.id,
+      rowIds: [],
+      showSketches: true,
+      openedColdFolds: new Set<string>(),
+      massSort: "size"
+    };
+    state.mode = "MAP";
+    await openGenerationRecordViewer(state, source, context);
+    const parentMap = state.map;
+    expect(state.mode).toBe("RECORD");
+    expect(state.record?.nodeId).toBe(displayed.id);
+    expect(parentMap).not.toBeNull();
+    expect(state.focusIndex).toBe(rowIndexForNode(view, stale.id));
+
+    let retakeTarget: unknown = null;
+    source.api.continueStory = async (_storyId, _instruction, _genId, target) => {
+      retakeTarget = target;
+      return { payload: state.payload, droppedFacts: [] };
+    };
+
+    await press(ctrlP());
+    await typeQuery(press, "retake");
+    expect(state.commands?.selectedId).toBe("retake");
+    await press(key("return", { sequence: "\r" }));
+
+    expect(retakeTarget).toEqual({ parentId: displayed.node.parentId });
+    expect(state.mode).toBe("NAV");
+    expect(state.record).toBeNull();
+    expect(state.map).toBeNull();
+  });
+
+  test("does not retake after a Map reroute loses ownership", async () => {
+    for (const interruption of ["escape", "palette"] as const) {
+      const { source, state, press } = testHarness();
+      state.map = {
+        view: "path",
+        pathCursorId: "p5-alt",
+        pathShowAllTakes: true,
+        treeCursorId: state.payload.path.at(-1)?.id ?? "p13",
+        rowIds: [],
+        showSketches: true,
+        openedColdFolds: new Set<string>(),
+        massSort: "size"
+      };
+      state.mode = "MAP";
+
+      const entered = deferred<void>();
+      const release = deferred<void>();
+      const switchLine = source.api.switchLine;
+      source.api.switchLine = async (...args) => {
+        entered.resolve();
+        await release.promise;
+        return switchLine(...args);
+      };
+      let retakeCalls = 0;
+      const payload = state.payload;
+      source.api.continueStory = async () => {
+        retakeCalls += 1;
+        return { payload, droppedFacts: [] };
+      };
+
+      await press(ctrlP());
+      await typeQuery(press, "retake");
+      const pending = press(key("return", { sequence: "\r" }));
+      await entered.promise;
+
+      let newerPalette: typeof state.commands = null;
+      if (interruption === "escape") {
+        await press(key("escape", { sequence: "\u001b" }));
+        expect(state.mode).toBe("NAV");
+        expect(state.map).toBeNull();
+      } else {
+        await press(ctrlP());
+        newerPalette = state.commands;
+        expect(state.mode).toBe("COMMANDS");
+        expect(newerPalette).not.toBeNull();
+        expect(newerPalette?.returnMode).toBe("MAP");
+      }
+
+      release.resolve();
+      await pending;
+
+      // The switch response is still adopted, but it cannot buy a retake
+      // after another interaction owns the landing surface.
+      expect(state.payload.path.at(-1)?.id).toBe("p5-alt");
+      expect(retakeCalls).toBe(0);
+      if (interruption === "palette") {
+        expect(state.mode).toBe("COMMANDS");
+        expect(state.commands).toBe(newerPalette);
+      } else {
+        expect(state.mode).toBe("NAV");
+        expect(state.map).toBeNull();
+      }
+    }
+  });
+
+  test("retakes after a render replaces the Map owner during reroute", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const cache = createWrapCache<ProseStyle>();
+    const repaint = () => {
+      const frame = renderStoryScreen(state, {
+        width: 100,
+        height: 30,
+        wrapCache: cache
+      });
+      Object.assign(state, frame.derived);
+    };
+    const backend = new ActionRuntime(state, repaint);
+    const press = (event: KeyEvent) => handleKey(
+      event, state, source, cache, repaint,
+      async () => undefined,
+      () => undefined,
+      null,
+      () => undefined,
+      () => undefined,
+      backend
+    );
+    state.map = {
+      view: "path",
+      pathCursorId: "p5-alt",
+      pathShowAllTakes: true,
+      treeCursorId: state.payload.path.at(-1)?.id ?? "p13",
+      rowIds: [],
+      showSketches: true,
+      openedColdFolds: new Set<string>(),
+      massSort: "size"
+    };
+    state.mode = "MAP";
+    const mapBeforeReroute = state.map;
+    const entered = deferred<void>();
+    const release = deferred<void>();
+    const switchLine = source.api.switchLine;
+    source.api.switchLine = async (...args) => {
+      entered.resolve();
+      await release.promise;
+      return switchLine(...args);
+    };
+    const targets: unknown[] = [];
+    source.api.continueStory = async (_storyId, _instruction, _genId, target) => {
+      targets.push(target);
+      return { payload: state.payload, droppedFacts: [] };
+    };
+
+    await press(ctrlP());
+    await typeQuery(press, "retake");
+    const pending = press(key("return", { sequence: "\r" }));
+    await entered.promise;
+
+    // ActionRuntime's task-start repaint commits renderMap's derived clone.
+    expect(state.map).not.toBe(mapBeforeReroute);
+    release.resolve();
+    await pending;
+
+    const targetParentId = source.payload.nodes.find(({ id }) => id === "p5-alt")?.parentId;
+    expect(targets).toEqual([{ parentId: targetParentId }]);
+    expect(state.mode).toBe("NAV");
+    expect(state.map).toBeNull();
+  });
+
+  test("keeps a palette opened during a Fact dossier anchor reroute", async () => {
+    const { source, state, press } = testHarness();
+    const fact = {
+      ...state.payload.facts[0]!,
+      id: "fact-anchor-reroute",
+      states: [
+        { id: "fact-anchor-base", text: "base", createdAt: "now", updatedAt: "now" },
+        {
+          id: "fact-anchor-state",
+          anchorPartId: "p5-alt",
+          text: "anchored",
+          createdAt: "now",
+          updatedAt: "now"
+        }
+      ]
+    };
+    state.payload = { ...state.payload, facts: [fact] };
+    const facts = state.facts = {
+      cursor: 0,
+      query: "",
+      chip: 0,
+      selectedTag: null,
+      filtering: false,
+      deleteArmedId: null,
+      scopeFilter: "everywhere" as const,
+      dossier: { factId: fact.id, stateIndex: 1, diff: false }
+    };
+    state.mode = "FACTS";
+
+    const entered = deferred<void>();
+    const release = deferred<void>();
+    const switchLine = source.api.switchLine;
+    source.api.switchLine = async (...args) => {
+      entered.resolve();
+      await release.promise;
+      const payload = await switchLine(...args);
+      return { ...payload, facts: [fact] };
+    };
+
+    const opening = press(key("return", { sequence: "\r" }));
+    await entered.promise;
+    await press(ctrlP());
+    const palette = state.commands;
+    expect(state.mode).toBe("COMMANDS");
+    expect(palette?.returnMode).toBe("FACTS");
+
+    release.resolve();
+    await opening;
+
+    expect(state.mode).toBe("COMMANDS");
+    expect(state.commands).toBe(palette);
+    expect(state.commands?.returnMode).toBe("NAV");
+    expect(state.facts).toBeNull();
+    expect(state.payload.path.at(-1)?.id).toBe("p5-alt");
+    expect(state.focusIndex).toBe(rowIndexForNode(createStoryViewModel(state.payload), "p5-alt"));
+    expect(facts.dossier).toEqual({ factId: fact.id, stateIndex: 1, diff: false });
+
+    await press(key("escape", { sequence: "\u001b" }));
+    expect(state.mode).toBe("NAV");
+    expect(state.commands).toBeNull();
+  });
+
+  test("keeps the palette visible after a Library create settles", async () => {
+    const { source, state, press, context } = testHarness();
+    await openLibrary(state, source, context);
+    const library = state.library;
+    if (library === null) throw new Error("library did not open");
+
+    const entered = deferred<void>();
+    const release = deferred<void>();
+    const createStory = source.api.createStory;
+    source.api.createStory = async (...args) => {
+      entered.resolve();
+      await release.promise;
+      return createStory(...args);
+    };
+
+    const creating = press(key("n"));
+    await entered.promise;
+    await press(ctrlP());
+    expect(state.mode).toBe("COMMANDS");
+    expect(state.commands?.returnMode).toBe("LIBRARY");
+    state.commands!.selection = {
+      text: "old story text",
+      spans: [{ key: "p12:text", text: "old story text", start: 0, end: 15 }]
+    };
+
+    release.resolve();
+    await creating;
+    expect(state.mode).toBe("COMMANDS");
+    expect(state.commands?.returnMode).toBe("NAV");
+    expect(state.commands?.selection ?? null).toBeNull();
+    expect(state.library).toBeNull();
+
+    await press(key("escape", { sequence: "\u001b" }));
+    expect(state.mode).toBe("NAV");
+    expect(state.commands).toBeNull();
+  });
+
+  test("keeps the palette visible after deleting the current Library story and adopting its fallback", async () => {
+    const { source, state, press, context } = testHarness();
+    await openLibrary(state, source, context);
+    const library = state.library;
+    if (library === null) throw new Error("library did not open");
+    const current = library.stories.find(({ id }) => id === state.payload.id);
+    if (current === undefined) throw new Error("current story is not in the library");
+    library.cursor = library.stories.findIndex(({ id }) => id === current.id);
+    await press(key("d", { sequence: "D", shift: true }));
+    if (library.prompt?.kind !== "delete") throw new Error("delete prompt did not open");
+
+    const fallback = {
+      ...structuredClone(state.payload),
+      id: "fallback-story",
+      title: "Fallback story"
+    };
+    const entered = deferred<void>();
+    const release = deferred<void>();
+    source.api.deleteStory = async () => {
+      entered.resolve();
+      await release.promise;
+      return { ok: true };
+    };
+    source.api.listStories = async () => [{
+      id: fallback.id,
+      title: fallback.title,
+      updatedAt: fallback.updatedAt,
+      partCount: fallback.nodes.length,
+      words: fallback.path.reduce((total, node) => total + node.text.length, 0),
+      forked: false,
+      lineCount: 1
+    }];
+    source.api.loadStory = async (storyId) => {
+      expect(storyId).toBe(fallback.id);
+      return fallback;
+    };
+    library.prompt.value = current.title;
+
+    const deleting = press(key("return", { sequence: "\r" }));
+    await entered.promise;
+    await press(ctrlP());
+    expect(state.mode).toBe("COMMANDS");
+    expect(state.commands?.returnMode).toBe("LIBRARY");
+    state.commands!.selection = {
+      text: "old story text",
+      spans: [{ key: "p12:text", text: "old story text", start: 0, end: 15 }]
+    };
+
+    release.resolve();
+    await deleting;
+    expect(state.payload.id).toBe(fallback.id);
+    expect(state.mode).toBe("COMMANDS");
+    expect(state.commands?.returnMode).toBe("NAV");
+    expect(state.commands?.selection ?? null).toBeNull();
+    expect(state.library).toBeNull();
+
+    await press(key("escape", { sequence: "\u001b" }));
+    expect(state.mode).toBe("NAV");
+    expect(state.commands).toBeNull();
+    expect(state.payload.id).toBe(fallback.id);
+  });});

--- a/tui/test/plain-text-paste.test.ts
+++ b/tui/test/plain-text-paste.test.ts
@@ -31,6 +31,7 @@ const {
   createAsideSurface,
   isAsideV2
 } = await import("../src/aside-surface.js");
+const { setComposerText } = await import("../src/composer-model.js");
 const { openSettingsPasteTarget } = await import("../src/settings-prompt-editor.js");
 const { handleOverlayAction } = await import("../src/overlay-actions.js");
 const { applyTerminalPaste } = await import("../src/terminal-paste.js");
@@ -212,6 +213,51 @@ describe("plain-text paste", () => {
     expect(harness.state.commands?.selectedId).toBe("theme:parchment");
     expect(harness.state.commands?.cursor).toBeGreaterThan(-1);
     expect(previews.at(-1)).toBe("parchment");
+  });
+
+  test("a deferred palette clipboard read preserves an Aside question during settlement", async () => {
+    for (const outcome of ["null", "failure"] as const) {
+      const harness = settingsHarness();
+      const surface = createAsideSurface(
+        harness.state.payload.id,
+        harness.state.payload.title
+      );
+      harness.state.aside = surface;
+      harness.state.mode = "ASIDE";
+      const question = "restore this question";
+      setComposerText(surface.composer, question);
+
+      const settle = deferred<void>();
+      harness.source.api.askAside = async () => {
+        await settle.promise;
+        if (outcome === "null") return null;
+        throw new Error("Aside failed");
+      };
+      await harness.press(key("return", { sequence: "\r" }));
+      expect(surface.busy).toBeTrue();
+
+      await harness.press(key("p", { sequence: "\u0010", ctrl: true }));
+      expect(harness.state.commands?.returnMode).toBe("ASIDE");
+
+      const readStarted = deferred<void>();
+      const read = deferred<string | null>();
+      clipboardReader = async () => {
+        readStarted.resolve();
+        return await read.promise;
+      };
+      const pasting = harness.press(key("v", { ctrl: true }));
+      await readStarted.promise;
+
+      // The Ask can settle while Ctrl+V still waits on the host clipboard.
+      settle.resolve();
+      await harness.backend.whenIdle();
+      expect(surface.composer.text).toBe(question);
+      expect(surface.busy).toBeFalse();
+
+      read.resolve(null);
+      await pasting;
+      expect(surface.composer.text).toBe(question);
+    }
   });
 
   test("a late clipboard read cannot modify a closed plain prompt", async () => {

--- a/tui/test/presented-input-queue.test.ts
+++ b/tui/test/presented-input-queue.test.ts
@@ -1,12 +1,28 @@
 import { describe, expect, test } from "bun:test";
-import type { KeyEvent } from "@opentui/core";
+import { TextRenderable, type KeyEvent } from "@opentui/core";
+import { createTestRenderer } from "@opentui/core/testing";
 import { ActionRuntime, withActionAdmission } from "../src/action-runtime.js";
 import { handleKey, initialState } from "../src/app.js";
+import { clearNativeSelectionIfMatches, storySelectionFromRendererSelection } from "../src/copy-actions.js";
 import { demoAppSource } from "../src/demo.js";
+import { createInteractiveInputAdmission } from "../src/interactive-input-admission.js";
+import { createPalette } from "../src/palette.js";
 import {
   createPresentedInputQueue,
   observeInputAdmission
 } from "../src/presented-input-queue.js";
+import {
+  capturePresentedInputSelection,
+  consumePresentedSelection,
+  guardFactsStorySelectionCapture,
+  reconcilePresentedSelection,
+  retirePresentedSelection,
+  type CapturedPresentedSelection,
+  type PresentedSelectionFrame
+} from "../src/presented-selection.js";
+import { buildStorySelectionProjection } from "../src/selection-projection.js";
+import { segment, type FrameLine } from "../src/screens/story/frame.js";
+import { createStorySurface } from "../src/story-surface.js";
 import { createWrapCache, type ProseStyle } from "../src/wrap.js";
 
 function key(name: string, sequence = name, ctrl = false): KeyEvent {
@@ -134,5 +150,235 @@ describe("presented input queue", () => {
     expect(quitRequests).toBe(0);
     expect(queue.pending).toBe(0);
     backend.dispose();
+  });
+
+  test("retains story selection when Facts opens before Ctrl-P Fact creation", async () => {
+    const setup = await createTestRenderer({ width: 80, height: 4 });
+    const source = demoAppSource(false);
+    const state = initialState(source, false);
+    const palette = createPalette("lantern", "256");
+    const surface = createStorySurface(setup.renderer, palette);
+    const selectedText = "selected story text";
+    const frame: FrameLine[] = [[{
+      ...segment(selectedText),
+      storySource: { key: "part:selection:text", text: selectedText, start: 0 }
+    }]];
+    const width = 80;
+    surface.paint(frame, palette, {
+      fullWidth: width,
+      pageWidth: width,
+      railStart: null,
+      factLeft: null,
+      railRight: null
+    }, null);
+    await setup.renderOnce();
+
+    const page = setup.renderer.root.findDescendantById("story") as TextRenderable;
+    const projection = buildStorySelectionProjection(frame, width);
+    state.storySelectionProjection = projection;
+    setup.renderer.startSelection(page, 0, 0);
+    setup.renderer.updateSelection(page, selectedText.length, 0, { finishDragging: true });
+    expect(storySelectionFromRendererSelection(setup.renderer, projection)?.text).toBe(selectedText);
+
+    const cache = createWrapCache<ProseStyle>();
+    const backend = new ActionRuntime(state, () => undefined);
+    const inputAdmission = createInteractiveInputAdmission();
+    const queue = createPresentedInputQueue({ flush() {}, ready: () => true });
+    let latestSelectionCapture: CapturedPresentedSelection | null = null;
+    const presentedFrame = (): PresentedSelectionFrame => ({
+      version: 1,
+      storyId: state.payload.id,
+      interactive: true,
+      state: { mode: state.mode },
+      composerSelectionProjection: null,
+      storySelectionProjection: state.mode === "NAV" || state.mode === "FACTS"
+        ? state.storySelectionProjection
+        : null
+    });
+    const press = async (event: KeyEvent): Promise<void> => {
+      const previous = latestSelectionCapture;
+      const queuedSelection = capturePresentedInputSelection(
+        setup.renderer,
+        presentedFrame(),
+        previous,
+        false
+      );
+      const guardedSelection = guardFactsStorySelectionCapture(queuedSelection, previous);
+      latestSelectionCapture = guardedSelection;
+      let settled!: () => void;
+      const done = new Promise<void>((resolve) => { settled = resolve; });
+      inputAdmission.enqueueText(queue, () => {
+        const selection = reconcilePresentedSelection(guardedSelection, 1, state);
+        if (selection.kind === "stale") {
+          retirePresentedSelection(setup.renderer, guardedSelection);
+          settled();
+          return;
+        }
+        const capturedStorySelection = selection.kind === "captured"
+          ? storySelectionFromRendererSelection(selection.native, selection.story)
+          : null;
+        if (selection.kind === "captured" && selection.native !== null) {
+          clearNativeSelectionIfMatches(setup.renderer, selection.native);
+        }
+        consumePresentedSelection(guardedSelection);
+        const work = observeInputAdmission((admit) => handleKey(
+          event,
+          state,
+          source,
+          cache,
+          admit,
+          () => { admit(); return Promise.resolve(); },
+          () => undefined,
+          setup.renderer,
+          () => undefined,
+          () => undefined,
+          withActionAdmission(backend, admit),
+          capturedStorySelection
+        ), (pending) => backend.observe(pending));
+        void work.then(settled, settled);
+        return work;
+      }, () => {
+        retirePresentedSelection(setup.renderer, guardedSelection);
+        settled();
+      });
+      await done;
+      await backend.settle();
+    };
+
+    try {
+      await press(key("f"));
+      expect(state.mode).toBe("FACTS");
+      expect(state.facts?.storySelection?.text).toBe(selectedText);
+
+      await press(key("p", "\u0010", true));
+      expect(state.mode).toBe("COMMANDS");
+      expect(state.commands?.selection?.text).toBe(selectedText);
+
+      for (const character of "new Fact from selection") await press(key(character));
+      expect(state.commands?.selectedId).toBe("new-fact-from-selection");
+      await press(key("return", "\r"));
+
+      expect(state.mode).toBe("EDITOR");
+      expect(state.editor?.kind).toBe("fact");
+      expect(state.editor?.kind === "fact" ? state.editor.composer.text : null).toBe(selectedText);
+    } finally {
+      backend.dispose();
+      setup.renderer.destroy();
+    }
+  });
+
+  test("does not project a fresh Facts-panel range onto story commands", async () => {
+    const setup = await createTestRenderer({ width: 80, height: 4 });
+    const source = demoAppSource(false);
+    const state = initialState(source, false);
+    const palette = createPalette("lantern", "256");
+    const surface = createStorySurface(setup.renderer, palette);
+    const storyText = "underlying story text";
+    const storyFrame: FrameLine[] = [[{
+      ...segment(storyText),
+      storySource: { key: "part:underlying:text", text: storyText, start: 0 }
+    }]];
+    const width = 80;
+    const layout = {
+      fullWidth: width,
+      pageWidth: width,
+      railStart: null,
+      factLeft: null,
+      railRight: null
+    };
+    surface.paint(storyFrame, palette, layout, null);
+    await setup.renderOnce();
+    state.storySelectionProjection = buildStorySelectionProjection(storyFrame, width);
+
+    const cache = createWrapCache<ProseStyle>();
+    const backend = new ActionRuntime(state, () => undefined);
+    const inputAdmission = createInteractiveInputAdmission();
+    const queue = createPresentedInputQueue({ flush() {}, ready: () => true });
+    let latestSelectionCapture: CapturedPresentedSelection | null = null;
+    const presentedFrame = (): PresentedSelectionFrame => ({
+      version: 1,
+      storyId: state.payload.id,
+      interactive: true,
+      state: { mode: state.mode },
+      composerSelectionProjection: null,
+      storySelectionProjection: state.mode === "NAV" || state.mode === "FACTS"
+        ? state.storySelectionProjection
+        : null
+    });
+    const press = async (event: KeyEvent): Promise<void> => {
+      const previous = latestSelectionCapture;
+      const queuedSelection = capturePresentedInputSelection(
+        setup.renderer,
+        presentedFrame(),
+        previous,
+        false
+      );
+      const guardedSelection = guardFactsStorySelectionCapture(queuedSelection, previous);
+      latestSelectionCapture = guardedSelection;
+      let settled!: () => void;
+      const done = new Promise<void>((resolve) => { settled = resolve; });
+      inputAdmission.enqueueText(queue, () => {
+        const selection = reconcilePresentedSelection(guardedSelection, 1, state);
+        if (selection.kind === "stale") {
+          retirePresentedSelection(setup.renderer, guardedSelection);
+          settled();
+          return;
+        }
+        const capturedStorySelection = selection.kind === "captured"
+          ? storySelectionFromRendererSelection(selection.native, selection.story)
+          : null;
+        if (selection.kind === "captured" && selection.native !== null) {
+          clearNativeSelectionIfMatches(setup.renderer, selection.native);
+        }
+        consumePresentedSelection(guardedSelection);
+        const work = observeInputAdmission((admit) => handleKey(
+          event,
+          state,
+          source,
+          cache,
+          admit,
+          () => { admit(); return Promise.resolve(); },
+          () => undefined,
+          setup.renderer,
+          () => undefined,
+          () => undefined,
+          withActionAdmission(backend, admit),
+          capturedStorySelection
+        ), (pending) => backend.observe(pending));
+        void work.then(settled, settled);
+        return work;
+      }, () => {
+        retirePresentedSelection(setup.renderer, guardedSelection);
+        settled();
+      });
+      await done;
+      await backend.settle();
+    };
+
+    try {
+      // Use the normal Facts entry key. There is no native range at this
+      // point, so the retained projection has no original selection owner.
+      await press(key("f"));
+      expect(state.mode).toBe("FACTS");
+
+      const panelText = "Facts panel cell";
+      surface.paint([[segment(panelText)]], palette, layout, null);
+      await setup.renderOnce();
+      const page = setup.renderer.root.findDescendantById("story") as TextRenderable;
+      setup.renderer.startSelection(page, 0, 0);
+      setup.renderer.updateSelection(page, panelText.length, 0, { finishDragging: true });
+      expect(setup.renderer.getSelection()).not.toBeNull();
+
+      await press(key("p", "\u0010", true));
+      expect(state.mode).toBe("COMMANDS");
+      expect(state.commands?.selection ?? null).toBeNull();
+      for (const character of "rewrite selection") await press(key(character));
+      expect(state.commands?.selectedId).not.toBe("rewrite-selection");
+      await press(key("return", "\r"));
+      expect(state.mode).not.toBe("EDITOR");
+    } finally {
+      backend.dispose();
+      setup.renderer.destroy();
+    }
   });
 });

--- a/tui/test/presented-mouse-action.test.ts
+++ b/tui/test/presented-mouse-action.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { initialState } from "../src/app.js";
+import { dispatch, initialState } from "../src/app.js";
 import { demoAppSource } from "../src/demo.js";
 import { createStoryIndex } from "../../shared/story-model.js";
 import { childrenOf, nodeById } from "../../shared/story-tree.js";
@@ -14,6 +14,9 @@ import {
 } from "../src/presented-mouse-action.js";
 import { createStoryViewModel } from "../src/model.js";
 import { initialSettingsOverlay } from "../src/settings-overlay-model.js";
+import { renderStoryScreen } from "../src/screens/story.js";
+import { createWrapCache, type ProseStyle } from "../src/wrap.js";
+import { createGenerationRecordDetailCache } from "../src/generation-record-detail-cache.js";
 
 type State = ReturnType<typeof initialState>;
 
@@ -357,6 +360,29 @@ describe("presented mouse reconciliation", () => {
     expect(reconcile(at(1), resolved, captured, interaction(at(1), 21))).toBe(null);
   });
 
+  test("uses the painted command cursor for Tag Manager clicks over dormant Facts", () => {
+    const state = initialState(demoAppSource(), false);
+    state.mode = "COMMANDS";
+    state.commands = {
+      query: "",
+      cursor: 1,
+      selectedId: "tags",
+      view: "tags",
+      returnMode: "FACTS"
+    };
+    state.facts = {
+      cursor: 0,
+      query: "",
+      chip: 0,
+      selectedTag: null,
+      filtering: false,
+      deleteArmedId: null
+    };
+    state.hitRows = [{ target: { kind: "list", index: 1 }, left: 0, right: 20 }];
+
+    expect(mouseToAction(click, state, false)).toEqual({ action: "open-selected" });
+  });
+
   test("refuses a list row click once that row holds another entry", () => {
     // Clicking an unselected menu row only moves the cursor, but onto whatever
     // that row holds now. A selection appearing shifts the entries beneath it.
@@ -411,6 +437,248 @@ describe("presented mouse reconciliation", () => {
     const filtered = { ...state, commands: { ...state.commands, query: "theme" } } as State;
     expect(reconcile(filtered, resolved, interaction(state, 20), interaction(filtered, 21)))
       .toBe(null);
+  });
+
+  test("models the displayed PROBS and RECORD take for queued palette clicks", () => {
+    const source = demoAppSource();
+    const view = createStoryViewModel(source.payload);
+    const stale = view.parts[0];
+    const displayed = view.parts[1];
+    const summaryId = source.payload.nodes.find((node) => node.role === "summary")?.id;
+    if (stale === undefined || displayed === undefined || summaryId === undefined) {
+      throw new Error("demo story needs two parts and a summary node");
+    }
+
+    for (const owner of ["PROBS", "RECORD"] as const) {
+      const state = initialState(source, false);
+      state.stream = null;
+      state.focusIndex = rowIndexForNode(createStoryViewModel(state.payload), stale.id);
+      if (owner === "PROBS") {
+        state.probs = {
+          nodeId: displayed.id,
+          tokenIndex: 0,
+          altIndex: 0,
+          expanded: false,
+          record: null,
+          loading: false,
+          empty: null
+        };
+      } else {
+        state.record = {
+          nodeId: displayed.id,
+          returnMode: "NAV",
+          list: { status: "ready", summaries: [] },
+          eventIndex: 0,
+          entryIndex: 0,
+          scrollTop: -1,
+          detail: { status: "idle" },
+          cache: createGenerationRecordDetailCache()
+        };
+      }
+      state.mode = "COMMANDS";
+      state.commands = {
+        query: "new Fact from here",
+        cursor: 0,
+        selectedId: "new-fact-from-here",
+        view: "commands",
+        returnMode: owner
+      };
+      state.hitRows = [{ target: { kind: "list", index: 0 }, left: 0, right: 20 }];
+
+      const captured = interaction(state, 20);
+      const action = mouseToAction(click, captured.state);
+      expect(action).toEqual({ action: "open-selected" });
+      expect(reconcile(state, action!, captured, interaction(state, 21)))
+        .toEqual({ action: "open-selected" });
+
+      // A real target change removes the contextual Fact command. The queued
+      // click must not fall back to stale NAV focus or run it on the summary.
+      if (owner === "PROBS") state.probs!.nodeId = summaryId;
+      else state.record!.nodeId = summaryId;
+      expect(reconcile(state, action!, captured, interaction(state, 22))).toBe(null);
+    }
+  });
+
+  test("refuses a palette click when contextual availability replaces its selection", () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const cache = createWrapCache<ProseStyle>();
+    state.mode = "COMMANDS";
+    state.facts = {
+      cursor: 0,
+      query: "",
+      chip: 0,
+      selectedTag: null,
+      filtering: false,
+      deleteArmedId: null,
+      scopeFilter: "everywhere",
+      dossier: null
+    };
+    state.commands = {
+      query: "facts",
+      cursor: 2,
+      selectedId: "facts-filter",
+      view: "commands",
+      returnMode: "FACTS"
+    };
+    const render = () => {
+      const frame = renderStoryScreen(state, { width: 100, height: 24, wrapCache: cache });
+      Object.assign(state, frame.derived);
+    };
+
+    render();
+    const selected = state.hitRows
+      .flatMap((hit, y) => [
+        ...(hit?.target.kind === "list" && hit.target.selected === true
+          ? [{ left: hit.left, y }]
+          : []),
+        ...(hit?.overrides ?? [])
+          .filter((region) => region.target.kind === "list" && region.target.selected === true)
+          .map((region) => ({ left: region.left, y }))
+      ])
+      .at(0);
+    expect(selected).toBeDefined();
+    const event: FrozenMouseEvent = {
+      ...click,
+      x: selected!.left + 2,
+      y: selected!.y
+    };
+    const captured = interaction(state, 20);
+    const action = mouseToAction(event, captured.state);
+    expect(action).toEqual({ action: "open-selected" });
+
+    // Opening the Fact dossier removes Facts-list commands. Rendering falls
+    // back to the old cursor, so its row now contains `edit-fact`; the stored
+    // selectedId is intentionally still `facts-filter` until a reducer runs.
+    state.facts!.dossier = {
+      factId: state.payload.facts[0]!.id,
+      stateIndex: 0,
+      diff: false
+    };
+    render();
+    expect(state.commands?.selectedId).toBe("facts-filter");
+
+    const reconciled = reconcilePresentedMouseAction({
+      action: action!,
+      event,
+      captured,
+      presented: interaction(state, 21),
+      state
+    });
+    expect(reconciled).toBeNull();
+    expect(state.mode).toBe("COMMANDS");
+  });
+
+  test("refuses a palette click when its focused story row becomes a summary", () => {
+    const state = initialState(demoAppSource(), false);
+    const cache = createWrapCache<ProseStyle>();
+    const view = createStoryViewModel(state.payload);
+    const partIndex = view.rows.findIndex((row) => row.kind === "part" && row.id === "p13");
+    const summaryIndex = view.rows.findIndex((row) => row.kind === "chapter-summary");
+    expect(partIndex).toBeGreaterThan(-1);
+    expect(summaryIndex).toBeGreaterThan(-1);
+    state.mode = "COMMANDS";
+    state.focusIndex = partIndex;
+    state.commands = {
+      query: "new Fact from here",
+      cursor: 0,
+      selectedId: "new-fact-from-here",
+      view: "commands",
+      returnMode: "NAV"
+    };
+    const render = () => {
+      const frame = renderStoryScreen(state, { width: 100, height: 24, wrapCache: cache });
+      Object.assign(state, frame.derived);
+    };
+    render();
+    const selected = state.hitRows
+      .flatMap((hit, y) => [
+        ...(hit?.target.kind === "list" && hit.target.selected === true
+          ? [{ left: hit.left, y }]
+          : []),
+        ...(hit?.overrides ?? [])
+          .filter((region) => region.target.kind === "list" && region.target.selected === true)
+          .map((region) => ({ left: region.left, y }))
+      ])
+      .at(0);
+    expect(selected).toBeDefined();
+    const event: FrozenMouseEvent = {
+      ...click,
+      x: selected!.left + 2,
+      y: selected!.y
+    };
+    const captured = interaction(state, 20);
+    const action = mouseToAction(event, captured.state);
+    expect(action).toEqual({ action: "open-selected" });
+
+    state.focusIndex = summaryIndex;
+    render();
+    expect(mouseToAction(event, state)).toBeNull();
+    expect(reconcilePresentedMouseAction({
+      action: action!,
+      event,
+      captured,
+      presented: interaction(state, 21),
+      state
+    })).toBeNull();
+  });
+
+  test("executes a palette command after a repaint changes its dormant Library", async () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const cache = createWrapCache<ProseStyle>();
+    expect(source.stories.length).toBeGreaterThan(1);
+    state.library = { stories: source.stories, cursor: 0, query: "", prompt: null };
+    state.mode = "COMMANDS";
+    state.commands = {
+      query: "chapters",
+      cursor: 0,
+      selectedId: "chapters",
+      view: "commands",
+      returnMode: "LIBRARY"
+    };
+
+    const repaint = () => {
+      const frame = renderStoryScreen(state, { width: 100, height: 24, wrapCache: cache });
+      Object.assign(state, frame.derived);
+    };
+    repaint();
+    const selected = state.hitRows
+      .flatMap((hit, y) => [
+        ...(hit?.target.kind === "list" && hit.target.selected === true
+          ? [{ left: hit.left, y }]
+          : []),
+        ...(hit?.overrides ?? [])
+          .filter((region) => region.target.kind === "list" && region.target.selected === true)
+          .map((region) => ({ left: region.left, y }))
+      ])
+      .at(0);
+    expect(selected).toBeDefined();
+    const event: FrozenMouseEvent = {
+      ...click,
+      x: selected!.left + 2,
+      y: selected!.y
+    };
+    const captured = interaction(state, 20);
+    const action = mouseToAction(event, captured.state);
+    expect(action).toEqual({ action: "open-selected" });
+
+    // The palette stays visible while its suspended Library refreshes.
+    state.library!.cursor = 1;
+    repaint();
+    const presented = interaction(state, 21);
+    const reconciled = reconcilePresentedMouseAction({
+      action: action!, event, captured, presented, state
+    });
+    expect(reconciled).toEqual({ action: "open-selected" });
+    if (reconciled === null) throw new Error("palette click was discarded");
+
+    await dispatch(
+      reconciled, state, source, cache,
+      () => undefined, async () => undefined, () => undefined
+    );
+    expect(state.mode).toBe("CHAPTERS");
+    expect(state.library).toBeNull();
   });
 
   test("freezes the live Library query with its presented frame", () => {

--- a/tui/test/presented-selection.test.ts
+++ b/tui/test/presented-selection.test.ts
@@ -11,6 +11,7 @@ import {
   capturePresentedInputSelection,
   capturePresentedSelection,
   consumePresentedSelection,
+  guardFactsStorySelectionCapture,
   hasCopyablePresentedSelection,
   reconcilePresentedSelection,
   retirePresentedSelection
@@ -61,6 +62,44 @@ test("presented selection discards a native range after semantic ownership chang
   expect(reconcilePresentedSelection(captured, 8, state).kind).toBe("stale");
   state.mode = "COMPOSE";
   expect(reconcilePresentedSelection(captured, 7, state).kind).toBe("stale");
+});
+
+test("Facts keeps only the unchanged NAV native range for its retained story projection", () => {
+  const state = initialState(demoAppSource(), false);
+  state.mode = "FACTS";
+  const storyProjection = [{ key: "part:text", text: "underlying prose", start: 0, end: 5 }];
+  const navFrame = {
+    version: 7,
+    storyId: state.payload.id,
+    interactive: true,
+    state: { mode: "NAV" as const },
+    composerSelectionProjection: null,
+    storySelectionProjection: storyProjection
+  };
+  const factsFrame = { ...navFrame, state: { mode: "FACTS" as const } };
+  let selected = nativeSelection("under", 0, 5);
+  const renderer = { getSelection: () => selected } as never;
+  const original = capturePresentedSelection(renderer, navFrame);
+  consumePresentedSelection(original);
+
+  const unchanged = guardFactsStorySelectionCapture(
+    capturePresentedSelection(renderer, factsFrame, original),
+    original
+  );
+  const retained = reconcilePresentedSelection(unchanged, 7, state);
+  expect(retained.kind).toBe("captured");
+  if (retained.kind !== "captured") throw new Error("expected retained selection");
+  expect(retained.story).toBe(storyProjection);
+
+  selected = nativeSelection("Facts row", 20, 29);
+  const changed = guardFactsStorySelectionCapture(
+    capturePresentedSelection(renderer, factsFrame, original),
+    original
+  );
+  const refused = reconcilePresentedSelection(changed, 7, state);
+  expect(refused.kind).toBe("captured");
+  if (refused.kind !== "captured") throw new Error("expected captured Facts range");
+  expect(refused.story).toBeNull();
 });
 
 test("presented selection rejects stale projections owned by a loading frame", () => {

--- a/tui/test/recovery-orchestration.test.ts
+++ b/tui/test/recovery-orchestration.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, test } from "bun:test";
+import type { KeyEvent } from "@opentui/core";
 import { applyBasicSettingsDraft } from "../../shared/settings-basic-draft.js";
 import { createFailureEnvelope } from "../../shared/failure-envelope.js";
 import type { StoryPayload, StorySummary } from "../../shared/types.js";
 import { ActionRuntime, beginInteraction } from "../src/action-runtime.js";
 import { ApiHttpError } from "../src/api.js";
-import { initialState } from "../src/app.js";
-import { createComposer } from "../src/composer-model.js";
+import { handleKey, initialState } from "../src/app.js";
+import { createComposer, setComposerText } from "../src/composer-model.js";
 import {
   connectionSucceeded,
   createConnectionMonitor,
@@ -24,7 +25,7 @@ import { applyOpeningFocus } from "../src/reading-position.js";
 import { adoptReconciliationSnapshot } from "../src/story-adoption.js";
 import { createPrunePlan, createUnusedTakesPrunePlan } from "../src/prune-model.js";
 import { nextRequestContext } from "../src/request-context.js";
-import { initialSettingsOverlay } from "../src/settings-overlay-model.js";
+import { initialSettingsOverlay, SETTINGS_ROW_IDS } from "../src/settings-overlay-model.js";
 
 function deferred<T>() {
   let resolve!: (value: T | PromiseLike<T>) => void;
@@ -36,1206 +37,411 @@ function deferred<T>() {
   return { promise, resolve, reject };
 }
 
+function key(name: string, sequence = name): KeyEvent {
+  return { name, sequence, shift: false, ctrl: false, meta: false } as KeyEvent;
+}
+
+function ctrlP(): KeyEvent {
+  return { ...key("p", "\u0010"), ctrl: true } as KeyEvent;
+}
+
+async function typeQuery(
+  press: (event: KeyEvent) => Promise<void>,
+  query: string
+): Promise<void> {
+  for (const character of query) await press(key(character));
+}
+
 describe("backend recovery orchestration", () => {
-  test("an explicit retry while online reloads the current story and library", async () => {
-    const source = demoAppSource();
-    const recoveredPayload = { ...source.payload, title: "recovered story title" };
-    const recoveredStories: StorySummary[] = source.stories.map((story) =>
-      story.id === recoveredPayload.id ? { ...story, title: recoveredPayload.title } : story);
-    let retries = 0;
-    let storyLoads = 0;
-    let catalogLoads = 0;
-    source.api.loadStory = async () => { storyLoads += 1; return recoveredPayload; };
-    source.api.listStories = async () => { catalogLoads += 1; return recoveredStories; };
-    source.connection = onlineMonitor(source.api, async () => { retries += 1; return true; });
-    const state = initialState(source, false);
-    state.library = { stories: source.stories, cursor: 0, query: "", prompt: null };
-    state.mode = "LIBRARY";
-    const cache = createWrapCache<ProseStyle>();
-    const backend = new ActionRuntime(state, () => undefined);
-
-    await handleOverlayAction({ action: "retry" }, state, source, {
-      backend,
-      cache,
-      repaint: () => undefined,
-      renderer: null,
-      applyTheme: () => undefined,
-      previewTheme: () => undefined
-    });
-
-    expect(retries).toBe(1);
-    expect(storyLoads).toBe(1);
-    expect(catalogLoads).toBe(1);
-    expect(state.payload).toBe(recoveredPayload);
-    expect(source.stories).toBe(recoveredStories);
-    expect(state.library?.stories).toBe(recoveredStories);
-    expect(state.toast).toBe("reconnected · story reloaded");
-  });
-
-  test("an explicit retry adopts a surviving fallback without losing a draft", async () => {
+  test("cross-story recovery keeps the palette on NAV and drops its old selection", async () => {
     const source = demoAppSource();
     const fallback = source.stories.find((story) => story.id !== source.payload.id)!;
     const recoveredPayload = { ...source.payload, id: fallback.id, title: fallback.title };
-    source.api.listStories = async () => [fallback];
-    source.api.loadStory = async (storyId) => {
-      expect(storyId).toBe(fallback.id);
-      return recoveredPayload;
-    };
-    source.connection = onlineMonitor(source.api, async () => true);
-    const state = initialState(source, false);
-    state.mode = "COMPOSE";
-    state.composer = createComposer("keep this draft");
-    state.focusIndex = 0;
-    const cache = createWrapCache<ProseStyle>();
-    const backend = new ActionRuntime(state, () => undefined);
-
-    await handleOverlayAction({ action: "retry" }, state, source, {
-      backend,
-      cache,
-      repaint: () => undefined,
-      renderer: null,
-      applyTheme: () => undefined,
-      previewTheme: () => undefined
+    const connection = controlledMonitor(source.api, {
+      down: true,
+      attempt: 1,
+      nextRetryAt: null,
+      error: "offline"
     });
-
-    expect(state.payload).toBe(recoveredPayload);
-    expect(source.stories).toEqual([fallback]);
-    expect(state.mode).toBe("COMPOSE");
-    expect(state.composer.text).toBe("keep this draft");
-    expect(state.focusIndex).toBe(
-      applyOpeningFocus(state.payload, state.readingPositions)
-    );
-  });
-
-  test("an input-safe explicit retry surfaces a 404 and remains retryable", async () => {
-    const source = demoAppSource();
-    const recoveredPayload = { ...source.payload, title: "recovered after retry" };
-    let retries = 0;
-    let storyLoads = 0;
-    let failReload = true;
-    source.connection = onlineMonitor(source.api, async () => { retries += 1; return true; });
+    source.connection = connection.monitor;
+    source.api.listStories = async () => [fallback];
+    const entered = deferred<void>();
+    const recovered = deferred<StoryPayload>();
     source.api.loadStory = async () => {
-      storyLoads += 1;
-      if (failReload) {
-        throw new ApiHttpError(createFailureEnvelope({
-          code: "not_found",
-          message: "story reload failed (404)",
-          status: 404
-        }));
-      }
-      return recoveredPayload;
+      entered.resolve();
+      return recovered.promise;
     };
+
     const state = initialState(source, false);
-    state.mode = "COMPOSE";
-    state.composer = createComposer("keep this draft");
+    state.mode = "FACTS";
+    state.facts = {
+      cursor: 0,
+      query: "",
+      chip: 0,
+      selectedTag: null,
+      filtering: false,
+      deleteArmedId: null
+    };
     const cache = createWrapCache<ProseStyle>();
-    const failed = deferred<void>();
+    const press = (event: KeyEvent) => handleKey(
+      event,
+      state,
+      source,
+      cache,
+      () => undefined,
+      async () => undefined,
+      () => undefined
+    );
+    await press(ctrlP());
+    const palette = state.commands;
+    if (palette === null) throw new Error("palette did not open");
+    palette.selection = {
+      text: "old story text",
+      spans: [{ key: "old:text", text: "old story text", start: 0, end: 15 }]
+    };
+
     const adopted = deferred<void>();
     const repaint = () => {
-      if (state.backendTask === null && state.toast === "story reload failed (404)") failed.resolve();
       if (state.backendTask === null && state.payload === recoveredPayload) adopted.resolve();
     };
     const backend = new ActionRuntime(state, repaint);
-    const context = {
+    const stop = startRecoveryOrchestration({
+      state,
+      source,
       backend,
       cache,
-      repaint,
-      renderer: null,
-      applyTheme: () => undefined,
-      previewTheme: () => undefined
-    };
+      repaint
+    });
 
-    backend.observe(handleOverlayAction({ action: "retry" }, state, source, context));
-    await failed.promise;
-
-    expect(state.composer.text).toBe("keep this draft");
-    expect(state.mode).toBe("COMPOSE");
-    expect(state.toast).toBe("story reload failed (404)");
-    expect(state.backendTask).toBe(null);
-
-    failReload = false;
-    backend.observe(handleOverlayAction({ action: "retry" }, state, source, context));
+    connection.publish(connectionSucceeded());
+    await entered.promise;
+    recovered.resolve(recoveredPayload);
     await adopted.promise;
 
-    expect(retries).toBe(2);
-    expect(storyLoads).toBe(2);
     expect(state.payload).toBe(recoveredPayload);
-    expect(state.composer.text).toBe("keep this draft");
-  });
-
-  test("an explicit offline retry coalesces its connection transition reload", async () => {
-    const source = demoAppSource();
-    const monitor = transitioningMonitor(source.api);
-    source.connection = monitor;
-    let storyLoads = 0;
-    let catalogLoads = 0;
-    let settingsLoads = 0;
-    source.api.loadStory = async () => { storyLoads += 1; return source.payload; };
-    source.api.listStories = async () => { catalogLoads += 1; return source.stories; };
-    source.api.getSettings = async () => { settingsLoads += 1; return source.settingsView; };
-    const state = initialState(source, false);
-    const cache = createWrapCache<ProseStyle>();
-    const backend = new ActionRuntime(state, () => undefined);
-    const stop = startRecoveryOrchestration({
-      state,
-      source,
-      backend,
-      cache,
-      repaint: () => undefined
-    });
-
-    await handleOverlayAction({ action: "retry" }, state, source, {
-      backend,
-      cache,
-      repaint: () => undefined,
-      renderer: null,
-      applyTheme: () => undefined,
-      previewTheme: () => undefined
-    });
-    await new Promise((resolve) => setTimeout(resolve, 150));
-
-    expect(storyLoads).toBe(1);
-    expect(catalogLoads).toBe(1);
-    expect(settingsLoads).toBe(1);
-    stop();
-  });
-
-  test("a real monitor supersession cannot publish stale explicit retry state or expose idle", async () => {
-    const source = demoAppSource();
-    const raw = source.api;
-    const originalPayload = source.payload;
-    const originalStories = source.stories;
-    const originalSettings = source.settings;
-    const stalePayload = { ...source.payload, title: "stale explicit retry" };
-    const freshPayload = { ...source.payload, title: "fresh explicit retry" };
-    const staleStories = source.stories.map((story) => story.id === source.payload.id
-      ? { ...story, title: stalePayload.title }
-      : story);
-    const freshStories = source.stories.map((story) => story.id === source.payload.id
-      ? { ...story, title: freshPayload.title }
-      : story);
-    const staleSettings = { ...source.settings, model: "stale explicit model" };
-    const freshSettings = { ...source.settings, model: "fresh explicit model" };
-    const alreadyFiredProbe = deferred<StorySummary[]>();
-    const staleLoad = deferred<StoryPayload>();
-    const freshLoad = deferred<StoryPayload>();
-    const staleEntered = deferred<void>();
-    const freshEntered = deferred<void>();
-    let catalogLoads = 0;
-    let settingsLoads = 0;
-    let storyLoads = 0;
-    raw.listStories = async () => {
-      catalogLoads += 1;
-      if (catalogLoads === 1) throw new Error("initial monitor outage");
-      if (catalogLoads === 2) return alreadyFiredProbe.promise;
-      if (catalogLoads === 4) return staleStories;
-      if (catalogLoads === 5) throw new Error("current monitor outage");
-      if (catalogLoads >= 6) return freshStories;
-      return originalStories;
-    };
-    raw.getSettings = async () => {
-      settingsLoads += 1;
-      return {
-        ...source.settingsView,
-        effective: settingsLoads === 1 ? staleSettings : freshSettings,
-        effectiveProse: settingsLoads === 1 ? staleSettings : freshSettings
-      };
-    };
-    raw.loadStory = async () => {
-      storyLoads += 1;
-      if (storyLoads === 1) {
-        staleEntered.resolve();
-        return staleLoad.promise;
-      }
-      freshEntered.resolve();
-      return freshLoad.promise;
-    };
-    const monitor = createConnectionMonitor(raw);
-    source.connection = monitor;
-    source.api = monitor.api;
-    await source.api.listStories().catch(() => undefined);
-    expect(monitor.state().down).toBeTrue();
-    const obsoleteProbeResult = monitor.retryNow();
-
-    const state = initialState(source, false);
-    const cache = createWrapCache<ProseStyle>();
-    const backend = new ActionRuntime(state, () => undefined);
-    const stop = startRecoveryOrchestration({
-      state,
-      source,
-      backend,
-      cache,
-      repaint: () => undefined
-    });
-    const retry = handleOverlayAction({ action: "retry" }, state, source, {
-      backend,
-      cache,
-      repaint: () => undefined,
-      renderer: null,
-      applyTheme: () => undefined,
-      previewTheme: () => undefined
-    });
-
-    await staleEntered.promise;
-    alreadyFiredProbe.reject(new Error("obsolete probe failed after reconnect"));
-    expect(await obsoleteProbeResult).toBeTrue();
-    expect(monitor.state().down).toBeFalse();
-    expect(await monitor.retryNow()).toBeFalse();
-    staleLoad.resolve(stalePayload);
-    await freshEntered.promise;
-
-    expect(state.payload).toBe(originalPayload);
-    expect(source.stories).toBe(originalStories);
-    expect(source.settings).toBe(originalSettings);
-    expect(state.backendTask?.kind).toBe("explicit-retry");
-    let competingMutationRan = false;
-    const admitted = await backend.run("competing mutation", async () => {
-      competingMutationRan = true;
-    });
-    expect(admitted).toBeFalse();
-    expect(competingMutationRan).toBeFalse();
-    expect(state.backendTask?.kind).toBe("explicit-retry");
-
-    freshLoad.resolve(freshPayload);
-    await retry;
-
-    expect(catalogLoads).toBe(6);
-    expect(settingsLoads).toBe(2);
-    expect(storyLoads).toBe(2);
-    expect(state.payload).toBe(freshPayload);
-    expect(source.stories).toBe(freshStories);
-    expect(source.settings).toBe(freshSettings);
-    expect(state.backendTask).toBe(null);
-    stop();
-    monitor.dispose();
-  });
-
-  test("an online explicit retry drains a boundary recovery under the same owner", async () => {
-    const source = demoAppSource();
-    const connection = controlledMonitor(source.api, connectionSucceeded());
-    source.connection = connection.monitor;
-    const stalePayload = { ...source.payload, title: "stale online explicit snapshot" };
-    const freshPayload = { ...source.payload, title: "fresh online explicit snapshot" };
-    const freshLoad = deferred<StoryPayload>();
-    const freshEntered = deferred<void>();
-    let storyLoads = 0;
-    source.api.loadStory = async () => {
-      storyLoads += 1;
-      if (storyLoads === 1) return stalePayload;
-      freshEntered.resolve();
-      return freshLoad.promise;
-    };
-    const state = initialState(source, false);
-    const backend = new ActionRuntime(state, () => undefined);
-    let firstOwnerId: number | null = null;
-    let invalidations = 0;
-    const stop = startRecoveryOrchestration({
-      state,
-      source,
-      backend,
-      cache: reconcileSpyCache(() => {
-        invalidations += 1;
-        if (invalidations === 1) {
-          firstOwnerId = state.backendTask?.id ?? null;
-          queueMicrotask(() => {
-            connection.publish({ down: true, attempt: 1, nextRetryAt: null, error: "boundary outage" });
-            connection.publish(connectionSucceeded());
-          });
-        }
-      }),
-      repaint: () => undefined
-    });
-
-    let retrySettled = false;
-    const retry = stop.retry().then(() => { retrySettled = true; });
-    await freshEntered.promise;
-
-    expect(firstOwnerId).not.toBe(null);
-    expect(state.backendTask).toMatchObject({ id: firstOwnerId, kind: "explicit-retry" });
-    expect(retrySettled).toBeFalse();
-    let competingMutationRan = false;
-    expect(await backend.run("competing mutation", async () => {
-      competingMutationRan = true;
-    })).toBeFalse();
-    expect(competingMutationRan).toBeFalse();
-
-    freshLoad.resolve(freshPayload);
-    await retry;
-
-    expect(storyLoads).toBe(2);
-    expect(state.payload).toBe(freshPayload);
-    expect(state.backendTask).toBe(null);
-    stop();
-  });
-
-  test("an online explicit probe leaves a changed-story boundary recovery to automatic ownership", async () => {
-    const source = demoAppSource();
-    const connection = controlledMonitor(source.api, connectionSucceeded());
-    source.connection = connection.monitor;
-    const fallback = source.stories.find((story) => story.id !== source.payload.id)!;
-    const stalePayload = { ...source.payload, id: fallback.id, title: "stale explicit fallback" };
-    const freshPayload = { ...stalePayload, title: "fresh automatic fallback" };
-    source.api.listStories = async () => [fallback];
-    const freshLoad = deferred<StoryPayload>();
-    const freshEntered = deferred<void>();
-    let storyLoads = 0;
-    source.api.loadStory = async (storyId) => {
-      expect(storyId).toBe(fallback.id);
-      storyLoads += 1;
-      if (storyLoads === 1) return stalePayload;
-      freshEntered.resolve();
-      return freshLoad.promise;
-    };
-    const state = initialState(source, false);
-    const adopted = deferred<void>();
-    const repaint = () => {
-      if (state.backendTask === null && state.payload === freshPayload) adopted.resolve();
-    };
-    const backend = new ActionRuntime(state, repaint);
-    let invalidations = 0;
-    const stop = startRecoveryOrchestration({
-      state,
-      source,
-      backend,
-      cache: reconcileSpyCache(() => {
-        invalidations += 1;
-        if (invalidations === 1) {
-          queueMicrotask(() => {
-            connection.publish({ down: true, attempt: 1, nextRetryAt: null, error: "boundary outage" });
-            connection.publish(connectionSucceeded());
-          });
-        }
-      }),
-      repaint
-    });
-
-    await stop.retry();
-    await freshEntered.promise;
-
-    expect(state.payload).toBe(stalePayload);
-    expect(state.backendTask).toMatchObject({ kind: "connection-reconcile", storyId: fallback.id });
-    freshLoad.resolve(freshPayload);
-    await adopted.promise;
-
-    expect(storyLoads).toBe(2);
-    expect(state.payload).toBe(freshPayload);
-    expect(state.connection.down).toBeFalse();
-    stop();
-  });
-
-  test("an automatic reconnect refreshes every generation setting projection", async () => {
-    const source = demoAppSource();
-    const connection = controlledMonitor(source.api, {
-      down: true, attempt: 1, nextRetryAt: null, error: "offline"
-    });
-    source.connection = connection.monitor;
-    const recoveredPayload = { ...source.payload, title: "fresh automatic reconnect" };
-    const recoveredSettings = {
-      ...source.settings,
-      provider: "anthropic" as const,
-      baseUrl: "https://api.anthropic.com",
-      model: "claude-sonnet-4-6",
-      systemPrompt: "Use the server's fresh voice.",
-      contextWindow: 8_192
-    };
-    if (!source.settingsView.editable) throw new Error("demo settings must be editable");
-    const recoveredView = {
-      ...source.settingsView,
-      document: applyBasicSettingsDraft(source.settingsView.document, recoveredSettings),
-      effective: recoveredSettings,
-      effectiveProse: recoveredSettings
-    };
-    let settingsLoads = 0;
-    const discoveryEntered = deferred<void>();
-    const discoverModels = source.api.discoverModels;
-    source.api.discoverModels = async (target, signal) => {
-      discoveryEntered.resolve();
-      return discoverModels(target, signal);
-    };
-    source.api.loadStory = async () => recoveredPayload;
-    source.api.getSettings = async () => {
-      settingsLoads += 1;
-      return recoveredView;
-    };
-    const state = initialState(source, false);
-    state.mode = "SETTINGS";
-    state.settings = initialSettingsOverlay(source.settingsView, state.config);
-    const settled = deferred<void>();
-    const repaint = () => {
-      if (state.backendTask === null && state.payload === recoveredPayload) settled.resolve();
-    };
-    const backend = new ActionRuntime(state, repaint);
-    const stop = startRecoveryOrchestration({
-      state,
-      source,
-      backend,
-      cache: createWrapCache<ProseStyle>(),
-      repaint
-    });
-
-    connection.publish(connectionSucceeded());
-    await settled.promise;
-    await discoveryEntered.promise;
-    await backend.whenIdle();
-
-    expect(settingsLoads).toBe(1);
-    expect(source.settings).toBe(recoveredSettings);
-    expect(state.settings?.draft.generation).toEqual(recoveredSettings);
-    expect(state.model).toBe(recoveredSettings.model);
-    expect(state.contextWindow).toBe(recoveredSettings.contextWindow);
-    expect(state.systemPrompt).toBe(recoveredSettings.systemPrompt);
-    expect(state.assistantPrefill).toBeFalse();
-    expect(nextRequestContext(state)).toMatchObject({
-      systemPrompt: recoveredSettings.systemPrompt,
-      assistantPrefill: false
-    });
-    stop();
-  });
-
-  test("a newer reconnect transition supersedes an in-flight automatic snapshot", async () => {
-    const source = demoAppSource();
-    const connection = controlledMonitor(source.api, {
-      down: true, attempt: 1, nextRetryAt: null, error: "offline"
-    });
-    source.connection = connection.monitor;
-    const stale = { ...source.payload, title: "stale first reconnect" };
-    const fresh = { ...source.payload, title: "fresh second reconnect" };
-    const staleSettings = { ...source.settings, model: "stale reconnect model" };
-    const freshSettings = { ...source.settings, model: "fresh reconnect model" };
-    const first = deferred<StoryPayload>();
-    const second = deferred<StoryPayload>();
-    const firstEntered = deferred<void>();
-    const secondEntered = deferred<void>();
-    let loads = 0;
-    let settingsLoads = 0;
-    source.api.getSettings = async () => {
-      settingsLoads += 1;
-      return {
-        ...source.settingsView,
-        effective: settingsLoads === 1 ? staleSettings : freshSettings,
-        effectiveProse: settingsLoads === 1 ? staleSettings : freshSettings
-      };
-    };
-    source.api.loadStory = async () => {
-      loads += 1;
-      if (loads === 1) {
-        firstEntered.resolve();
-        return first.promise;
-      }
-      secondEntered.resolve();
-      return second.promise;
-    };
-    const state = initialState(source, false);
-    const adopted = deferred<void>();
-    const repaint = () => {
-      if (state.backendTask === null && state.payload === fresh) adopted.resolve();
-    };
-    const backend = new ActionRuntime(state, repaint);
-    const stop = startRecoveryOrchestration({
-      state,
-      source,
-      backend,
-      cache: createWrapCache<ProseStyle>(),
-      repaint
-    });
-
-    connection.publish(connectionSucceeded());
-    await firstEntered.promise;
-    connection.publish({ down: true, attempt: 2, nextRetryAt: null, error: "offline again" });
-    connection.publish(connectionSucceeded());
-    first.resolve(stale);
-    await secondEntered.promise;
-
-    expect(state.payload).not.toBe(stale);
-    expect(source.settings).not.toBe(staleSettings);
-    second.resolve(fresh);
-    await adopted.promise;
-
-    expect(loads).toBe(2);
-    expect(settingsLoads).toBe(2);
-    expect(state.payload).toBe(fresh);
-    expect(source.settings).toBe(freshSettings);
-    expect(state.model).toBe(freshSettings.model);
-    stop();
-  });
-
-  test("a publish-boundary reconnect drains under the same automatic owner", async () => {
-    const source = demoAppSource();
-    const connection = controlledMonitor(source.api, {
-      down: true, attempt: 1, nextRetryAt: null, error: "offline"
-    });
-    source.connection = connection.monitor;
-    const stalePayload = { ...source.payload, title: "stale publish-boundary snapshot" };
-    const freshPayload = { ...source.payload, title: "fresh publish-boundary snapshot" };
-    const freshLoad = deferred<StoryPayload>();
-    const freshEntered = deferred<void>();
-    let storyLoads = 0;
-    source.api.loadStory = async () => {
-      storyLoads += 1;
-      if (storyLoads === 1) return stalePayload;
-      freshEntered.resolve();
-      return freshLoad.promise;
-    };
-    const state = initialState(source, false);
-    const adopted = deferred<void>();
-    const repaint = () => {
-      if (state.backendTask === null && state.payload === freshPayload) adopted.resolve();
-    };
-    const backend = new ActionRuntime(state, repaint);
-    let firstOwnerId: number | null = null;
-    let invalidations = 0;
-    const stop = startRecoveryOrchestration({
-      state,
-      source,
-      backend,
-      cache: reconcileSpyCache(() => {
-        invalidations += 1;
-        if (invalidations === 1) {
-          firstOwnerId = state.backendTask?.id ?? null;
-          queueMicrotask(() => {
-            connection.publish({ down: true, attempt: 1, nextRetryAt: null, error: "boundary outage" });
-            connection.publish(connectionSucceeded());
-          });
-        }
-      }),
-      repaint
-    });
-
-    connection.publish(connectionSucceeded());
-    await freshEntered.promise;
-
-    expect(firstOwnerId).not.toBe(null);
-    expect(state.backendTask).toMatchObject({
-      id: firstOwnerId,
-      kind: "connection-reconcile"
-    });
-    let competingMutationRan = false;
-    expect(await backend.run("competing mutation", async () => {
-      competingMutationRan = true;
-    })).toBeFalse();
-    expect(competingMutationRan).toBeFalse();
-
-    freshLoad.resolve(freshPayload);
-    await adopted.promise;
-
-    expect(storyLoads).toBe(2);
-    expect(state.payload).toBe(freshPayload);
-    expect(state.backendTask).toBe(null);
-    stop();
-  });
-
-  test("a stale error cannot settle a newer intent across its async return boundary", async () => {
-    const source = demoAppSource();
-    const connection = controlledMonitor(source.api, {
-      down: true, attempt: 1, nextRetryAt: null, error: "offline"
-    });
-    source.connection = connection.monitor;
-    const staleLoad = deferred<StoryPayload>();
-    const staleEntered = deferred<void>();
-    const freshLoad = deferred<StoryPayload>();
-    const freshEntered = deferred<void>();
-    const freshPayload = { ...source.payload, title: "fresh after stale error" };
-    let storyLoads = 0;
-    source.api.loadStory = async () => {
-      storyLoads += 1;
-      if (storyLoads === 1) {
-        staleEntered.resolve();
-        return staleLoad.promise;
-      }
-      freshEntered.resolve();
-      return freshLoad.promise;
-    };
-    const state = initialState(source, false);
-    const adopted = deferred<void>();
-    const repaint = () => {
-      if (state.backendTask === null && state.payload === freshPayload) adopted.resolve();
-    };
-    const backend = new ActionRuntime(state, repaint);
-    const stop = startRecoveryOrchestration({
-      state,
-      source,
-      backend,
-      cache: createWrapCache<ProseStyle>(),
-      repaint
-    });
-
-    connection.publish(connectionSucceeded());
-    await staleEntered.promise;
-    const firstOwnerId = state.backendTask?.id ?? null;
-    staleLoad.reject(new ApiHttpError(createFailureEnvelope({
-      code: "internal",
-      message: "obsolete recovery error",
-      status: 500
-    })));
-    // Three chained promise turns place the transition after reconcileOwned's
-    // failure result but before its backend owner accepts that result.
-    let boundary = Promise.resolve();
-    for (let turn = 0; turn < 3; turn += 1) boundary = boundary.then(() => undefined);
-    void boundary.then(() => {
-      connection.publish({ down: true, attempt: 1, nextRetryAt: null, error: "boundary outage" });
-      connection.publish(connectionSucceeded());
-    });
-    await freshEntered.promise;
-
-    expect(firstOwnerId).not.toBe(null);
-    expect(state.backendTask).toMatchObject({
-      id: firstOwnerId,
-      kind: "connection-reconcile"
-    });
-    expect(state.toast).not.toBe("obsolete recovery error");
-    freshLoad.resolve(freshPayload);
-    await adopted.promise;
-
-    expect(storyLoads).toBe(2);
-    expect(state.payload).toBe(freshPayload);
-    expect(state.toast).toBe("reconnected · story reloaded");
-    stop();
-  });
-
-  test("a reconnect supersedes warning recovery without stale publication or releasing its owner", async () => {
-    const source = demoAppSource();
-    const feed = new RecoveryWarningFeed();
-    const connection = controlledMonitor(source.api, connectionSucceeded());
-    source.backendRecovery = feed;
-    source.connection = connection.monitor;
-    const originalPayload = source.payload;
-    const originalStories = source.stories;
-    const originalSettings = source.settings;
-    const stalePayload = { ...source.payload, title: "stale warning recovery" };
-    const freshPayload = { ...source.payload, title: "fresh warning recovery" };
-    const staleStories = source.stories.map((story) => story.id === source.payload.id
-      ? { ...story, title: stalePayload.title }
-      : story);
-    const freshStories = source.stories.map((story) => story.id === source.payload.id
-      ? { ...story, title: freshPayload.title }
-      : story);
-    const staleSettings = { ...source.settings, model: "stale warning model" };
-    const freshSettings = { ...source.settings, model: "fresh warning model" };
-    const staleLoad = deferred<StoryPayload>();
-    const freshLoad = deferred<StoryPayload>();
-    const staleEntered = deferred<void>();
-    const freshEntered = deferred<void>();
-    let catalogLoads = 0;
-    let settingsLoads = 0;
-    let storyLoads = 0;
-    source.api.listStories = async () => {
-      catalogLoads += 1;
-      return catalogLoads === 1 ? staleStories : freshStories;
-    };
-    source.api.getSettings = async () => {
-      settingsLoads += 1;
-      return {
-        ...source.settingsView,
-        effective: settingsLoads === 1 ? staleSettings : freshSettings,
-        effectiveProse: settingsLoads === 1 ? staleSettings : freshSettings
-      };
-    };
-    source.api.loadStory = async () => {
-      storyLoads += 1;
-      if (storyLoads === 1) {
-        staleEntered.resolve();
-        return staleLoad.promise;
-      }
-      freshEntered.resolve();
-      return freshLoad.promise;
-    };
-    const state = initialState(source, false);
-    const adopted = deferred<void>();
-    const repaint = () => {
-      if (state.backendTask === null && state.payload === freshPayload) adopted.resolve();
-    };
-    const backend = new ActionRuntime(state, repaint);
-    const stop = startRecoveryOrchestration({
-      state,
-      source,
-      backend,
-      cache: createWrapCache<ProseStyle>(),
-      repaint
-    });
-
-    feed.publish([], true);
-    await staleEntered.promise;
-    connection.publish({ down: true, attempt: 1, nextRetryAt: null, error: "offline again" });
-    connection.publish(connectionSucceeded());
-    staleLoad.resolve(stalePayload);
-    await freshEntered.promise;
-
-    expect(state.payload).toBe(originalPayload);
-    expect(source.stories).toBe(originalStories);
-    expect(source.settings).toBe(originalSettings);
-    expect(state.backendTask).toMatchObject({
-      kind: "connection-reconcile",
-      label: "recovering backend state"
-    });
-    let competingMutationRan = false;
-    const admitted = await backend.run("competing mutation", async () => {
-      competingMutationRan = true;
-    });
-    expect(admitted).toBeFalse();
-    expect(competingMutationRan).toBeFalse();
-    expect(state.backendTask?.label).toBe("recovering backend state");
-
-    freshLoad.resolve(freshPayload);
-    await adopted.promise;
-
-    expect(catalogLoads).toBe(2);
-    expect(settingsLoads).toBe(2);
-    expect(storyLoads).toBe(2);
-    expect(state.payload).toBe(freshPayload);
-    expect(source.stories).toBe(freshStories);
-    expect(source.settings).toBe(freshSettings);
-    expect(state.backendTask).toBe(null);
-    stop();
-  });
-
-  test("disposal rejects an automatic snapshot that settles late", async () => {
-    const source = demoAppSource();
-    const connection = controlledMonitor(source.api, {
-      down: true, attempt: 1, nextRetryAt: null, error: "offline"
-    });
-    source.connection = connection.monitor;
-    const entered = deferred<void>();
-    const reload = deferred<StoryPayload>();
-    const late = { ...source.payload, title: "must not land after disposal" };
-    source.api.loadStory = async () => {
-      entered.resolve();
-      return reload.promise;
-    };
-    const state = initialState(source, false);
-    const original = state.payload;
-    const settled = deferred<void>();
-    let requestStarted = false;
-    const repaint = () => {
-      if (requestStarted && state.backendTask === null) settled.resolve();
-    };
-    const backend = new ActionRuntime(state, repaint);
-    const stop = startRecoveryOrchestration({
-      state,
-      source,
-      backend,
-      cache: createWrapCache<ProseStyle>(),
-      repaint
-    });
-
-    connection.publish(connectionSucceeded());
-    await entered.promise;
-    requestStarted = true;
-    stop();
-    reload.resolve(late);
-    await settled.promise;
-
-    expect(state.payload).toBe(original);
-    expect(state.toast).not.toBe("reconnected · story reloaded");
-  });
-
-  test("a clean startup recovery reloads without announcing itself", async () => {
-    // Every start publishes an empty warning batch to force this reload, so a
-    // toast here fires on every launch and reports bookkeeping the reader never
-    // saw go wrong. The reload still has to happen.
-    const source = demoAppSource();
-    const feed = new RecoveryWarningFeed();
-    const recoveredPayload = { ...source.payload };
-    source.backendRecovery = feed;
-    let reloads = 0;
-    source.api.loadStory = async () => { reloads += 1; return recoveredPayload; };
-    const state = initialState(source, false);
-    const settled = deferred<void>();
-    const repaint = () => {
-      if (state.backendTask === null && state.payload === recoveredPayload) settled.resolve();
-    };
-    const backend = new ActionRuntime(state, repaint);
-    const stop = startRecoveryOrchestration({
-      state,
-      source,
-      backend,
-      cache: createWrapCache<ProseStyle>(),
-      repaint
-    });
-
-    feed.publish([], true);
-    await settled.promise;
-
-    expect(reloads).toBe(1);
-    expect(state.toast).toBe(null);
-    stop();
-  });
-
-  test("generation recovery retires the provider record before reloading", async () => {
-    const source = demoAppSource();
-    const feed = new RecoveryWarningFeed();
-    source.backendRecovery = feed;
-    const calls: string[] = [];
-    source.api.acknowledgeUnknownOutcomes = async (
-      storyId,
-      originalProviderMutationId
-    ) => {
-      expect(feed.publish([warning])).toBeFalse();
-      calls.push(`retire:${storyId}:${originalProviderMutationId}`);
-      return source.payload;
-    };
-    source.api.loadStory = async (storyId) => {
-      calls.push(`load:${storyId}`);
-      return source.payload;
-    };
-    const warning: WorkerRecoveryWarning = {
-      mutationId: "m1-generation-recovery",
-      method: "continueStory",
-      storyId: source.payload.id,
-      resolution: "archived",
-      error: new WorkerApiError(createFailureEnvelope({
-        code: "generation_outcome_unknown",
-        message: "Provider outcome is unknown.",
-        status: 409
-      }))
-    };
-    const state = initialState(source, false);
-    const settled = deferred<void>();
-    const repaint = () => {
-      if (state.backendTask === null
-        && calls.includes(`load:${source.payload.id}`)) {
-        settled.resolve();
-      }
-    };
-    const backend = new ActionRuntime(state, repaint);
-    const stop = startRecoveryOrchestration({
-      state,
-      source,
-      backend,
-      cache: createWrapCache<ProseStyle>(),
-      repaint
-    });
-
-    expect(feed.publish([warning])).toBeTrue();
-    await settled.promise;
-
-    expect(calls).toEqual([
-      `retire:${source.payload.id}:${warning.mutationId}`,
-      `load:${source.payload.id}`
-    ]);
-    expect(state.toast).toBe(
-      "something interrupted the model · you can try again"
-    );
-    await new Promise((resolve) => setTimeout(resolve, 0));
-    expect(feed.publish([warning])).toBeFalse();
-    stop();
-  });
-
-  test("same-story warnings remain visible and acknowledge after local input", async () => {
-    const source = demoAppSource();
-    const feed = new RecoveryWarningFeed();
-    source.backendRecovery = feed;
-    const entered = deferred<void>();
-    const reload = deferred<StoryPayload>();
-    let reloads = 0;
-    source.api.loadStory = async () => {
-      reloads += 1;
-      entered.resolve();
-      return reload.promise;
-    };
-    const warning: WorkerRecoveryWarning = {
-      mutationId: "m1-local-input",
-      method: "renameStory",
-      storyId: source.payload.id,
-      resolution: "archived",
-      error: new WorkerApiError(createFailureEnvelope({
-        code: "mutation_outcome_unknown",
-        message: "Reload state.",
-        status: 409
-      }))
-    };
-    const state = initialState(source, false);
-    const cache = createWrapCache<ProseStyle>();
-    const settled = deferred<void>();
-    const repaint = () => {
-      if (state.backendTask === null
-        && state.toast === "interrupted change checked") {
-        settled.resolve();
-      }
-    };
-    const backend = new ActionRuntime(state, repaint);
-    const stop = startRecoveryOrchestration({
-      state,
-      source,
-      backend,
-      cache,
-      repaint
-    });
-
-    expect(feed.publish([warning])).toBeTrue();
-    await entered.promise;
-    beginInteraction(state);
-    reload.resolve(source.payload);
-    await settled.promise;
-    await new Promise((resolve) => setTimeout(resolve, 0));
-    expect(state.toast).toBe("interrupted change checked");
-    expect(reloads).toBe(1);
-    expect(feed.publish([warning])).toBeFalse();
-    stop();
-  });
-
-  test("same-story recovery closes invalid newer targets but preserves a draft and focus", async () => {
-    const source = demoAppSource();
-    const feed = new RecoveryWarningFeed();
-    const entered = deferred<void>();
-    const reload = deferred<StoryPayload>();
-    const deletedLeaf = createDemoController().deleteNode("p13", 1);
-    const recoveredPayload = {
-      ...deletedLeaf,
-      title: "authoritative title",
-      chapterBreaks: deletedLeaf.chapterBreaks.filter(({ id }) => id !== "chapter-break-1"),
-      facts: deletedLeaf.facts.filter(({ id }) => id !== "fact-1")
-    };
-    source.backendRecovery = feed;
-    source.api.loadStory = async () => { entered.resolve(); return reload.promise; };
-    const state = initialState(source, false);
-    const focusId = "p12";
-    state.focusIndex = rowIndexForNode(createStoryViewModel(state.payload), focusId);
-    state.mode = "COMPOSE";
-    state.composer = createComposer("keep this draft");
-    state.viewScroll = 7;
-    state.lastViewportStart = 7;
-    const cache = createWrapCache<ProseStyle>();
-    const settled = deferred<void>();
-    const repaint = () => {
-      if (state.backendTask === null && state.payload === recoveredPayload) settled.resolve();
-    };
-    const backend = new ActionRuntime(state, repaint);
-    const stop = startRecoveryOrchestration({
-      state,
-      source,
-      backend,
-      cache,
-      repaint
-    });
-
-    feed.publish([], true);
-    await entered.promise;
-    state.undo = [{ kind: "create-break", breakId: "chapter-break-1" }];
-    state.prune = {
-      kind: "subtree", nodeId: "p13", part: 13, take: 1,
-      takeCount: 1, parts: 1, lines: 1, tags: []
-    };
-    state.tag = {
-      nodeId: "p13", name: "newer prompt", statusIndex: 0,
-      choosingStatus: false, existing: false, returnMode: "NAV"
-    };
-    state.chapterDeleteArmedId = "chapter-break-1";
-    state.chapters = {
-      cursor: 1,
-      rename: { breakId: "chapter-break-1", composer: createComposer("newer title") }, deleteArmedId: "chapter-break-1"
-    };
-    state.facts = {
-      cursor: 0, query: "", chip: 0, selectedTag: null, filtering: false, deleteArmedId: "fact-1"
-    };
-
-    reload.resolve(recoveredPayload);
-    await settled.promise;
-
-    expect(state.mode).toBe("COMPOSE");
-    expect(state.composer.text).toBe("keep this draft");
-    expect(rowPart(createStoryViewModel(state.payload), state.focusIndex)?.id).toBe(focusId);
-    expect(state.viewScroll).toBe(7);
-    expect(state.lastViewportStart).toBe(7);
-    expect(state.undo).toEqual([]);
-    expect(state.prune).toBe(null);
-    expect(state.tag).toBe(null);
-    expect(state.chapterDeleteArmedId).toBe(null);
-    expect(state.chapters?.rename).toBe(null);
-    expect(state.chapters?.deleteArmedId).toBe(null);
-    expect(state.facts?.deleteArmedId).toBe(null);
-    stop();
-  });
-
-  test("same-story recovery preserves target-valid prompts opened while loading", async () => {
-    const source = demoAppSource();
-    const feed = new RecoveryWarningFeed();
-    const entered = deferred<void>();
-    const reload = deferred<StoryPayload>();
-    const prunedLeaf = createDemoController().deleteNode("p13", 1);
-    const recoveredPayload = {
-      ...prunedLeaf,
-      title: "authoritative title",
-      tags: [...prunedLeaf.tags, {
-        ...source.payload.tags[0]!,
-        nodeId: "p12-t4",
-        name: "remote tag"
-      }]
-    };
-    source.backendRecovery = feed;
-    source.api.loadStory = async () => { entered.resolve(); return reload.promise; };
-    const state = initialState(source, false);
-    const settled = deferred<void>();
-    const repaint = () => {
-      if (state.backendTask === null && state.payload === recoveredPayload) settled.resolve();
-    };
-    const backend = new ActionRuntime(state, repaint);
-    const stop = startRecoveryOrchestration({
-      state,
-      source,
-      backend,
-      cache: createWrapCache<ProseStyle>(),
-      repaint
-    });
-
-    feed.publish([], true);
-    await entered.promise;
-    const prune = createPrunePlan(state.payload, "p12")!;
-    const tag = {
-      nodeId: "p12-t4", name: "typed while loading", statusIndex: 2,
-      choosingStatus: true, existing: false, returnMode: "NAV" as const
-    };
-    const rename = { breakId: "chapter-break-1", composer: createComposer("typed chapter title") };
-    state.undo = [{ kind: "create-break", breakId: "chapter-break-1" }];
-    state.prune = prune;
-    state.tag = tag;
-    state.mode = "TAG";
-    state.chapters = { cursor: 1, rename, deleteArmedId: "chapter-break-2" };
-    state.facts = {
-      cursor: 0, query: "", chip: 0, selectedTag: null, filtering: false, deleteArmedId: "fact-1"
-    };
-
-    reload.resolve(recoveredPayload);
-    await settled.promise;
-
-    expect(state.undo).toEqual([]);
-    expect(state.prune).toBe(prune);
-    expect(state.prune).toMatchObject({ kind: "subtree", nodeId: "p12", parts: 1 });
-    expect(state.tag).toBe(tag);
-    expect(state.tag).toMatchObject({
-      name: "typed while loading", choosingStatus: true, existing: true
-    });
-    expect(state.mode).toBe("TAG");
-    expect(state.chapters?.rename).toBe(rename);
-    expect(state.chapters?.deleteArmedId).toBe("chapter-break-2");
-    expect(state.facts?.deleteArmedId).toBe("fact-1");
-    stop();
-  });
-
-  test("same-story recovery reconciles a semantic panel and keeps its valid confirmation", async () => {
-    const source = demoAppSource();
-    const feed = new RecoveryWarningFeed();
-    const selectedId = source.payload.facts[1]!.id;
-    const recoveredPayload = { ...source.payload, facts: [...source.payload.facts].reverse() };
-    source.backendRecovery = feed;
-    source.api.loadStory = async () => recoveredPayload;
-    const state = initialState(source, false);
-    const facts = {
-      cursor: 1, query: "", chip: 0, selectedTag: null, filtering: false, deleteArmedId: selectedId
-    };
-    state.mode = "FACTS";
-    state.facts = facts;
-    const settled = deferred<void>();
-    const repaint = () => {
-      if (state.backendTask === null && state.payload === recoveredPayload) settled.resolve();
-    };
-    const backend = new ActionRuntime(state, repaint);
-    const stop = startRecoveryOrchestration({
-      state,
-      source,
-      backend,
-      cache: createWrapCache<ProseStyle>(),
-      repaint
-    });
-
-    feed.publish([], true);
-    await settled.promise;
-
-    expect(state.mode).toBe("FACTS");
-    expect(state.facts).toBe(facts);
-    expect(factRows(state.payload.facts, null, "")[state.facts!.cursor]?.id).toBe(selectedId);
-    expect(state.facts!.deleteArmedId).toBe(selectedId);
-    stop();
-  });
-
-  test("reconciliation refreshes whole-story prune safety metadata and closes an empty preview", () => {
-    const source = demoAppSource();
-    const state = initialState(source, false);
-    const preview = createUnusedTakesPrunePlan(state.payload)!;
-    const reducedPayload = createDemoController().deleteNode("p12-t1", 1);
-    state.prune = preview;
-
-    adoptReconciliationSnapshot(state, reducedPayload, createWrapCache<ProseStyle>());
-
-    expect(state.prune).toBe(preview);
-    expect(state.prune).toMatchObject({ kind: "unused-takes", takes: 4, parts: 4 });
-
-    const emptyState = initialState(demoAppSource(), false);
-    emptyState.prune = createUnusedTakesPrunePlan(emptyState.payload);
-    const activeIds = new Set(emptyState.payload.path.map(({ id }) => id));
-    const activeLineOnly = {
-      ...emptyState.payload,
-      nodes: emptyState.payload.nodes.filter(({ id }) => activeIds.has(id)),
-      tags: emptyState.payload.tags.filter(({ nodeId }) => activeIds.has(nodeId))
-    };
-    adoptReconciliationSnapshot(emptyState, activeLineOnly, createWrapCache<ProseStyle>());
-    expect(emptyState.prune).toBe(null);
-  });
-
-  test("reconciliation drops a stale Generation Profile import prompt", () => {
-    const source = demoAppSource();
-    const state = initialState(source, false);
-    state.mode = "SETTINGS";
-    state.settings = initialSettingsOverlay(source.settingsView, state.config);
-    state.settings.profileTransfer = {
-      phase: "file", path: "/tmp/stale.preset", candidates: [], error: null
-    };
-
-    adoptReconciliationSnapshot(
-      state,
-      { ...state.payload, id: "recovered-story" },
-      createWrapCache<ProseStyle>()
-    );
-
-    expect(state.settings).toBe(null);
+    expect(state.mode).toBe("COMMANDS");
+    expect(state.commands).toBe(palette);
+    expect(state.commands?.returnMode).toBe("NAV");
+    expect(state.commands?.selection ?? null).toBeNull();
+
+    await typeQuery(press, "new Fact from selection");
+    expect(state.commands?.selectedId).not.toBe("new-fact-from-selection");
+
+    await press(key("escape", "\u001b"));
     expect(state.mode).toBe("NAV");
+    expect(state.commands).toBeNull();
+    stop();
   });
 
-  test("direct chapter deletion remains armed only on the surviving focused divider", () => {
+  test("cross-story recovery restores an unsent Direct draft beneath the palette", async () => {
     const source = demoAppSource();
+    const fallback = source.stories.find((story) => story.id !== source.payload.id)!;
+    const recoveredPayload = { ...source.payload, id: fallback.id, title: fallback.title };
+    const connection = controlledMonitor(source.api, {
+      down: true,
+      attempt: 1,
+      nextRetryAt: null,
+      error: "offline"
+    });
+    source.connection = connection.monitor;
+    source.api.listStories = async () => [fallback];
+    const entered = deferred<void>();
+    const recovered = deferred<StoryPayload>();
+    source.api.loadStory = async () => {
+      entered.resolve();
+      return recovered.promise;
+    };
+
     const state = initialState(source, false);
-    const view = createStoryViewModel(state.payload);
-    state.focusIndex = view.rows.findIndex((row) =>
-      row.kind === "chapter-divider" && row.break.id === "chapter-break-1");
-    state.chapterDeleteArmedId = "chapter-break-1";
+    state.mode = "COMPOSE";
+    const draft = "keep this Direct draft";
+    setComposerText(state.composer, draft);
+    const cache = createWrapCache<ProseStyle>();
+    const press = (event: KeyEvent) => handleKey(
+      event,
+      state,
+      source,
+      cache,
+      () => undefined,
+      async () => undefined,
+      () => undefined
+    );
+    await press(ctrlP());
+    const palette = state.commands;
+    if (palette === null) throw new Error("palette did not open");
+    expect(palette.returnMode).toBe("COMPOSE");
+    palette.selection = {
+      text: "old story text",
+      spans: [{ key: "old:text", text: "old story text", start: 0, end: 15 }]
+    };
 
-    adoptReconciliationSnapshot(state, { ...state.payload, title: "refreshed" }, createWrapCache<ProseStyle>());
-    expect(state.chapterDeleteArmedId).toBe("chapter-break-1");
+    const adopted = deferred<void>();
+    const repaint = () => {
+      if (state.backendTask === null && state.payload === recoveredPayload) adopted.resolve();
+    };
+    const backend = new ActionRuntime(state, repaint);
+    const stop = startRecoveryOrchestration({ state, source, backend, cache, repaint });
 
-    state.focusIndex = rowIndexForNode(createStoryViewModel(state.payload), "p12");
-    adoptReconciliationSnapshot(state, { ...state.payload, title: "refreshed again" }, createWrapCache<ProseStyle>());
-    expect(state.chapterDeleteArmedId).toBe(null);
+    connection.publish(connectionSucceeded());
+    await entered.promise;
+    recovered.resolve(recoveredPayload);
+    await adopted.promise;
+
+    expect(state.payload).toBe(recoveredPayload);
+    expect(state.mode).toBe("COMMANDS");
+    expect(state.commands).toBe(palette);
+    expect(state.commands?.returnMode).toBe("COMPOSE");
+    expect(state.commands?.selection ?? null).toBeNull();
+    expect(state.retakePrompt).toBeNull();
+    expect(state.pendingGenerationDraft).toBeNull();
+
+    await press(key("escape", "\u001b"));
+    expect(state.mode).toBe("COMPOSE");
+    expect(state.commands).toBeNull();
+    expect(state.composer.text).toBe(draft);
+    stop();
   });
 
-  test("reconciliation repairs removed map and action targets without leaving a dead mode", () => {
-    const recoveredPayload = createDemoController().deleteNode("p13", 1);
+  test("cross-story recovery keeps a Library rename draft behind the palette", async () => {
+    const source = demoAppSource();
+    const fallback = source.stories.find((story) => story.id !== source.payload.id)!;
+    const recoveredPayload = { ...source.payload, id: fallback.id, title: fallback.title };
+    const connection = controlledMonitor(source.api, {
+      down: true,
+      attempt: 1,
+      nextRetryAt: null,
+      error: "offline"
+    });
+    source.connection = connection.monitor;
+    source.api.listStories = async () => [fallback];
+    const entered = deferred<void>();
+    const recovered = deferred<StoryPayload>();
+    source.api.loadStory = async () => {
+      entered.resolve();
+      return recovered.promise;
+    };
 
-    const tagState = initialState(demoAppSource(), false);
-    tagState.mode = "TAG";
-    tagState.map = {
-      view: "path", pathCursorId: "p13", pathShowAllTakes: true, treeCursorId: "p13", rowIds: [],
-      showSketches: false, openedColdFolds: new Set(), massSort: "size"
-    };
-    tagState.tag = {
-      nodeId: "p13", name: "stale", statusIndex: 0,
-      choosingStatus: false, existing: false, returnMode: "MAP"
-    };
-    adoptReconciliationSnapshot(tagState, recoveredPayload, createWrapCache<ProseStyle>());
-    expect(tagState.tag).toBe(null);
-    expect(tagState.mode).toBe("MAP");
-    expect(tagState.map?.pathCursorId).toBe(recoveredPayload.path.at(-1)?.id);
+    const state = initialState(source, false);
+    const cache = createWrapCache<ProseStyle>();
+    const press = (event: KeyEvent) => handleKey(
+      event,
+      state,
+      source,
+      cache,
+      () => undefined,
+      async () => undefined,
+      () => undefined
+    );
+    await press(key("o"));
+    const library = state.library;
+    if (library === null) throw new Error("Library did not open");
+    library.cursor = library.stories.findIndex((story) => story.id === fallback.id);
+    await press(key("e"));
+    const prompt = library.prompt;
+    if (prompt?.kind !== "rename") throw new Error("Library rename did not open");
+    setComposerText(prompt.composer, "draft story title");
+    await press(ctrlP());
 
-    const actionsState = initialState(demoAppSource(), false);
-    actionsState.mode = "ACTIONS";
-    actionsState.actions = {
-      cursor: 0,
-      partId: "p13",
-      selectionText: null
+    const palette = state.commands;
+    if (palette === null) throw new Error("palette did not open");
+    expect(palette.returnMode).toBe("LIBRARY");
+
+    const adopted = deferred<void>();
+    const repaint = () => {
+      if (state.backendTask === null && state.payload === recoveredPayload) adopted.resolve();
     };
-    adoptReconciliationSnapshot(actionsState, recoveredPayload, createWrapCache<ProseStyle>());
-    expect(actionsState.actions).toBe(null);
-    expect(actionsState.mode).toBe("NAV");
+    const backend = new ActionRuntime(state, repaint);
+    const stop = startRecoveryOrchestration({ state, source, backend, cache, repaint });
+
+    connection.publish(connectionSucceeded());
+    await entered.promise;
+    recovered.resolve(recoveredPayload);
+    await adopted.promise;
+
+    expect(state.mode).toBe("COMMANDS");
+    expect(state.commands).toBe(palette);
+    expect(state.commands?.returnMode).toBe("LIBRARY");
+    expect(state.library).toBe(library);
+    expect(state.library?.prompt).toBe(prompt);
+    expect(state.library?.prompt?.kind === "rename"
+      ? state.library.prompt.composer.text
+      : null).toBe("draft story title");
+
+    await press(key("escape", "\u001b"));
+    expect(state.mode).toBe("LIBRARY");
+    expect(state.library).toBe(library);
+    expect(state.library?.prompt).toBe(prompt);
+    stop();
   });
+
+  test("cross-story recovery keeps an unsaved Settings field behind the tag manager", async () => {
+    const source = demoAppSource();
+    const fallback = source.stories.find((story) => story.id !== source.payload.id)!;
+    const recoveredPayload = { ...source.payload, id: fallback.id, title: fallback.title };
+    const connection = controlledMonitor(source.api, {
+      down: true,
+      attempt: 1,
+      nextRetryAt: null,
+      error: "offline"
+    });
+    source.connection = connection.monitor;
+    source.api.listStories = async () => [fallback];
+    const entered = deferred<void>();
+    const recovered = deferred<StoryPayload>();
+    source.api.loadStory = async () => {
+      entered.resolve();
+      return recovered.promise;
+    };
+
+    const state = initialState(source, false);
+    state.config = { ...state.config, settingsViewMode: "advanced" };
+    source.config = state.config;
+    const cache = createWrapCache<ProseStyle>();
+    const press = (event: KeyEvent) => handleKey(
+      event,
+      state,
+      source,
+      cache,
+      () => undefined,
+      async () => undefined,
+      () => undefined
+    );
+    await press(key(","));
+    const modelRow = SETTINGS_ROW_IDS.indexOf("model");
+    while (state.settings!.cursor < modelRow) await press(key("down"));
+    await press(key("return", "\r"));
+    const settings = state.settings;
+    const edit = settings?.edit;
+    if (settings === null || edit == null) throw new Error("Settings field did not open");
+    setComposerText(edit.composer, "unsaved model draft");
+    await press(ctrlP());
+
+    const palette = state.commands;
+    if (palette === null) throw new Error("palette did not open");
+    expect(palette.returnMode).toBe("SETTINGS");
+    await typeQuery(press, "tag manager");
+    await press(key("return", "\r"));
+    expect(state.commands).toBe(palette);
+    expect(state.commands?.view).toBe("tags");
+    const collidingTagNodeId = state.payload.tags[0]?.nodeId;
+    if (collidingTagNodeId === undefined) throw new Error("recovery fixture needs a tag");
+    palette.deleteArmedTagNodeId = collidingTagNodeId;
+    const adopted = deferred<void>();
+    const repaint = () => {
+      if (state.backendTask === null && state.payload === recoveredPayload) adopted.resolve();
+    };
+    const backend = new ActionRuntime(state, repaint);
+    const stop = startRecoveryOrchestration({ state, source, backend, cache, repaint });
+
+    connection.publish(connectionSucceeded());
+    await entered.promise;
+    recovered.resolve(recoveredPayload);
+    await adopted.promise;
+
+    expect(state.mode).toBe("COMMANDS");
+    expect(state.commands).toBe(palette);
+    expect(state.commands?.returnMode).toBe("SETTINGS");
+    expect(state.commands?.view).toBe("tags");
+    expect(state.commands?.deleteArmedTagNodeId).toBe(null);
+    expect(state.settings).toBe(settings);
+    expect(state.settings?.edit).toBe(edit);
+    expect(state.settings?.edit?.composer.text).toBe("unsaved model draft");
+    await press(key("D"));
+    expect(state.commands?.deleteArmedTagNodeId).toBe(collidingTagNodeId);
+    await press(key("escape", "\u001b"));
+
+    await press(key("escape", "\u001b"));
+    expect(state.mode).toBe("COMMANDS");
+    expect(state.commands).toBe(palette);
+    expect(state.commands?.view).toBe("commands");
+    expect(state.settings?.edit?.composer.text).toBe("unsaved model draft");
+    await press(key("escape", "\u001b"));
+    expect(state.mode).toBe("SETTINGS");
+    expect(state.settings?.edit).toBe(edit);
+    expect(state.settings?.edit?.composer.text).toBe("unsaved model draft");
+    stop();
+  });
+
+  test("cross-story recovery keeps a global Settings prompt behind the palette", async () => {
+    const source = demoAppSource();
+    const fallback = source.stories.find((story) => story.id !== source.payload.id)!;
+    const recoveredPayload = { ...source.payload, id: fallback.id, title: fallback.title };
+    const connection = controlledMonitor(source.api, {
+      down: true,
+      attempt: 1,
+      nextRetryAt: null,
+      error: "offline"
+    });
+    source.connection = connection.monitor;
+    source.api.listStories = async () => [fallback];
+    const entered = deferred<void>();
+    const recovered = deferred<StoryPayload>();
+    source.api.loadStory = async () => {
+      entered.resolve();
+      return recovered.promise;
+    };
+
+    const state = initialState(source, false);
+    state.config = { ...state.config, settingsViewMode: "advanced" };
+    source.config = state.config;
+    const cache = createWrapCache<ProseStyle>();
+    const press = (event: KeyEvent) => handleKey(
+      event,
+      state,
+      source,
+      cache,
+      () => undefined,
+      async () => undefined,
+      () => undefined
+    );
+    await press(key(","));
+    const row = SETTINGS_ROW_IDS.indexOf("default-author-brief");
+    while (state.settings!.cursor < row) await press(key("down"));
+    await press(key("return", "\r"));
+    const settings = state.settings;
+    const editor = state.editor;
+    if (settings === null
+      || state.mode !== "EDITOR"
+      || editor?.kind !== "document"
+      || editor.target.kind !== "settings-prompt") {
+      throw new Error("global Settings prompt did not open");
+    }
+    setComposerText(editor.composer, "unsaved global prompt");
+    await press(ctrlP());
+
+    const palette = state.commands;
+    if (palette === null) throw new Error("palette did not open");
+    expect(palette.returnMode).toBe("EDITOR");
+    const adopted = deferred<void>();
+    const repaint = () => {
+      if (state.backendTask === null && state.payload === recoveredPayload) adopted.resolve();
+    };
+    const backend = new ActionRuntime(state, repaint);
+    const stop = startRecoveryOrchestration({ state, source, backend, cache, repaint });
+
+    connection.publish(connectionSucceeded());
+    await entered.promise;
+    recovered.resolve(recoveredPayload);
+    await adopted.promise;
+
+    expect(state.mode).toBe("COMMANDS");
+    expect(state.commands).toBe(palette);
+    expect(state.commands?.returnMode).toBe("EDITOR");
+    expect(state.settings).toBe(settings);
+    expect(state.editor).toBe(editor);
+    expect(state.editor?.kind === "document" ? state.editor.composer.text : null)
+      .toBe("unsaved global prompt");
+
+    await press(key("escape", "\u001b"));
+    expect(state.mode).toBe("EDITOR");
+    expect(state.editor).toBe(editor);
+    expect(state.editor?.kind === "document" ? state.editor.composer.text : null)
+      .toBe("unsaved global prompt");
+    stop();
+  });
+
 });
+
 
 function onlineMonitor(
   api: ReturnType<typeof demoAppSource>["api"],

--- a/tui/test/recovery-reconciliation.test.ts
+++ b/tui/test/recovery-reconciliation.test.ts
@@ -1,0 +1,554 @@
+import { describe, expect, test } from "bun:test";
+import type { KeyEvent } from "@opentui/core";
+import { applyBasicSettingsDraft } from "../../shared/settings-basic-draft.js";
+import { createFailureEnvelope } from "../../shared/failure-envelope.js";
+import type { StoryPayload, StorySummary } from "../../shared/types.js";
+import { ActionRuntime, beginInteraction } from "../src/action-runtime.js";
+import { ApiHttpError } from "../src/api.js";
+import { handleKey, initialState } from "../src/app.js";
+import { createComposer, setComposerText } from "../src/composer-model.js";
+import {
+  connectionSucceeded,
+  createConnectionMonitor,
+  type ConnectionMonitor,
+  type ConnectionState
+} from "../src/connection.js";
+import { createDemoController, demoAppSource } from "../src/demo.js";
+import { openPartEditor } from "../src/editor-action.js";
+import { openMap } from "../src/map-actions.js";
+import { handleOverlayAction } from "../src/overlay-actions.js";
+import { startRecoveryOrchestration } from "../src/recovery-orchestration.js";
+import { RecoveryWarningFeed } from "../src/recovery-warning-feed.js";
+import { WorkerApiError, type WorkerRecoveryWarning } from "../src/worker-api.js";
+import { createWrapCache, type ProseStyle } from "../src/wrap.js";
+import { createStoryViewModel, rowIndexForNode, rowPart } from "../src/model.js";
+import { factRows } from "../src/facts-model.js";
+import { applyOpeningFocus } from "../src/reading-position.js";
+import { adoptReconciliationSnapshot, adoptSameStoryPayload } from "../src/story-adoption.js";
+import { createPrunePlan, createUnusedTakesPrunePlan } from "../src/prune-model.js";
+import { nextRequestContext } from "../src/request-context.js";
+import { initialSettingsOverlay, SETTINGS_ROW_IDS } from "../src/settings-overlay-model.js";
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+function key(name: string, sequence = name): KeyEvent {
+  return { name, sequence, shift: false, ctrl: false, meta: false } as KeyEvent;
+}
+
+function ctrlP(): KeyEvent {
+  return { ...key("p", "\u0010"), ctrl: true } as KeyEvent;
+}
+
+async function typeQuery(
+  press: (event: KeyEvent) => Promise<void>,
+  query: string
+): Promise<void> {
+  for (const character of query) await press(key(character));
+}
+
+describe("backend recovery orchestration", () => {
+  test("same-story warnings remain visible and acknowledge after local input", async () => {
+    const source = demoAppSource();
+    const feed = new RecoveryWarningFeed();
+    source.backendRecovery = feed;
+    const entered = deferred<void>();
+    const reload = deferred<StoryPayload>();
+    let reloads = 0;
+    source.api.loadStory = async () => {
+      reloads += 1;
+      entered.resolve();
+      return reload.promise;
+    };
+    const warning: WorkerRecoveryWarning = {
+      mutationId: "m1-local-input",
+      method: "renameStory",
+      storyId: source.payload.id,
+      resolution: "archived",
+      error: new WorkerApiError(createFailureEnvelope({
+        code: "mutation_outcome_unknown",
+        message: "Reload state.",
+        status: 409
+      }))
+    };
+    const state = initialState(source, false);
+    const cache = createWrapCache<ProseStyle>();
+    const settled = deferred<void>();
+    const repaint = () => {
+      if (state.backendTask === null
+        && state.toast === "interrupted change checked") {
+        settled.resolve();
+      }
+    };
+    const backend = new ActionRuntime(state, repaint);
+    const stop = startRecoveryOrchestration({
+      state,
+      source,
+      backend,
+      cache,
+      repaint
+    });
+
+    expect(feed.publish([warning])).toBeTrue();
+    await entered.promise;
+    beginInteraction(state);
+    reload.resolve(source.payload);
+    await settled.promise;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(state.toast).toBe("interrupted change checked");
+    expect(reloads).toBe(1);
+    expect(feed.publish([warning])).toBeFalse();
+    stop();
+  });
+
+  test("same-story recovery closes invalid newer targets but preserves a draft and focus", async () => {
+    const source = demoAppSource();
+    const feed = new RecoveryWarningFeed();
+    const entered = deferred<void>();
+    const reload = deferred<StoryPayload>();
+    const deletedLeaf = createDemoController().deleteNode("p13", 1);
+    const recoveredPayload = {
+      ...deletedLeaf,
+      title: "authoritative title",
+      chapterBreaks: deletedLeaf.chapterBreaks.filter(({ id }) => id !== "chapter-break-1"),
+      facts: deletedLeaf.facts.filter(({ id }) => id !== "fact-1")
+    };
+    source.backendRecovery = feed;
+    source.api.loadStory = async () => { entered.resolve(); return reload.promise; };
+    const state = initialState(source, false);
+    const focusId = "p12";
+    state.focusIndex = rowIndexForNode(createStoryViewModel(state.payload), focusId);
+    state.mode = "COMPOSE";
+    state.composer = createComposer("keep this draft");
+    state.viewScroll = 7;
+    state.lastViewportStart = 7;
+    const cache = createWrapCache<ProseStyle>();
+    const settled = deferred<void>();
+    const repaint = () => {
+      if (state.backendTask === null && state.payload === recoveredPayload) settled.resolve();
+    };
+    const backend = new ActionRuntime(state, repaint);
+    const stop = startRecoveryOrchestration({
+      state,
+      source,
+      backend,
+      cache,
+      repaint
+    });
+
+    feed.publish([], true);
+    await entered.promise;
+    state.undo = [{ kind: "create-break", breakId: "chapter-break-1" }];
+    state.prune = {
+      kind: "subtree", nodeId: "p13", part: 13, take: 1,
+      takeCount: 1, parts: 1, lines: 1, tags: []
+    };
+    state.tag = {
+      nodeId: "p13", name: "newer prompt", statusIndex: 0,
+      choosingStatus: false, existing: false, returnMode: "NAV"
+    };
+    state.chapterDeleteArmedId = "chapter-break-1";
+    state.chapters = {
+      cursor: 1,
+      rename: { breakId: "chapter-break-1", composer: createComposer("newer title") }, deleteArmedId: "chapter-break-1"
+    };
+    state.facts = {
+      cursor: 0, query: "", chip: 0, selectedTag: null, filtering: false, deleteArmedId: "fact-1"
+    };
+
+    reload.resolve(recoveredPayload);
+    await settled.promise;
+
+    expect(state.mode).toBe("COMPOSE");
+    expect(state.composer.text).toBe("keep this draft");
+    expect(rowPart(createStoryViewModel(state.payload), state.focusIndex)?.id).toBe(focusId);
+    expect(state.viewScroll).toBe(7);
+    expect(state.lastViewportStart).toBe(7);
+    expect(state.undo).toEqual([]);
+    expect(state.prune).toBe(null);
+    expect(state.tag).toBe(null);
+    expect(state.chapterDeleteArmedId).toBe(null);
+    expect(state.chapters?.rename).toBe(null);
+    expect(state.chapters?.deleteArmedId).toBe(null);
+    expect(state.facts?.deleteArmedId).toBe(null);
+    stop();
+  });
+
+  test("same-story recovery preserves target-valid prompts opened while loading", async () => {
+    const source = demoAppSource();
+    const feed = new RecoveryWarningFeed();
+    const entered = deferred<void>();
+    const reload = deferred<StoryPayload>();
+    const prunedLeaf = createDemoController().deleteNode("p13", 1);
+    const recoveredPayload = {
+      ...prunedLeaf,
+      title: "authoritative title",
+      tags: [...prunedLeaf.tags, {
+        ...source.payload.tags[0]!,
+        nodeId: "p12-t4",
+        name: "remote tag"
+      }]
+    };
+    source.backendRecovery = feed;
+    source.api.loadStory = async () => { entered.resolve(); return reload.promise; };
+    const state = initialState(source, false);
+    const settled = deferred<void>();
+    const repaint = () => {
+      if (state.backendTask === null && state.payload === recoveredPayload) settled.resolve();
+    };
+    const backend = new ActionRuntime(state, repaint);
+    const stop = startRecoveryOrchestration({
+      state,
+      source,
+      backend,
+      cache: createWrapCache<ProseStyle>(),
+      repaint
+    });
+
+    feed.publish([], true);
+    await entered.promise;
+    const prune = createPrunePlan(state.payload, "p12")!;
+    const tag = {
+      nodeId: "p12-t4", name: "typed while loading", statusIndex: 2,
+      choosingStatus: true, existing: false, returnMode: "NAV" as const
+    };
+    const rename = { breakId: "chapter-break-1", composer: createComposer("typed chapter title") };
+    state.undo = [{ kind: "create-break", breakId: "chapter-break-1" }];
+    state.prune = prune;
+    state.tag = tag;
+    state.mode = "TAG";
+    state.chapters = { cursor: 1, rename, deleteArmedId: "chapter-break-2" };
+    state.facts = {
+      cursor: 0, query: "", chip: 0, selectedTag: null, filtering: false, deleteArmedId: "fact-1"
+    };
+
+    reload.resolve(recoveredPayload);
+    await settled.promise;
+
+    expect(state.undo).toEqual([]);
+    expect(state.prune).toBe(prune);
+    expect(state.prune).toMatchObject({ kind: "subtree", nodeId: "p12", parts: 1 });
+    expect(state.tag).toBe(tag);
+    expect(state.tag).toMatchObject({
+      name: "typed while loading", choosingStatus: true, existing: true
+    });
+    expect(state.mode).toBe("TAG");
+    expect(state.chapters?.rename).toBe(rename);
+    expect(state.chapters?.deleteArmedId).toBe("chapter-break-2");
+    expect(state.facts?.deleteArmedId).toBe("fact-1");
+    stop();
+  });
+
+  test("same-story recovery reconciles a semantic panel and keeps its valid confirmation", async () => {
+    const source = demoAppSource();
+    const feed = new RecoveryWarningFeed();
+    const selectedId = source.payload.facts[1]!.id;
+    const recoveredPayload = { ...source.payload, facts: [...source.payload.facts].reverse() };
+    source.backendRecovery = feed;
+    source.api.loadStory = async () => recoveredPayload;
+    const state = initialState(source, false);
+    const facts = {
+      cursor: 1, query: "", chip: 0, selectedTag: null, filtering: false, deleteArmedId: selectedId
+    };
+    state.mode = "FACTS";
+    state.facts = facts;
+    const settled = deferred<void>();
+    const repaint = () => {
+      if (state.backendTask === null && state.payload === recoveredPayload) settled.resolve();
+    };
+    const backend = new ActionRuntime(state, repaint);
+    const stop = startRecoveryOrchestration({
+      state,
+      source,
+      backend,
+      cache: createWrapCache<ProseStyle>(),
+      repaint
+    });
+
+    feed.publish([], true);
+    await settled.promise;
+
+    expect(state.mode).toBe("FACTS");
+    expect(state.facts).toBe(facts);
+    expect(factRows(state.payload.facts, null, "")[state.facts!.cursor]?.id).toBe(selectedId);
+    expect(state.facts!.deleteArmedId).toBe(selectedId);
+    stop();
+  });
+
+  test("reconciliation refreshes whole-story prune safety metadata and closes an empty preview", () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const preview = createUnusedTakesPrunePlan(state.payload)!;
+    const reducedPayload = createDemoController().deleteNode("p12-t1", 1);
+    state.prune = preview;
+
+    adoptReconciliationSnapshot(state, reducedPayload, createWrapCache<ProseStyle>());
+
+    expect(state.prune).toBe(preview);
+    expect(state.prune).toMatchObject({ kind: "unused-takes", takes: 4, parts: 4 });
+
+    const emptyState = initialState(demoAppSource(), false);
+    emptyState.prune = createUnusedTakesPrunePlan(emptyState.payload);
+    const activeIds = new Set(emptyState.payload.path.map(({ id }) => id));
+    const activeLineOnly = {
+      ...emptyState.payload,
+      nodes: emptyState.payload.nodes.filter(({ id }) => activeIds.has(id)),
+      tags: emptyState.payload.tags.filter(({ nodeId }) => activeIds.has(nodeId))
+    };
+    adoptReconciliationSnapshot(emptyState, activeLineOnly, createWrapCache<ProseStyle>());
+    expect(emptyState.prune).toBe(null);
+  });
+
+  test("reconciliation drops a stale Generation Profile import prompt", () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    state.mode = "SETTINGS";
+    state.settings = initialSettingsOverlay(source.settingsView, state.config);
+    state.settings.profileTransfer = {
+      phase: "file", path: "/tmp/stale.preset", candidates: [], error: null
+    };
+
+    adoptReconciliationSnapshot(
+      state,
+      { ...state.payload, id: "recovered-story" },
+      createWrapCache<ProseStyle>()
+    );
+
+    expect(state.settings).toBe(null);
+    expect(state.mode).toBe("NAV");
+  });
+
+  test("direct chapter deletion remains armed only on the surviving focused divider", () => {
+    const source = demoAppSource();
+    const state = initialState(source, false);
+    const view = createStoryViewModel(state.payload);
+    state.focusIndex = view.rows.findIndex((row) =>
+      row.kind === "chapter-divider" && row.break.id === "chapter-break-1");
+    state.chapterDeleteArmedId = "chapter-break-1";
+
+    adoptReconciliationSnapshot(state, { ...state.payload, title: "refreshed" }, createWrapCache<ProseStyle>());
+    expect(state.chapterDeleteArmedId).toBe("chapter-break-1");
+
+    state.focusIndex = rowIndexForNode(createStoryViewModel(state.payload), "p12");
+    adoptReconciliationSnapshot(state, { ...state.payload, title: "refreshed again" }, createWrapCache<ProseStyle>());
+    expect(state.chapterDeleteArmedId).toBe(null);
+  });
+
+  test("reconciliation repairs removed map and action targets without leaving a dead mode", () => {
+    const recoveredPayload = createDemoController().deleteNode("p13", 1);
+
+    const tagState = initialState(demoAppSource(), false);
+    tagState.mode = "TAG";
+    tagState.map = {
+      view: "path", pathCursorId: "p13", pathShowAllTakes: true, treeCursorId: "p13", rowIds: [],
+      showSketches: false, openedColdFolds: new Set(), massSort: "size"
+    };
+    tagState.tag = {
+      nodeId: "p13", name: "stale", statusIndex: 0,
+      choosingStatus: false, existing: false, returnMode: "MAP"
+    };
+    adoptReconciliationSnapshot(tagState, recoveredPayload, createWrapCache<ProseStyle>());
+    expect(tagState.tag).toBe(null);
+    expect(tagState.mode).toBe("MAP");
+    expect(tagState.map?.pathCursorId).toBe(recoveredPayload.path.at(-1)?.id);
+
+    const actionsState = initialState(demoAppSource(), false);
+    actionsState.mode = "ACTIONS";
+    actionsState.actions = {
+      cursor: 0,
+      partId: "p13",
+      selectionText: null
+    };
+    adoptReconciliationSnapshot(actionsState, recoveredPayload, createWrapCache<ProseStyle>());
+    expect(actionsState.actions).toBe(null);
+    expect(actionsState.mode).toBe("NAV");
+  });
+
+  test("same-story reconciliation retargets a palette away from removed owners", async () => {
+    const recoveredPayload = createDemoController().deleteNode("p13", 1);
+    const pressEscape = (
+      state: ReturnType<typeof initialState>,
+      source: ReturnType<typeof demoAppSource>,
+      cache: ReturnType<typeof createWrapCache<ProseStyle>>
+    ) => handleKey(
+      key("escape", "\u001b"),
+      state,
+      source,
+      cache,
+      () => undefined,
+      async () => undefined,
+      () => undefined
+    );
+
+    const actionsSource = demoAppSource();
+    const actionsState = initialState(actionsSource, false);
+    actionsState.actions = { cursor: 0, partId: "p13", selectionText: null };
+    actionsState.mode = "COMMANDS";
+    actionsState.commands = {
+      query: "", cursor: 0, selectedId: null, view: "commands", returnMode: "ACTIONS"
+    };
+    const actionsCache = createWrapCache<ProseStyle>();
+    adoptSameStoryPayload(actionsState, recoveredPayload, actionsCache);
+    expect(actionsState.actions).toBe(null);
+    expect(actionsState.mode).toBe("COMMANDS");
+    expect(actionsState.commands?.returnMode).toBe("NAV");
+    await pressEscape(actionsState, actionsSource, actionsCache);
+    expect(actionsState.mode).toBe("NAV");
+
+    const tagSource = demoAppSource();
+    const tagState = initialState(tagSource, false);
+    openMap(tagState);
+    tagState.tag = {
+      nodeId: "p13", name: "stale", statusIndex: 0,
+      choosingStatus: false, existing: false, returnMode: "MAP"
+    };
+    tagState.mode = "COMMANDS";
+    tagState.commands = {
+      query: "", cursor: 0, selectedId: null, view: "commands", returnMode: "TAG"
+    };
+    const tagCache = createWrapCache<ProseStyle>();
+    adoptSameStoryPayload(tagState, recoveredPayload, tagCache);
+    expect(tagState.tag).toBe(null);
+    expect(tagState.mode).toBe("COMMANDS");
+    expect(tagState.commands?.returnMode).toBe("MAP");
+    await pressEscape(tagState, tagSource, tagCache);
+    expect(tagState.mode).toBe("MAP");
+    expect(tagState.map).not.toBe(null);
+
+    const editorSource = demoAppSource();
+    const editorState = initialState(editorSource, false);
+    editorState.focusIndex = rowIndexForNode(createStoryViewModel(editorState.payload), "p13");
+    openPartEditor(editorState, false);
+    editorState.editor!.returnMode = "FACTS";
+    editorState.facts = {
+      cursor: 0, query: "", chip: 0, selectedTag: null, filtering: false, deleteArmedId: null
+    };
+    editorState.mode = "COMMANDS";
+    editorState.commands = {
+      query: "", cursor: 0, selectedId: null, view: "commands", returnMode: "EDITOR"
+    };
+    const editorCache = createWrapCache<ProseStyle>();
+    adoptSameStoryPayload(editorState, recoveredPayload, editorCache);
+    expect(editorState.editor).toBe(null);
+    expect(editorState.mode).toBe("COMMANDS");
+    expect(editorState.commands?.returnMode).toBe("FACTS");
+    await pressEscape(editorState, editorSource, editorCache);
+    expect(editorState.mode).toBe("FACTS");
+
+    const mapSource = demoAppSource();
+    const mapState = initialState(mapSource, false);
+    openMap(mapState);
+    mapState.mode = "COMMANDS";
+    mapState.commands = {
+      query: "", cursor: 0, selectedId: null, view: "commands", returnMode: "MAP"
+    };
+    const emptyPayload = {
+      ...mapSource.payload,
+      nodes: [], path: [], activeRootId: null, tags: [], recentNodeIds: [], facts: [], chapterBreaks: []
+    };
+    const mapCache = createWrapCache<ProseStyle>();
+    adoptSameStoryPayload(mapState, emptyPayload, mapCache);
+    expect(mapState.map).toBe(null);
+    expect(mapState.mode).toBe("COMMANDS");
+    expect(mapState.commands?.returnMode).toBe("NAV");
+    await pressEscape(mapState, mapSource, mapCache);
+    expect(mapState.mode).toBe("NAV");
+  });
+});
+
+
+function onlineMonitor(
+  api: ReturnType<typeof demoAppSource>["api"],
+  retryNow: () => Promise<boolean>
+): ConnectionMonitor {
+  return {
+    api,
+    state: connectionSucceeded,
+    retryNow,
+    subscribe: () => () => undefined,
+    dispose: () => undefined
+  };
+}
+
+function transitioningMonitor(api: ReturnType<typeof demoAppSource>["api"]): ConnectionMonitor {
+  let current: ConnectionState = {
+    down: true,
+    attempt: 1,
+    nextRetryAt: null,
+    error: "offline"
+  };
+  let listener: ((state: ConnectionState) => void) | null = null;
+  return {
+    api,
+    state: () => ({ ...current }),
+    async retryNow() {
+      current = connectionSucceeded();
+      listener?.(current);
+      return true;
+    },
+    subscribe(next) {
+      listener = next;
+      return () => { listener = null; };
+    },
+    dispose: () => undefined
+  };
+}
+
+function controlledMonitor(
+  api: ReturnType<typeof demoAppSource>["api"],
+  initial: ConnectionState
+): { monitor: ConnectionMonitor; publish(connection: ConnectionState): void } {
+  let current = initial;
+  let listener: ((state: ConnectionState) => void) | null = null;
+  return {
+    monitor: {
+      api,
+      state: () => ({ ...current }),
+      retryNow: async () => !current.down,
+      subscribe(next) {
+        listener = next;
+        return () => { listener = null; };
+      },
+      dispose: () => undefined
+    },
+    publish(connection) {
+      current = connection;
+      listener?.(connection);
+    }
+  };
+}
+
+
+/** Fire once per adoption commit. reconcileWrapCache reads partIds() exactly
+ * once for a same-story snapshot and calls one full invalidate() for a
+ * different story, so either signal marks one committed reconciliation. */
+function reconcileSpyCache(onReconcile: () => void): ReturnType<typeof createWrapCache<ProseStyle>> {
+  const cache = createWrapCache<ProseStyle>();
+  return {
+    wrap: (partId, width, text, runs, identity) => cache.wrap(partId, width, text, runs, identity),
+    lineCount: (partId, width, text, identity) => cache.lineCount(partId, width, text, identity),
+    isWarm: (partId, width, text, runs, identity) => cache.isWarm(partId, width, text, runs, identity),
+    appendCandidate: (partId, width, appendStart) => cache.appendCandidate(partId, width, appendStart),
+    prime: (partId, width, text, runs, lines, identity) => cache.prime(partId, width, text, runs, lines, identity),
+    invalidate: (partId) => {
+      if (partId === undefined) onReconcile();
+      cache.invalidate(partId);
+    },
+    rebind: (partId, source, textLength) => cache.rebind(partId, source, textLength),
+    partIds: () => {
+      onReconcile();
+      return cache.partIds();
+    },
+    get epoch() { return cache.epoch; },
+    get revision() { return cache.revision; },
+    get hits() { return cache.hits; },
+    get misses() { return cache.misses; }
+  };
+}

--- a/tui/test/recovery-reconnect-orchestration.test.ts
+++ b/tui/test/recovery-reconnect-orchestration.test.ts
@@ -1,0 +1,643 @@
+import { describe, expect, test } from "bun:test";
+import type { KeyEvent } from "@opentui/core";
+import { applyBasicSettingsDraft } from "../../shared/settings-basic-draft.js";
+import { createFailureEnvelope } from "../../shared/failure-envelope.js";
+import type { StoryPayload, StorySummary } from "../../shared/types.js";
+import { ActionRuntime, beginInteraction } from "../src/action-runtime.js";
+import { ApiHttpError } from "../src/api.js";
+import { handleKey, initialState } from "../src/app.js";
+import { createComposer, setComposerText } from "../src/composer-model.js";
+import {
+  connectionSucceeded,
+  createConnectionMonitor,
+  type ConnectionMonitor,
+  type ConnectionState
+} from "../src/connection.js";
+import { createDemoController, demoAppSource } from "../src/demo.js";
+import { handleOverlayAction } from "../src/overlay-actions.js";
+import { startRecoveryOrchestration } from "../src/recovery-orchestration.js";
+import { RecoveryWarningFeed } from "../src/recovery-warning-feed.js";
+import { WorkerApiError, type WorkerRecoveryWarning } from "../src/worker-api.js";
+import { createWrapCache, type ProseStyle } from "../src/wrap.js";
+import { createStoryViewModel, rowIndexForNode, rowPart } from "../src/model.js";
+import { factRows } from "../src/facts-model.js";
+import { applyOpeningFocus } from "../src/reading-position.js";
+import { adoptReconciliationSnapshot } from "../src/story-adoption.js";
+import { createPrunePlan, createUnusedTakesPrunePlan } from "../src/prune-model.js";
+import { nextRequestContext } from "../src/request-context.js";
+import { initialSettingsOverlay, SETTINGS_ROW_IDS } from "../src/settings-overlay-model.js";
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+function key(name: string, sequence = name): KeyEvent {
+  return { name, sequence, shift: false, ctrl: false, meta: false } as KeyEvent;
+}
+
+function ctrlP(): KeyEvent {
+  return { ...key("p", "\u0010"), ctrl: true } as KeyEvent;
+}
+
+async function typeQuery(
+  press: (event: KeyEvent) => Promise<void>,
+  query: string
+): Promise<void> {
+  for (const character of query) await press(key(character));
+}
+
+describe("backend recovery orchestration", () => {
+  test("an automatic reconnect refreshes every generation setting projection", async () => {
+    const source = demoAppSource();
+    const connection = controlledMonitor(source.api, {
+      down: true, attempt: 1, nextRetryAt: null, error: "offline"
+    });
+    source.connection = connection.monitor;
+    const recoveredPayload = { ...source.payload, title: "fresh automatic reconnect" };
+    const recoveredSettings = {
+      ...source.settings,
+      provider: "anthropic" as const,
+      baseUrl: "https://api.anthropic.com",
+      model: "claude-sonnet-4-6",
+      systemPrompt: "Use the server's fresh voice.",
+      contextWindow: 8_192
+    };
+    if (!source.settingsView.editable) throw new Error("demo settings must be editable");
+    const recoveredView = {
+      ...source.settingsView,
+      document: applyBasicSettingsDraft(source.settingsView.document, recoveredSettings),
+      effective: recoveredSettings,
+      effectiveProse: recoveredSettings
+    };
+    let settingsLoads = 0;
+    const discoveryEntered = deferred<void>();
+    const discoverModels = source.api.discoverModels;
+    source.api.discoverModels = async (target, signal) => {
+      discoveryEntered.resolve();
+      return discoverModels(target, signal);
+    };
+    source.api.loadStory = async () => recoveredPayload;
+    source.api.getSettings = async () => {
+      settingsLoads += 1;
+      return recoveredView;
+    };
+    const state = initialState(source, false);
+    state.mode = "SETTINGS";
+    state.settings = initialSettingsOverlay(source.settingsView, state.config);
+    const settled = deferred<void>();
+    const repaint = () => {
+      if (state.backendTask === null && state.payload === recoveredPayload) settled.resolve();
+    };
+    const backend = new ActionRuntime(state, repaint);
+    const stop = startRecoveryOrchestration({
+      state,
+      source,
+      backend,
+      cache: createWrapCache<ProseStyle>(),
+      repaint
+    });
+
+    connection.publish(connectionSucceeded());
+    await settled.promise;
+    await discoveryEntered.promise;
+    await backend.whenIdle();
+
+    expect(settingsLoads).toBe(1);
+    expect(source.settings).toBe(recoveredSettings);
+    expect(state.settings?.draft.generation).toEqual(recoveredSettings);
+    expect(state.model).toBe(recoveredSettings.model);
+    expect(state.contextWindow).toBe(recoveredSettings.contextWindow);
+    expect(state.systemPrompt).toBe(recoveredSettings.systemPrompt);
+    expect(state.assistantPrefill).toBeFalse();
+    expect(nextRequestContext(state)).toMatchObject({
+      systemPrompt: recoveredSettings.systemPrompt,
+      assistantPrefill: false
+    });
+    stop();
+  });
+
+  test("a newer reconnect transition supersedes an in-flight automatic snapshot", async () => {
+    const source = demoAppSource();
+    const connection = controlledMonitor(source.api, {
+      down: true, attempt: 1, nextRetryAt: null, error: "offline"
+    });
+    source.connection = connection.monitor;
+    const stale = { ...source.payload, title: "stale first reconnect" };
+    const fresh = { ...source.payload, title: "fresh second reconnect" };
+    const staleSettings = { ...source.settings, model: "stale reconnect model" };
+    const freshSettings = { ...source.settings, model: "fresh reconnect model" };
+    const first = deferred<StoryPayload>();
+    const second = deferred<StoryPayload>();
+    const firstEntered = deferred<void>();
+    const secondEntered = deferred<void>();
+    let loads = 0;
+    let settingsLoads = 0;
+    source.api.getSettings = async () => {
+      settingsLoads += 1;
+      return {
+        ...source.settingsView,
+        effective: settingsLoads === 1 ? staleSettings : freshSettings,
+        effectiveProse: settingsLoads === 1 ? staleSettings : freshSettings
+      };
+    };
+    source.api.loadStory = async () => {
+      loads += 1;
+      if (loads === 1) {
+        firstEntered.resolve();
+        return first.promise;
+      }
+      secondEntered.resolve();
+      return second.promise;
+    };
+    const state = initialState(source, false);
+    const adopted = deferred<void>();
+    const repaint = () => {
+      if (state.backendTask === null && state.payload === fresh) adopted.resolve();
+    };
+    const backend = new ActionRuntime(state, repaint);
+    const stop = startRecoveryOrchestration({
+      state,
+      source,
+      backend,
+      cache: createWrapCache<ProseStyle>(),
+      repaint
+    });
+
+    connection.publish(connectionSucceeded());
+    await firstEntered.promise;
+    connection.publish({ down: true, attempt: 2, nextRetryAt: null, error: "offline again" });
+    connection.publish(connectionSucceeded());
+    first.resolve(stale);
+    await secondEntered.promise;
+
+    expect(state.payload).not.toBe(stale);
+    expect(source.settings).not.toBe(staleSettings);
+    second.resolve(fresh);
+    await adopted.promise;
+
+    expect(loads).toBe(2);
+    expect(settingsLoads).toBe(2);
+    expect(state.payload).toBe(fresh);
+    expect(source.settings).toBe(freshSettings);
+    expect(state.model).toBe(freshSettings.model);
+    stop();
+  });
+
+  test("a publish-boundary reconnect drains under the same automatic owner", async () => {
+    const source = demoAppSource();
+    const connection = controlledMonitor(source.api, {
+      down: true, attempt: 1, nextRetryAt: null, error: "offline"
+    });
+    source.connection = connection.monitor;
+    const stalePayload = { ...source.payload, title: "stale publish-boundary snapshot" };
+    const freshPayload = { ...source.payload, title: "fresh publish-boundary snapshot" };
+    const freshLoad = deferred<StoryPayload>();
+    const freshEntered = deferred<void>();
+    let storyLoads = 0;
+    source.api.loadStory = async () => {
+      storyLoads += 1;
+      if (storyLoads === 1) return stalePayload;
+      freshEntered.resolve();
+      return freshLoad.promise;
+    };
+    const state = initialState(source, false);
+    const adopted = deferred<void>();
+    const repaint = () => {
+      if (state.backendTask === null && state.payload === freshPayload) adopted.resolve();
+    };
+    const backend = new ActionRuntime(state, repaint);
+    let firstOwnerId: number | null = null;
+    let invalidations = 0;
+    const stop = startRecoveryOrchestration({
+      state,
+      source,
+      backend,
+      cache: reconcileSpyCache(() => {
+        invalidations += 1;
+        if (invalidations === 1) {
+          firstOwnerId = state.backendTask?.id ?? null;
+          queueMicrotask(() => {
+            connection.publish({ down: true, attempt: 1, nextRetryAt: null, error: "boundary outage" });
+            connection.publish(connectionSucceeded());
+          });
+        }
+      }),
+      repaint
+    });
+
+    connection.publish(connectionSucceeded());
+    await freshEntered.promise;
+
+    expect(firstOwnerId).not.toBe(null);
+    expect(state.backendTask).toMatchObject({
+      id: firstOwnerId,
+      kind: "connection-reconcile"
+    });
+    let competingMutationRan = false;
+    expect(await backend.run("competing mutation", async () => {
+      competingMutationRan = true;
+    })).toBeFalse();
+    expect(competingMutationRan).toBeFalse();
+
+    freshLoad.resolve(freshPayload);
+    await adopted.promise;
+
+    expect(storyLoads).toBe(2);
+    expect(state.payload).toBe(freshPayload);
+    expect(state.backendTask).toBe(null);
+    stop();
+  });
+
+  test("a stale error cannot settle a newer intent across its async return boundary", async () => {
+    const source = demoAppSource();
+    const connection = controlledMonitor(source.api, {
+      down: true, attempt: 1, nextRetryAt: null, error: "offline"
+    });
+    source.connection = connection.monitor;
+    const staleLoad = deferred<StoryPayload>();
+    const staleEntered = deferred<void>();
+    const freshLoad = deferred<StoryPayload>();
+    const freshEntered = deferred<void>();
+    const freshPayload = { ...source.payload, title: "fresh after stale error" };
+    let storyLoads = 0;
+    source.api.loadStory = async () => {
+      storyLoads += 1;
+      if (storyLoads === 1) {
+        staleEntered.resolve();
+        return staleLoad.promise;
+      }
+      freshEntered.resolve();
+      return freshLoad.promise;
+    };
+    const state = initialState(source, false);
+    const adopted = deferred<void>();
+    const repaint = () => {
+      if (state.backendTask === null && state.payload === freshPayload) adopted.resolve();
+    };
+    const backend = new ActionRuntime(state, repaint);
+    const stop = startRecoveryOrchestration({
+      state,
+      source,
+      backend,
+      cache: createWrapCache<ProseStyle>(),
+      repaint
+    });
+
+    connection.publish(connectionSucceeded());
+    await staleEntered.promise;
+    const firstOwnerId = state.backendTask?.id ?? null;
+    staleLoad.reject(new ApiHttpError(createFailureEnvelope({
+      code: "internal",
+      message: "obsolete recovery error",
+      status: 500
+    })));
+    // Three chained promise turns place the transition after reconcileOwned's
+    // failure result but before its backend owner accepts that result.
+    let boundary = Promise.resolve();
+    for (let turn = 0; turn < 3; turn += 1) boundary = boundary.then(() => undefined);
+    void boundary.then(() => {
+      connection.publish({ down: true, attempt: 1, nextRetryAt: null, error: "boundary outage" });
+      connection.publish(connectionSucceeded());
+    });
+    await freshEntered.promise;
+
+    expect(firstOwnerId).not.toBe(null);
+    expect(state.backendTask).toMatchObject({
+      id: firstOwnerId,
+      kind: "connection-reconcile"
+    });
+    expect(state.toast).not.toBe("obsolete recovery error");
+    freshLoad.resolve(freshPayload);
+    await adopted.promise;
+
+    expect(storyLoads).toBe(2);
+    expect(state.payload).toBe(freshPayload);
+    expect(state.toast).toBe("reconnected · story reloaded");
+    stop();
+  });
+
+  test("a reconnect supersedes warning recovery without stale publication or releasing its owner", async () => {
+    const source = demoAppSource();
+    const feed = new RecoveryWarningFeed();
+    const connection = controlledMonitor(source.api, connectionSucceeded());
+    source.backendRecovery = feed;
+    source.connection = connection.monitor;
+    const originalPayload = source.payload;
+    const originalStories = source.stories;
+    const originalSettings = source.settings;
+    const stalePayload = { ...source.payload, title: "stale warning recovery" };
+    const freshPayload = { ...source.payload, title: "fresh warning recovery" };
+    const staleStories = source.stories.map((story) => story.id === source.payload.id
+      ? { ...story, title: stalePayload.title }
+      : story);
+    const freshStories = source.stories.map((story) => story.id === source.payload.id
+      ? { ...story, title: freshPayload.title }
+      : story);
+    const staleSettings = { ...source.settings, model: "stale warning model" };
+    const freshSettings = { ...source.settings, model: "fresh warning model" };
+    const staleLoad = deferred<StoryPayload>();
+    const freshLoad = deferred<StoryPayload>();
+    const staleEntered = deferred<void>();
+    const freshEntered = deferred<void>();
+    let catalogLoads = 0;
+    let settingsLoads = 0;
+    let storyLoads = 0;
+    source.api.listStories = async () => {
+      catalogLoads += 1;
+      return catalogLoads === 1 ? staleStories : freshStories;
+    };
+    source.api.getSettings = async () => {
+      settingsLoads += 1;
+      return {
+        ...source.settingsView,
+        effective: settingsLoads === 1 ? staleSettings : freshSettings,
+        effectiveProse: settingsLoads === 1 ? staleSettings : freshSettings
+      };
+    };
+    source.api.loadStory = async () => {
+      storyLoads += 1;
+      if (storyLoads === 1) {
+        staleEntered.resolve();
+        return staleLoad.promise;
+      }
+      freshEntered.resolve();
+      return freshLoad.promise;
+    };
+    const state = initialState(source, false);
+    const adopted = deferred<void>();
+    const repaint = () => {
+      if (state.backendTask === null && state.payload === freshPayload) adopted.resolve();
+    };
+    const backend = new ActionRuntime(state, repaint);
+    const stop = startRecoveryOrchestration({
+      state,
+      source,
+      backend,
+      cache: createWrapCache<ProseStyle>(),
+      repaint
+    });
+
+    feed.publish([], true);
+    await staleEntered.promise;
+    connection.publish({ down: true, attempt: 1, nextRetryAt: null, error: "offline again" });
+    connection.publish(connectionSucceeded());
+    staleLoad.resolve(stalePayload);
+    await freshEntered.promise;
+
+    expect(state.payload).toBe(originalPayload);
+    expect(source.stories).toBe(originalStories);
+    expect(source.settings).toBe(originalSettings);
+    expect(state.backendTask).toMatchObject({
+      kind: "connection-reconcile",
+      label: "recovering backend state"
+    });
+    let competingMutationRan = false;
+    const admitted = await backend.run("competing mutation", async () => {
+      competingMutationRan = true;
+    });
+    expect(admitted).toBeFalse();
+    expect(competingMutationRan).toBeFalse();
+    expect(state.backendTask?.label).toBe("recovering backend state");
+
+    freshLoad.resolve(freshPayload);
+    await adopted.promise;
+
+    expect(catalogLoads).toBe(2);
+    expect(settingsLoads).toBe(2);
+    expect(storyLoads).toBe(2);
+    expect(state.payload).toBe(freshPayload);
+    expect(source.stories).toBe(freshStories);
+    expect(source.settings).toBe(freshSettings);
+    expect(state.backendTask).toBe(null);
+    stop();
+  });
+
+  test("disposal rejects an automatic snapshot that settles late", async () => {
+    const source = demoAppSource();
+    const connection = controlledMonitor(source.api, {
+      down: true, attempt: 1, nextRetryAt: null, error: "offline"
+    });
+    source.connection = connection.monitor;
+    const entered = deferred<void>();
+    const reload = deferred<StoryPayload>();
+    const late = { ...source.payload, title: "must not land after disposal" };
+    source.api.loadStory = async () => {
+      entered.resolve();
+      return reload.promise;
+    };
+    const state = initialState(source, false);
+    const original = state.payload;
+    const settled = deferred<void>();
+    let requestStarted = false;
+    const repaint = () => {
+      if (requestStarted && state.backendTask === null) settled.resolve();
+    };
+    const backend = new ActionRuntime(state, repaint);
+    const stop = startRecoveryOrchestration({
+      state,
+      source,
+      backend,
+      cache: createWrapCache<ProseStyle>(),
+      repaint
+    });
+
+    connection.publish(connectionSucceeded());
+    await entered.promise;
+    requestStarted = true;
+    stop();
+    reload.resolve(late);
+    await settled.promise;
+
+    expect(state.payload).toBe(original);
+    expect(state.toast).not.toBe("reconnected · story reloaded");
+  });
+
+  test("a clean startup recovery reloads without announcing itself", async () => {
+    // Every start publishes an empty warning batch to force this reload, so a
+    // toast here fires on every launch and reports bookkeeping the reader never
+    // saw go wrong. The reload still has to happen.
+    const source = demoAppSource();
+    const feed = new RecoveryWarningFeed();
+    const recoveredPayload = { ...source.payload };
+    source.backendRecovery = feed;
+    let reloads = 0;
+    source.api.loadStory = async () => { reloads += 1; return recoveredPayload; };
+    const state = initialState(source, false);
+    const settled = deferred<void>();
+    const repaint = () => {
+      if (state.backendTask === null && state.payload === recoveredPayload) settled.resolve();
+    };
+    const backend = new ActionRuntime(state, repaint);
+    const stop = startRecoveryOrchestration({
+      state,
+      source,
+      backend,
+      cache: createWrapCache<ProseStyle>(),
+      repaint
+    });
+
+    feed.publish([], true);
+    await settled.promise;
+
+    expect(reloads).toBe(1);
+    expect(state.toast).toBe(null);
+    stop();
+  });
+
+  test("generation recovery retires the provider record before reloading", async () => {
+    const source = demoAppSource();
+    const feed = new RecoveryWarningFeed();
+    source.backendRecovery = feed;
+    const calls: string[] = [];
+    source.api.acknowledgeUnknownOutcomes = async (
+      storyId,
+      originalProviderMutationId
+    ) => {
+      expect(feed.publish([warning])).toBeFalse();
+      calls.push(`retire:${storyId}:${originalProviderMutationId}`);
+      return source.payload;
+    };
+    source.api.loadStory = async (storyId) => {
+      calls.push(`load:${storyId}`);
+      return source.payload;
+    };
+    const warning: WorkerRecoveryWarning = {
+      mutationId: "m1-generation-recovery",
+      method: "continueStory",
+      storyId: source.payload.id,
+      resolution: "archived",
+      error: new WorkerApiError(createFailureEnvelope({
+        code: "generation_outcome_unknown",
+        message: "Provider outcome is unknown.",
+        status: 409
+      }))
+    };
+    const state = initialState(source, false);
+    const settled = deferred<void>();
+    const repaint = () => {
+      if (state.backendTask === null
+        && calls.includes(`load:${source.payload.id}`)) {
+        settled.resolve();
+      }
+    };
+    const backend = new ActionRuntime(state, repaint);
+    const stop = startRecoveryOrchestration({
+      state,
+      source,
+      backend,
+      cache: createWrapCache<ProseStyle>(),
+      repaint
+    });
+
+    expect(feed.publish([warning])).toBeTrue();
+    await settled.promise;
+
+    expect(calls).toEqual([
+      `retire:${source.payload.id}:${warning.mutationId}`,
+      `load:${source.payload.id}`
+    ]);
+    expect(state.toast).toBe(
+      "something interrupted the model · you can try again"
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(feed.publish([warning])).toBeFalse();
+    stop();
+  });
+
+});
+
+
+function onlineMonitor(
+  api: ReturnType<typeof demoAppSource>["api"],
+  retryNow: () => Promise<boolean>
+): ConnectionMonitor {
+  return {
+    api,
+    state: connectionSucceeded,
+    retryNow,
+    subscribe: () => () => undefined,
+    dispose: () => undefined
+  };
+}
+
+function transitioningMonitor(api: ReturnType<typeof demoAppSource>["api"]): ConnectionMonitor {
+  let current: ConnectionState = {
+    down: true,
+    attempt: 1,
+    nextRetryAt: null,
+    error: "offline"
+  };
+  let listener: ((state: ConnectionState) => void) | null = null;
+  return {
+    api,
+    state: () => ({ ...current }),
+    async retryNow() {
+      current = connectionSucceeded();
+      listener?.(current);
+      return true;
+    },
+    subscribe(next) {
+      listener = next;
+      return () => { listener = null; };
+    },
+    dispose: () => undefined
+  };
+}
+
+function controlledMonitor(
+  api: ReturnType<typeof demoAppSource>["api"],
+  initial: ConnectionState
+): { monitor: ConnectionMonitor; publish(connection: ConnectionState): void } {
+  let current = initial;
+  let listener: ((state: ConnectionState) => void) | null = null;
+  return {
+    monitor: {
+      api,
+      state: () => ({ ...current }),
+      retryNow: async () => !current.down,
+      subscribe(next) {
+        listener = next;
+        return () => { listener = null; };
+      },
+      dispose: () => undefined
+    },
+    publish(connection) {
+      current = connection;
+      listener?.(connection);
+    }
+  };
+}
+
+
+/** Fire once per adoption commit. reconcileWrapCache reads partIds() exactly
+ * once for a same-story snapshot and calls one full invalidate() for a
+ * different story, so either signal marks one committed reconciliation. */
+function reconcileSpyCache(onReconcile: () => void): ReturnType<typeof createWrapCache<ProseStyle>> {
+  const cache = createWrapCache<ProseStyle>();
+  return {
+    wrap: (partId, width, text, runs, identity) => cache.wrap(partId, width, text, runs, identity),
+    lineCount: (partId, width, text, identity) => cache.lineCount(partId, width, text, identity),
+    isWarm: (partId, width, text, runs, identity) => cache.isWarm(partId, width, text, runs, identity),
+    appendCandidate: (partId, width, appendStart) => cache.appendCandidate(partId, width, appendStart),
+    prime: (partId, width, text, runs, lines, identity) => cache.prime(partId, width, text, runs, lines, identity),
+    invalidate: (partId) => {
+      if (partId === undefined) onReconcile();
+      cache.invalidate(partId);
+    },
+    rebind: (partId, source, textLength) => cache.rebind(partId, source, textLength),
+    partIds: () => {
+      onReconcile();
+      return cache.partIds();
+    },
+    get epoch() { return cache.epoch; },
+    get revision() { return cache.revision; },
+    get hits() { return cache.hits; },
+    get misses() { return cache.misses; }
+  };
+}

--- a/tui/test/recovery-retry-orchestration.test.ts
+++ b/tui/test/recovery-retry-orchestration.test.ts
@@ -1,0 +1,532 @@
+import { describe, expect, test } from "bun:test";
+import type { KeyEvent } from "@opentui/core";
+import { applyBasicSettingsDraft } from "../../shared/settings-basic-draft.js";
+import { createFailureEnvelope } from "../../shared/failure-envelope.js";
+import type { StoryPayload, StorySummary } from "../../shared/types.js";
+import { ActionRuntime, beginInteraction } from "../src/action-runtime.js";
+import { ApiHttpError } from "../src/api.js";
+import { handleKey, initialState } from "../src/app.js";
+import { createComposer, setComposerText } from "../src/composer-model.js";
+import {
+  connectionSucceeded,
+  createConnectionMonitor,
+  type ConnectionMonitor,
+  type ConnectionState
+} from "../src/connection.js";
+import { createDemoController, demoAppSource } from "../src/demo.js";
+import { handleOverlayAction } from "../src/overlay-actions.js";
+import { startRecoveryOrchestration } from "../src/recovery-orchestration.js";
+import { RecoveryWarningFeed } from "../src/recovery-warning-feed.js";
+import { WorkerApiError, type WorkerRecoveryWarning } from "../src/worker-api.js";
+import { createWrapCache, type ProseStyle } from "../src/wrap.js";
+import { createStoryViewModel, rowIndexForNode, rowPart } from "../src/model.js";
+import { factRows } from "../src/facts-model.js";
+import { applyOpeningFocus } from "../src/reading-position.js";
+import { adoptReconciliationSnapshot } from "../src/story-adoption.js";
+import { createPrunePlan, createUnusedTakesPrunePlan } from "../src/prune-model.js";
+import { nextRequestContext } from "../src/request-context.js";
+import { initialSettingsOverlay, SETTINGS_ROW_IDS } from "../src/settings-overlay-model.js";
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+function key(name: string, sequence = name): KeyEvent {
+  return { name, sequence, shift: false, ctrl: false, meta: false } as KeyEvent;
+}
+
+function ctrlP(): KeyEvent {
+  return { ...key("p", "\u0010"), ctrl: true } as KeyEvent;
+}
+
+async function typeQuery(
+  press: (event: KeyEvent) => Promise<void>,
+  query: string
+): Promise<void> {
+  for (const character of query) await press(key(character));
+}
+
+describe("backend recovery orchestration", () => {
+  test("an explicit retry while online reloads the current story and library", async () => {
+    const source = demoAppSource();
+    const recoveredPayload = { ...source.payload, title: "recovered story title" };
+    const recoveredStories: StorySummary[] = source.stories.map((story) =>
+      story.id === recoveredPayload.id ? { ...story, title: recoveredPayload.title } : story);
+    let retries = 0;
+    let storyLoads = 0;
+    let catalogLoads = 0;
+    source.api.loadStory = async () => { storyLoads += 1; return recoveredPayload; };
+    source.api.listStories = async () => { catalogLoads += 1; return recoveredStories; };
+    source.connection = onlineMonitor(source.api, async () => { retries += 1; return true; });
+    const state = initialState(source, false);
+    state.library = { stories: source.stories, cursor: 0, query: "", prompt: null };
+    state.mode = "LIBRARY";
+    const cache = createWrapCache<ProseStyle>();
+    const backend = new ActionRuntime(state, () => undefined);
+
+    await handleOverlayAction({ action: "retry" }, state, source, {
+      backend,
+      cache,
+      repaint: () => undefined,
+      renderer: null,
+      applyTheme: () => undefined,
+      previewTheme: () => undefined
+    });
+
+    expect(retries).toBe(1);
+    expect(storyLoads).toBe(1);
+    expect(catalogLoads).toBe(1);
+    expect(state.payload).toBe(recoveredPayload);
+    expect(source.stories).toBe(recoveredStories);
+    expect(state.library?.stories).toBe(recoveredStories);
+    expect(state.toast).toBe("reconnected · story reloaded");
+  });
+
+  test("an explicit retry adopts a surviving fallback without losing a draft", async () => {
+    const source = demoAppSource();
+    const fallback = source.stories.find((story) => story.id !== source.payload.id)!;
+    const recoveredPayload = { ...source.payload, id: fallback.id, title: fallback.title };
+    source.api.listStories = async () => [fallback];
+    source.api.loadStory = async (storyId) => {
+      expect(storyId).toBe(fallback.id);
+      return recoveredPayload;
+    };
+    source.connection = onlineMonitor(source.api, async () => true);
+    const state = initialState(source, false);
+    state.mode = "COMPOSE";
+    state.composer = createComposer("keep this draft");
+    state.focusIndex = 0;
+    const cache = createWrapCache<ProseStyle>();
+    const backend = new ActionRuntime(state, () => undefined);
+
+    await handleOverlayAction({ action: "retry" }, state, source, {
+      backend,
+      cache,
+      repaint: () => undefined,
+      renderer: null,
+      applyTheme: () => undefined,
+      previewTheme: () => undefined
+    });
+
+    expect(state.payload).toBe(recoveredPayload);
+    expect(source.stories).toEqual([fallback]);
+    expect(state.mode).toBe("COMPOSE");
+    expect(state.composer.text).toBe("keep this draft");
+    expect(state.focusIndex).toBe(
+      applyOpeningFocus(state.payload, state.readingPositions)
+    );
+  });
+
+  test("an input-safe explicit retry surfaces a 404 and remains retryable", async () => {
+    const source = demoAppSource();
+    const recoveredPayload = { ...source.payload, title: "recovered after retry" };
+    let retries = 0;
+    let storyLoads = 0;
+    let failReload = true;
+    source.connection = onlineMonitor(source.api, async () => { retries += 1; return true; });
+    source.api.loadStory = async () => {
+      storyLoads += 1;
+      if (failReload) {
+        throw new ApiHttpError(createFailureEnvelope({
+          code: "not_found",
+          message: "story reload failed (404)",
+          status: 404
+        }));
+      }
+      return recoveredPayload;
+    };
+    const state = initialState(source, false);
+    state.mode = "COMPOSE";
+    state.composer = createComposer("keep this draft");
+    const cache = createWrapCache<ProseStyle>();
+    const failed = deferred<void>();
+    const adopted = deferred<void>();
+    const repaint = () => {
+      if (state.backendTask === null && state.toast === "story reload failed (404)") failed.resolve();
+      if (state.backendTask === null && state.payload === recoveredPayload) adopted.resolve();
+    };
+    const backend = new ActionRuntime(state, repaint);
+    const context = {
+      backend,
+      cache,
+      repaint,
+      renderer: null,
+      applyTheme: () => undefined,
+      previewTheme: () => undefined
+    };
+
+    backend.observe(handleOverlayAction({ action: "retry" }, state, source, context));
+    await failed.promise;
+
+    expect(state.composer.text).toBe("keep this draft");
+    expect(state.mode).toBe("COMPOSE");
+    expect(state.toast).toBe("story reload failed (404)");
+    expect(state.backendTask).toBe(null);
+
+    failReload = false;
+    backend.observe(handleOverlayAction({ action: "retry" }, state, source, context));
+    await adopted.promise;
+
+    expect(retries).toBe(2);
+    expect(storyLoads).toBe(2);
+    expect(state.payload).toBe(recoveredPayload);
+    expect(state.composer.text).toBe("keep this draft");
+  });
+
+  test("an explicit offline retry coalesces its connection transition reload", async () => {
+    const source = demoAppSource();
+    const monitor = transitioningMonitor(source.api);
+    source.connection = monitor;
+    let storyLoads = 0;
+    let catalogLoads = 0;
+    let settingsLoads = 0;
+    source.api.loadStory = async () => { storyLoads += 1; return source.payload; };
+    source.api.listStories = async () => { catalogLoads += 1; return source.stories; };
+    source.api.getSettings = async () => { settingsLoads += 1; return source.settingsView; };
+    const state = initialState(source, false);
+    const cache = createWrapCache<ProseStyle>();
+    const backend = new ActionRuntime(state, () => undefined);
+    const stop = startRecoveryOrchestration({
+      state,
+      source,
+      backend,
+      cache,
+      repaint: () => undefined
+    });
+
+    await handleOverlayAction({ action: "retry" }, state, source, {
+      backend,
+      cache,
+      repaint: () => undefined,
+      renderer: null,
+      applyTheme: () => undefined,
+      previewTheme: () => undefined
+    });
+    await new Promise((resolve) => setTimeout(resolve, 150));
+
+    expect(storyLoads).toBe(1);
+    expect(catalogLoads).toBe(1);
+    expect(settingsLoads).toBe(1);
+    stop();
+  });
+
+  test("a real monitor supersession cannot publish stale explicit retry state or expose idle", async () => {
+    const source = demoAppSource();
+    const raw = source.api;
+    const originalPayload = source.payload;
+    const originalStories = source.stories;
+    const originalSettings = source.settings;
+    const stalePayload = { ...source.payload, title: "stale explicit retry" };
+    const freshPayload = { ...source.payload, title: "fresh explicit retry" };
+    const staleStories = source.stories.map((story) => story.id === source.payload.id
+      ? { ...story, title: stalePayload.title }
+      : story);
+    const freshStories = source.stories.map((story) => story.id === source.payload.id
+      ? { ...story, title: freshPayload.title }
+      : story);
+    const staleSettings = { ...source.settings, model: "stale explicit model" };
+    const freshSettings = { ...source.settings, model: "fresh explicit model" };
+    const alreadyFiredProbe = deferred<StorySummary[]>();
+    const staleLoad = deferred<StoryPayload>();
+    const freshLoad = deferred<StoryPayload>();
+    const staleEntered = deferred<void>();
+    const freshEntered = deferred<void>();
+    let catalogLoads = 0;
+    let settingsLoads = 0;
+    let storyLoads = 0;
+    raw.listStories = async () => {
+      catalogLoads += 1;
+      if (catalogLoads === 1) throw new Error("initial monitor outage");
+      if (catalogLoads === 2) return alreadyFiredProbe.promise;
+      if (catalogLoads === 4) return staleStories;
+      if (catalogLoads === 5) throw new Error("current monitor outage");
+      if (catalogLoads >= 6) return freshStories;
+      return originalStories;
+    };
+    raw.getSettings = async () => {
+      settingsLoads += 1;
+      return {
+        ...source.settingsView,
+        effective: settingsLoads === 1 ? staleSettings : freshSettings,
+        effectiveProse: settingsLoads === 1 ? staleSettings : freshSettings
+      };
+    };
+    raw.loadStory = async () => {
+      storyLoads += 1;
+      if (storyLoads === 1) {
+        staleEntered.resolve();
+        return staleLoad.promise;
+      }
+      freshEntered.resolve();
+      return freshLoad.promise;
+    };
+    const monitor = createConnectionMonitor(raw);
+    source.connection = monitor;
+    source.api = monitor.api;
+    await source.api.listStories().catch(() => undefined);
+    expect(monitor.state().down).toBeTrue();
+    const obsoleteProbeResult = monitor.retryNow();
+
+    const state = initialState(source, false);
+    const cache = createWrapCache<ProseStyle>();
+    const backend = new ActionRuntime(state, () => undefined);
+    const stop = startRecoveryOrchestration({
+      state,
+      source,
+      backend,
+      cache,
+      repaint: () => undefined
+    });
+    const retry = handleOverlayAction({ action: "retry" }, state, source, {
+      backend,
+      cache,
+      repaint: () => undefined,
+      renderer: null,
+      applyTheme: () => undefined,
+      previewTheme: () => undefined
+    });
+
+    await staleEntered.promise;
+    alreadyFiredProbe.reject(new Error("obsolete probe failed after reconnect"));
+    expect(await obsoleteProbeResult).toBeTrue();
+    expect(monitor.state().down).toBeFalse();
+    expect(await monitor.retryNow()).toBeFalse();
+    staleLoad.resolve(stalePayload);
+    await freshEntered.promise;
+
+    expect(state.payload).toBe(originalPayload);
+    expect(source.stories).toBe(originalStories);
+    expect(source.settings).toBe(originalSettings);
+    expect(state.backendTask?.kind).toBe("explicit-retry");
+    let competingMutationRan = false;
+    const admitted = await backend.run("competing mutation", async () => {
+      competingMutationRan = true;
+    });
+    expect(admitted).toBeFalse();
+    expect(competingMutationRan).toBeFalse();
+    expect(state.backendTask?.kind).toBe("explicit-retry");
+
+    freshLoad.resolve(freshPayload);
+    await retry;
+
+    expect(catalogLoads).toBe(6);
+    expect(settingsLoads).toBe(2);
+    expect(storyLoads).toBe(2);
+    expect(state.payload).toBe(freshPayload);
+    expect(source.stories).toBe(freshStories);
+    expect(source.settings).toBe(freshSettings);
+    expect(state.backendTask).toBe(null);
+    stop();
+    monitor.dispose();
+  });
+
+  test("an online explicit retry drains a boundary recovery under the same owner", async () => {
+    const source = demoAppSource();
+    const connection = controlledMonitor(source.api, connectionSucceeded());
+    source.connection = connection.monitor;
+    const stalePayload = { ...source.payload, title: "stale online explicit snapshot" };
+    const freshPayload = { ...source.payload, title: "fresh online explicit snapshot" };
+    const freshLoad = deferred<StoryPayload>();
+    const freshEntered = deferred<void>();
+    let storyLoads = 0;
+    source.api.loadStory = async () => {
+      storyLoads += 1;
+      if (storyLoads === 1) return stalePayload;
+      freshEntered.resolve();
+      return freshLoad.promise;
+    };
+    const state = initialState(source, false);
+    const backend = new ActionRuntime(state, () => undefined);
+    let firstOwnerId: number | null = null;
+    let invalidations = 0;
+    const stop = startRecoveryOrchestration({
+      state,
+      source,
+      backend,
+      cache: reconcileSpyCache(() => {
+        invalidations += 1;
+        if (invalidations === 1) {
+          firstOwnerId = state.backendTask?.id ?? null;
+          queueMicrotask(() => {
+            connection.publish({ down: true, attempt: 1, nextRetryAt: null, error: "boundary outage" });
+            connection.publish(connectionSucceeded());
+          });
+        }
+      }),
+      repaint: () => undefined
+    });
+
+    let retrySettled = false;
+    const retry = stop.retry().then(() => { retrySettled = true; });
+    await freshEntered.promise;
+
+    expect(firstOwnerId).not.toBe(null);
+    expect(state.backendTask).toMatchObject({ id: firstOwnerId, kind: "explicit-retry" });
+    expect(retrySettled).toBeFalse();
+    let competingMutationRan = false;
+    expect(await backend.run("competing mutation", async () => {
+      competingMutationRan = true;
+    })).toBeFalse();
+    expect(competingMutationRan).toBeFalse();
+
+    freshLoad.resolve(freshPayload);
+    await retry;
+
+    expect(storyLoads).toBe(2);
+    expect(state.payload).toBe(freshPayload);
+    expect(state.backendTask).toBe(null);
+    stop();
+  });
+
+  test("an online explicit probe leaves a changed-story boundary recovery to automatic ownership", async () => {
+    const source = demoAppSource();
+    const connection = controlledMonitor(source.api, connectionSucceeded());
+    source.connection = connection.monitor;
+    const fallback = source.stories.find((story) => story.id !== source.payload.id)!;
+    const stalePayload = { ...source.payload, id: fallback.id, title: "stale explicit fallback" };
+    const freshPayload = { ...stalePayload, title: "fresh automatic fallback" };
+    source.api.listStories = async () => [fallback];
+    const freshLoad = deferred<StoryPayload>();
+    const freshEntered = deferred<void>();
+    let storyLoads = 0;
+    source.api.loadStory = async (storyId) => {
+      expect(storyId).toBe(fallback.id);
+      storyLoads += 1;
+      if (storyLoads === 1) return stalePayload;
+      freshEntered.resolve();
+      return freshLoad.promise;
+    };
+    const state = initialState(source, false);
+    const adopted = deferred<void>();
+    const repaint = () => {
+      if (state.backendTask === null && state.payload === freshPayload) adopted.resolve();
+    };
+    const backend = new ActionRuntime(state, repaint);
+    let invalidations = 0;
+    const stop = startRecoveryOrchestration({
+      state,
+      source,
+      backend,
+      cache: reconcileSpyCache(() => {
+        invalidations += 1;
+        if (invalidations === 1) {
+          queueMicrotask(() => {
+            connection.publish({ down: true, attempt: 1, nextRetryAt: null, error: "boundary outage" });
+            connection.publish(connectionSucceeded());
+          });
+        }
+      }),
+      repaint
+    });
+
+    await stop.retry();
+    await freshEntered.promise;
+
+    expect(state.payload).toBe(stalePayload);
+    expect(state.backendTask).toMatchObject({ kind: "connection-reconcile", storyId: fallback.id });
+    freshLoad.resolve(freshPayload);
+    await adopted.promise;
+
+    expect(storyLoads).toBe(2);
+    expect(state.payload).toBe(freshPayload);
+    expect(state.connection.down).toBeFalse();
+    stop();
+  });
+
+});
+
+
+function onlineMonitor(
+  api: ReturnType<typeof demoAppSource>["api"],
+  retryNow: () => Promise<boolean>
+): ConnectionMonitor {
+  return {
+    api,
+    state: connectionSucceeded,
+    retryNow,
+    subscribe: () => () => undefined,
+    dispose: () => undefined
+  };
+}
+
+function transitioningMonitor(api: ReturnType<typeof demoAppSource>["api"]): ConnectionMonitor {
+  let current: ConnectionState = {
+    down: true,
+    attempt: 1,
+    nextRetryAt: null,
+    error: "offline"
+  };
+  let listener: ((state: ConnectionState) => void) | null = null;
+  return {
+    api,
+    state: () => ({ ...current }),
+    async retryNow() {
+      current = connectionSucceeded();
+      listener?.(current);
+      return true;
+    },
+    subscribe(next) {
+      listener = next;
+      return () => { listener = null; };
+    },
+    dispose: () => undefined
+  };
+}
+
+function controlledMonitor(
+  api: ReturnType<typeof demoAppSource>["api"],
+  initial: ConnectionState
+): { monitor: ConnectionMonitor; publish(connection: ConnectionState): void } {
+  let current = initial;
+  let listener: ((state: ConnectionState) => void) | null = null;
+  return {
+    monitor: {
+      api,
+      state: () => ({ ...current }),
+      retryNow: async () => !current.down,
+      subscribe(next) {
+        listener = next;
+        return () => { listener = null; };
+      },
+      dispose: () => undefined
+    },
+    publish(connection) {
+      current = connection;
+      listener?.(connection);
+    }
+  };
+}
+
+
+/** Fire once per adoption commit. reconcileWrapCache reads partIds() exactly
+ * once for a same-story snapshot and calls one full invalidate() for a
+ * different story, so either signal marks one committed reconciliation. */
+function reconcileSpyCache(onReconcile: () => void): ReturnType<typeof createWrapCache<ProseStyle>> {
+  const cache = createWrapCache<ProseStyle>();
+  return {
+    wrap: (partId, width, text, runs, identity) => cache.wrap(partId, width, text, runs, identity),
+    lineCount: (partId, width, text, identity) => cache.lineCount(partId, width, text, identity),
+    isWarm: (partId, width, text, runs, identity) => cache.isWarm(partId, width, text, runs, identity),
+    appendCandidate: (partId, width, appendStart) => cache.appendCandidate(partId, width, appendStart),
+    prime: (partId, width, text, runs, lines, identity) => cache.prime(partId, width, text, runs, lines, identity),
+    invalidate: (partId) => {
+      if (partId === undefined) onReconcile();
+      cache.invalidate(partId);
+    },
+    rebind: (partId, source, textLength) => cache.rebind(partId, source, textLength),
+    partIds: () => {
+      onReconcile();
+      return cache.partIds();
+    },
+    get epoch() { return cache.epoch; },
+    get revision() { return cache.revision; },
+    get hits() { return cache.hits; },
+    get misses() { return cache.misses; }
+  };
+}

--- a/tui/test/request-viewer.test.ts
+++ b/tui/test/request-viewer.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, test } from "bun:test";
 import type { KeyEvent, MouseEvent } from "@opentui/core";
 import { dispatch, handleKey, initialState } from "../src/app.js";
+import { createAsideSurface } from "../src/aside-surface.js";
 import { setComposerText } from "../src/composer-model.js";
 import { commandPaletteModel } from "../src/command-model.js";
 import { openRetakeComposer } from "../src/composer-ownership.js";
 import { demoAppSource } from "../src/demo.js";
+import { openAuthorsNoteEditor } from "../src/editor-action.js";
 import { captureMouseActionState, mouseToAction } from "../src/mouse-actions.js";
 import {
   reconcilePresentedMouseAction,
@@ -522,6 +524,59 @@ describe("next request viewer", () => {
       expect(state.mode).toBe("COMPOSE");
       expect(state.composer).toBe(composer);
       expect(state.retakePrompt).toBe(retakeOwner);
+    }
+  });
+
+  test("the palette restores exact Aside and editor owners after next request", async () => {
+    const cases = [
+      {
+        setup: (state: ReturnType<typeof initialState>) => {
+          const aside = createAsideSurface(state.payload.id, state.payload.title);
+          setComposerText(aside.composer, "Keep this Aside draft.");
+          state.aside = aside;
+          state.mode = "ASIDE" as const;
+          return { mode: "ASIDE" as const, owner: aside, draft: aside.composer.text };
+        }
+      },
+      {
+        setup: (state: ReturnType<typeof initialState>) => {
+          openAuthorsNoteEditor(state);
+          if (state.editor === null || state.editor.kind !== "document") {
+            throw new Error("Author's Note editor did not open");
+          }
+          setComposerText(state.editor.composer, "Keep this editor draft.");
+          return { mode: "EDITOR" as const, owner: state.editor, draft: state.editor.composer.text };
+        }
+      }
+    ];
+
+    for (const scenario of cases) {
+      const { source, state } = harness();
+      const retained = scenario.setup(state);
+      const run = (action: Parameters<typeof dispatch>[0]) => dispatch(
+        action, state, source, createWrapCache(),
+        () => undefined, async () => undefined, () => undefined
+      );
+
+      await run({ action: "open-commands" });
+      state.commands = {
+        query: "next request",
+        cursor: 0,
+        selectedId: "next-request",
+        view: "commands",
+        returnMode: retained.mode
+      };
+      await run({ action: "open-selected" });
+
+      expect(state.mode).toBe("REQUEST");
+      expect(state.request?.returnMode).toBe(retained.mode);
+      expect(state.editor ?? state.aside).toBe(retained.owner);
+      expect(state.editor?.composer.text ?? state.aside?.composer.text).toBe(retained.draft);
+
+      await run({ action: "cancel" });
+      expect(state.mode).toBe(retained.mode);
+      expect(state.editor ?? state.aside).toBe(retained.owner);
+      expect(state.editor?.composer.text ?? state.aside?.composer.text).toBe(retained.draft);
     }
   });
 


### PR DESCRIPTION
## Outcome

The command palette now opens from every TUI surface. It keeps the exact
screen, draft, selection, and cursor that was active before it opened.

## Changes

- Add contextual commands for all Fact, Fact State, Fact editor, and Fact map
  controls.
- Replace the Facts Budget document editor with a compact numeric field.
- Keep command targets stable across mouse input, story refreshes, and delayed
  operations.
- Make command access, paste, Aside quit, and existing panel controls consistent
  across keyboard and mouse input.
- Preserve existing store shapes. This change does not require a migration.
- Document the global command access and Facts Budget behavior.

## Verification

- `bun run typecheck`
- `bun run test` — all 16 shards passed
- `bun run build:standalone`
- `bun bench/perf.ts`
- `npm run build`
- `npm test` — 2,815 passed, 229 skipped, 0 failed
- Autoreview — clean
- Thermo-nuclear code quality review — approved; clean and not overengineered
- `git diff --check`

## Risk

The main risk is transient-surface ownership while an asynchronous operation
settles. Integration tests cover Direct, Aside, editors, Facts, Map,
Probabilities, Generation Records, Search, recovery, and story changes.

Tracks #382
