### PR TITLE
chore(release): prepare 0.10.9-rc.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ This file records notable changes to 1667. Product terms use the definitions in
 
 ## 0.10.9-rc.2 - 2026-09-03
 
-- **The Apparatus has a clear closing edge.** A labeled rule separates inactive
-  take previews from the next story part.
+- **The Apparatus is easier to use.** A labeled rule separates inactive take
+  previews from the next story part. Click a preview to select that take.
 
 ## 0.10.9-rc.1 - 2026-09-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This file records notable changes to 1667. Product terms use the definitions in
 
 ## Unreleased
 
+## 0.10.9-rc.2 - 2026-09-03
+
 - **The Apparatus has a clear closing edge.** A labeled rule separates inactive
   take previews from the next story part.
 

--- a/docs/apparatus.md
+++ b/docs/apparatus.md
@@ -20,5 +20,7 @@ take text. A closing rule separates the Apparatus from the next story part.
 Press `1` to select the shown site. Then press a shown letter to select that
 take. An invalid second key cancels the selection.
 
+Click an inactive take preview to select that take.
+
 Use the experiment to compare this view with the story map. Report whether the
 Apparatus makes take selection faster or more difficult.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "1667-workspace",
-  "version": "0.10.9-rc.1",
+  "version": "0.10.9-rc.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "1667-workspace",
-      "version": "0.10.9-rc.1",
+      "version": "0.10.9-rc.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@earendil-works/pi-ai": "0.84.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667-workspace",
-  "version": "0.10.9-rc.1",
+  "version": "0.10.9-rc.2",
   "private": true,
   "description": "Source workspace for the 1667 terminal writing environment",
   "license": "Apache-2.0",

--- a/shared/release-notes.ts
+++ b/shared/release-notes.ts
@@ -13,7 +13,7 @@ export const RELEASE_NOTES: readonly ReleaseNote[] = [
   {
     version: "0.10.9-rc.2",
     date: "2026-09-03",
-    body: "- **The Apparatus has a clear closing edge.** A labeled rule separates inactive\n  take previews from the next story part."
+    body: "- **The Apparatus is easier to use.** A labeled rule separates inactive take\n  previews from the next story part. Click a preview to select that take."
   },
   {
     version: "0.10.9-rc.1",

--- a/shared/release-notes.ts
+++ b/shared/release-notes.ts
@@ -11,6 +11,11 @@ export interface ReleaseNote {
  *  a release, and is not included. */
 export const RELEASE_NOTES: readonly ReleaseNote[] = [
   {
+    version: "0.10.9-rc.2",
+    date: "2026-09-03",
+    body: "- **The Apparatus has a clear closing edge.** A labeled rule separates inactive\n  take previews from the next story part."
+  },
+  {
     version: "0.10.9-rc.1",
     date: "2026-09-02",
     body: "- **An optional Apparatus shows inactive take previews.** Turn it on in the\n  experimental Settings group. Press `1` and a shown letter to select a take.\n  The experiment is off by default."

--- a/tui/package.json
+++ b/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667",
-  "version": "0.10.9-rc.1",
+  "version": "0.10.9-rc.2",
   "private": true,
   "description": "A terminal environment for writing fiction with language models",
   "license": "Apache-2.0",

--- a/tui/src/hit.ts
+++ b/tui/src/hit.ts
@@ -21,8 +21,8 @@ export type HitTarget =
   | { kind: "chip"; index: number; group?: "tag" | "scope" }
   | { kind: "take"; row: number; take: number }
   | { kind: "map-view"; view: MapView }
-  /** Exact sibling control in the focused story-part gutter. */
-  | { kind: "story-take"; take: number }
+  /** Exact sibling control in the focused story-part surface. */
+  | { kind: "story-take"; take: number; rowId?: string }
   /** Shortcut from story chrome into one exact Settings row. */
   | { kind: "settings-row"; row: SettingsRowId; profilePurpose?: SettingsRoutePurpose }
   | {

--- a/tui/src/mouse-actions.ts
+++ b/tui/src/mouse-actions.ts
@@ -479,7 +479,11 @@ export function mouseToAction(
   if (target.kind === "take" && event.button === 0) return { action: "apply", index: target.row, take: target.take };
   if (target.kind === "map-view" && event.button === 0) return { action: "set-map-view", view: target.view };
   if (target.kind === "story-take" && event.button === 0 && state.mode === "NAV") {
-    return { action: "take-at", take: target.take };
+    return {
+      action: "take-at",
+      take: target.take,
+      ...(target.rowId === undefined ? {} : { rowId: target.rowId })
+    };
   }
   if (target.kind === "list" && event.button === 0) {
     const identity = target.rowId === undefined ? {} : { rowId: target.rowId };

--- a/tui/src/screens/story/apparatus-band.ts
+++ b/tui/src/screens/story/apparatus-band.ts
@@ -45,7 +45,7 @@ export function renderApparatusBand(
       segment(armed ? "letter selects take" : "1 + letter selects take", "focus / accent")
     ], measure, narrow)
   ];
-  lines.push(...shown.map((doorway) => doorwayLine(doorway, measure, narrow)));
+  lines.push(...shown.map((doorway) => doorwayLine(doorway, part.id, measure, narrow)));
   if (remaining > 0) {
     lines.push(bandLine([
       segment(`+ ${remaining} more takes`, "brass dim"),
@@ -58,7 +58,12 @@ export function renderApparatusBand(
   return { height: lines.length, lines };
 }
 
-function doorwayLine(doorway: ApparatusDoorway, measure: number, narrow: boolean): FrameLine {
+function doorwayLine(
+  doorway: ApparatusDoorway,
+  rowId: string,
+  measure: number,
+  narrow: boolean
+): FrameLine {
   const label = doorway.label ?? "—";
   const preview = doorway.preview.replace(/\s+/gu, " ").trim();
   const text = preview.length === 0 ? "⟨not yet generated⟩" : `"${preview}"`;
@@ -69,10 +74,11 @@ function doorwayLine(doorway: ApparatusDoorway, measure: number, narrow: boolean
   const suffix = continuation;
   const previewWidth = Math.max(1, measure - visibleWidth(prefix) - visibleWidth(suffix));
   const previewText = truncate(text, previewWidth);
+  const hit = { kind: "story-take" as const, take: doorway.takeIndex, rowId };
   return bandLine([
-    segment(prefix, "chrome"),
-    segment(previewText, doorway.label === null ? "brass dim" : "prose · dim"),
-    segment(suffix, "brass dim")
+    segment(prefix, "chrome", hit),
+    segment(previewText, doorway.label === null ? "brass dim" : "prose · dim", hit),
+    segment(suffix, "brass dim", hit)
   ], measure, narrow);
 }
 

--- a/tui/test/apparatus-e2e.test.ts
+++ b/tui/test/apparatus-e2e.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, test } from "bun:test";
 import type { CliRenderer, KeyEvent } from "@opentui/core";
 import type { NodeStub } from "../../shared/types.js";
-import { handleKey, initialState } from "../src/app.js";
+import { dispatch, handleKey, initialState } from "../src/app.js";
 import { demoAppSource } from "../src/demo.js";
+import { mouseToAction } from "../src/mouse-actions.js";
 import { createStoryViewModel, rowPart } from "../src/model.js";
 import { renderStoryScreen } from "../src/screens/story.js";
-import { frameText, visibleWidth } from "../src/screens/story/frame.js";
+import { frameText, plainLine, visibleWidth } from "../src/screens/story/frame.js";
 import { createWrapCache, type ProseStyle } from "../src/wrap.js";
 
 function key(name: string, sequence = name): KeyEvent {
@@ -127,6 +128,34 @@ describe("apparatus beta surface", () => {
     await press("b", state, source, 80);
     expect(state.apparatusArmedNodeId).toBeNull();
     expect(rowPart(createStoryViewModel(state.payload), state.focusIndex)?.id).toBe("p12-t1");
+  });
+
+  test("promotes a shown doorway preview by mouse click", async () => {
+    const source = apparatusSource();
+    const state = initialState(source, false);
+    const rendered = renderStoryScreen(state, { width: 120, height: 80 });
+    Object.assign(state, rendered.derived);
+    const preview = '"Ashe left the compass closed';
+    const row = rendered.lines.findIndex((line) => plainLine(line).includes(preview));
+    expect(row).toBeGreaterThan(-1);
+    const hit = state.hitRows[row]?.overrides?.find(({ target }) =>
+      target.kind === "story-take" && target.take === 1
+    );
+    expect(hit).toBeDefined();
+    expect(hit?.target).toEqual({ kind: "story-take", take: 1, rowId: "p12" });
+
+    const action = mouseToAction({
+      type: "down", button: 0,
+      x: hit!.left + Math.floor((hit!.right - hit!.left) / 2), y: row,
+      modifiers: { shift: false, alt: false, ctrl: false }
+    } as never, state);
+    expect(action).toEqual({ action: "take-at", take: 1, rowId: "p12" });
+    await dispatch(action!, state, source, createWrapCache<ProseStyle>(),
+      () => undefined, async () => undefined, () => undefined);
+
+    expect(rowPart(createStoryViewModel(state.payload), state.focusIndex)?.id).toBe("p12-t1");
+    expect(frameText(renderStoryScreen(state, { width: 120, height: 80 }).lines))
+      .toContain("Ashe left the compass closed");
   });
 
   test("promotes the fourth doorway shown at wide width", async () => {


### PR DESCRIPTION
Tracks #390

## Summary

- add direct mouse selection for visible Apparatus take previews
- release the clear Apparatus closing edge from beta feedback
- update package versions and embedded release notes

## Verification

- `bun test tui/test/apparatus-e2e.test.ts tui/test/apparatus-model.test.ts tui/test/mouse-actions.test.ts tui/test/hit-map-chrome.test.ts`
- `npm --prefix tui run typecheck`
- `npm run notes:check-version -- 0.10.9-rc.2`
- `npm run build`
- `git diff --check`