### PR TITLE
chore(release): prepare 0.10.7-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This file records notable changes to 1667. Product terms use the definitions in
 
 ## Unreleased
 
+## 0.10.7-rc.1 - 2026-09-01
+
 - **The command palette is available from every screen.** Press `Ctrl+P` from
   Aside, editors, menus, and full-screen panels. Close the palette to return to
   the exact screen and input that you were using.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "1667-workspace",
-  "version": "0.10.6",
+  "version": "0.10.7-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "1667-workspace",
-      "version": "0.10.6",
+      "version": "0.10.7-rc.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@earendil-works/pi-ai": "0.84.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667-workspace",
-  "version": "0.10.6",
+  "version": "0.10.7-rc.1",
   "private": true,
   "description": "Source workspace for the 1667 terminal writing environment",
   "license": "Apache-2.0",

--- a/shared/release-notes.ts
+++ b/shared/release-notes.ts
@@ -11,6 +11,11 @@ export interface ReleaseNote {
  *  a release, and is not included. */
 export const RELEASE_NOTES: readonly ReleaseNote[] = [
   {
+    version: "0.10.7-rc.1",
+    date: "2026-09-01",
+    body: "- **The command palette is available from every screen.** Press `Ctrl+P` from\n  Aside, editors, menus, and full-screen panels. Close the palette to return to\n  the exact screen and input that you were using.\n- **The command palette covers all Fact controls.** Create, edit, end, move,\n  re-anchor, convert, and delete Facts and Fact States. The available commands\n  follow the selected Fact, state, story part, or map row.\n- **The Facts Budget command uses a numeric field.** Enter a token limit, clear\n  the field for no limit, and save with `Enter` or `Ctrl+S`. The field works\n  with the keyboard and mouse."
+  },
+  {
     version: "0.10.6",
     date: "2026-08-31",
     body: "- **This release has no additional product changes.** It contains the same\n  behavior as 0.10.6-rc.1."

--- a/tui/package.json
+++ b/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667",
-  "version": "0.10.6",
+  "version": "0.10.7-rc.1",
   "private": true,
   "description": "A terminal environment for writing fiction with language models",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Outcome

Prepare `0.10.7-rc.1` for beta publication.

## Changes

- Set the root, TUI, and lockfile versions to `0.10.7-rc.1`.
- Add the dated beta section to the changelog.
- Regenerate the embedded release notes.

## Verification

- `npm run notes:check-version -- 0.10.7-rc.1`
- `npm run build`
- `npm test` — 2,815 passed, 229 skipped, 0 failed
- `bun run typecheck`
- `bun run test` — all 16 shards passed
- `bun run build:standalone`
- `bun bench/perf.ts`
- `git diff --check`

Tracks #382
