### PR TITLE
chore(release): prepare 0.10.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This file records notable changes to 1667. Product terms use the definitions in
 
 ## Unreleased
 
+## 0.10.9 - 2026-09-04
+
 - **You can check prose against Facts.** Run a chapter check or a story-line
   check from the command palette. 1667 reports verified contradictions and
   changes no prose.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "1667-workspace",
-  "version": "0.10.9-rc.2",
+  "version": "0.10.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "1667-workspace",
-      "version": "0.10.9-rc.2",
+      "version": "0.10.9",
       "license": "Apache-2.0",
       "dependencies": {
         "@earendil-works/pi-ai": "0.84.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667-workspace",
-  "version": "0.10.9-rc.2",
+  "version": "0.10.9",
   "private": true,
   "description": "Source workspace for the 1667 terminal writing environment",
   "license": "Apache-2.0",

--- a/shared/release-notes.ts
+++ b/shared/release-notes.ts
@@ -11,6 +11,11 @@ export interface ReleaseNote {
  *  a release, and is not included. */
 export const RELEASE_NOTES: readonly ReleaseNote[] = [
   {
+    version: "0.10.9",
+    date: "2026-09-04",
+    body: "- **You can check prose against Facts.** Run a chapter check or a story-line\n  check from the command palette. 1667 reports verified contradictions and\n  changes no prose."
+  },
+  {
     version: "0.10.9-rc.2",
     date: "2026-09-03",
     body: "- **The Apparatus is easier to use.** A labeled rule separates inactive take\n  previews from the next story part. Click a preview to select that take."

--- a/tui/package.json
+++ b/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1667",
-  "version": "0.10.9-rc.2",
+  "version": "0.10.9",
   "private": true,
   "description": "A terminal environment for writing fiction with language models",
   "license": "Apache-2.0",


### PR DESCRIPTION
Prepares the stable 0.10.9 release. This release makes Fact consistency checks available on the stable channel.

Changes:
- set root, lockfile, and TUI versions to 0.10.9
- move the Fact consistency note into the 0.10.9 changelog section
- regenerate embedded release notes

Verification:
- `npm run build`
- `npm test` — 2,842 pass, 241 skip, 0 fail
- `npm run prompt:check`
- `cd tui && bun run typecheck`
- `cd tui && bun run test` — all 16 shards, 2,573 pass, 0 fail
- `cd tui && bun run build:standalone` with Bun 1.4.0
- `npm run notes:check-version -- 0.10.9`
- `git diff --check`

Risk and limitation:
- The local performance run exceeded five existing 16 ms, 500-part repaint budgets. The release diff has no rendering or benchmark changes. The same source passed the required PR matrix before release preparation. All other performance budgets passed.

Tracks #394