### PR TITLE
chore(release): prepare 0.10.8-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ This file records notable changes to 1667. Product terms use the definitions in
 
 ## Unreleased
 
+## 0.10.8-rc.1 - 2026-09-01
+
+- **Model selectors use the same controls.** Use Left/Right or click the arrows
+  for discovered and subscription models. Press Enter to open the searchable
+  model list. Unavailable controls no longer show actions that do not work.
+- **Subscription requests omit unsupported temperature.** ChatGPT and Claude
+  subscription requests keep your saved temperature preference, but do not
+  send it to providers that reject the field.
+
 ## 0.10.7 - 2026-09-01
 
 - **This release has no additional product changes.** It contains the same

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "1667-workspace",
-  "version": "0.10.7",
+  "version": "0.10.8-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "1667-workspace",
-      "version": "0.10.7",
+      "version": "0.10.8-rc.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@earendil-works/pi-ai": "0.84.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667-workspace",
-  "version": "0.10.7",
+  "version": "0.10.8-rc.1",
   "private": true,
   "description": "Source workspace for the 1667 terminal writing environment",
   "license": "Apache-2.0",

--- a/shared/release-notes.ts
+++ b/shared/release-notes.ts
@@ -11,6 +11,11 @@ export interface ReleaseNote {
  *  a release, and is not included. */
 export const RELEASE_NOTES: readonly ReleaseNote[] = [
   {
+    version: "0.10.8-rc.1",
+    date: "2026-09-01",
+    body: "- **Model selectors use the same controls.** Use Left/Right or click the arrows\n  for discovered and subscription models. Press Enter to open the searchable\n  model list. Unavailable controls no longer show actions that do not work.\n- **Subscription requests omit unsupported temperature.** ChatGPT and Claude\n  subscription requests keep your saved temperature preference, but do not\n  send it to providers that reject the field."
+  },
+  {
     version: "0.10.7",
     date: "2026-09-01",
     body: "- **This release has no additional product changes.** It contains the same\n  behavior as 0.10.7-rc.1."

--- a/tui/package.json
+++ b/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667",
-  "version": "0.10.7",
+  "version": "0.10.8-rc.1",
   "private": true,
   "description": "A terminal environment for writing fiction with language models",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Outcome

Prepare `0.10.8-rc.1` for beta publication.

## Changes

- Set the root, TUI, and lockfile versions to `0.10.8-rc.1`.
- Add the dated beta section to the changelog.
- Regenerate the embedded release notes.

## Verification

- `npm run notes:check-version -- 0.10.8-rc.1`
- `npm run build`
- `npm test` — 2,816 passed, 229 skipped, 0 failed
- `bun run typecheck`
- `bun run test` — all 16 shards passed
- `bun run build:standalone`
- `bun bench/perf.ts` — passed before the release-only metadata change; local reruns were load-sensitive, so CI remains the merge gate
- `git diff --check`

Tracks #385