### PR TITLE
fix(tui): separate apparatus from story text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This file records notable changes to 1667. Product terms use the definitions in
 
 ## Unreleased
 
+- **The Apparatus has a clear closing edge.** A labeled rule separates inactive
+  take previews from the next story part.
+
 ## 0.10.9-rc.1 - 2026-09-02
 
 - **An optional Apparatus shows inactive take previews.** Turn it on in the

--- a/docs/apparatus.md
+++ b/docs/apparatus.md
@@ -15,7 +15,7 @@ The Apparatus is a beta experiment. It is off by default. Open Settings. Set
 
 The active take stays in the story text. The Apparatus shows only inactive
 takes. Each row contains a stored preview. The row does not contain the full
-take text.
+take text. A closing rule separates the Apparatus from the next story part.
 
 Press `1` to select the shown site. Then press a shown letter to select that
 take. An invalid second key cancels the selection.

--- a/tui/src/screens/story/apparatus-band.ts
+++ b/tui/src/screens/story/apparatus-band.ts
@@ -52,6 +52,9 @@ export function renderApparatusBand(
       ...(armed ? [] : [segment(" · m opens map", "chrome")])
     ], measure, narrow));
   }
+  lines.push(bandLine([
+    segment("── end apparatus ──", "chrome")
+  ], measure, narrow));
   return { height: lines.length, lines };
 }
 

--- a/tui/test/apparatus-e2e.test.ts
+++ b/tui/test/apparatus-e2e.test.ts
@@ -67,9 +67,18 @@ describe("apparatus beta surface", () => {
     expect(text).toContain("apparatus · ¶12 · site 1 · negative · 5 takes");
     expect(text).toContain("active take omitted · stored previews");
     expect(text).toContain('1  b  "Ashe left the compass closed');
+    expect(text).toContain("── end apparatus ──");
     expect(text).not.toContain("variant");
     expect(text).not.toContain("witness");
     expect(text).not.toContain("sigla");
+  });
+
+  test("ends the apparatus before the next story part", () => {
+    const source = apparatusSource();
+    const state = initialState(source, false);
+    const text = frameText(renderStoryScreen(state, { width: 120, height: 80 }).lines);
+
+    expect(text).toMatch(/── end apparatus ──\s*\n\s*» continue/u);
   });
 
   test("bounds the band at 80 columns", () => {
@@ -81,6 +90,7 @@ describe("apparatus beta surface", () => {
     expect(lines.every((line) => visibleWidth(line.map((part) => part.text).join("")) <= 80)).toBeTrue();
     expect(frameText(lines)).toContain("apparatus · ¶12");
     expect(frameText(lines)).toContain("+ 2 more takes · m opens map");
+    expect(frameText(lines)).toContain("── end apparatus ──");
   });
 
   test("promotes a labeled doorway and consumes an invalid chord key", async () => {


### PR DESCRIPTION
## Summary

- Add a labeled closing rule to the Apparatus.
- Separate inactive take previews from the next story part.
- Keep the boundary visible at 80 columns.

Tracks #390

## Verification

- `bun test test/apparatus-e2e.test.ts test/apparatus-model.test.ts`
- `bun run typecheck`
- `npm run build`
- `git diff --check`
- autoreview: clean