### PR TITLE
chore(release): prepare 0.10.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ This file records notable changes to 1667. Product terms use the definitions in
 
 ## Unreleased
 
+## 0.10.8 - 2026-09-01
+
+- **This release has no additional product changes.** It contains the same
+  behavior as 0.10.8-rc.1.
+
 ## 0.10.8-rc.1 - 2026-09-01
 
 - **Model selectors use the same controls.** Use Left/Right or click the arrows

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "1667-workspace",
-  "version": "0.10.8-rc.1",
+  "version": "0.10.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "1667-workspace",
-      "version": "0.10.8-rc.1",
+      "version": "0.10.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@earendil-works/pi-ai": "0.84.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667-workspace",
-  "version": "0.10.8-rc.1",
+  "version": "0.10.8",
   "private": true,
   "description": "Source workspace for the 1667 terminal writing environment",
   "license": "Apache-2.0",

--- a/shared/release-notes.ts
+++ b/shared/release-notes.ts
@@ -11,6 +11,11 @@ export interface ReleaseNote {
  *  a release, and is not included. */
 export const RELEASE_NOTES: readonly ReleaseNote[] = [
   {
+    version: "0.10.8",
+    date: "2026-09-01",
+    body: "- **This release has no additional product changes.** It contains the same\n  behavior as 0.10.8-rc.1."
+  },
+  {
     version: "0.10.8-rc.1",
     date: "2026-09-01",
     body: "- **Model selectors use the same controls.** Use Left/Right or click the arrows\n  for discovered and subscription models. Press Enter to open the searchable\n  model list. Unavailable controls no longer show actions that do not work.\n- **Subscription requests omit unsupported temperature.** ChatGPT and Claude\n  subscription requests keep your saved temperature preference, but do not\n  send it to providers that reject the field."

--- a/tui/package.json
+++ b/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667",
-  "version": "0.10.8-rc.1",
+  "version": "0.10.8",
   "private": true,
   "description": "A terminal environment for writing fiction with language models",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Outcome

Prepare the stable 0.10.8 publication. This release contains the same product behavior as 0.10.8-rc.1.

## Changes

- Set workspace and TUI versions to 0.10.8.
- Add the stable changelog entry.
- Regenerate release notes.

## Verification

- `npm run build`
- `npm test`
- `cd tui && npm test`
- `cd tui && npm run typecheck`
- `cd tui && npm run build:standalone`
- `npm run notes:check-version -- 0.10.8`
- `git diff --check`

Tracks #385