### PR TITLE
chore(release): prepare 0.10.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ This file records notable changes to 1667. Product terms use the definitions in
 
 ## Unreleased
 
+## 0.10.7 - 2026-09-01
+
+- **This release has no additional product changes.** It contains the same
+  behavior as 0.10.7-rc.1.
+
 ## 0.10.7-rc.1 - 2026-09-01
 
 - **The command palette is available from every screen.** Press `Ctrl+P` from

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "1667-workspace",
-  "version": "0.10.7-rc.1",
+  "version": "0.10.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "1667-workspace",
-      "version": "0.10.7-rc.1",
+      "version": "0.10.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@earendil-works/pi-ai": "0.84.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667-workspace",
-  "version": "0.10.7-rc.1",
+  "version": "0.10.7",
   "private": true,
   "description": "Source workspace for the 1667 terminal writing environment",
   "license": "Apache-2.0",

--- a/shared/release-notes.ts
+++ b/shared/release-notes.ts
@@ -11,6 +11,11 @@ export interface ReleaseNote {
  *  a release, and is not included. */
 export const RELEASE_NOTES: readonly ReleaseNote[] = [
   {
+    version: "0.10.7",
+    date: "2026-09-01",
+    body: "- **This release has no additional product changes.** It contains the same\n  behavior as 0.10.7-rc.1."
+  },
+  {
     version: "0.10.7-rc.1",
     date: "2026-09-01",
     body: "- **The command palette is available from every screen.** Press `Ctrl+P` from\n  Aside, editors, menus, and full-screen panels. Close the palette to return to\n  the exact screen and input that you were using.\n- **The command palette covers all Fact controls.** Create, edit, end, move,\n  re-anchor, convert, and delete Facts and Fact States. The available commands\n  follow the selected Fact, state, story part, or map row.\n- **The Facts Budget command uses a numeric field.** Enter a token limit, clear\n  the field for no limit, and save with `Enter` or `Ctrl+S`. The field works\n  with the keyboard and mouse."

--- a/tui/package.json
+++ b/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667",
-  "version": "0.10.7-rc.1",
+  "version": "0.10.7",
   "private": true,
   "description": "A terminal environment for writing fiction with language models",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Outcome

Prepare stable 0.10.7 from the published and verified 0.10.7-rc.1 source.
This release has no additional product changes.

## Changes

- Set the root and TUI versions to 0.10.7.
- Add the stable changelog entry.
- Regenerate the bundled release notes.

## Verification

- `npm run build`
- `npm test`: 2,815 passed, 229 skipped, 0 failed
- `bun run typecheck`
- `bun run test`: all 16 shards passed
- `bun run build:standalone`
- `npm run notes:check-version -- 0.10.7`
- Performance timing requires the isolated CI runner. The local host had unrelated load above 60 during the timing gate.

## Risk

Low. This commit changes release metadata only. It uses the exact source that
published 0.10.7-rc.1.

Tracks #382
