### PR TITLE
chore(release): prepare 0.10.9-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This file records notable changes to 1667. Product terms use the definitions in
 
 ## Unreleased
 
+## 0.10.9-rc.1 - 2026-09-02
+
 - **An optional Apparatus shows inactive take previews.** Turn it on in the
   experimental Settings group. Press `1` and a shown letter to select a take.
   The experiment is off by default.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "1667-workspace",
-  "version": "0.10.8",
+  "version": "0.10.9-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "1667-workspace",
-      "version": "0.10.8",
+      "version": "0.10.9-rc.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@earendil-works/pi-ai": "0.84.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667-workspace",
-  "version": "0.10.8",
+  "version": "0.10.9-rc.1",
   "private": true,
   "description": "Source workspace for the 1667 terminal writing environment",
   "license": "Apache-2.0",

--- a/shared/release-notes.ts
+++ b/shared/release-notes.ts
@@ -11,6 +11,11 @@ export interface ReleaseNote {
  *  a release, and is not included. */
 export const RELEASE_NOTES: readonly ReleaseNote[] = [
   {
+    version: "0.10.9-rc.1",
+    date: "2026-09-02",
+    body: "- **An optional Apparatus shows inactive take previews.** Turn it on in the\n  experimental Settings group. Press `1` and a shown letter to select a take.\n  The experiment is off by default."
+  },
+  {
     version: "0.10.8",
     date: "2026-09-01",
     body: "- **This release has no additional product changes.** It contains the same\n  behavior as 0.10.8-rc.1."

--- a/tui/package.json
+++ b/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667",
-  "version": "0.10.8",
+  "version": "0.10.9-rc.1",
   "private": true,
   "description": "A terminal environment for writing fiction with language models",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary

- Set the workspace and TUI versions to `0.10.9-rc.1`.
- Add the Apparatus beta release notes.
- Regenerate the release-note source.

Tracks #390

## Verification

- `npm run notes:check-version -- 0.10.9-rc.1`
- `npm run build`
- `git diff --check`